### PR TITLE
Reader: Komikku-style webtoon progress bar

### DIFF
--- a/design/reader-slider-playground.html
+++ b/design/reader-slider-playground.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="indigo">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tsumiru — Reader Slider (match Komikku)</title>
+<style>
+/* theme-kit tokens, VERBATIM */
+[data-theme='indigo']{--bg:#0b0d1a;--bg2:#11142a;--ink:#eef0fb;--muted:#9aa0c4;--faint:#6b7099;--accent:#7c7bff;--accent2:#33d6ff;--glow:rgba(124,123,255,.35);--grad:linear-gradient(180deg,#7c7bff,#33d6ff);}
+[data-theme='carbon']{--bg:#08100e;--bg2:#0c1714;--ink:#eafcf6;--muted:#8fb6ac;--faint:#5d7e76;--accent:#19e6b0;--accent2:#22d3ee;--glow:rgba(25,230,176,.3);--grad:linear-gradient(180deg,#19e6b0,#22d3ee);}
+[data-theme='plum']{--bg:#120a16;--bg2:#1b0f22;--ink:#fbeefb;--muted:#caa0c9;--faint:#946b93;--accent:#ff5db1;--accent2:#ff9f5c;--glow:rgba(255,93,177,.32);--grad:linear-gradient(180deg,#ff5db1,#ff9f5c);}
+
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Inter',-apple-system,system-ui,sans-serif;background:#05060d;color:#e7e9f5;display:flex;min-height:100vh}
+
+/* controls */
+.controls{width:320px;flex-shrink:0;height:100vh;overflow-y:auto;padding:20px;background:#0a0c16;border-right:1px solid rgba(255,255,255,.07)}
+.controls h1{font-size:15px;margin-bottom:3px}
+.controls .sub{font-size:11px;color:#7a80a8;margin-bottom:16px;line-height:1.5}
+.presets{display:flex;gap:6px;margin-bottom:18px}
+.presets button{flex:1;padding:8px 4px;font-size:11px;font-weight:600;cursor:pointer;background:rgba(124,123,255,.12);color:#c9c8ff;border:1px solid rgba(124,123,255,.3);border-radius:9px}
+.grp{font-size:11px;font-weight:700;color:#aeb3d6;text-transform:uppercase;letter-spacing:.04em;margin:16px 0 8px}
+.ctl{margin-bottom:13px}
+.ctl label{display:block;font-size:11px;color:#aeb3d6;margin-bottom:5px}
+.ctl .v{float:right;color:#7c7bff;font-family:monospace}
+.ctl input[type=range]{width:100%;accent-color:#7c7bff}
+.seg{display:flex;gap:4px}
+.seg button{flex:1;padding:6px 4px;font-size:11px;cursor:pointer;border-radius:7px;background:rgba(255,255,255,.04);color:#aeb3d6;border:1px solid rgba(255,255,255,.08)}
+.seg button.on{background:rgba(124,123,255,.2);color:#fff;border-color:rgba(124,123,255,.5)}
+
+/* stage */
+.stage{flex:1;display:flex;flex-direction:column;align-items:center;gap:16px;padding:28px;overflow-y:auto;height:100vh}
+.phone{width:380px;height:760px;border-radius:30px;border:9px solid #1a1c28;overflow:hidden;position:relative;box-shadow:0 30px 80px rgba(0,0,0,.6)}
+.reader{position:absolute;inset:0;background:
+  radial-gradient(circle at 30% 25%,#ffcaa0 0,transparent 45%),
+  radial-gradient(circle at 65% 60%,#e0a0b0 0,transparent 50%),
+  linear-gradient(160deg,#d8c8c0,#b9a8b8);}
+.topbar{position:absolute;top:0;left:0;right:0;height:56px;display:flex;align-items:center;padding:0 14px;gap:10px;color:var(--ink);z-index:4}
+.botbar{position:absolute;bottom:0;left:0;right:0;height:96px;z-index:4;display:flex;flex-direction:column;justify-content:flex-end}
+.botbar .pg{text-align:center;color:var(--ink);font-size:12px;padding:6px}
+.botbar .acts{display:flex;justify-content:space-evenly;padding:14px;color:var(--ink)}
+
+/* slider */
+.slider{position:absolute;right:8px;z-index:6;display:flex;flex-direction:column;align-items:center}
+.jbtn{flex-shrink:0;border-radius:50%;display:grid;place-items:center;cursor:pointer}
+.jbtn svg{width:46%;height:46%}
+.capsule{flex:1;min-height:0;display:flex;flex-direction:column;align-items:center;border-radius:999px}
+.capsule .num{flex-shrink:0;color:var(--ink);font-weight:600;font-variant-numeric:tabular-nums}
+.bar{flex:1;min-height:0;position:relative;display:flex;justify-content:center}
+.track{position:absolute;top:0;bottom:0;border-radius:999px}
+.fill{position:absolute;top:0;left:0;right:0;border-radius:999px;background:var(--grad)}
+.dots{position:absolute;top:0;bottom:0;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;justify-content:space-between;align-items:center}
+.dot{border-radius:50%;background:rgba(255,255,255,.55)}
+.marker{position:absolute;left:50%;transform:translate(-50%,-50%);background:var(--grad);border-radius:999px;box-shadow:0 0 8px var(--glow)}
+
+/* prompt */
+.prompt-box{width:760px;max-width:92%;background:#0a0c16;border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:14px 16px}
+.prompt-box .ph{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
+.prompt-box .ph button{font-size:11px;padding:5px 12px;cursor:pointer;border-radius:7px;background:rgba(124,123,255,.18);color:#c9c8ff;border:1px solid rgba(124,123,255,.4)}
+#prompt{font-size:12px;line-height:1.55;color:#c2c6e6;font-family:monospace;white-space:pre-wrap}
+</style>
+</head>
+<body>
+<div class="controls">
+  <h1>Reader slider · match Komikku</h1>
+  <div class="sub">Dials in the webtoon vertical progress slider in our real theme colours. Lock it here, then it goes into Flutter 1:1.</div>
+  <div class="presets">
+    <button onclick="preset('komikku')">Komikku</button>
+    <button onclick="preset('subtle')">Subtle</button>
+    <button onclick="preset('bold')">Bold</button>
+  </div>
+
+  <div class="ctl"><label>Theme</label><div class="seg" id="themeSeg">
+    <button data-t="indigo" class="on">Indigo</button><button data-t="carbon">Carbon</button><button data-t="plum">Plum</button></div></div>
+
+  <div class="grp">Capsule</div>
+  <div class="ctl"><label>Width <span class="v" id="capWv"></span></label><input type="range" id="capW" min="34" max="64" step="1"></div>
+  <div class="ctl"><label>Background opacity <span class="v" id="capOv"></span></label><input type="range" id="capO" min="0" max="100" step="5"></div>
+  <div class="ctl"><label>Height</label><div class="seg" id="fullSeg"><button data-f="1" class="on">Full</button><button data-f="0">Inset</button></div></div>
+  <div class="ctl"><label>Number font <span class="v" id="numFv"></span></label><input type="range" id="numF" min="10" max="18" step="1"></div>
+  <div class="ctl"><label>Number gap from bar <span class="v" id="numGv"></span></label><input type="range" id="numG" min="2" max="24" step="1"></div>
+
+  <div class="grp">Bar</div>
+  <div class="ctl"><label>Track thickness <span class="v" id="trkv"></span></label><input type="range" id="trk" min="4" max="18" step="1"></div>
+  <div class="ctl"><label>Track opacity <span class="v" id="trkOv"></span></label><input type="range" id="trkO" min="0" max="100" step="5"></div>
+  <div class="ctl"><label>Tick dot size <span class="v" id="dotv"></span></label><input type="range" id="dot" min="0" max="8" step="1"></div>
+  <div class="ctl"><label>Marker line length <span class="v" id="mklv"></span></label><input type="range" id="mkl" min="10" max="40" step="2"></div>
+  <div class="ctl"><label>Marker line thickness <span class="v" id="mktv"></span></label><input type="range" id="mkt" min="2" max="8" step="1"></div>
+
+  <div class="grp">Jump buttons</div>
+  <div class="ctl"><label>Size <span class="v" id="btnSv"></span></label><input type="range" id="btnS" min="28" max="52" step="2"></div>
+  <div class="ctl"><label>Button opacity <span class="v" id="btnOv"></span></label><input type="range" id="btnO" min="0" max="100" step="5"></div>
+
+  <div class="grp">Reader bars</div>
+  <div class="ctl"><label>Top/bottom bar opacity <span class="v" id="barOv"></span></label><input type="range" id="barO" min="0" max="100" step="5"></div>
+</div>
+
+<div class="stage">
+  <div class="phone"><div class="reader" id="reader">
+    <div class="topbar" id="topbar">← &nbsp; <b>Reincarnator's Stream</b></div>
+    <div class="slider" id="slider"></div>
+    <div class="botbar" id="botbar"><div class="pg">6 / 15</div><div class="acts">🔖 &nbsp;&nbsp; 🗔 &nbsp;&nbsp; ⚙</div></div>
+  </div></div>
+  <div class="prompt-box"><div class="ph"><span>Prompt → paste back to Claude</span><button onclick="copyP()" id="cpy">Copy</button></div><div id="prompt"></div></div>
+</div>
+
+<script>
+const CUR=5,TOTAL=15; // 0-based current=5 -> shows 6
+const DEF={theme:'indigo',capW:46,capO:52,full:1,numF:13,numG:10,trk:9,trkO:55,dot:4,mkl:26,mkt:4,btnS:42,btnO:52,barO:55};
+const state={...DEF};
+
+const TRI_UP='<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 7l6 9H6z"/></svg>';
+const TRI_DN='<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 17l-6-9h12z"/></svg>';
+
+function hexA(varName,a){const c=getComputedStyle(document.documentElement.querySelector? document.body:document.body);return a;}
+
+function render(){
+  const root=document.querySelector('[data-theme]');
+  document.querySelector('.phone [data-theme]');
+  document.querySelector('#reader');
+  document.documentElement.setAttribute('data-theme',state.theme);
+
+  const cs=getComputedStyle(document.documentElement);
+  const ink=cs.getPropertyValue('--ink').trim();
+  const accent=cs.getPropertyValue('--accent').trim();
+  const accent2=cs.getPropertyValue('--accent2').trim();
+  const bg=cs.getPropertyValue('--bg').trim();
+  const bg2=cs.getPropertyValue('--bg2').trim();
+
+  // bars
+  const barCol=`color-mix(in srgb, ${bg} ${state.barO}%, transparent)`;
+  document.getElementById('topbar').style.background=barCol;
+  document.getElementById('botbar').style.background=`linear-gradient(to top, ${bg}, ${barCol}, transparent)`;
+
+  // slider geometry
+  const slider=document.getElementById('slider');
+  slider.style.top = state.full? '60px':'120px';
+  slider.style.bottom = state.full? '100px':'150px';
+  slider.style.width = (state.capW+0) + 'px';
+
+  const progress = CUR/(TOTAL-1); // fraction from top
+  // Capsule + buttons = the ACTIVE THEME's surface, translucent (Komikku-style:
+  // the dark tint is just the theme showing through, art visible behind).
+  const capBg=`color-mix(in srgb, ${bg2} ${state.capO}%, transparent)`;
+  const btnBg=`color-mix(in srgb, ${bg2} ${state.btnO}%, transparent)`;
+  const btnBorder=`1px solid color-mix(in srgb, ${accent} 28%, transparent)`;
+  const btnIcon=`color-mix(in srgb, ${accent} 60%, white)`; // bright theme accent
+
+  // dots
+  let dotsHtml='';
+  if(state.dot>0 && TOTAL<=80){ for(let i=0;i<TOTAL;i++){ dotsHtml+=`<div class="dot" style="width:${state.dot}px;height:${state.dot}px"></div>`; } }
+
+  slider.innerHTML = `
+    <div class="jbtn" style="width:${state.btnS}px;height:${state.btnS}px;background:${btnBg};border:${btnBorder};color:${btnIcon}">${TRI_UP}</div>
+    <div style="height:8px"></div>
+    <div class="capsule" style="width:${state.capW}px;background:${capBg}">
+      <div class="num" style="font-size:${state.numF}px;padding-top:${state.numG}px;padding-bottom:${state.numG}px">6</div>
+      <div class="bar">
+        <div class="track" style="width:${state.trk}px;background:color-mix(in srgb, ${accent} ${state.trkO}%, transparent)"></div>
+        <div class="fill" style="width:${state.trk}px;height:${progress*100}%"></div>
+        <div class="dots">${dotsHtml}</div>
+        <div class="marker" style="top:${progress*100}%;width:${state.mkl}px;height:${state.mkt}px"></div>
+      </div>
+      <div class="num" style="font-size:${state.numF}px;padding-top:${state.numG}px;padding-bottom:${state.numG}px">15</div>
+    </div>
+    <div style="height:8px"></div>
+    <div class="jbtn" style="width:${state.btnS}px;height:${state.btnS}px;background:${btnBg};border:${btnBorder};color:${btnIcon}">${TRI_DN}</div>
+  `;
+
+  // sync control labels
+  const set=(id,val)=>{const e=document.getElementById(id);if(e)e.textContent=val;};
+  set('capWv',state.capW+'px');set('capOv',state.capO+'%');set('numFv',state.numF+'px');set('numGv',state.numG+'px');
+  set('trkv',state.trk+'px');set('trkOv',state.trkO+'%');set('dotv',state.dot?state.dot+'px':'off');set('mklv',state.mkl+'px');set('mktv',state.mkt+'px');
+  set('btnSv',state.btnS+'px');set('btnOv',state.btnO+'%');set('barOv',state.barO+'%');
+  ['capW','capO','numF','numG','trk','trkO','dot','mkl','mkt','btnS','btnO','barO'].forEach(k=>{const e=document.getElementById(k);if(e)e.value=state[k];});
+  segOn('themeSeg','t',state.theme);segOn('fullSeg','f',String(state.full));
+  updatePrompt();
+}
+function segOn(id,attr,val){document.querySelectorAll(`#${id} button`).forEach(b=>b.classList.toggle('on',b.getAttribute('data-'+attr)===val));}
+
+function updatePrompt(){
+  const p=[];
+  p.push(`Reader vertical slider, ${state.theme} theme, Komikku layout:`);
+  p.push(`• Capsule ${state.capW}px wide, bg opacity ${state.capO}%, ${state.full?'FULL height (top 60 / bottom 100)':'inset'}.`);
+  p.push(`• Bar track ${state.trk}px thick at accent ${state.trkO}% opacity; gradient fill above marker.`);
+  p.push(`• Marker line ${state.mkl}px long × ${state.mkt}px thick, white + glow.`);
+  p.push(`• Tick dots: ${state.dot?state.dot+'px white@55%':'off'}, one per page.`);
+  p.push(`• Numbers ${state.numF}px, ${state.numG}px gap from the bar.`);
+  p.push(`• Jump buttons ${state.btnS}px, translucent theme surface, opacity ${state.btnO}%, bright accent triangle up/down icons.`);
+  p.push(`• Top/bottom reader bars at ${state.barO}% bg opacity.`);
+  document.getElementById('prompt').textContent=p.join('\n');
+}
+function copyP(){navigator.clipboard.writeText(document.getElementById('prompt').textContent);const b=document.getElementById('cpy');b.textContent='Copied!';setTimeout(()=>b.textContent='Copy',1200);}
+
+function preset(n){
+  if(n==='komikku')Object.assign(state,{capW:46,capO:52,full:1,numF:13,numG:10,trk:9,trkO:55,dot:4,mkl:26,mkt:4,btnS:42,btnO:52,barO:55});
+  if(n==='subtle')Object.assign(state,{capW:40,capO:38,full:1,numF:12,numG:8,trk:7,trkO:40,dot:3,mkl:20,mkt:3,btnS:36,btnO:36,barO:40});
+  if(n==='bold')Object.assign(state,{capW:54,capO:65,full:1,numF:15,numG:12,trk:13,trkO:75,dot:5,mkl:34,mkt:5,btnS:48,btnO:65,barO:65});
+  render();
+}
+
+// wire
+['capW','capO','numF','numG','trk','trkO','dot','mkl','mkt','btnS','btnO','barO'].forEach(k=>{
+  document.getElementById(k).addEventListener('input',e=>{state[k]=+e.target.value;render();});
+});
+document.querySelectorAll('#themeSeg button').forEach(b=>b.onclick=()=>{state.theme=b.getAttribute('data-t');render();});
+document.querySelectorAll('#fullSeg button').forEach(b=>b.onclick=()=>{state.full=+b.getAttribute('data-f');render();});
+
+render();
+</script>
+</body>
+</html>

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -29,7 +29,7 @@ enum DBKeys {
   quickSearchToggle(true),
   swipeToggle(true),
   lastPageSwipeEnabled(false),
-  infinityScrollingMode(false),
+  infinityScrollingMode(true),
   scrollAnimation(true),
   showNSFW(true),
   downloadedBadge(false),

--- a/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
@@ -26,6 +26,7 @@ class BrandPageSeekBar extends StatelessWidget {
     required this.onChanged,
     this.axis = Axis.horizontal,
     this.inverted = false,
+    this.capsuleColor,
   });
 
   /// 0-based current page.
@@ -38,6 +39,10 @@ class BrandPageSeekBar extends StatelessWidget {
 
   /// Flip the fill/seek direction (RTL paging).
   final bool inverted;
+
+  /// Capsule background. Pass [readerNavSurface] in vertical (webtoon) mode so
+  /// the bar shares ONE theme-surface colour with its jump buttons.
+  final Color? capsuleColor;
 
   void _seek(Offset local, Size size) {
     final lastIndex = max(maxValue - 1, 1);
@@ -81,33 +86,48 @@ class BrandPageSeekBar extends StatelessWidget {
       },
     );
 
-    final current = Text("${(currentValue + 1).clamp(1, maxValue)}");
-    final total = Text("$maxValue");
-    const thickness = 40.0;
+    final numStyle = TextStyle(
+      fontSize: 13,
+      fontWeight: FontWeight.w600,
+      color: cs.onSurface,
+      fontFeatures: const [ui.FontFeature.tabularFigures()],
+    );
+    final current =
+        Text("${(currentValue + 1).clamp(1, maxValue)}", style: numStyle);
+    final total = Text("$maxValue", style: numStyle);
+    const thickness = 26.0;
+    // Gap between the page numbers and the bar — Komikku keeps them clear of
+    // the slider (the "6 / 15 touching the slider" complaint).
+    const gap = SizedBox.square(dimension: 10);
 
     final content = axis == Axis.horizontal
         ? Row(
             children: [
               inverted ? total : current,
+              gap,
               Expanded(child: SizedBox(height: thickness, child: bar)),
+              gap,
               inverted ? current : total,
             ],
           )
         : Column(
             children: [
               current,
+              gap,
               Expanded(child: SizedBox(width: thickness, child: bar)),
+              gap,
               total,
             ],
           );
 
     return Card(
-      color: context.theme.appBarTheme.backgroundColor?.withValues(alpha: .7),
+      color: capsuleColor ??
+          context.theme.appBarTheme.backgroundColor?.withValues(alpha: .7),
       shape: RoundedRectangleBorder(borderRadius: KBorderRadius.r32.radius),
       child: Padding(
         padding: axis == Axis.horizontal
-            ? const EdgeInsets.symmetric(horizontal: 16, vertical: 2)
-            : const EdgeInsets.symmetric(horizontal: 2, vertical: 16),
+            ? const EdgeInsets.symmetric(horizontal: 16, vertical: 6)
+            : const EdgeInsets.symmetric(horizontal: 6, vertical: 16),
         child: content,
       ),
     );
@@ -143,10 +163,10 @@ class _SeekPainter extends CustomPainter {
     Offset along(double d) =>
         horizontal ? Offset(d, cross) : Offset(cross, d);
 
-    // Track.
+    // Track — accent-tinted (Komikku's slider inactive track), subtle.
     canvas.drawRRect(
       RRect.fromRectAndRadius(bar(0, length), radius),
-      Paint()..color = scheme.onSurface.withValues(alpha: 0.16),
+      Paint()..color = scheme.primary.withValues(alpha: 0.22),
     );
 
     // Gradient fill up to the current position.
@@ -163,30 +183,35 @@ class _SeekPainter extends CustomPainter {
     if (count > 1 && count <= 80) {
       final dot = Paint()..color = scheme.onSurface.withValues(alpha: 0.5);
       for (var i = 0; i < count; i++) {
-        canvas.drawCircle(along(length * (i / (count - 1))), 2.2, dot);
+        canvas.drawCircle(along(length * (i / (count - 1))), 2.0, dot);
       }
     }
 
-    // Line marker at the current position (perpendicular to the bar).
+    // Marker line at the current position (perpendicular to the bar), painted
+    // with the brand gradient + a soft glow — Komikku's line, our colours.
     final pos = length * fill;
-    const half = 16.0;
+    const half = 13.0;
+    const mkt = 4.0;
     final p1 = horizontal ? Offset(pos, cross - half) : Offset(cross - half, pos);
     final p2 = horizontal ? Offset(pos, cross + half) : Offset(cross + half, pos);
+    // Glow.
     canvas.drawLine(
       p1,
       p2,
       Paint()
-        ..color = scheme.primary.withValues(alpha: 0.5)
-        ..strokeWidth = 9
+        ..color = scheme.primary.withValues(alpha: 0.55)
+        ..strokeWidth = mkt + 5
         ..strokeCap = StrokeCap.round
         ..maskFilter = const ui.MaskFilter.blur(BlurStyle.normal, 5),
     );
+    // Gradient marker.
+    final markerRect = Rect.fromPoints(p1, p2).inflate(mkt);
     canvas.drawLine(
       p1,
       p2,
       Paint()
-        ..color = Colors.white
-        ..strokeWidth = 4
+        ..shader = brandGradient(scheme).createShader(markerRect)
+        ..strokeWidth = mkt
         ..strokeCap = StrokeCap.round,
     );
   }

--- a/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
@@ -1,0 +1,167 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:math';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import '../../../../../constants/app_sizes.dart';
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/theme/brand.dart';
+
+/// Reading-progress bar, themed with the brand gradient. Lays out **horizontal**
+/// (page-flip manga) or **vertical** (webtoon / vertical scroll); tap or drag
+/// anywhere along it to seek. The filled portion is the indigo→cyan brand
+/// gradient with a soft glow, on a subtle rounded track — Komikku-clean but in
+/// our theme.
+class BrandPageSeekBar extends StatelessWidget {
+  const BrandPageSeekBar({
+    super.key,
+    required this.currentValue,
+    required this.maxValue,
+    required this.onChanged,
+    this.axis = Axis.horizontal,
+    this.inverted = false,
+  });
+
+  /// 0-based current page.
+  final int currentValue;
+
+  /// Total page count.
+  final int maxValue;
+  final ValueChanged<int> onChanged;
+  final Axis axis;
+
+  /// Flip the fill/seek direction (RTL paging).
+  final bool inverted;
+
+  void _seek(Offset local, Size size) {
+    final lastIndex = max(maxValue - 1, 1);
+    var frac = axis == Axis.horizontal
+        ? (local.dx / size.width)
+        : (local.dy / size.height);
+    frac = frac.clamp(0.0, 1.0);
+    if (inverted) frac = 1 - frac;
+    onChanged((frac * lastIndex).round());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    final lastIndex = max(maxValue - 1, 1);
+    final progress = (currentValue / lastIndex).clamp(0.0, 1.0);
+    final fill = inverted ? 1 - progress : progress;
+
+    final bar = LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.biggest;
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (d) => _seek(d.localPosition, size),
+          onHorizontalDragUpdate: axis == Axis.horizontal
+              ? (d) => _seek(d.localPosition, size)
+              : null,
+          onVerticalDragUpdate: axis == Axis.vertical
+              ? (d) => _seek(d.localPosition, size)
+              : null,
+          child: CustomPaint(
+            size: Size.infinite,
+            painter: _SeekPainter(axis: axis, fill: fill, scheme: cs),
+          ),
+        );
+      },
+    );
+
+    final current = Text("${(currentValue + 1).clamp(1, maxValue)}");
+    final total = Text("$maxValue");
+    const thickness = 28.0;
+
+    final content = axis == Axis.horizontal
+        ? Row(
+            children: [
+              inverted ? total : current,
+              Expanded(child: SizedBox(height: thickness, child: bar)),
+              inverted ? current : total,
+            ],
+          )
+        : Column(
+            children: [
+              current,
+              Expanded(child: SizedBox(width: thickness, child: bar)),
+              total,
+            ],
+          );
+
+    return Card(
+      color: context.theme.appBarTheme.backgroundColor?.withValues(alpha: .7),
+      shape: RoundedRectangleBorder(borderRadius: KBorderRadius.r32.radius),
+      child: Padding(
+        padding: axis == Axis.horizontal
+            ? const EdgeInsets.symmetric(horizontal: 16, vertical: 2)
+            : const EdgeInsets.symmetric(horizontal: 2, vertical: 16),
+        child: content,
+      ),
+    );
+  }
+}
+
+class _SeekPainter extends CustomPainter {
+  _SeekPainter({required this.axis, required this.fill, required this.scheme});
+
+  final Axis axis;
+  final double fill;
+  final ColorScheme scheme;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const t = 6.0;
+    final radius = Radius.circular(t / 2);
+
+    late final Rect track;
+    late final Rect filled;
+    late final Offset thumb;
+    if (axis == Axis.horizontal) {
+      final cy = size.height / 2;
+      track = Rect.fromLTWH(0, cy - t / 2, size.width, t);
+      filled = Rect.fromLTWH(0, cy - t / 2, size.width * fill, t);
+      thumb = Offset(size.width * fill, cy);
+    } else {
+      final cx = size.width / 2;
+      track = Rect.fromLTWH(cx - t / 2, 0, t, size.height);
+      filled = Rect.fromLTWH(cx - t / 2, 0, t, size.height * fill);
+      thumb = Offset(cx, size.height * fill);
+    }
+
+    // Track.
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(track, radius),
+      Paint()..color = scheme.onSurface.withValues(alpha: 0.16),
+    );
+
+    // Gradient fill.
+    if (filled.width > 0 && filled.height > 0) {
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(filled, radius),
+        Paint()..shader = brandGradient(scheme).createShader(filled),
+      );
+    }
+
+    // Thumb glow + knob.
+    canvas.drawCircle(
+      thumb,
+      10,
+      Paint()
+        ..color = scheme.primary.withValues(alpha: 0.45)
+        ..maskFilter = const ui.MaskFilter.blur(BlurStyle.normal, 6),
+    );
+    canvas.drawCircle(thumb, 7, Paint()..color = Colors.white);
+  }
+
+  @override
+  bool shouldRepaint(_SeekPainter old) =>
+      old.fill != fill || old.axis != axis || old.scheme != scheme;
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
@@ -70,7 +70,12 @@ class BrandPageSeekBar extends StatelessWidget {
               : null,
           child: CustomPaint(
             size: Size.infinite,
-            painter: _SeekPainter(axis: axis, fill: fill, scheme: cs),
+            painter: _SeekPainter(
+              axis: axis,
+              fill: fill,
+              scheme: cs,
+              count: maxValue,
+            ),
           ),
         );
       },
@@ -110,58 +115,86 @@ class BrandPageSeekBar extends StatelessWidget {
 }
 
 class _SeekPainter extends CustomPainter {
-  _SeekPainter({required this.axis, required this.fill, required this.scheme});
+  _SeekPainter({
+    required this.axis,
+    required this.fill,
+    required this.scheme,
+    required this.count,
+  });
 
   final Axis axis;
   final double fill;
   final ColorScheme scheme;
 
+  /// Page count — one tick dot per page (Komikku style).
+  final int count;
+
   @override
   void paint(Canvas canvas, Size size) {
-    const t = 6.0;
+    const t = 5.0;
     final radius = Radius.circular(t / 2);
+    final horizontal = axis == Axis.horizontal;
+    final length = horizontal ? size.width : size.height;
+    final cross = horizontal ? size.height / 2 : size.width / 2;
 
-    late final Rect track;
-    late final Rect filled;
-    late final Offset thumb;
-    if (axis == Axis.horizontal) {
-      final cy = size.height / 2;
-      track = Rect.fromLTWH(0, cy - t / 2, size.width, t);
-      filled = Rect.fromLTWH(0, cy - t / 2, size.width * fill, t);
-      thumb = Offset(size.width * fill, cy);
-    } else {
-      final cx = size.width / 2;
-      track = Rect.fromLTWH(cx - t / 2, 0, t, size.height);
-      filled = Rect.fromLTWH(cx - t / 2, 0, t, size.height * fill);
-      thumb = Offset(cx, size.height * fill);
-    }
+    Rect bar(double from, double to) => horizontal
+        ? Rect.fromLTRB(from, cross - t / 2, to, cross + t / 2)
+        : Rect.fromLTRB(cross - t / 2, from, cross + t / 2, to);
+    Offset along(double d) =>
+        horizontal ? Offset(d, cross) : Offset(cross, d);
 
     // Track.
     canvas.drawRRect(
-      RRect.fromRectAndRadius(track, radius),
+      RRect.fromRectAndRadius(bar(0, length), radius),
       Paint()..color = scheme.onSurface.withValues(alpha: 0.16),
     );
 
-    // Gradient fill.
-    if (filled.width > 0 && filled.height > 0) {
+    // Gradient fill up to the current position.
+    final fillEnd = (length * fill).clamp(0.0, length);
+    if (fillEnd > 0.5) {
+      final filled = bar(0, fillEnd);
       canvas.drawRRect(
         RRect.fromRectAndRadius(filled, radius),
         Paint()..shader = brandGradient(scheme).createShader(filled),
       );
     }
 
-    // Thumb glow + knob.
-    canvas.drawCircle(
-      thumb,
-      10,
+    // Per-page tick dots — skip when too dense to stay clean.
+    if (count > 1 && count <= 80) {
+      final dot = Paint()..color = scheme.onSurface.withValues(alpha: 0.45);
+      for (var i = 0; i < count; i++) {
+        canvas.drawCircle(along(length * (i / (count - 1))), 1.4, dot);
+      }
+    }
+
+    // Thin line marker at the current position (perpendicular to the bar).
+    final pos = length * fill;
+    const half = 11.0;
+    final p1 = horizontal ? Offset(pos, cross - half) : Offset(cross - half, pos);
+    final p2 = horizontal ? Offset(pos, cross + half) : Offset(cross + half, pos);
+    canvas.drawLine(
+      p1,
+      p2,
       Paint()
-        ..color = scheme.primary.withValues(alpha: 0.45)
-        ..maskFilter = const ui.MaskFilter.blur(BlurStyle.normal, 6),
+        ..color = scheme.primary.withValues(alpha: 0.5)
+        ..strokeWidth = 6
+        ..strokeCap = StrokeCap.round
+        ..maskFilter = const ui.MaskFilter.blur(BlurStyle.normal, 4),
     );
-    canvas.drawCircle(thumb, 7, Paint()..color = Colors.white);
+    canvas.drawLine(
+      p1,
+      p2,
+      Paint()
+        ..color = Colors.white
+        ..strokeWidth = 3
+        ..strokeCap = StrokeCap.round,
+    );
   }
 
   @override
   bool shouldRepaint(_SeekPainter old) =>
-      old.fill != fill || old.axis != axis || old.scheme != scheme;
+      old.fill != fill ||
+      old.axis != axis ||
+      old.scheme != scheme ||
+      old.count != count;
 }

--- a/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/brand_page_seekbar.dart
@@ -83,7 +83,7 @@ class BrandPageSeekBar extends StatelessWidget {
 
     final current = Text("${(currentValue + 1).clamp(1, maxValue)}");
     final total = Text("$maxValue");
-    const thickness = 28.0;
+    const thickness = 40.0;
 
     final content = axis == Axis.horizontal
         ? Row(
@@ -131,7 +131,7 @@ class _SeekPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    const t = 5.0;
+    const t = 9.0;
     final radius = Radius.circular(t / 2);
     final horizontal = axis == Axis.horizontal;
     final length = horizontal ? size.width : size.height;
@@ -161,15 +161,15 @@ class _SeekPainter extends CustomPainter {
 
     // Per-page tick dots — skip when too dense to stay clean.
     if (count > 1 && count <= 80) {
-      final dot = Paint()..color = scheme.onSurface.withValues(alpha: 0.45);
+      final dot = Paint()..color = scheme.onSurface.withValues(alpha: 0.5);
       for (var i = 0; i < count; i++) {
-        canvas.drawCircle(along(length * (i / (count - 1))), 1.4, dot);
+        canvas.drawCircle(along(length * (i / (count - 1))), 2.2, dot);
       }
     }
 
-    // Thin line marker at the current position (perpendicular to the bar).
+    // Line marker at the current position (perpendicular to the bar).
     final pos = length * fill;
-    const half = 11.0;
+    const half = 16.0;
     final p1 = horizontal ? Offset(pos, cross - half) : Offset(cross - half, pos);
     final p2 = horizontal ? Offset(pos, cross + half) : Offset(cross + half, pos);
     canvas.drawLine(
@@ -177,16 +177,16 @@ class _SeekPainter extends CustomPainter {
       p2,
       Paint()
         ..color = scheme.primary.withValues(alpha: 0.5)
-        ..strokeWidth = 6
+        ..strokeWidth = 9
         ..strokeCap = StrokeCap.round
-        ..maskFilter = const ui.MaskFilter.blur(BlurStyle.normal, 4),
+        ..maskFilter = const ui.MaskFilter.blur(BlurStyle.normal, 5),
     );
     canvas.drawLine(
       p1,
       p2,
       Paint()
         ..color = Colors.white
-        ..strokeWidth = 3
+        ..strokeWidth = 4
         ..strokeCap = StrokeCap.round,
     );
   }

--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -151,6 +151,12 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     required SwipeDirection direction,
     required DragEndDetails details,
   }) {
+    // Swipe-to-change-chapter is a manga (horizontal-paging) gesture only.
+    // In webtoon / vertical-scroll modes a horizontal swipe changing chapter
+    // is a terrible experience, so ignore it — the vertical scroll (and
+    // infinite scroll) handle moving between chapters there.
+    if (scrollDirection == Axis.vertical) return;
+
     // In continuous vertical readers, treat drag end as a swipe only at
     // chapter edges to avoid interfering with normal scrolling.
 
@@ -317,6 +323,10 @@ class DirectionalSwipeGestureHandler extends HookWidget {
     required DragEndDetails details,
     required Axis allowedAxis,
   }) {
+    // Manga-only gesture: in vertical/webtoon modes a horizontal swipe must
+    // not change chapter (vertical scroll + infinite scroll handle that).
+    if (scrollDirection == Axis.vertical) return;
+
     if (readerSwipeChapterToggle) {
       _handleOriginalSwipeBehavior(context, details, allowedAxis);
       return;

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
@@ -67,7 +67,7 @@ class ContinuousReaderMode extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Check if infinity scrolling mode is enabled
     final infinityScrollingEnabled =
-        ref.watch(infinityScrollingModeEnabledProvider).ifNull(false);
+        ref.watch(infinityScrollingModeEnabledProvider).ifNull(true);
 
     // Use infinity mode for webtoon with infinity scrolling enabled
     if (infinityScrollingEnabled &&

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous_reader_mode.dart
@@ -62,7 +62,7 @@ class InfinityContinuousReaderMode extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final infinityScrollingEnabled =
-        ref.watch(infinityScrollingModeEnabledProvider).ifNull(false);
+        ref.watch(infinityScrollingModeEnabledProvider).ifNull(true);
 
     if (!infinityScrollingEnabled || scrollDirection != Axis.vertical) {
       return _buildSingleChapterMode(context, ref);

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -439,67 +439,58 @@ class ReaderWrapper extends HookConsumerWidget {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Row(
-                      children: [
-                        // Chapter prev/next arrows are a manga (horizontal)
-                        // gesture; in webtoon you flow via scroll/infinite.
-                        if (scrollDirection == Axis.horizontal)
+                    // Horizontal (manga): inline seek bar flanked by chapter
+                    // prev/next arrows. Vertical (webtoon): the side bar carries
+                    // the page count + chapter jumps, so this whole row (and its
+                    // redundant "1 / 15") is dropped.
+                    if (scrollDirection == Axis.horizontal) ...[
+                      Row(
+                        children: [
                           Card(
-                          shape: const CircleBorder(),
-                          child: IconButton(
-                            onPressed: nextPrevChapterPair?.second != null
-                                ? () => ReaderRoute(
-                                      mangaId:
-                                          nextPrevChapterPair!.second!.mangaId,
-                                      chapterId: nextPrevChapterPair.second!.id,
-                                      toPrev: true,
-                                      transVertical:
-                                          scrollDirection != Axis.vertical,
-                                    ).pushReplacement(context)
-                                : null,
-                            icon: const Icon(
-                              Icons.skip_previous_rounded,
+                            shape: const CircleBorder(),
+                            child: IconButton(
+                              onPressed: nextPrevChapterPair?.second != null
+                                  ? () => ReaderRoute(
+                                        mangaId: nextPrevChapterPair!
+                                            .second!.mangaId,
+                                        chapterId:
+                                            nextPrevChapterPair.second!.id,
+                                        toPrev: true,
+                                        transVertical:
+                                            scrollDirection != Axis.vertical,
+                                      ).pushReplacement(context)
+                                  : null,
+                              icon: const Icon(Icons.skip_previous_rounded),
                             ),
                           ),
-                        ),
-                        Expanded(
-                          // Horizontal (manga) → gradient seek bar inline.
-                          // Vertical (webtoon) → just the page count here; the
-                          // seek bar floats vertically on the side (below).
-                          child: scrollDirection == Axis.horizontal
-                              ? BrandPageSeekBar(
-                                  currentValue: currentIndex,
-                                  maxValue: totalPageCount ??
-                                      chapterPages.chapter.pageCount,
-                                  onChanged: (index) => onChanged(index),
-                                  inverted: invertTap,
-                                )
-                              : Center(
-                                  child: Text(
-                                    "${currentIndex + 1}"
-                                    " / ${totalPageCount ?? chapterPages.chapter.pageCount}",
-                                  ),
-                                ),
-                        ),
-                        if (scrollDirection == Axis.horizontal)
-                          Card(
-                          shape: const CircleBorder(),
-                          child: IconButton(
-                            onPressed: nextPrevChapterPair?.first != null
-                                ? () => ReaderRoute(
-                                      mangaId:
-                                          nextPrevChapterPair!.first!.mangaId,
-                                      chapterId: nextPrevChapterPair.first!.id,
-                                      transVertical:
-                                          scrollDirection != Axis.vertical,
-                                    ).pushReplacement(context)
-                                : null,
-                            icon: const Icon(Icons.skip_next_rounded),
+                          Expanded(
+                            child: BrandPageSeekBar(
+                              currentValue: currentIndex,
+                              maxValue: totalPageCount ??
+                                  chapterPages.chapter.pageCount,
+                              onChanged: (index) => onChanged(index),
+                              inverted: invertTap,
+                            ),
                           ),
-                        )
-                      ],
-                    ),
-                    const Gap(8),
+                          Card(
+                            shape: const CircleBorder(),
+                            child: IconButton(
+                              onPressed: nextPrevChapterPair?.first != null
+                                  ? () => ReaderRoute(
+                                        mangaId:
+                                            nextPrevChapterPair!.first!.mangaId,
+                                        chapterId: nextPrevChapterPair.first!.id,
+                                        transVertical:
+                                            scrollDirection != Axis.vertical,
+                                      ).pushReplacement(context)
+                                  : null,
+                              icon: const Icon(Icons.skip_next_rounded),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const Gap(8),
+                    ],
                     Card(
                       // Translucent bottom bar (Komikku-style).
                       color: context.theme.cardColor.withValues(alpha: 0.7),
@@ -629,40 +620,51 @@ class ReaderWrapper extends HookConsumerWidget {
             // Webtoon / vertical scroll: the seek bar floats vertically on the
             // side (the bottom bar shows only the page count in this mode).
             if (scrollDirection == Axis.vertical && visibility.value)
-              Positioned(
-                right: 6,
-                top: 80,
-                // Extend down to just above the bottom menu.
-                bottom: 100,
-                width: 66,
-                child: Column(
-                  children: [
-                    // Jump to the start of this chapter.
-                    BrandCircleButton(
-                      icon: Icons.vertical_align_top_rounded,
-                      onPressed: () => onChanged(0),
-                    ),
-                    const Gap(8),
-                    Expanded(
-                      child: BrandPageSeekBar(
-                        currentValue: currentIndex,
-                        maxValue:
-                            totalPageCount ?? chapterPages.chapter.pageCount,
-                        onChanged: (index) => onChanged(index),
-                        axis: Axis.vertical,
+              Builder(builder: (context) {
+                final navSurface =
+                    readerNavSurface(context.theme.colorScheme);
+                final lastPage =
+                    (totalPageCount ?? chapterPages.chapter.pageCount) - 1;
+                return Positioned(
+                  right: 6,
+                  top: 80,
+                  // Extend down to just above the bottom menu.
+                  bottom: 100,
+                  width: 56,
+                  child: Column(
+                    children: [
+                      // Jump to the start of this chapter — Komikku skip-previous
+                      // glyph rotated to point up.
+                      BrandFilledCircleButton(
+                        icon: Icons.skip_previous_rounded,
+                        quarterTurns: 1,
+                        color: navSurface,
+                        onPressed: () => onChanged(0),
                       ),
-                    ),
-                    const Gap(8),
-                    // Jump to the end of this chapter.
-                    BrandCircleButton(
-                      icon: Icons.vertical_align_bottom_rounded,
-                      onPressed: () => onChanged(
-                        (totalPageCount ?? chapterPages.chapter.pageCount) - 1,
+                      const Gap(8),
+                      Expanded(
+                        child: BrandPageSeekBar(
+                          currentValue: currentIndex,
+                          maxValue:
+                              totalPageCount ?? chapterPages.chapter.pageCount,
+                          onChanged: (index) => onChanged(index),
+                          axis: Axis.vertical,
+                          capsuleColor: navSurface,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-              ),
+                      const Gap(8),
+                      // Jump to the end of this chapter — Komikku skip-next
+                      // glyph rotated to point down.
+                      BrandFilledCircleButton(
+                        icon: Icons.skip_next_rounded,
+                        quarterTurns: 1,
+                        color: navSurface,
+                        onPressed: () => onChanged(lastPage),
+                      ),
+                    ],
+                  ),
+                );
+              }),
           ],
         ),
       ),

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -632,8 +632,8 @@ class ReaderWrapper extends HookConsumerWidget {
               Positioned(
                 right: 6,
                 top: 80,
-                // Clear the bottom controls so they never overlap the bar.
-                bottom: 150,
+                // Extend down to just above the bottom menu.
+                bottom: 100,
                 width: 66,
                 child: Column(
                   children: [

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -42,8 +42,8 @@ import '../../../widgets/chapter_actions/single_chapter_action_icon.dart';
 import '../../manga_details/controller/manga_details_controller.dart';
 import '../controller/reader_controller.dart';
 import '../utils/last_page_swipe_utils.dart';
+import 'brand_page_seekbar.dart';
 import 'directional_swipe_gesture_handler.dart';
-import 'page_number_slider.dart';
 import 'reader_navigation_layout/reader_navigation_layout.dart';
 
 class ReaderWrapper extends HookConsumerWidget {
@@ -455,13 +455,23 @@ class ReaderWrapper extends HookConsumerWidget {
                           ),
                         ),
                         Expanded(
-                          child: PageNumberSlider(
-                            currentValue: currentIndex,
-                            maxValue: totalPageCount ??
-                                chapterPages.chapter.pageCount,
-                            onChanged: (index) => onChanged(index),
-                            inverted: invertTap,
-                          ),
+                          // Horizontal (manga) → gradient seek bar inline.
+                          // Vertical (webtoon) → just the page count here; the
+                          // seek bar floats vertically on the side (below).
+                          child: scrollDirection == Axis.horizontal
+                              ? BrandPageSeekBar(
+                                  currentValue: currentIndex,
+                                  maxValue: totalPageCount ??
+                                      chapterPages.chapter.pageCount,
+                                  onChanged: (index) => onChanged(index),
+                                  inverted: invertTap,
+                                )
+                              : Center(
+                                  child: Text(
+                                    "${currentIndex + 1}"
+                                    " / ${totalPageCount ?? chapterPages.chapter.pageCount}",
+                                  ),
+                                ),
                         ),
                         Card(
                           shape: const CircleBorder(),
@@ -523,7 +533,10 @@ class ReaderWrapper extends HookConsumerWidget {
                 ),
               )
             : null,
-        body: Shortcuts.manager(
+        body: Stack(
+          children: [
+            Positioned.fill(
+              child: Shortcuts.manager(
           manager: readerShortcutManager(scrollDirection),
           child: Actions(
             actions: {
@@ -600,6 +613,25 @@ class ReaderWrapper extends HookConsumerWidget {
               ),
             ),
           ),
+              ),
+            ),
+            // Webtoon / vertical scroll: the seek bar floats vertically on the
+            // side (the bottom bar shows only the page count in this mode).
+            if (scrollDirection == Axis.vertical && visibility.value)
+              Positioned(
+                right: 6,
+                top: 88,
+                bottom: 96,
+                width: 56,
+                child: BrandPageSeekBar(
+                  currentValue: currentIndex,
+                  maxValue:
+                      totalPageCount ?? chapterPages.chapter.pageCount,
+                  onChanged: (index) => onChanged(index),
+                  axis: Axis.vertical,
+                ),
+              ),
+          ],
         ),
       ),
     );

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -23,6 +23,7 @@ import '../../../../../routes/router_config.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/launch_url_in_web.dart';
 import '../../../../../utils/misc/toast/toast.dart';
+import '../../../../../utils/theme/brand.dart';
 import '../../../../../widgets/popup_widgets/radio_list_popup.dart';
 import '../../../../settings/presentation/reader/widgets/reader_initial_overlay_tile/reader_initial_overlay_tile.dart';
 import '../../../../settings/presentation/reader/widgets/reader_invert_tap_tile/reader_invert_tap_tile.dart';
@@ -633,19 +634,15 @@ class ReaderWrapper extends HookConsumerWidget {
                 top: 80,
                 // Clear the bottom controls so they never overlap the bar.
                 bottom: 150,
-                width: 56,
+                width: 66,
                 child: Column(
                   children: [
                     // Jump to the start of this chapter.
-                    Card(
-                      shape: const CircleBorder(),
-                      child: IconButton(
-                        iconSize: 20,
-                        icon: const Icon(Icons.vertical_align_top_rounded),
-                        onPressed: () => onChanged(0),
-                      ),
+                    BrandCircleButton(
+                      icon: Icons.vertical_align_top_rounded,
+                      onPressed: () => onChanged(0),
                     ),
-                    const Gap(6),
+                    const Gap(8),
                     Expanded(
                       child: BrandPageSeekBar(
                         currentValue: currentIndex,
@@ -655,18 +652,12 @@ class ReaderWrapper extends HookConsumerWidget {
                         axis: Axis.vertical,
                       ),
                     ),
-                    const Gap(6),
+                    const Gap(8),
                     // Jump to the end of this chapter.
-                    Card(
-                      shape: const CircleBorder(),
-                      child: IconButton(
-                        iconSize: 20,
-                        icon: const Icon(Icons.vertical_align_bottom_rounded),
-                        onPressed: () => onChanged(
-                          (totalPageCount ??
-                                  chapterPages.chapter.pageCount) -
-                              1,
-                        ),
+                    BrandCircleButton(
+                      icon: Icons.vertical_align_bottom_rounded,
+                      onPressed: () => onChanged(
+                        (totalPageCount ?? chapterPages.chapter.pageCount) - 1,
                       ),
                     ),
                   ],

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -351,6 +351,10 @@ class ReaderWrapper extends HookConsumerWidget {
                         )
                       : null,
                 ),
+                // Translucent so the page art shows through (Komikku-style).
+                backgroundColor: context
+                    .theme.appBarTheme.backgroundColor
+                    ?.withValues(alpha: 0.55),
                 elevation: 0,
                 actions: [
                   chapter.realUrl.isBlank
@@ -436,7 +440,10 @@ class ReaderWrapper extends HookConsumerWidget {
                   children: [
                     Row(
                       children: [
-                        Card(
+                        // Chapter prev/next arrows are a manga (horizontal)
+                        // gesture; in webtoon you flow via scroll/infinite.
+                        if (scrollDirection == Axis.horizontal)
+                          Card(
                           shape: const CircleBorder(),
                           child: IconButton(
                             onPressed: nextPrevChapterPair?.second != null
@@ -473,7 +480,8 @@ class ReaderWrapper extends HookConsumerWidget {
                                   ),
                                 ),
                         ),
-                        Card(
+                        if (scrollDirection == Axis.horizontal)
+                          Card(
                           shape: const CircleBorder(),
                           child: IconButton(
                             onPressed: nextPrevChapterPair?.first != null
@@ -492,6 +500,8 @@ class ReaderWrapper extends HookConsumerWidget {
                     ),
                     const Gap(8),
                     Card(
+                      // Translucent bottom bar (Komikku-style).
+                      color: context.theme.cardColor.withValues(alpha: 0.7),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.vertical(
                           top: KRadius.r8.radius,
@@ -620,15 +630,46 @@ class ReaderWrapper extends HookConsumerWidget {
             if (scrollDirection == Axis.vertical && visibility.value)
               Positioned(
                 right: 6,
-                top: 88,
-                bottom: 96,
+                top: 80,
+                // Clear the bottom controls so they never overlap the bar.
+                bottom: 150,
                 width: 56,
-                child: BrandPageSeekBar(
-                  currentValue: currentIndex,
-                  maxValue:
-                      totalPageCount ?? chapterPages.chapter.pageCount,
-                  onChanged: (index) => onChanged(index),
-                  axis: Axis.vertical,
+                child: Column(
+                  children: [
+                    // Jump to the start of this chapter.
+                    Card(
+                      shape: const CircleBorder(),
+                      child: IconButton(
+                        iconSize: 20,
+                        icon: const Icon(Icons.vertical_align_top_rounded),
+                        onPressed: () => onChanged(0),
+                      ),
+                    ),
+                    const Gap(6),
+                    Expanded(
+                      child: BrandPageSeekBar(
+                        currentValue: currentIndex,
+                        maxValue:
+                            totalPageCount ?? chapterPages.chapter.pageCount,
+                        onChanged: (index) => onChanged(index),
+                        axis: Axis.vertical,
+                      ),
+                    ),
+                    const Gap(6),
+                    // Jump to the end of this chapter.
+                    Card(
+                      shape: const CircleBorder(),
+                      child: IconButton(
+                        iconSize: 20,
+                        icon: const Icon(Icons.vertical_align_bottom_rounded),
+                        onPressed: () => onChanged(
+                          (totalPageCount ??
+                                  chapterPages.chapter.pageCount) -
+                              1,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
           ],

--- a/lib/src/utils/theme/brand.dart
+++ b/lib/src/utils/theme/brand.dart
@@ -30,6 +30,15 @@ List<BoxShadow> brandGlow(ColorScheme cs) => [
 /// The gradient is bright, so on-gradient content (text/icons) is dark.
 const Color onBrandGradient = Color(0xFF0B0D1A);
 
+/// Translucent theme surface for the reader's vertical nav. The Komikku vertical
+/// slider is one cohesive unit: the page-count capsule AND the chapter jump
+/// buttons share ONE colour, gleaned from the active theme (NOT solid dark, NOT
+/// a gradient), translucent so the page art shows through. Mirrors Komikku's
+/// `surfaceColorAtElevation(3.dp)` at ~0.9 alpha — both call sites must use this
+/// so the buttons and the bar can never theme-drift apart again.
+Color readerNavSurface(ColorScheme cs) =>
+    cs.surfaceContainerHigh.withValues(alpha: 0.82);
+
 /// A lighter, more vibrant accent for text/outline actions (links, "Uninstall").
 Color brandBrightAccent(ColorScheme cs) =>
     Color.lerp(cs.primary, Colors.white, 0.22)!;
@@ -224,6 +233,58 @@ class BrandCircleButton extends StatelessWidget {
             width: size,
             height: size,
             child: Icon(icon, size: size * 0.55, color: brandBrightAccent(cs)),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Komikku-style filled round icon button for the reader vertical nav. Filled
+/// with [color] (the shared [readerNavSurface] so it matches the bar capsule
+/// exactly), glyph in the theme `primary`. [quarterTurns] rotates the icon so
+/// the chapter skip glyphs point up / down like Komikku's vertical slider.
+class BrandFilledCircleButton extends StatelessWidget {
+  const BrandFilledCircleButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    required this.color,
+    this.size = 44,
+    this.quarterTurns = 0,
+  });
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final Color color;
+  final double size;
+  final int quarterTurns;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final enabled = onPressed != null;
+    return DecoratedBox(
+      decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onPressed,
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: RotatedBox(
+              quarterTurns: quarterTurns,
+              child: Icon(
+                icon,
+                size: size * 0.5,
+                color: enabled
+                    ? cs.primary
+                    : cs.onSurface.withValues(alpha: 0.3),
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/src/utils/theme/brand.dart
+++ b/lib/src/utils/theme/brand.dart
@@ -190,8 +190,9 @@ class BrandGlassButton extends StatelessWidget {
   }
 }
 
-/// Small circular brand-gradient button — gradient fill + glow + dark glyph.
-/// Single source for round brand actions (reader chapter-end jumps, etc.).
+/// Small circular **glass** brand button — translucent fill + accent border +
+/// bright accent glyph. Single source for round brand actions (reader
+/// chapter-end jumps, etc.).
 class BrandCircleButton extends StatelessWidget {
   const BrandCircleButton({
     super.key,
@@ -210,8 +211,8 @@ class BrandCircleButton extends StatelessWidget {
     return DecoratedBox(
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        gradient: brandGradient(cs),
-        boxShadow: brandGlow(cs),
+        color: Colors.white.withValues(alpha: 0.06),
+        border: Border.all(color: cs.outlineVariant),
       ),
       child: Material(
         color: Colors.transparent,
@@ -222,7 +223,7 @@ class BrandCircleButton extends StatelessWidget {
           child: SizedBox(
             width: size,
             height: size,
-            child: Icon(icon, size: size * 0.52, color: onBrandGradient),
+            child: Icon(icon, size: size * 0.55, color: brandBrightAccent(cs)),
           ),
         ),
       ),

--- a/lib/src/utils/theme/brand.dart
+++ b/lib/src/utils/theme/brand.dart
@@ -190,6 +190,46 @@ class BrandGlassButton extends StatelessWidget {
   }
 }
 
+/// Small circular brand-gradient button — gradient fill + glow + dark glyph.
+/// Single source for round brand actions (reader chapter-end jumps, etc.).
+class BrandCircleButton extends StatelessWidget {
+  const BrandCircleButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    this.size = 42,
+  });
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: brandGradient(cs),
+        boxShadow: brandGlow(cs),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onPressed,
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: Icon(icon, size: size * 0.52, color: onBrandGradient),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Genre / tag chip — glass fill tinted with a UNIQUE per-label color
 /// (hue derived from the label, so every genre is visually distinct).
 class BrandChip extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,9 +2,9 @@ name: tsumiru
 description: A manga reader client for Suwayomi Server.
 
 publish_to: "none"
-# Public version matches the Tsumiru release line (v0.4.0); build number keeps
+# Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.4.1+30
+version: 0.5.0+31
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Reworks the webtoon (vertical) reading-progress bar to match Komikku, so it feels right for manhwa reading.

## What changed
- **Capsule + jump buttons share one translucent theme surface.** Previously the chapter-jump buttons were a separate widget with their own background, so they could never theme-match the bar (the source of the repeated "buttons don't match" problems). They now derive a single `readerNavSurface` colour from the active theme.
- **Komikku jump icons** — skip-previous / skip-next glyphs rotated to point up/down (jump to start / end of chapter), replacing the `vertical_align` icons.
- **Gradient position marker** — the brand indigo→cyan gradient with a soft glow, replacing the flat white line.
- **Spacing** — page numbers no longer touch the slider.
- **Removed the redundant `N / total`** readout from the bottom bar in webtoon mode; the side bar already shows the count.

Horizontal (manga) paging mode is unchanged apart from inheriting the gradient marker.

Bumps version to `0.5.0+31`.