### PR TITLE
Add architecture documentation

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,30 @@
+# Tsumiru Architecture
+
+Tsumiru is a Flutter client for [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) (the Tachidesk backend) — a manga/manhwa reader that runs on Android, Linux, Windows, macOS, and Web. It is its own application (published at `tsumiru-app/tsumiru`), originally based on [Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi), focused on being a great daily-driver, especially for webtoon/manhwa reading.
+
+This directory documents how the app is built and how each subsystem works, so contributors (human or AI) can orient quickly and change code safely.
+
+## Read this first
+
+- **[repo-build-release.md](repo-build-release.md)** — remotes, the branch model, the release flow, and the version scheme. **`tsumiru-app/tsumiru` `main` (remote `tsumiru`) is canonical.** Always `git fetch tsumiru` and verify your base against it and the latest release before building or branching.
+
+## Subsystem maps
+
+| Doc | Covers |
+|---|---|
+| [overview.md](overview.md) | Tech stack, layered structure, the conventions every feature reuses |
+| [app-shell-navigation.md](app-shell-navigation.md) | App bootstrap, `go_router` route tree, the nav shell (rail vs bottom bar) |
+| [data-layer.md](data-layer.md) | GraphQL clients, the repository pattern, Riverpod + codegen, `DBKeys`, image/auth plumbing |
+| [theming-l10n.md](theming-l10n.md) | `ThemeData` construction (flex_color_scheme), Appearance settings, localization |
+| [auth.md](auth.md) | Auth modes (none/basic/simpleLogin/uiLogin), token lifecycle, the GraphQL auth link |
+| [reader.md](reader.md) | Reader modes, the webtoon/infinity continuous scroll, pinch-to-zoom |
+| [library.md](library.md) | Categories, sort/filter/display, badges |
+| [manga-details-downloads.md](manga-details-downloads.md) | Manga details, chapter list + actions, the download queue |
+| [browse-sources-extensions.md](browse-sources-extensions.md) | Extensions, sources, source browsing, global search |
+| [settings.md](settings.md) | The settings sections, server connection, backup & restore, the two-tier persistence model |
+| [other-features.md](other-features.md) | about/update-check, history, migration, offline (WIP), quick_open |
+| [shared-infrastructure.md](shared-infrastructure.md) | `constants/`, `utils/`, shared `widgets/`, the conventions reused everywhere |
+
+## How these docs are maintained
+
+These maps describe the code as of the `docs-architecture` work (June 2026). When you change a subsystem materially, update its doc in the same PR. Gotchas and "non-obvious things" sections are the highest-value content — keep them current.

--- a/docs/architecture/app-shell-navigation.md
+++ b/docs/architecture/app-shell-navigation.md
@@ -1,0 +1,72 @@
+# App Shell & Navigation
+
+## Purpose
+
+App bootstrap, the `go_router` typed route tree, and the stateful navigation shell (NavigationRail on tablet/desktop, bottom NavigationBar on phone).
+
+## Key files
+
+| Path | Responsibility |
+|---|---|
+| `lib/main.dart` | Bootstrap: Hive init, auth migration, auth preload, `ProviderContainer` setup, `runApp` |
+| `lib/src/sorayomi.dart` | Root widget `Sorayomi`; wires `GraphQLProvider`, `MaterialApp.router`, theming, locale, `ReauthBannerHost` |
+| `lib/src/routes/router_config.dart` | `@riverpod routerConfig` `GoRouter`; typed `ShellRoute`/`GoRoute` defs; `Routes` constants; navigator keys |
+| `lib/src/routes/router_config.g.dart` | Generated `$appRoutes` (build_runner) |
+| `lib/src/routes/sub_routes/*.dart` | `part` files, one per nav section |
+| `lib/src/widgets/shell/navigation_shell_screen.dart` | `NavigationShellScreen` — dispatches to big/small nav bar; runs update check on first mount |
+| `lib/src/widgets/shell/big_screen_navigation_bar.dart` | `BigScreenNavigationBar` — `NavigationRail` (extended on desktop, logo in leading) |
+| `lib/src/widgets/shell/small_screen_navigation_bar.dart` | `SmallScreenNavigationBar` — M3 bottom `NavigationBar` |
+| `lib/src/constants/navigation_bar_data.dart` | `NavigationBarData` — `phoneNavList`/`tabletNavList`, `getNavList(context)` |
+
+## Bootstrap sequence (`main()`)
+
+1. `WidgetsFlutterBinding.ensureInitialized()`, `PackageInfo.fromPlatform()`, `SharedPreferences.getInstance()`, `initHiveForFlutter()`.
+2. `GoRouter.optionURLReflectsImperativeAPIs = true`.
+3. `ProviderContainer` with three pre-seeded overrides: `packageInfoProvider`, `sharedPreferencesProvider`, `hiveStoreProvider`.
+4. `migrateBasicAuthCredentials` — one-shot legacy basic-auth → secure storage migration (non-fatal).
+5. `Future.wait([authCredentialsStoreProvider.future, credentialsProvider.future])` — both auth providers loaded **before first frame** (prevents tokenless image requests caching as 401s).
+6. `container.read(authCoordinatorProvider.notifier)` — eagerly construct so the proactive-refresh listener is live before any image request.
+7. `runApp(UncontrolledProviderScope(container, child: Sorayomi()))`.
+
+Initial location: `/library/0`.
+
+`Sorayomi.build()` wraps: `GraphQLProvider` → `MaterialApp.router` → `FToastBuilder` → `ReauthBannerHost`.
+
+## Routing
+
+`go_router` with typed routes (`@TypedShellRoute` / `@TypedGoRoute` / `@TypedStatefulShellRoute`) generated into `router_config.g.dart`. The `GoRouter` itself is a `@riverpod` provider (`routerConfigProvider`).
+
+Route tree (outer → inner):
+
+```
+QuickSearchRoute (ShellRouteData — wraps everything in SearchStackScreen)
+  NavigationShellRoute (StatefulShellRouteData — NavigationShellScreen)
+    LibraryBranch    → /library/:categoryId
+    UpdatesBranch    → /updates
+    HistoryBranch    → /history
+    BrowserBranch    → BrowseShellRoute (nested StatefulShellRoute: Sources / Extensions)
+    DownloadsBranch  → /downloads
+    MoreBranch       → /more → settings, about, ...
+  MangaRoute         → /manga/:mangaId            (outside the shell)
+    ReaderRoute      → /manga/:mangaId/chapter/:chapterId
+  GlobalSearchRoute, UpdateStatusRoute, Migration*Route
+```
+
+Navigator keys: `rootNavigatorKey`, `_quickOpenNavigatorKey` (also `$parentNavigatorKey` for `ReaderRoute`/`GlobalSearchRoute` → they present full-screen above the shell), `_shellNavigatorKey`, `_browseNavigatorKey`.
+
+Navigation is always typed: `const FooRoute(...).go(context)` / `.push(context)` — no string-based navigation.
+
+## Screen-size split
+
+- **Phone** (< 600): `SmallScreenNavigationBar` (M3 bottom bar), 5 items (History omitted — lives under More).
+- **Tablet** (≥ 600, `context.isTablet`): `BigScreenNavigationBar` (`NavigationRail`), 6 items incl. History.
+- **Desktop** (≥ 1200, `context.isDesktop`): rail is **extended** (256px) with logo + title in `leading`.
+
+## Gotchas
+
+- **History index offset on phone.** The stateful shell always has 6 branches (0–5); phone shows 5 (History hidden). `NavigationShellScreen` has `getAdjustedIndex`/`getReverseAdjustedIndex` that ±1 for indices ≥ 2 on phone. Changing the nav item count must update these or the wrong branch is selected.
+- **Reader presents above the shell** via `_quickOpenNavigatorKey` as `$parentNavigatorKey` — nav bars are fully hidden while reading.
+- **`MangaRoute` is outside the stateful shell** (inside `QuickSearchRoute`) — manga detail renders without a nav bar.
+- **`NavigationBarData.navList`** (static field) is a stale legacy alias for `phoneNavList`; always use `getNavList(context)`.
+- **Browse is a tab-within-a-tab** — a nested `StatefulShellRoute` (Sources / Extensions) with its own navigator.
+- **`isTablet` uses `width`, not shortestSide** despite a misleading comment — a landscape phone ≥ 600px wide gets the rail layout.

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -1,0 +1,52 @@
+# Auth
+
+> Security-sensitive subsystem. Read the gotchas before changing anything here.
+
+## Purpose
+
+Pluggable authentication for all traffic (queries, mutations, subscriptions, image fetches) to a Suwayomi-Server. Four modes: `none`, `basic`, `simpleLogin`, `uiLogin` (JWT), with token refresh, proactive expiry rotation, secure storage, and a reauth banner.
+
+## Key files
+
+| Path | Responsibility |
+|---|---|
+| `features/auth/data/auth_state.dart` | `NeedsReauth` notifier (keepAlive bool) — set on 401 death, cleared on reauth |
+| `features/auth/data/auth_credentials_store.dart` | `AuthCredentialsStore` AsyncNotifier — in-memory snapshot, writes through to secure storage |
+| `features/auth/data/secure_credentials_provider.dart` | Thin wrapper over `FlutterSecureStorage` (`encryptedSharedPreferences: true` on Android) |
+| `features/auth/data/suwayomi_auth_link.dart` | GraphQL `Link` — injects headers, handles 401 → refresh → retry (ui) / reauth signal (simple) |
+| `features/auth/data/auth_coordinator.dart` | `AuthCoordinator` — login, refresh, test-connection, proactive-refresh Timer, single-flight `Completer` |
+| `features/auth/data/simple_login_client.dart` | Raw client POSTing `/login.html`, returns the `JSESSIONID` |
+| `features/auth/data/jwt_utils.dart` | `decodeJwtExp()` — parses JWT `exp` (no signature verification; for Timer sizing only) |
+| `features/auth/data/auth_lifecycle_observer.dart` | On app resume, refresh if due (covers Android Doze Timer gaps) |
+| `features/auth/data/basic_auth_migration.dart` | One-shot legacy basic-auth → secure storage migration |
+| `features/auth/presentation/reauth_banner.dart` | `ReauthBannerHost` — shows/clears a `MaterialBanner` on `needsReauthProvider` |
+| `.../settings/.../authentication/` + `credential_popup/` | Auth-type picker, credentials entry, Test Connection, logout |
+
+## Modes & credential injection
+
+| Mode | HTTP | WebSocket | Images |
+|---|---|---|---|
+| `none` | — | — | — |
+| `basic` | `AuthLink`: `Authorization: Basic …` | WS handshake header | header |
+| `simpleLogin` | `SuwayomiAuthLink`: `Cookie: JSESSIONID=…` | WS handshake header | cookie header |
+| `uiLogin` | `SuwayomiAuthLink`: `Authorization: Bearer <jwt>` | WS `initialPayload` `{Authorization: <bare token>}` | `?token=` query param |
+
+`AuthType` is stored in SharedPreferences (`DBKeys.authType`); username in SharedPreferences (`DBKeys.authUsername`). **Credentials go to `flutter_secure_storage`**: `auth.password`, `auth.simple.cookie`, `auth.ui.accessToken`, `auth.ui.refreshToken`, `auth.basic.credentials`.
+
+## Token lifecycle (ui_login)
+
+- `uiAccessTokenExpiresAt` derived from JWT `exp` on every set; **not persisted** (recomputed on `build()`).
+- **Proactive refresh:** `AuthCoordinator` schedules a Timer at `exp − 60s` (capped 24h). Transient failure → backoff `[30s,60s,120s,300s]`. Auth failure → clear tokens, set `NeedsReauth`. App-resume observer covers Doze gaps.
+- **On-demand (401 path in `SuwayomiAuthLink`):** detect 401 → (`simpleLogin`: call reauth immediately; `uiLogin`: `refreshUiAccessToken()`) → single-flight via file-static `Completer` → refresh via a **raw un-authed client** → on success retry once (retry 401 → reauth); auth-failure → clear + reauth; transient → yield original 401.
+- **Reauth flow:** `NeedsReauth=true` → `ReauthBannerHost` banner → `LoginCredentialsPopup` → coordinator login → `NeedsReauth=false`.
+
+## Gotchas (security-sensitive)
+
+- **Single-flight is a file-static `_refreshInFlight`, not an instance field** — survives Riverpod invalidation mid-refresh. Tests must call `debugResetAuthCoordinatorSingleFlight()` in `setUp`.
+- **Bare token in WS `connection_init`** (`{Authorization: <token>}`, no "Bearer ") — adding the prefix silently breaks subscriptions. Differs from the HTTP header.
+- **Simple Login leaks server-side sessions on Test Connection** — `POST /login.html` always creates a session; discarding the cookie doesn't destroy it; no logout-without-cookie endpoint.
+- **`decodeJwtExp` does NOT verify the signature** — intentional (expiry is for Timer sizing only; the server enforces access).
+- **`uiAccessTokenExpiresAt` not persisted** — if the JWT is malformed, expiry is null and no proactive Timer is scheduled (refresh only happens reactively on 401).
+- **Migrated basic creds live under `auth.basic.credentials`**, tracked by a separate `credentialsProvider`, not `AuthCredentialsState`. Logout must call `clearBasicCredentials()` or they persist invisibly.
+- **Refresh client must stay un-authed** — if it ever gains a `SuwayomiAuthLink`, refresh recurses infinitely.
+- **`isLocalAddress` suppresses the insecure-transport warning** for `localhost`/`127.x`/`10.x`/`172.16–31.x`/`192.168.x` only.

--- a/docs/architecture/browse-sources-extensions.md
+++ b/docs/architecture/browse-sources-extensions.md
@@ -1,0 +1,41 @@
+# Browse: Sources & Extensions
+
+## Purpose
+
+The "Browse" tab: discovering/installing extensions, listing sources, browsing a single source (popular/latest/search with filters), and global search across all sources.
+
+## Structure
+
+`browse_screen.dart` is a two-tab shell (Sources / Extensions) with a shared AppBar. Sources-tab search pushes `GlobalSearchRoute`; Extensions-tab search filters in place via `extensionQueryProvider`.
+
+| Area | Key files |
+|---|---|
+| Extensions | `presentation/extension/{extension_screen, controller/extension_controller}.dart`, `widgets/extension_list_tile.dart`, `data/extension_repository/extension_repository.dart` |
+| Sources | `presentation/source/{source_screen, controller/source_controller}.dart`, `widgets/source_list_tile.dart`, `data/source_repository/source_repository.dart` |
+| Source manga list | `presentation/source_manga_list/{source_manga_list_screen, controller/...}.dart`, `widgets/{source_manga_grid_view, source_manga_list_view, source_manga_filter, filter_to_widget}.dart` |
+| Global search | `presentation/global_search/{global_search_screen, controller/source_quick_search_controller}.dart`, `widgets/source_short_search.dart` |
+| Source preferences | `presentation/source_preference/...` |
+
+## Domain types
+
+All `typedef`s over GraphQL codegen (except `Language`, which is `freezed`): `Extension = Fragment$ExtensionDto`, `SourceDto = Fragment$SourceDto`, `SourceType = Enum$FetchSourceMangaType` (POPULAR/LATEST/SEARCH/$unknown), `MangaPage = Fragment$SourceMangaPage`. Filters: `Filter`/`PrimitiveFilter` union + 7 concrete subtypes; `SourcePreference` union + 5 types.
+
+## Notable behavior
+
+- **Extensions:** grouped into update/installed/by-language; NSFW-gated; language allowlist persisted (`DBKeys.extensionLanguageFilter`). Install via `UpdateExtension` or file upload (`InstallExternalExtension`).
+- **Sources:** grouped lastUsed/all/by-language/localSource; tapping saves `sourceLastUsedProvider` and navigates to `SourceTypeRoute(POPULAR)`.
+- **Source browsing:** `infinite_scroll_pagination` `PagingController<int, MangaDto>` (`firstPageKey: 1`); POPULAR/LATEST/SEARCH chips; filter drawer (end-drawer tablet / bottom-sheet phone) rendered via exhaustive `switch` in `filter_to_widget.dart`.
+- **Global search:** `quickSearchResultsProvider(query)` fans out `sourceQuickSearchMangaListProvider(sourceId, query)` across filtered sources, all wrapped in `rateLimitQueueProvider(query)`.
+
+## Gotchas
+
+- **Extension list fetch is a mutation** (`FetchExtensionList`) — every "refresh" tells the server to re-check for updates (a roundtrip).
+- **`SourceType.SEARCH` is labelled "Filter"** in the UI (`sourceTypeFilter`), matching Tachiyomi convention.
+- **`sourceDisplayModeProvider` uses `DisplayMode.sourceDisplayList`** (grid/list subset); `descriptiveList` is lumped with `list`.
+- **Filter leaf widgets use `kPositionPlaceholder`** — real position is assigned by the parent; don't set it in the leaf.
+- **Global search rate-limits by query string** (a queue per distinct query), not by time.
+- **`baseSourcePreferenceListProvider` uses `ref.read`** (not reactive) — invalidate to refresh.
+- **Source language filter sorts enabled-first once** on dialog open (frozen for the session).
+- **Local source `lang` is the literal `"localsourcelang"`** — explicitly removed and pinned to the bottom.
+- **`MangaPageDto` fragment is dead code** (repo uses `SourceMangaPage`).
+- **Installing an extension auto-adds its language** to the source language filter so the new source is visible.

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -1,0 +1,67 @@
+# Data Layer
+
+## Purpose
+
+All manga/chapter/library data is fetched via the Suwayomi GraphQL API (`/api/graphql`); images come from a REST surface. Settings persist locally via SharedPreferences; Hive backs the GraphQL cache store.
+
+## Key files
+
+| Path | Responsibility |
+|---|---|
+| `lib/src/global_providers/global_providers.dart` | Creates/provides the HTTP + WebSocket `GraphQLClient`s, `SharedPreferences`, `HiveStore`, rate-limit queue, top-level prefs |
+| `lib/src/graphql/schema.graphql` / `fragments.graphql` | Full schema; shared `PageInfoDto` fragment |
+| `lib/src/graphql/__generated__/*.graphql.dart` | Codegen output (inputs, enums, scalars, fragments) |
+| `lib/src/constants/endpoints.dart` | `Endpoints.baseApi(...)` — the single URL builder (HTTP/GraphQL/WebSocket, port toggle) |
+| `lib/src/constants/db_keys.dart` | `DBKeys` — every SharedPreferences key + default |
+| `lib/src/utils/mixin/shared_preferences_client_mixin.dart` | `SharedPreferenceClientMixin<T>` / `SharedPreferenceEnumClientMixin<T>` |
+| `lib/src/widgets/server_image.dart` | `ServerImage` — `CachedNetworkImage` with per-auth-type header/token injection |
+| `lib/src/utils/extensions/cache_manager_extensions.dart` | Same auth/URL logic for imperative `CacheManager.getSingleFile` |
+| `lib/src/features/<f>/data/<name>_repository.dart` (+ `graphql/*.graphql`) | Per-feature repositories + operations |
+
+## The two GraphQL clients
+
+**`graphQlClientProvider`** (HTTP queries/mutations):
+- `HttpLink` to `Endpoints.baseApi(..., isGraphQl: true)`, wrapped in `TimeoutHttpClient` (configurable timeout + retry).
+- Auth links prepended per `authTypeKeyProvider`: `basic` → `AuthLink`; `simpleLogin`/`uiLogin` → `SuwayomiAuthLink` (see [auth.md](auth.md)).
+- Cache: `GraphQLCache(store: hiveStoreProvider)`, default `FetchPolicy.noCache` — **every query hits the network**; Hive is effectively write-only.
+
+**`graphQlSubscriptionClientProvider`** (WebSocket subscriptions):
+- `WebSocketLink`, `subProtocol: graphqlTransportWs`.
+- **Auth is on the socket, not a Link**: `ui_login` → `initialPayload` async fn returning `{Authorization: <bare token>}` (no "Bearer "); `simple_login`/`basic` → `handshakeHeaders`.
+
+**`graphQlClientNotifierProvider`** — `ValueNotifier<GraphQLClient>` for the `GraphQLProvider` widget.
+
+## Repository pattern
+
+```
+features/<f>/data/<name>_repository.dart      # class taking GraphQLClient + @riverpod factory
+features/<f>/data/graphql/query.graphql       # operations
+features/<f>/data/graphql/__generated__/...    # graphql_codegen output
+features/<f>/domain/<type>/graphql/fragment.graphql  # fragments near their domain type
+```
+
+- Repository methods call codegen extension methods: `client.query$AllCategories()`, `client.mutate$CreateCategory(Options$Mutation$CreateCategory(variables: ...))` — not raw `client.query(QueryOptions(...))`.
+- The `@riverpod` factory is a one-liner: `CategoryRepository(ref.watch(graphQlClientProvider))`.
+- After changing `.graphql` files or `@riverpod`: `dart run build_runner build --delete-conflicting-outputs`.
+
+## Riverpod conventions
+
+- `@riverpod` on a function → `AutoDisposeProvider<T>` (repositories).
+- `@riverpod` on a class extending `_$X` → `AutoDisposeNotifierProvider<T?>`.
+- **Persisted prefs** follow the mixin pattern: class mixes `SharedPreference[Enum]ClientMixin`, `build()` calls `initialize(DBKeys.key)` (watches `sharedPreferencesProvider`, `ref.listenSelf` auto-persists), callers use `.update(value)`.
+- `sharedPreferencesProvider` and `hiveStoreProvider` are `throw UnimplementedError()` sentinels — overridden in `ProviderScope` at startup.
+
+## Image / CacheManager auth
+
+- `basic` → `Authorization` header.
+- `simple_login` → `Cookie` header (watched reactively via `.select`).
+- `ui_login` → token as `?token=<urlencoded>` query param (headers unreliable for `cached_network_image`); **`cacheKey` is always the bare `baseApi` URL (no token)** so cache survives token rotation; token read via `ref.read` (non-reactive) to avoid rebuild storms in webtoon scroll.
+
+## Gotchas
+
+- **WebSocket auth via a `Link` is silently ineffective** — must use `initialPayload`/`SocketClientConfig.headers`. (Cost a debug session historically.)
+- **`ui_login` WS sends a bare token, not `Bearer <token>`** (server `onInit` doesn't strip the prefix). HTTP uses `Bearer`.
+- **`cacheKey` must be the un-tokened URL** — otherwise every token rotation busts the whole image cache.
+- **Subscription 401 mid-stream is not handled** — `SuwayomiAuthLink` only inspects the first event. Acceptable because Suwayomi subscriptions are short-lived.
+- **Token refresh uses a raw, un-authed client** to avoid infinite recursion on 401.
+- **Default `FetchPolicy.noCache`** — don't expect GraphQL cache reads.

--- a/docs/architecture/library.md
+++ b/docs/architecture/library.md
@@ -1,0 +1,49 @@
+# Library
+
+## Purpose
+
+Displays saved manga organized into server-side categories, with client-side sort, filter, search, and three display modes. All view state persists to SharedPreferences.
+
+## Key files
+
+| Path | Responsibility |
+|---|---|
+| `features/library/data/category_repository.dart` | Fetch categories + per-category manga; category CRUD/reorder |
+| `features/library/data/graphql/query.graphql` | `AllCategories`, `GetCategoryMangas` + category mutations |
+| `features/library/presentation/library/controller/library_controller.dart` | All library providers: fetch, filter, sort, display mode, query |
+| `.../library/library_screen.dart` | Tab bar per category, AppBar search + filter, tablet end-drawer |
+| `.../library/category_manga_list.dart` | Per-tab grid/list/descriptive-list |
+| `.../library/widgets/library_manga_{organizer,filter,sort_tile,display}.dart` | Filter/Sort/Display tabs |
+| `.../category/...` | Edit-category screen, tiles, dialogs, create FAB |
+| `lib/src/widgets/manga_cover/providers/manga_cover_providers.dart` | `DownloadedBadge` / `UnreadBadge` (shared with browse) |
+
+## Data flow
+
+1. `categoryControllerProvider` → `AllCategories` (ordered `ORDER ASC`).
+2. `nonZeroCategoryListProvider` keeps only categories with `mangas.totalCount > 0` (the tab bar source).
+3. Each tab → `CategoryMangaList(categoryId)` → `categoryMangaListProvider(categoryId)` (`GetCategoryMangas`).
+4. `categoryMangaListWithQueryAndFilterProvider(categoryId)` watches the raw list + all filter/sort/query providers, applies `applyMangaFilter` then `applyMangaSort` inline.
+
+**`applyMangaFilter`** — five tri-state `bool?` filters ANDed (`null`=off, `true`/`false` via XOR): unread (`unreadCount>0`), downloaded (`downloadCount>0`), completed (`status=="COMPLETED"`), started (`lastReadChapter!=null`), bookmarked (`bookmarkCount>0`); text query last.
+
+**`applyMangaSort`** — `MangaSort` × direction (`sortDirToggle` = `1` asc / `-1` desc): `alphabetical`, `unread`, `dateAdded` (`inLibraryAt`), `lastUpdated` (`latestFetchedChapter.fetchedAt`), `lastChapterDate` (`latestUploadedChapter.uploadDate`), `totalChapters`, `lastRead` (`lastReadChapter.lastReadAt`).
+
+## Display, badges, grid
+
+- `DisplayMode`: `grid` (`MangaCoverGridTile`), `list` (itemExtent 96), `descriptiveList` (itemExtent 176). Default `grid`.
+- Badges: `downloadedBadge` (default **false**), `unreadBadge` (default **true**) — shared providers in `manga_cover/providers/`, controlled in the Display tab.
+- Grid: `mangaCoverGridDelegate(size)` = `SliverGridDelegateWithMaxCrossAxisExtent(maxCrossAxisExtent: gridMangaCoverWidth (192), childAspectRatio: 0.75, spacing 2.0)` — column count varies with width.
+
+## Persistence (DBKeys)
+
+`mangaSort` (**`MangaSort.lastRead`**), `mangaSortDirection` (`true`/asc), `mangaFilter{Downloaded,Unread,Completed,Started,Bookmarked}` (`null`), `libraryDisplayMode` (`grid`), `downloadedBadge` (`false`), `unreadBadge` (`true`), `gridMangaCoverWidth` (`192.0`). Search query is session-only (no persistence).
+
+## Gotchas
+
+- **`lastRead` sort is internally reversed** — the comparator is `m2.lastReadAt.compareTo(m1.lastReadAt)` (args swapped). So the "ascending" direction (`sortDirToggle = 1`) actually yields **most-recently-read first**. Every other sort key is normal. Do not "fix" this — it's intentional Mihon-parity, and the **default sort is `lastRead`**, so new installs open most-recent-first.
+- **Empty categories are hidden** (`nonZeroCategoryListProvider`) — a new empty category is invisible in the tab bar until it has a manga. The edit screen shows all.
+- **Filter/sort/display changes are global**, applied to all tabs at once — no per-category state.
+- **`LibraryDisplayCategory` provider is vestigial** (declared, never set).
+- **Tab index** comes from the `:categoryId` route param clamped to range — not persisted.
+- **Badge providers live outside the library tree** (`widgets/manga_cover/providers/`), shared with browse. A `LanguageBadge` is fully commented out.
+- **Timestamps are string-encoded epochs** parsed inline (`int.tryParse(... ?? '0') ?? 0`) — invalid/missing sort to the bottom.

--- a/docs/architecture/manga-details-downloads.md
+++ b/docs/architecture/manga-details-downloads.md
@@ -1,0 +1,51 @@
+# Manga Details, Chapters & Downloads
+
+(The reader lives in the same feature folder but is documented in [reader.md](reader.md).)
+
+## Key files
+
+| Path | Responsibility |
+|---|---|
+| `manga_book/data/manga_book/manga_book_repository.dart` | All manga/chapter queries + mutations (get manga, `fetchChapters`, update manga, patch chapter, batch update, delete download, set meta, get pages) |
+| `manga_book/data/downloads/downloads_repository.dart` | Download queue: holds query + subscription clients; start/stop/clear/enqueue/dequeue/reorder + the live status stream |
+| `manga_book/domain/manga/manga_model.dart` | `MangaDto` (typedef), `MangaMeta` (freezed), `MangaMetaKeys` |
+| `manga_book/domain/chapter/chapter_model.dart` | `ChapterDto` (typedef); `.index` = `sourceOrder` |
+| `manga_book/domain/chapter/chapter_download_presets.dart` | `DownloadPreset` enum + `chaptersToQueueForPreset()` (pure, testable) |
+| `manga_book/domain/downloads/downloads_model.dart` | `DownloadDto`, `DownloaderState`, `DownloadState`, `DownloadUpdateType` (typedefs) |
+| `.../manga_details/manga_details_screen.dart` | Root; owns `selectedChapters`; switches AppBar normal/multi-select |
+| `.../manga_details/controller/manga_details_controller.dart` | All manga-details providers |
+| `.../manga_details/widgets/{small,big}_screen_manga_details.dart` | Phone / tablet layouts |
+| `.../manga_details/widgets/chapter_list_tile.dart` | Chapter row + trailing `DownloadStatusIcon` |
+| `.../manga_details/widgets/chapter_download_presets_button.dart` | Bulk-download presets (operates on the **unfiltered** list) |
+| `.../manga_details/widgets/manga_chapter_{organizer,filter}.dart` | Filter/Sort sheet (tri-state + scanlator radio) |
+| `manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart` | Multi-select action bar |
+| `manga_book/widgets/download_status_icon.dart` | Inline per-chapter download progress/state |
+| `.../downloads/downloads_screen.dart` (+ `controller/`, `widgets/`) | Standalone queue screen |
+
+## Manga details
+
+`MangaDetailsScreen(mangaId, categoryId?)` watches `mangaWithIdProvider`, `mangaChapterListProvider` (**fetched via the `fetchChapters` mutation**, keepAlive), and `mangaChapterListWithFilterProvider`. First build fires `refresh()`; pull-to-refresh wired. AppBar has normal vs multi-select modes; FAB points to `firstUnreadInFilteredChapterListProvider`. On pop, invalidates `categoryMangaListProvider(categoryId)`. Phone = `CustomScrollView` + `SliverList`; tablet = end-drawer organizer.
+
+## Chapters & actions
+
+- Filtering/sorting is client-side in `mangaChapterListWithFilterProvider`. Filter/sort state is **global** (SharedPreferences); the **scanlator** filter is **per-manga** (server meta `flutter_scanlator`). `ChapterSort`: `source`, `fetchedDate`, `uploadDate`.
+- Tile: tap → reader; long-press / right-click → multi-select.
+- Multi-select bar: bookmark add/remove, mark-previous-read, mark read (`lastPageRead: 0`), mark unread, download, delete — then clears selection + refreshes.
+- **Bulk-download presets** operate on the **full unfiltered** list: sort by `chapterNumber` asc, find highest read, walk forward collecting un-downloaded IDs ("Next N" skips downloaded).
+- Single vs bulk: `SingleChapterActionIcon` → `putChapter`; `MultiChaptersActionIcon` → `modifyBulkChapters` (`UpdateChapters`).
+
+## Downloads
+
+Two-source state: `downloadStatusProvider` polls `GetDownloadStatus` for the initial snapshot; `downloadUpdatesProvider` opens a `DownloadStatusChanged` subscription (`graphQlSubscriptionClientProvider`, `maxUpdates: 150`). `downloadsMapProvider` (`Map<int, DownloadDto>` keyed by chapter id) merges deltas: `DEQUEUED`/`FINISHED` remove; others upsert. `downloadsChapterIdsProvider` sorts by `position`. Each `DownloadProgressListTile` and inline `DownloadStatusIcon` watches `downloadsFromIdProvider(chapterId)` (a `.select`) so tiles rebuild independently. `DownloadStatusIcon` triggers a chapter-list refresh on `FINISHED` via `Future.microtask`.
+
+## Gotchas
+
+- **Bottom inset for the multi-select bar** must be read from `View.of(context).viewPadding.bottom / devicePixelRatio` — inside the shell nav, `MediaQuery` padding/viewPadding report 0 for the bottom-sheet's descendants. (Upstream PR #381.)
+- **`fetchChapters` is a mutation** — it triggers a source fetch, not a DB read. Use `query$Chapters` for a local-only lookup.
+- **Download presets use the unfiltered list** and compute from the highest **read** chapter by `chapterNumber`, independent of UI sort.
+- **Scanlator "no filter" sentinel is the string `"flutter_scanlator"`**, not `null`.
+- **`DownloadStatusIcon` `FINISHED` refresh uses `Future.microtask`** — removing it causes "setState during build".
+- **`downloadsMapProvider` throws `UnimplementedError` on an unknown `DownloadUpdateType`** — a new server state crashes the subscription listener until handled.
+- **Two distinct GraphQL clients** (query + subscription) — auth/interceptor changes must touch both in `global_providers.dart`.
+- **`mangaChapterListProvider` is keepAlive** — reflect chapter changes via `updateChapter()` or `ref.invalidate`, not a plain rebuild.
+- **`ChapterDto.index` is `sourceOrder`**, not list position.

--- a/docs/architecture/other-features.md
+++ b/docs/architecture/other-features.md
@@ -1,0 +1,46 @@
+# Other Features
+
+Smaller features: about, history, migration, offline (WIP), quick_open.
+
+## about
+
+App/server version info + update checks.
+
+- `data/about_repository.dart` — **two update paths**: `checkUpdate()` hits the **GitHub Releases REST API** directly; `checkServerUpdate()` uses the server's GraphQL `checkForServerUpdates`. Both use `pub_semver`.
+- `controllers/about_controller.dart` — `aboutProvider` (GraphQL `GetAbout`); `packageInfoProvider` is `throw UnimplementedError()` (overridden in `main.dart`).
+- URLs (all in `lib/src/constants/urls.dart`): `sorayomiGithubUrl` = `github.com/tsumiru-app/tsumiru`, `sorayomiLatestReleaseUrl`/`...ApiUrl` (releases + GitHub API), `sorayomiWhatsNew` = `tsumiru-app.github.io/changelogs/`, `tachideskHelp` = `tsumiru-app.github.io/docs/...`.
+- **Gotcha:** the update check strips the leading `v` from `tag_name` (`Version.parse(tag.substring(1))`) — a tag format change throws. (This was the crash fixed in `004f1a5`.)
+
+## history
+
+Per-manga reading history grouped by date, with search + per-item removal.
+
+- `data/history_repository.dart` — GraphQL with `ChapterFilterInput` (`lastReadAt`/`isRead`/`lastPageRead`); **dedup is client-side** (over-fetches `pageSize*10`, keeps most-recent chapter per manga, re-paginates). `clearAllHistory()` is `throw UnimplementedError`.
+- `presentation/history_controller.dart` — `ReadingHistory` notifier; `removeFromHistory()` patches `isRead=false, lastPageRead=0` (no true delete; `lastReadAt` can't be cleared via the API).
+- `HistoryGroup` (freezed) groups by date key with localized headers.
+- **Gotchas:** the `pageSize*10` over-fetch can be slow at scale; removed items may reappear until server restart; manga-title search is client-side only.
+
+## migration
+
+Migrate a manga from one source to another (status/categories/progress/bookmarks, optional source delete). Five-screen flow.
+
+- `data/migration_repository.dart` — sequential GraphQL; chapter matching by number (±0.01) → exact name → partial name; chapters updated one-by-one. `cancelMigration()` is `throw UnimplementedError`.
+- `controller/migration_controller.dart` — `MigrationExecution` notifier with **artificial progress delays**; global search via `rateLimitQueueProvider`.
+- **Gotchas:** `migrateDownloads` and `migrateTracking` flags exist in the UI but are **not implemented**; cancel is unimplemented (controller fakes `cancelled`); progress percentages are cosmetic (real work happens at the 75%→100% step).
+
+## offline (WIP — does not compile)
+
+Intended on-device Drift/SQLite catalog for offline reading.
+
+- **The source files are missing** — `data/` contains only `offline_database.g.dart` and `offline_repository.g.dart`, whose `part of` source files do not exist in the repo. **Any compile will fail** with "target of URI doesn't exist".
+- The generated schema reveals tables: `offline_mangas`, `offline_chapters` (with `deviceState` enum, `pageCount`, `bytes`), `offline_categories`, `offline_manga_categories`, `offline_pages`. Providers declared: `offlineDatabaseProvider`, `offlinePathsProvider`, `offlineRepositoryProvider`, `offlineEnabledProvider` (default false, overridden on native at startup), `offlineSyncProvider`.
+- **Status:** abandoned/in-progress WIP. The actual feature work lives on the `feat/offline-viewing` branch (backed up on the `tsumiru` remote), not in `main`.
+
+## quick_open
+
+Command-palette overlay for fast navigation (library/manga/chapters/sources via typed prefixes).
+
+- `controller/quick_search_controller.dart` — `processesQuickSearchProvider` routes by prefix/context: `?` help, `@source` / `@source/query` sources, `#cat` / `#cat/manga` / `#cat/manga:chapter` library drill-down, context-aware default (chapter search on a manga route, else manga search).
+- `domain/quick_search_result.dart` — `QuickSearchResult` freezed union (helpText/source/category/manga/chapter/globalSearch/...).
+- `widgets/search_stack_screen.dart` stacks the overlay on the shell.
+- **Gotcha:** `processesQuickSearchProvider` takes a `BuildContext` (for `context.location` route awareness) — unusual for Riverpod; it must be called from a widget subtree and falls back to manga search if route parsing fails.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,55 @@
+# Overview
+
+## Tech stack
+
+- **Flutter 3.32.4 / Dart 3.8.1** (pinned).
+- **Riverpod** (`hooks_riverpod`) + `riverpod_generator` (`@riverpod`) for state/DI.
+- **flutter_hooks** for local widget state.
+- **graphql_flutter** + **graphql_codegen** for the Suwayomi GraphQL API.
+- **freezed** + **json_serializable** for data classes.
+- **go_router** + **go_router_builder** for typed routing.
+- **flex_color_scheme** for theming.
+- **scrollable_positioned_list** (a pinned fork) for the multi-image readers.
+- **cached_network_image** + **flutter_cache_manager** for image fetches.
+- **flutter_secure_storage** for credentials; **shared_preferences** for settings; **Hive** for the GraphQL cache store.
+
+After adding `@riverpod` annotations or `.graphql` files: `dart run build_runner build --delete-conflicting-outputs`.
+
+## Layered structure
+
+```
+lib/
+  main.dart                 # bootstrap: Hive, prefs, auth preload, runApp
+  src/
+    sorayomi.dart           # root widget: GraphQLProvider + MaterialApp.router + theming
+    routes/                 # go_router typed route tree (+ sub_routes/ part files)
+    global_providers/       # GraphQL clients, SharedPreferences, HiveStore, auth-type
+    graphql/                # shared schema + fragments + codegen output
+    constants/              # DBKeys (prefs registry), enums, urls, endpoints, sizes, gen assets
+    utils/                  # context extensions, the SharedPreference mixins, AsyncValue helpers
+    widgets/                # shared widgets (ServerImage, manga covers, async buttons, shell nav)
+    l10n/                   # ARB files + generated localizations
+    features/<area>/        # per-feature: data/ (repository + .graphql), domain/ (typedefs), presentation/ (screens + controllers)
+```
+
+Each feature follows the same internal shape: `data/` (a repository class + a `@riverpod` factory + `.graphql` operations), `domain/` (mostly `typedef`s over GraphQL codegen fragments), `presentation/` (screens + `controller/` providers + `widgets/`).
+
+## Conventions reused everywhere
+
+These appear across every feature — learn them once:
+
+- **Persisted setting:** add a case to `DBKeys` (with its default), declare a `@riverpod` notifier that mixes in `SharedPreferenceClientMixin<T>` (or `SharedPreferenceEnumClientMixin<T>` for enums), call `initialize(DBKeys.yourKey)` in `build()`. Read/persist is automatic via `ref.listenSelf`. See [shared-infrastructure.md](shared-infrastructure.md).
+- **Repository:** a plain class taking a `GraphQLClient`, calling codegen extension methods (`client.query$Foo()`, `client.mutate$Bar(...)`), plus a `@riverpod` factory injecting `graphQlClientProvider`. See [data-layer.md](data-layer.md).
+- **Domain types are `typedef`s** over generated fragments (`typedef MangaDto = Fragment$MangaDto`), not bespoke classes (except a few `freezed` ones).
+- **Async UI:** `asyncValue.showUiWhenData(context, builder)` renders a shimmer while loading and an `Emoticons` error widget on error — skip custom loading/error handling.
+- **Async mutations:** `AppUtils.guard(future, toast)` runs a future, surfaces errors as a toast, returns `T?`.
+- **Strings:** all user-facing text goes through `context.l10n.someKey` (ARB/l10n). No hardcoded strings.
+- **Sizes:** use `KEdgeInsets.X.size` / `KBorderRadius.X.radius` tokens, never hardcoded padding/radii.
+- **Responsive:** `context.isDesktop` (width ≥ 1200), `context.isTablet` (≥ 600), `context.showNavbar` (> 800) — distinct thresholds, don't conflate.
+
+## The big cross-cutting gotchas
+
+- **`SharedPreferenceEnumClientMixin` stores enums by index**, not name — reordering enum cases silently corrupts stored prefs (`ReaderMode`, `MangaSort`, `DisplayMode`, etc.).
+- **`DBKeys` key string = the enum case `.name`** — renaming a case is a breaking migration.
+- **Two GraphQL clients** (HTTP + WebSocket). WebSocket auth must be on the socket (`initialPayload`/`handshakeHeaders`), never a `Link`. See [auth.md](auth.md) / [data-layer.md](data-layer.md).
+- **Several "fetch" operations are mutations** (`fetchChapters`, `FetchExtensionList`) — calling them triggers a server-side source refresh, not just a DB read.

--- a/docs/architecture/reader.md
+++ b/docs/architecture/reader.md
@@ -1,0 +1,60 @@
+# Reader
+
+The reader is central (Tsumiru is webtoon/manhwa-first). It renders pages from the server, supports seven reading modes, pinch-to-zoom, gesture navigation, page-progress tracking, and seamless multi-chapter loading in webtoon/infinity mode.
+
+## Key files
+
+| Path | Responsibility |
+|---|---|
+| `.../reader/reader_screen.dart` | Entry; resolves `ReaderMode`, dispatches to continuous or single-page mode |
+| `.../reader/controller/reader_controller.dart` | `chapterProvider`, `chapterPagesProvider` |
+| `.../reader/widgets/reader_wrapper.dart` | Scaffold: AppBar, bottom sheet (slider + chapter nav + settings drawer), keyboard/volume listeners, magnifier, gesture handlers; `_PageViewEnhancer`, `ReaderView` |
+| `.../reader_mode/continuous_reader_mode.dart` | Non-infinity continuous (webtoon, continuousVertical, continuousHorizontal*) via `ScrollablePositionedList` |
+| `.../reader_mode/single_page_reader_mode.dart` | Paged reader via `PageView` (prefetch ±2) |
+| `.../reader_mode/infinity_continuous_reader_mode.dart` | Router: infinity+vertical → `MultiChapterContinuousReaderMode`; else single-chapter SPL fallback |
+| `.../infinity_continuous/multichapter_continuous_reader_mode.dart` | The real webtoon-infinity reader: dynamic adjacent-chapter loading, page-height measurement, prepend re-anchor |
+| `.../infinity_continuous/measure_size.dart` | `MeasureSize` — reports rendered size to cache true page heights (prevents scroll-snap) |
+| `.../infinity_continuous/infinity_continuous_{config,utils,navigation,feedback}.dart` | Constants, helpers, navigation, chapter-load snackbars + separator |
+| `.../reader/widgets/directional_swipe_gesture_handler.dart` | Swipe-to-chapter-nav / simple boundary-swipe recognizers |
+| `.../reader/widgets/reader_navigation_layout/` | Tap-zone layouts: edge, kindlish, lShaped, rightAndLeft, disabled |
+| `lib/src/widgets/zoom/scroll_offset_to_scroll_controller.dart` | Adapts SPL's `ScrollOffsetController` to a `ScrollController` for `zoom_view` |
+
+## Reader modes
+
+`ReaderMode` (`constants/enum.dart`): `defaultReader`, `continuousVertical`, `singleHorizontalLTR`, `singleHorizontalRTL`, `continuousHorizontalLTR`, `continuousHorizontalRTL`, `singleVertical`, `webtoon`. **Default: `webtoon`.**
+
+`ReaderScreen` switches on `manga.metaData.readerMode ?? globalDefault` (per-manga override via `MangaMetaKeys`):
+
+| Mode | Widget | Mechanism |
+|---|---|---|
+| `webtoon` | `ContinuousReaderMode` (no separator) → may delegate to `MultiChapterContinuousReaderMode` | SPL vertical, no gaps |
+| `continuousVertical` | `ContinuousReaderMode` (separator, never infinity) | SPL, 16px gaps |
+| `continuousHorizontal*` | `ContinuousReaderMode` (horizontal ± reverse) | SPL horizontal |
+| `single*` | `SinglePageReaderMode` | `PageView` |
+
+**Continuous scroll:** `ScrollablePositionedList.separated`; `initialScrollIndex = chapter.lastPageRead`; `minCacheExtent = viewport*2`; position listener with an 800ms debounce to suppress programmatic jumps; "most visible" page picked by greatest visible fraction > 0.4; special case forces last page when its trailing edge ≤ 1.0 (fixes mark-as-read for short final images).
+
+**Page-height caching (infinity):** each image wrapped in `MeasureSize`; first rendered height cached per image URL; re-entry uses the cached height to prevent strip collapse + backward snap.
+
+## Pinch-to-zoom
+
+`zoom_view` package. Continuous modes wrap the SPL in `ZoomView` with a `ScrollOffsetToScrollController` adapter; `maxScale 5.0`, `doubleTapDrag`, **`forceHoldOnPointerDown: true`** (so the scale recognizer wins the arena vs SPL/PageView drag — closes #256). Paged mode wraps `PageView` directly. Mobile-only (`!kIsWeb && (Android||iOS)`). Setting: `pinchToZoomProvider` (`DBKeys.pinchToZoom`, default `true`), read via `ref.read` (mid-session change needs reload).
+
+## Reader settings / overlay
+
+Overlay visibility is `useState` in `ReaderWrapper` (initial from `readerInitialOverlayProvider`), toggled by tap. Settings drawer: mode, nav layout, padding, magnifier size — written back per-manga via `patchMangaMeta`.
+
+Reader DBKeys: `readerMode` (webtoon), `readerPadding` (0.0), `readerMagnifierSize` (1.0), `readerNavigationLayout` (disabled), `swipeToggle` (true), `lastPageSwipeEnabled` (false), `infinityScrollingMode` (false), `readerOverlay` (true), `pinchToZoom` (true), `readerIgnoreSafeArea` (false). Per-manga overrides via `MangaMetaKeys` take precedence.
+
+Page-progress: `onPageChanged` debounces 2s then `putChapter` (`lastPageRead`); final page fires immediately with `isRead: true, lastPageRead: 0`. Uses actual loaded page count, not metadata.
+
+## Gotchas / tech debt
+
+- **Three near-identical continuous implementations** (`ContinuousReaderMode`, the infinity-off fallback, `MultiChapterContinuousReaderMode`) — scroll fixes must be applied to all or they diverge again.
+- **800ms `programmaticNavigationDelay`** blocks programmatic nav (incl. slider) while scrolling; slider uses `forceNavigation: true` + a 300ms reset that can race.
+- **Prepend re-anchor is one-frame deferred** — on a slow device SPL may not register the new `itemCount` in that frame → viewport snaps to wrong content.
+- **`_PageViewEnhancer._checkBoundarySwipe` is dead code** (`return;`).
+- **Overscroll chapter nav can fire on momentum** (300ms window can expire before animation settles).
+- **`infinityScrollingMode` toggle only shows when the global default is `webtoon`** — hidden if global is `continuousVertical` but per-manga is `webtoon`.
+- **`minVisibleAreaThreshold = 0.4` is duplicated** in `_ScrollConfig` and `InfinityContinuousConfig` (not shared).
+- **Requires the pinned `scrollable_positioned_list` fork** (exposes `ScrollOffsetController.position`) — won't compile against pub.dev.

--- a/docs/architecture/repo-build-release.md
+++ b/docs/architecture/repo-build-release.md
@@ -1,0 +1,82 @@
+# Repo, Build & Release Model
+
+> **The #1 rule:** `tsumiru-app/tsumiru` `main` (git remote `tsumiru`) is the canonical source of truth. **Before building, branching, or releasing, run `git fetch tsumiru` and verify your local base against `tsumiru/main` AND the latest GitHub release.** Building on a stale base produces an app missing the in-app branding, version, and fixes that shipped in the latest release.
+
+## Remotes & branch model
+
+Tsumiru is its **own application** published at `tsumiru-app/tsumiru` — not a personal fork. It descends from Tachidesk-Sorayomi (kept for attribution and the occasional upstream sync), but the project lives and ships on its own now.
+
+| Remote | URL | Role |
+|---|---|---|
+| `tsumiru` | `github.com/tsumiru-app/tsumiru` | **The app — canonical.** `main` and releases here are ground truth |
+| `upstream` | `github.com/Suwayomi/Tachidesk-Sorayomi` | The project Tsumiru descends from (attribution / occasional sync) |
+| `origin` | `github.com/aaronbamblett/Tachidesk-Sorayomi` | **Legacy/stale** — the old personal fork, no longer used. Some local clones still carry this remote in config |
+| `ariqpradipa` | `github.com/ariqpradipa/Tachidesk-Sorayomi` | Author of adopted reader PR #362 |
+
+**Workflow:** Tsumiru uses **pull requests** (public project). Branch off `tsumiru/main`, open a PR, let CI gate it, then merge. Branch and commit names are plain/human — no `feat/`-style prefixes. Push/PR-create/merge happen on the `tsumiru` remote.
+
+## Version scheme
+
+`pubspec.yaml`: `version: 0.4.1+30`
+
+- **Public version** (`0.4.1`) matches the release tag line (`v0.4.1`). Release tags carry a `v` prefix; the pubspec version does not.
+- **Build number** (`+30`) is a monotonically increasing integer (inherited from the upstream `0.6.4+N` series). It MUST increase on every build pushed to a device — Android rejects a same-or-lower build number as a downgrade. CI does not enforce this; bump it manually before tagging.
+
+## Release flow
+
+Pushing a `v*.*.*` tag fires two workflows in parallel:
+
+**`release-fork.yml`** (primary release builder) — Flutter pinned to `3.32.4` (stable). A 5-job matrix (`fail-fast: false`):
+
+| Job | Runner | Output |
+|---|---|---|
+| android | ubuntu-latest | 4 APKs (universal + arm64-v8a + armeabi-v7a + x86_64), debug-keystore signed via repo secrets so upgrades stay clean |
+| linux | ubuntu-latest | AppImage (fastforge + appimagetool) |
+| web | ubuntu-latest | `*-web.zip` |
+| macos | macos-latest | `.app` zip |
+| windows | **windows-2022** (pinned, not `latest`) | `*-windows-x64.zip` |
+
+- Android signing secrets: `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`.
+- Linux build deps: `clang cmake ninja-build pkg-config libgtk-3-dev libx11-dev libblkid-dev liblzma-dev libsecret-1-dev libjsoncpp-dev` (last two needed for `flutter_secure_storage_linux`).
+- Artifacts attach to the release only on a tag push (guarded by `startsWith(github.ref, 'refs/tags/')`); `workflow_dispatch` builds but does not attach.
+
+**`flatpak.yml`** (self-hosted Flatpak repo → GitHub Pages) — three sequential jobs: build the Linux bundle, package + GPG-sign in the `freedesktop:24.08` flatter container, deploy to Pages at `tsumiru-app.github.io/tsumiru`. Needs secrets `FLATPAK_GPG_PRIVATE_KEY` + `FLATPAK_GPG_KEY_ID`. Manifest id is still `io.github.aaronbamblett.tsumiru`.
+
+**Manual-only / vestigial:**
+- `publish.yml` — inherited upstream (winget/homebrew/Play/iOS). Stale: still names `tachidesk-sorayomi`, needs secrets this fork lacks. `workflow_dispatch` only; do not run.
+- `web.yml` — inherited upstream Pages deployer (`baseHref: /Tachidesk-Sorayomi/`). Stale; Web is covered by `release-fork.yml`.
+
+## CI quality gates
+
+- `claude-code-review.yml` — Claude code-review commentary on PRs (needs `CLAUDE_CODE_OAUTH_TOKEN`). Not a build/test gate.
+- `claude.yml` — `@claude` interactive assistant. Not a gate.
+- **Gap:** there is currently **no workflow that runs `flutter analyze` / `flutter test` on PRs** — a broken build can merge undetected until a release tag. (A visual-verification + test gate is planned; see the vault plans.)
+
+## Codegen — what regenerates and when
+
+Every CI build step runs, before building:
+
+```bash
+flutter pub get
+flutter gen-l10n
+dart run build_runner build --delete-conflicting-outputs
+```
+
+`build_runner` regenerates: `*.g.dart` (riverpod_generator, json_serializable, go_router_builder), `*.freezed.dart` (freezed), `*.graphql.dart` (graphql_codegen), and `lib/src/constants/gen/` (flutter_gen). `flutter gen-l10n` regenerates `lib/src/l10n/generated/` from the ARB files (`l10n.yaml`: `synthetic-package: false`). `flutter_native_splash` / `flutter_launcher_icons` are NOT run in CI — their outputs are committed as static assets.
+
+`analysis_options.yaml` excludes generated files; adds `prefer_relative_imports` and `directives_ordering`; suppresses `invalid_annotation_target` (common with freezed/riverpod).
+
+## Pinned git dependencies (instability vectors)
+
+- `scrollable_positioned_list` → `github.com/yakagami/scrollable_positioned_list@4641e83` (fork exposing `ScrollOffsetController.position`, needed for pinch-zoom coordination). The reader will not compile against the pub.dev package.
+- `flutter_android_volume_keydown` → `github.com/DattatreyaReddy/flutter_android_volume_keydown` (floating HEAD, no ref pinned).
+
+## Local build / run
+
+```bash
+flutter pub get
+dart run build_runner build --delete-conflicting-outputs
+flutter run -d chrome      # web (no native toolchain needed)
+flutter run -d linux       # native Linux desktop (requires cmake/ninja/GTK dev libs)
+flutter build apk --debug  # local Android APK
+```

--- a/docs/architecture/settings.md
+++ b/docs/architecture/settings.md
@@ -1,0 +1,43 @@
+# Settings
+
+The largest feature area (~103 files). Split into two persistence tiers: **client-local** (SharedPreferences) and **server-side** (Suwayomi GraphQL mutations).
+
+## Structure & routing
+
+Entry is the "More" tab (`more_screen.dart`, a shell-nav destination) — it inlines `ServerUrlTile` + `AppThemeModeTile`, then links to `BackupRoute` and `SettingsRoute`. `SettingsScreen` is the hub for eight sections:
+
+| Section | Screen |
+|---|---|
+| General | `presentation/general/general_screen.dart` |
+| Appearance | `presentation/appearance/` (see [theming-l10n.md](theming-l10n.md)) |
+| Library | `presentation/library/library_settings_screen.dart` |
+| Downloads | `presentation/downloads/downloads_settings_screen.dart` |
+| Reader | `presentation/reader/reader_settings_screen.dart` |
+| Browse | `presentation/browse/browse_settings_screen.dart` |
+| Backup & Restore | `presentation/backup/backup_screen.dart` |
+| Server | `presentation/server/server_screen.dart` |
+
+## Notable subsystems
+
+- **Server connection** (`server/widget/client/`): `serverUrlProvider` (web defaults to `Uri.base.origin`, strips trailing `/`), `serverPortProvider` + `serverPortToggleProvider` (port appended to URLs only when toggle on), `ServerSearchButton` (LAN /24 scan via `network_info_plus` + `Socket.connect`). **Timeout settings live in General**, not Server (`serverRequestTimeout` 5000ms, `autoRefreshOnTimeout`, `autoRefreshRetryDelay` 1000ms).
+- **Authentication** (`server/widget/authentication/` + `credential_popup/`): see [auth.md](auth.md). Auth type in SharedPreferences; credentials in secure storage; Test Connection surfaces typed failures.
+- **Server screen** (GraphQL-backed): `ServerBindingSection`, `SocksProxySection`, `CloudFlareSection`, `MiscSettingsSection` — all watch `settingsProvider` and only render when `valueOrNull != null`; mutations return `SettingsDto` → `updateState(result)`.
+- **Backup & Restore**: manual create (flags + returns URL) / restore (file picker → validate → missing-sources dialog → async restore polled via `RestoreStatusProgress`); automatic backup (server-side path/time/interval/TTL).
+- **Reader/Library/Downloads/Browse settings**: Reader is all client-local (~14 tiles); Library/Downloads/Browse are mostly server-side via `settingsProvider`.
+
+## Persistence (two tiers)
+
+**Client-local:** the `DBKeys` + `SharedPreference[Enum]ClientMixin` pattern — see [shared-infrastructure.md](shared-infrastructure.md). `DBKeys` is the single registry; key string = enum case `.name`.
+
+**Server-side:** fetch once via `Query$ServerSettings` → `settingsProvider`; each typed `setSettings` mutation returns the full `SettingsDto` → `settingsProvider.notifier.updateState(result)` (no refetch). DTOs are `typedef`s over codegen fragments.
+
+`SettingsPropTile` is the universal tile (a `SettingsPropType` union: textField / numberPicker / numberSlider / switchTile).
+
+## Gotchas
+
+- **Two distinct "server port" concepts:** `serverPortProvider` (client connects TO, SharedPreferences, default 4567) vs `ServerBindingSection` (the port the server LISTENS ON, GraphQL). Independent.
+- **`serverPortToggleProvider` is architecture-critical** — it globally gates whether the port is appended to all API URLs (`Endpoints.baseApi(..., addPort:)`). Defaults `true` (non-web).
+- **`backup_settings_repository.dart:47` copy-paste bug** — `includeChapters` is set to `includeCategories`; the user's `includeChapters` choice is never sent.
+- **`reader_continuous_reading_tile.dart` is an empty (0-byte) file** — dead placeholder.
+- **`more_screen.dart` ≠ `settings_screen.dart`** — MoreScreen is a main tab with its own inline URL/theme tiles (same providers as the Server section).
+- **Server-side sections silently show nothing if the server is offline** (no error UI).

--- a/docs/architecture/shared-infrastructure.md
+++ b/docs/architecture/shared-infrastructure.md
@@ -1,0 +1,49 @@
+# Shared Infrastructure
+
+`constants/`, `utils/`, shared `widgets/`, `abstracts/` — the persistence registry, app-wide enums/constants, the context-extension toolkit, auth-aware image fetching, and reusable widgets every feature draws on.
+
+## DBKeys — the prefs registry
+
+`lib/src/constants/db_keys.dart` — a single enum that is the authoritative list of every SharedPreferences key, each case carrying its `initial` value as a constructor arg. The key string on disk = the enum case `.name`. Companion `DBStoreName` enum (`settings`) names the Hive store.
+
+**The two mixins** (`lib/src/utils/mixin/shared_preferences_client_mixin.dart`):
+
+- `SharedPreferenceClientMixin<T>` — non-enum types (bool/double/int/String/List\<String\>, or custom via `toJson`/`fromJson`). `initialize(DBKeys.key)` watches `sharedPreferencesProvider`, sets `_key = key.name`, reads `key.initial`, registers `ref.listenSelf` to auto-persist. `_set` dispatches by type; `null` → `remove`. Public: `update(T?)`, `updateWithPreviousState(...)`.
+- `SharedPreferenceEnumClientMixin<T extends Enum>` — stores the enum **index** via `setInt`; `initialize(DBKeys.key, enumList: SomeEnum.values)`.
+
+## Constants
+
+- **`enum.dart`:** `AuthType` (none/basic/simpleLogin/uiLogin), `ReaderMode` (8; default webtoon), `ReaderNavigationLayout` (default disabled), `MangaSort` (7; default lastRead), `ChapterSort` (source/uploadDate/fetchedDate), `DisplayMode` (grid/list/descriptiveList), `MangaStatus`, `IncludeOrExclude` (tri-state). Most carry `toLocale(BuildContext)`.
+- **`urls.dart`:** external URLs, rebranded to `tsumiru-app` (`sorayomiGithubUrl`, `...LatestReleaseUrl`, `...ApiUrl`, `tachideskHelp`, `sorayomiWhatsNew`, `flareSolverr`).
+- **`endpoints.dart`:** `Endpoints.baseApi(...)` — the central URL builder (`baseUrl`, `port`, `addPort`, `isGraphQl`, `isWebsocket`); plus per-area URL classes.
+- **`app_constants.dart`:** `kDuration` (500ms), `kInstantDuration`, `kLongDuration`, `kCurve`, magnifier constants, `kDebounceDuration` (500ms), `kPositionPlaceholder` (-1).
+- **`app_sizes.dart`:** `KEdgeInsets` / `KBorderRadius` / `KRadius` tokens; `mangaCoverGridDelegate(double?)`.
+- **`gen/assets.gen.dart`:** FlutterGen output. `Assets.icons.darkIcon` / `lightIcon` are the Tsumiru icons; the `launcher` sub-namespace still uses old `sorayomi*` file names (matches on-disk asset names).
+
+## Utils
+
+- **Context extensions** (`utils/extensions/custom_extensions/context_extensions.dart`): `context.l10n`, `isDesktop` (≥1200), `isTablet` (≥600), `showNavbar` (>800), `theme`/`textTheme`/`colorScheme`/`isDarkMode`, `responsiveValue<T>(...)`, `pushBottomSheet`, `showFullScreenDialog`, `location` (current GoRouter path).
+- **`cache_manager_extensions.dart`:** `CacheManager.getServerFile(ref, url)` — mirrors `ServerImage` auth (ui_login token as `?token=`, cacheKey = untokened `baseApi`).
+- **`async_value_extensions.dart`:** `showUiWhenData(context, builder, ...)` (shimmer / `Emoticons` error / builder), `valueOrToast`, `copyWithData`.
+- **String/int/bool extensions:** `isBlank`/`isNotBlank`, `query(...)`, `parseTimestamp`; `liesBetween`, `getValueOnNullOrNegative`, `compact`; `bool?.ifNull([alt=false])` (used everywhere instead of `?? false`).
+- **`app_utils.dart`:** `wrapOn(wrapper, child)`, `guard<T>(future, toast)`.
+- **`toast/toast.dart`:** `Toast` (FToast wrapper); `toast` provider returns `Toast?` (null when no context) — callers null-check.
+
+## Shared widgets
+
+- **`ServerImage`** (`widgets/server_image.dart`): auth-aware `CachedNetworkImage`. Dispatches by `authTypeKeyProvider`; `simple_login` cookie watched reactively (`.select`), `ui_login` token via `ref.read` (non-reactive, to avoid webtoon rebuild storms), `cacheKey = baseApi` (untokened). Error widget evicts cache + speculatively refreshes the token + remounts. `ServerImageWithCpi` adds a progress ring.
+- **`MangaCoverGridTile` / `MangaBadgesRow` / `MangaBadge`** (`widgets/manga_cover/`): cover tiles with `showTitle`/`showBadges`/`showCountBadges`; badges read `downloadedBadgeProvider` / `unreadBadgeProvider`. `languageBadge` is commented out.
+- **Async buttons** (`widgets/async_buttons/`): six variants, all `useState(false)` loading → disable + spinner.
+- **`Emoticons`** (error state), **`CenterSorayomiShimmerIndicator`** (loading), **popup widgets** (Radio/MultiSelect/Slider/TextField popups), **`SettingsPropTile`** (generic settings row).
+- **Shell widgets** (`widgets/shell/`): see [app-shell-navigation.md](app-shell-navigation.md).
+
+## Gotchas
+
+- **Enums are stored by index** (`SharedPreferenceEnumClientMixin`) — reordering cases silently corrupts stored prefs (`ReaderMode`, `ReaderNavigationLayout`, `MangaSort`, `ChapterSort`, `DisplayMode`).
+- **`DBKeys` key = enum case `.name`** — renaming is a breaking migration.
+- **`ServerImage` uses `ref.read` for the ui token** (not `watch`) — deliberate, to avoid scroll-yanking rebuild storms on the ~4-min token rotation.
+- **`cacheKey = baseApi` (untokened), fetch URL = tokened** — keep this split for any new auth mode or token rotation busts the cache.
+- **`languageBadge` is fully commented out** (the `DBKeys.languageBadge` key exists but no live provider reads it).
+- **Launcher assets still use `sorayomi*` names** in `assets.gen.dart` (on-disk file names not yet renamed).
+- **`AuthType` has four values** — any `switch` on it must handle all four.
+- **`isDesktop` (≥1200) ≠ `showNavbar` (>800)** — distinct thresholds.

--- a/docs/architecture/theming-l10n.md
+++ b/docs/architecture/theming-l10n.md
@@ -1,0 +1,45 @@
+# Theming & Localization
+
+## Theming (current state)
+
+`Sorayomi.build()` constructs both `theme:` and `darkTheme:` inline via `FlexThemeData.light/dark(scheme: appScheme, useMaterial3: true, useMaterial3ErrorColors: true)`, then `.copyWith(appBarTheme: AppBarTheme(centerTitle: false), tabBarTheme: TabBarThemeData(tabAlignment: center))`.
+
+- `appScheme` — a `FlexScheme` enum from `appSchemeProvider` (default `FlexScheme.material`). The picker iterates the **full** `FlexColor.schemes` set — there is no curated palette or seed color.
+- `darkIsTrueBlack` — from `isTrueBlackProvider` (default `false`), passed only to `FlexThemeData.dark`.
+- `themeMode` — `appThemeModeProvider` (default `ThemeMode.system`).
+- No `ColorScheme.fromSeed`, no Material You / dynamic color.
+
+> A redesign to a curated branded named-theme system (Indigo Night + Carbon + Plum + custom seed) is planned — see the vault plans. This doc reflects the current flex_color_scheme implementation.
+
+## Appearance settings
+
+`AppearanceScreen` (`features/settings/presentation/appearance/`) is a `ListView` of four controls:
+
+| Widget | Provider | DBKey | Default |
+|---|---|---|---|
+| `AppThemeModeTile` | `appThemeModeProvider` | `themeMode` | `ThemeMode.system` |
+| `IsTrueBlackTile` | `isTrueBlackProvider` | `isTrueBlack` | `false` (shown only when mode ≠ Light) |
+| `AppThemeSelector` | `appSchemeProvider` | `flexScheme` | `FlexScheme.material` |
+| `GridCoverWidthSlider` | `gridMinWidthProvider` | `gridMangaCoverWidth` | `192.0` |
+
+The **language** picker is in **General** settings (`l10nProvider` / `DBKeys.l10n`), not Appearance.
+
+All five providers use `SharedPreference[Enum]ClientMixin` and live in the same file as their widget (`part 'foo.g.dart'`).
+
+## Localization
+
+Config (`l10n.yaml`): `arb-dir: lib/src/l10n`, `template-arb-file: app_en.arb`, `output-dir: lib/src/l10n/generated`, `synthetic-package: false` (generated files committed).
+
+- 27 ARB locales; English is the source of truth. New locales arrive via Weblate post-merge.
+- Generate with `flutter gen-l10n` (manual / not auto-run by build_runner) → `app_localizations_<lang>.dart`.
+- Wired in `Sorayomi` via `AppLocalizations.localizationsDelegates` + `supportedLocales`; `locale:` is `ref.watch(l10nProvider)` (nullable → OS default).
+- Access in widgets: `context.l10n.someKey` (`context_extensions.dart`: `AppLocalizations.of(this)!`).
+- Locale persisted as a JSON map (`{languageCode, scriptCode?, countryCode?}`) under `DBKeys.l10n`.
+
+## Gotchas
+
+- **True black is dark-only** — `darkIsTrueBlack` is passed only to the dark theme; toggling it in light mode persists but does nothing visible.
+- **`appTitle` in `app_en.arb` is already "Tsumiru"** — the rebrand lives in l10n too, not just the app name.
+- **`synthetic-package: false`** — regenerate l10n manually (`flutter gen-l10n`) after ARB changes; build_runner does not.
+- **`copyWith` overrides** (`centerTitle: false`, `tabAlignment: center`) are applied after `FlexThemeData` — any future theme work that conflicts must also use `copyWith`.
+- **`FlexScheme.material` is the default but not necessarily first in the picker** — the picker scrolls all `FlexColor.schemes.keys` in insertion order; the highlight is by equality.


### PR DESCRIPTION
Adds a whole-codebase architecture reference under `docs/architecture/` for contributors.

- Index + overview (tech stack, layered structure, the conventions every feature reuses).
- **repo-build-release.md** — remotes, branch model (`tsumiru-app/tsumiru` main is canonical), release flow, version scheme, the 'always fetch before building' rule.
- One doc per subsystem: app shell/navigation, data layer, theming/l10n, auth, reader, library, manga-details/downloads, browse, settings, other features, shared infrastructure.

Each doc captures responsibilities, key files, data flow, and a gotchas section. Docs only — no code changes.