### PR TITLE
Usable phone-landscape layout

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -130,6 +130,15 @@ class ReaderWrapper extends HookConsumerWidget {
     );
     final invertTap = ref.watch(invertTapProvider).ifNull();
 
+    // Webtoon (vertical) normally uses the vertical side seek bar, but on a phone
+    // in landscape there's no vertical room for it to be usable — fall back to
+    // the standard horizontal bottom bar, like Komikku.
+    final screenSize = MediaQuery.sizeOf(context);
+    final isLandscapePhone = screenSize.shortestSide < 600 &&
+        screenSize.width > screenSize.height;
+    final useBottomSeekBar = scrollDirection == Axis.horizontal ||
+        (scrollDirection == Axis.vertical && isLandscapePhone);
+
     final bool volumeTap = ref.watch(volumeTapProvider).ifNull();
     final bool volumeTapInvert = ref.watch(volumeTapInvertProvider).ifNull();
 
@@ -443,7 +452,7 @@ class ReaderWrapper extends HookConsumerWidget {
                     // prev/next arrows. Vertical (webtoon): the side bar carries
                     // the page count + chapter jumps, so this whole row (and its
                     // redundant "1 / 15") is dropped.
-                    if (scrollDirection == Axis.horizontal) ...[
+                    if (useBottomSeekBar) ...[
                       Row(
                         children: [
                           Card(
@@ -619,7 +628,9 @@ class ReaderWrapper extends HookConsumerWidget {
             ),
             // Webtoon / vertical scroll: the seek bar floats vertically on the
             // side (the bottom bar shows only the page count in this mode).
-            if (scrollDirection == Axis.vertical && visibility.value)
+            if (scrollDirection == Axis.vertical &&
+                !isLandscapePhone &&
+                visibility.value)
               Builder(builder: (context) {
                 final navSurface =
                     readerNavSurface(context.theme.colorScheme);

--- a/lib/src/widgets/shell/big_screen_navigation_bar.dart
+++ b/lib/src/widgets/shell/big_screen_navigation_bar.dart
@@ -36,6 +36,12 @@ class BigScreenNavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The rail shows on any wide screen (width >= 600), which includes a phone
+    // in landscape (short side < 600). There the height is tight, so drop the
+    // app-icon header to make room for all destinations ("More" was falling off
+    // the bottom). Real tablets keep the header.
+    final isPhone = MediaQuery.sizeOf(context).shortestSide < 600;
+
     final Widget leadingIcon;
     if (context.isDesktop) {
       leadingIcon = SizedBox(
@@ -69,21 +75,34 @@ class BigScreenNavigationBar extends StatelessWidget {
       );
     }
 
-    return NavigationRail(
-      useIndicator: true,
-      elevation: 5,
+    // The rail doesn't scroll on its own, so in landscape (short height) its
+    // destinations overflow the bottom. Let it scroll when it can't fit, while
+    // still filling the height when there's room (so spacing/indicator look
+    // right).
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minHeight: constraints.maxHeight),
+          child: IntrinsicHeight(
+            child: NavigationRail(
+              useIndicator: true,
+              elevation: 5,
       extended: context.isDesktop,
       minExtendedWidth: _extendedWidth,
       labelType: context.isDesktop
           ? NavigationRailLabelType.none
           : NavigationRailLabelType.all,
-      leading: leadingIcon,
+      leading: isPhone ? null : leadingIcon,
       destinations: NavigationBarData.getNavList(context)
           .map<NavigationRailDestination>(
               (e) => getNavigationRailDestination(context, e))
           .toList(),
       selectedIndex: selectedIndex,
       onDestinationSelected: onDestinationSelected,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/widgets/shell/navigation_shell_screen.dart
+++ b/lib/src/widgets/shell/navigation_shell_screen.dart
@@ -95,17 +95,22 @@ class NavigationShellScreen extends HookConsumerWidget {
 
     if (context.isTablet) {
       return Scaffold(
-        body: Row(
-          children: [
-            BigScreenNavigationBar(
-              selectedIndex: child.currentIndex,
-              onDestinationSelected: (index) => child.goBranch(
-                getAdjustedIndex(index),
-                initialLocation: index == child.currentIndex,
+        // No bottom bar here, so the rail + content would draw under the system
+        // navigation controls (and any landscape cutout). SafeArea keeps both
+        // out of that unusable strip so the controls never overlap a cover.
+        body: SafeArea(
+          child: Row(
+            children: [
+              BigScreenNavigationBar(
+                selectedIndex: child.currentIndex,
+                onDestinationSelected: (index) => child.goBranch(
+                  getAdjustedIndex(index),
+                  initialLocation: index == child.currentIndex,
+                ),
               ),
-            ),
-            Expanded(child: child),
-          ],
+              Expanded(child: child),
+            ],
+          ),
         ),
       );
     } else {


### PR DESCRIPTION
Three fixes so the app is usable on a phone in landscape:

- **Navigation rail** scrolls when it can't fit, and drops the app-icon header on phones (the rail shows on any width ≥ 600, i.e. a phone in landscape) so all destinations including **More** fit instead of overflowing off the bottom.
- The rail-layout body is wrapped in **SafeArea** so neither the rail nor the content draws under the system navigation controls / landscape display cutout.
- The webtoon reader uses the **horizontal bottom seek bar** instead of the vertical side bar on a phone in landscape, where there's no vertical room for it to be usable (matches Komikku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)