### PR TITLE
UX defaults & layout polish

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -32,7 +32,7 @@ enum DBKeys {
   infinityScrollingMode(false),
   scrollAnimation(true),
   showNSFW(true),
-  downloadedBadge(true),
+  downloadedBadge(false),
   unreadBadge(true),
   languageBadge(false),
   l10n(Locale('en')),

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -44,7 +44,7 @@ enum DBKeys {
   chapterFilterDownloaded(null),
   chapterFilterUnread(null),
   chapterFilterBookmarked(null),
-  mangaSort(MangaSort.alphabetical),
+  mangaSort(MangaSort.lastRead),
   mangaSortDirection(true), // asc=true, dsc=false
   chapterSort(ChapterSort.source),
   chapterSortDirection(false), // asc=true, dsc=false

--- a/lib/src/features/browse_center/presentation/browse/browse_screen.dart
+++ b/lib/src/features/browse_center/presentation/browse/browse_screen.dart
@@ -52,7 +52,6 @@ class BrowseScreen extends HookConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.browse),
-        centerTitle: true,
         actions: [
           IconButton(
             onPressed: () => showSearch.value = (true),

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -53,7 +53,6 @@ class LibraryScreen extends HookConsumerWidget {
                 min(categoryId.getValueOnNullOrNegative(), data.length - 1),
             child: Scaffold(
               appBar: AppBar(
-                centerTitle: true,
                 title: !showSearch.value
                     ? Text(context.l10n.library)
                     : SearchField(
@@ -154,7 +153,6 @@ class LibraryScreen extends HookConsumerWidget {
       wrapper: (body) => Scaffold(
         appBar: AppBar(
           title: Text(context.l10n.library),
-          centerTitle: true,
         ),
         body: body,
       ),

--- a/lib/src/sorayomi.dart
+++ b/lib/src/sorayomi.dart
@@ -44,6 +44,7 @@ class Sorayomi extends ConsumerWidget {
           useMaterial3: true,
           useMaterial3ErrorColors: true,
         ).copyWith(
+          appBarTheme: const AppBarTheme(centerTitle: false),
           tabBarTheme: const TabBarThemeData(tabAlignment: TabAlignment.center),
         ),
         darkTheme: FlexThemeData.dark(
@@ -52,6 +53,7 @@ class Sorayomi extends ConsumerWidget {
           useMaterial3ErrorColors: true,
           darkIsTrueBlack: isTrueBlack.ifNull(),
         ).copyWith(
+          appBarTheme: const AppBarTheme(centerTitle: false),
           tabBarTheme: const TabBarThemeData(tabAlignment: TabAlignment.center),
         ),
         themeMode: themeMode ?? ThemeMode.system,

--- a/lib/src/widgets/shell/big_screen_navigation_bar.dart
+++ b/lib/src/widgets/shell/big_screen_navigation_bar.dart
@@ -20,6 +20,11 @@ class BigScreenNavigationBar extends StatelessWidget {
   final int selectedIndex;
   final ValueChanged<int> onDestinationSelected;
 
+  /// Width of the extended rail. Set explicitly on the [NavigationRail] below
+  /// AND used to size the [leading] so the header fills the rail and can
+  /// left-align (the rail's Column centers a narrower leading child).
+  static const double _extendedWidth = 256;
+
   NavigationRailDestination getNavigationRailDestination(
       BuildContext context, NavigationBarData data) {
     return NavigationRailDestination(
@@ -33,15 +38,25 @@ class BigScreenNavigationBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final Widget leadingIcon;
     if (context.isDesktop) {
-      leadingIcon = TextButton.icon(
-        onPressed: () => const AboutRoute().go(context),
-        icon: ImageIcon(
-          AssetImage(Assets.icons.darkIcon.path),
-          size: 48,
-        ),
-        label: Text(context.l10n.appTitle),
-        style: TextButton.styleFrom(
-          foregroundColor: context.textTheme.bodyLarge?.color,
+      leadingIcon = SizedBox(
+        width: _extendedWidth,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: () => const AboutRoute().go(context),
+              icon: ImageIcon(
+                AssetImage(Assets.icons.darkIcon.path),
+                size: 48,
+              ),
+              label: Text(context.l10n.appTitle),
+              style: TextButton.styleFrom(
+                foregroundColor: context.textTheme.bodyLarge?.color,
+                alignment: Alignment.centerLeft,
+              ),
+            ),
+          ),
         ),
       );
     } else {
@@ -58,6 +73,7 @@ class BigScreenNavigationBar extends StatelessWidget {
       useIndicator: true,
       elevation: 5,
       extended: context.isDesktop,
+      minExtendedWidth: _extendedWidth,
       labelType: context.isDesktop
           ? NavigationRailLabelType.none
           : NavigationRailLabelType.all,

--- a/test/defaults/library_defaults_test.dart
+++ b/test/defaults/library_defaults_test.dart
@@ -10,4 +10,8 @@ void main() {
   test('default sort direction stays ascending-toggle (most-recent-first for lastRead)', () {
     expect(DBKeys.mangaSortDirection.initial, true);
   });
+
+  test('downloaded badge is off by default', () {
+    expect(DBKeys.downloadedBadge.initial, false);
+  });
 }

--- a/test/defaults/library_defaults_test.dart
+++ b/test/defaults/library_defaults_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/db_keys.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+
+void main() {
+  test('default library sort is Last Read', () {
+    expect(DBKeys.mangaSort.initial, MangaSort.lastRead);
+  });
+
+  test('default sort direction stays ascending-toggle (most-recent-first for lastRead)', () {
+    expect(DBKeys.mangaSortDirection.initial, true);
+  });
+}


### PR DESCRIPTION
Brings out-of-the-box behavior in line with standard app / Komikku conventions.

- **Default library sort = Last Read** (most-recent-first). Only affects fresh installs / unset prefs. The `lastRead` comparator is internally reversed, so the existing ascending direction already yields most-recent-first — only the sort field changes.
- **Downloaded cover badge off by default** — cleaner covers out of the box; opt-in.
- **Left-aligned app-bar titles** app-wide (global `AppBarTheme(centerTitle: false)`; removed scattered per-screen overrides).
- **Left-aligned desktop navigation-rail header** (logo + Tsumiru title), matching the nav items below.

Tests: defaults covered by `test/defaults/library_defaults_test.dart`; full suite green.