### PR TITLE
Offline reading + reader/library polish

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,7 +29,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 34 // flutter.compileSdkVersion
+    compileSdkVersion 36 // bumped for background_downloader / flutter_foreground_task
     ndkVersion "27.0.12077973"
     namespace "io.github.aaronbamblett.tsumiru"
     compileOptions {
@@ -50,7 +50,7 @@ android {
         applicationId "io.github.aaronbamblett.tsumiru"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 23 // raised for flutter_foreground_task (Android 6.0+)
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.github.aaronbamblett.tsumiru">
      <uses-permission android:name="android.permission.INTERNET" />
+     <!-- Background chapter downloads: keep the download orchestration alive with
+          the screen off via a foreground service (dataSync type, Android 14+),
+          with a progress notification (Android 13+). -->
+     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+     <uses-permission android:name="android.permission.WAKE_LOCK" />
    <application
         android:label="Tsumiru"
         android:name="${applicationName}"
@@ -33,5 +40,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- flutter_foreground_task: hosts the background download isolate. -->
+        <service
+            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false" />
     </application>
 </manifest>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.8.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "2.1.10" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "com.google.firebase.crashlytics" version "2.9.9" apply false

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -19,6 +21,10 @@ import 'src/features/auth/data/auth_coordinator.dart';
 import 'src/features/auth/data/auth_credentials_store.dart';
 import 'src/features/auth/data/basic_auth_migration.dart';
 import 'src/features/auth/data/secure_credentials_provider.dart';
+import 'src/features/offline/data/offline_background_downloads.dart';
+import 'src/features/offline/data/offline_bootstrap.dart';
+import 'src/features/offline/data/offline_download_providers.dart';
+import 'src/features/offline/data/offline_repository.dart';
 import 'src/features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import 'src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import 'src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
@@ -35,6 +41,17 @@ Future<void> main() async {
   SystemChrome.setPreferredOrientations(DeviceOrientation.values);
   GoRouter.optionURLReflectsImperativeAPIs = true;
 
+  // Open the on-device offline catalog. Null on web (offline disabled there);
+  // failure is non-fatal — the app still launches, offline features stay off.
+  final offlineStorage = await () async {
+    try {
+      return await initOfflineStorage();
+    } catch (e, st) {
+      debugPrint('offline storage init failed: $e\n$st');
+      return null;
+    }
+  }();
+
   // Build a ProviderContainer so we can run migration and preload auth
   // providers before the first frame. Using UncontrolledProviderScope below
   // ensures the widget tree uses this same container instance.
@@ -43,6 +60,12 @@ Future<void> main() async {
       packageInfoProvider.overrideWithValue(packageInfo),
       sharedPreferencesProvider.overrideWithValue(sharedPreferences),
       hiveStoreProvider.overrideWithValue(HiveStore()),
+      if (offlineStorage != null) ...[
+        offlineDatabaseProvider.overrideWithValue(offlineStorage.db),
+        offlinePathsProvider.overrideWithValue(offlineStorage.paths),
+        offlinePageStoreProvider.overrideWithValue(offlineStorage.store),
+        offlineEnabledProvider.overrideWithValue(true),
+      ],
     ],
   );
 
@@ -91,6 +114,20 @@ Future<void> main() async {
     await _seedTestConfig(container);
   } catch (e, st) {
     debugPrint('test-config seed failed: $e\n$st');
+  }
+
+  // 5) Sweep any chapter left mid-download by a prior crash/kill back to a
+  //    clean state so it can be retried. Fire-and-forget; native only.
+  if (offlineStorage != null) {
+    // Push read progress made offline, re-apply keep-rules (queues anything
+    // missing), then resume the download queue: chapters stranded `downloading`
+    // by the last exit and previously-errored ones are retried, one at a time,
+    // re-fetching only pages not already on disk. Fire-and-forget; native only.
+    unawaited(Future(() async {
+      await pushPendingProgress(container);
+      await reconcileAllAtLaunch(container);
+      await initOfflineDownloads(container);
+    }));
   }
 
   runApp(

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -37,6 +37,7 @@ enum DBKeys {
   languageBadge(false),
   l10n(Locale('en')),
   mangaFilterDownloaded(null),
+  mangaFilterOffline(null),
   mangaFilterUnread(null),
   mangaFilterCompleted(null),
   mangaFilterStarted(null),
@@ -56,7 +57,10 @@ enum DBKeys {
   volumeTapInvert(false),
   hideEmptyCategory(false),
   pinchToZoom(true),
-  readerIgnoreSafeArea(false),
+  // Default to edge-to-edge like Komikku (fullscreen=true + drawUnderCutout):
+  // the webtoon strip fills the whole screen, including the status-bar / camera
+  // -cutout row at the top. Users can re-enable insets in reader settings.
+  readerIgnoreSafeArea(true),
   appTheme(AppTheme.indigoNight),
   customThemeColor(0xFF7C7BFF),
   historyEnabled(true),
@@ -65,6 +69,17 @@ enum DBKeys {
   serverRequestTimeout(5000), // milliseconds
   autoRefreshOnTimeout(false),
   autoRefreshRetryDelay(1000), // milliseconds
+  // Offline safety-net settings
+  offlineTimeEvictEnabled(false),
+  offlineKeepDays(30),
+  offlineStorageCapEnabled(false),
+  offlineStorageCapMb(2000),
+  // How many chapter pages download at once. Low by default: a self-hosted
+  // server saturates fast and starts returning 500/503 under heavy parallelism.
+  offlineDownloadConcurrency(2),
+  // Lock phones to portrait (landscape on a phone currently looks broken). Off
+  // by default — many readers prefer landscape; tablets/desktop ignore it.
+  forcePortrait(false),
   ;
 
   const DBKeys(this.initial);

--- a/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
+++ b/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
@@ -7,6 +7,8 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../../../features/offline/data/offline_read_fallback.dart';
+import '../../../../../features/offline/data/offline_repository.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../data/category_repository.dart';
 import '../../../domain/category/category_model.dart';
@@ -16,8 +18,11 @@ part 'edit_category_controller.g.dart';
 @riverpod
 class CategoryController extends _$CategoryController {
   @override
-  Future<List<CategoryDto>?> build() =>
-      ref.watch(categoryRepositoryProvider).getCategoryList();
+  Future<List<CategoryDto>?> build() => categoriesWithOfflineFallback(
+        fetch: () => ref.watch(categoryRepositoryProvider).getCategoryList(),
+        db: ref.watch(offlineDatabaseProvider),
+        offlineEnabled: ref.watch(offlineEnabledProvider),
+      );
 
   Future<AsyncValue<void>> deleteCategory(int categoryId) async {
     final response = await AsyncValue.guard(() => ref

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -16,7 +16,15 @@ import '../../../../widgets/emoticons.dart';
 import '../../../../widgets/manga_cover/grid/manga_cover_grid_tile.dart';
 import '../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart';
 import '../../../../widgets/manga_cover/list/manga_cover_list_tile.dart';
+import '../../../../widgets/selection_action_bar.dart';
+import '../../../manga_book/data/downloads/downloads_repository.dart';
+import '../../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import '../../../manga_book/domain/manga/manga_model.dart';
 import '../../../manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart';
+import '../../../offline/data/offline_database.dart';
+import '../../../offline/data/offline_download_providers.dart';
+import '../../../offline/data/offline_repository.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
 import 'controller/library_controller.dart';
 
@@ -35,6 +43,49 @@ class CategoryMangaList extends HookConsumerWidget {
       if (mangaList.isNotLoading) refresh();
       return;
     }, []);
+
+    // Multi-select: long-press starts selection (Komikku-style), tap toggles
+    // while selecting else opens the manga. Selection is per this category list.
+    final selection = useState<Set<int>>(const {});
+    final selecting = selection.value.isNotEmpty;
+    void toggle(int id) {
+      final next = {...selection.value};
+      if (!next.add(id)) next.remove(id);
+      selection.value = next;
+    }
+
+    void open(MangaDto manga) {
+      if (selecting) {
+        toggle(manga.id);
+      } else {
+        MangaRoute(mangaId: manga.id, categoryId: categoryId).push(context);
+      }
+    }
+
+    // Mark every chapter of the selected series read / unread, via the bulk
+    // chapter mutation (one batch per series).
+    Future<void> markSelection(bool read) async {
+      final ids = selection.value.toList();
+      selection.value = const {};
+      final repo = ref.read(mangaBookRepositoryProvider);
+      for (final id in ids) {
+        final chapters = await repo.getChapterList(id);
+        final cids = <int>[for (final c in chapters ?? const []) c.id];
+        if (cids.isNotEmpty) {
+          await repo.modifyBulkChapters(
+              ChapterBatch(ids: cids, patch: ChapterChange(isRead: read)));
+        }
+      }
+      refresh();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(read
+              ? 'Marked ${ids.length} series read'
+              : 'Marked ${ids.length} series unread'),
+        ));
+      }
+    }
+
     return mangaList.showUiWhenData(
       context,
       (data) {
@@ -47,87 +98,204 @@ class CategoryMangaList extends HookConsumerWidget {
             ),
           );
         }
-        final Widget mangaList = switch (displayMode) {
+        final items = data!;
+        final Widget grid = switch (displayMode) {
           DisplayMode.list || null => ListView.builder(
               itemExtent: 96,
-              itemCount: (data?.length).getValueOnNullOrNegative(),
+              itemCount: items.length,
               itemBuilder: (context, index) => MangaCoverListTile(
-                manga: data![index],
-                onPressed: () {
-                  MangaRoute(
-                    mangaId: data[index].id,
-                    categoryId: categoryId,
-                  ).push(context);
-                },
-                onLongPress: () async {
-                  await showDialog(
-                    context: context,
-                    builder: (context) => EditMangaCategoryDialog(
-                      mangaId: data[index].id,
-                      title: data[index].title,
-                    ),
-                  );
-                  refresh();
-                },
+                manga: items[index],
+                selected: selection.value.contains(items[index].id),
+                onPressed: () => open(items[index]),
+                onLongPress: () => toggle(items[index].id),
                 showCountBadges: true,
               ),
             ),
           DisplayMode.grid => GridView.builder(
               gridDelegate: mangaCoverGridDelegate(gridWidth),
-              itemCount: (data?.length).getValueOnNullOrNegative(),
+              itemCount: items.length,
               itemBuilder: (context, index) => MangaCoverGridTile(
-                onLongPress: () async {
-                  await showDialog(
-                    context: context,
-                    builder: (context) => EditMangaCategoryDialog(
-                      mangaId: data[index].id,
-                      title: data[index].title,
-                    ),
-                  );
-                  refresh();
-                },
-                manga: data![index],
-                onPressed: () {
-                  MangaRoute(
-                    mangaId: data[index].id,
-                    categoryId: categoryId,
-                  ).push(context);
-                },
+                manga: items[index],
+                selected: selection.value.contains(items[index].id),
+                onLongPress: () => toggle(items[index].id),
+                onPressed: () => open(items[index]),
                 showCountBadges: true,
                 showDarkOverlay: false,
               ),
             ),
           DisplayMode.descriptiveList => ListView.builder(
               itemExtent: 176,
-              itemCount: (data?.length).getValueOnNullOrNegative(),
+              itemCount: items.length,
               itemBuilder: (context, index) => MangaCoverDescriptiveListTile(
-                manga: data![index],
-                onPressed: () {
-                  MangaRoute(
-                    mangaId: data[index].id,
-                    categoryId: categoryId,
-                  ).push(context);
-                },
-                onLongPress: () async {
-                  await showDialog(
-                    context: context,
-                    builder: (context) => EditMangaCategoryDialog(
-                      mangaId: data[index].id,
-                      title: data[index].title,
-                    ),
-                  );
-                  refresh();
-                },
+                manga: items[index],
+                selected: selection.value.contains(items[index].id),
+                onPressed: () => open(items[index]),
+                onLongPress: () => toggle(items[index].id),
                 showBadges: true,
               ),
-            )
+            ),
         };
-        return RefreshIndicator(
+
+        final list = RefreshIndicator(
           onRefresh: () async => refresh(),
-          child: mangaList,
+          child: grid,
+        );
+
+        // While selecting, swallow the system back to exit selection first, and
+        // show a contextual action bar (Komikku-style) over the grid.
+        return PopScope(
+          canPop: !selecting,
+          onPopInvokedWithResult: (didPop, _) {
+            if (!didPop) selection.value = const {};
+          },
+          child: Stack(
+            children: [
+              list,
+              if (selecting)
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: _SelectionBar(
+                    count: selection.value.length,
+                    onSelectAll: () =>
+                        selection.value = {for (final m in items) m.id},
+                    onClear: () => selection.value = const {},
+                    onMarkRead: () => markSelection(true),
+                    onMarkUnread: () => markSelection(false),
+                    onKeepOffline: () async {
+                      final ids = selection.value.toList();
+                      selection.value = const {};
+                      final db = ref.read(offlineDatabaseProvider);
+                      for (final id in ids) {
+                        await db.setKeepRule(id, OfflineKeepRule.all, 3);
+                        await reconcileMangaWidget(ref, id);
+                      }
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                          content: Text('Keeping ${ids.length} series offline'),
+                        ));
+                      }
+                    },
+                    onDownloadToServer: () async {
+                      final ids = selection.value.toList();
+                      selection.value = const {};
+                      final repo = ref.read(mangaBookRepositoryProvider);
+                      final dl = ref.read(downloadsRepositoryProvider);
+                      for (final id in ids) {
+                        final chapters = await repo.getChapterList(id);
+                        final chapterIds = <int>[
+                          for (final c in chapters ?? const []) c.id,
+                        ];
+                        if (chapterIds.isNotEmpty) {
+                          await dl.addChaptersBatchToDownloadQueue(chapterIds);
+                        }
+                      }
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                          content:
+                              Text('Downloading ${ids.length} series to server'),
+                        ));
+                      }
+                    },
+                    onEditCategories: () async {
+                      // Single-manga category dialog when exactly one is picked;
+                      // multi-manga category editing is a follow-up.
+                      if (selection.value.length == 1) {
+                        final id = selection.value.first;
+                        final manga =
+                            items.firstWhere((m) => m.id == id);
+                        selection.value = const {};
+                        await showDialog(
+                          context: context,
+                          builder: (context) => EditMangaCategoryDialog(
+                            mangaId: id,
+                            title: manga.title,
+                          ),
+                        );
+                        refresh();
+                      }
+                    },
+                  ),
+                ),
+            ],
+          ),
         );
       },
       refresh: refresh,
+    );
+  }
+}
+
+/// Bottom action bar shown while library manga are multi-selected. Mirrors
+/// Komikku's library selection menu, scoped to the actions we can wire to
+/// existing APIs (sync offline / download to server). Mark-read and multi-manga
+/// category edits are a follow-up.
+class _SelectionBar extends StatelessWidget {
+  const _SelectionBar({
+    required this.count,
+    required this.onSelectAll,
+    required this.onClear,
+    required this.onMarkRead,
+    required this.onMarkUnread,
+    required this.onKeepOffline,
+    required this.onDownloadToServer,
+    required this.onEditCategories,
+  });
+
+  final int count;
+  final VoidCallback onSelectAll;
+  final VoidCallback onClear;
+  final VoidCallback onMarkRead;
+  final VoidCallback onMarkUnread;
+  final VoidCallback onKeepOffline;
+  final VoidCallback onDownloadToServer;
+  final VoidCallback onEditCategories;
+
+  @override
+  Widget build(BuildContext context) {
+    return SelectionActionBar(
+      leading: [
+        IconButton(
+          tooltip: 'Clear',
+          icon: const Icon(Icons.close_rounded),
+          onPressed: onClear,
+        ),
+        Text('$count', style: context.textTheme.titleMedium),
+      ],
+      actions: [
+        IconButton(
+          tooltip: 'Select all',
+          icon: const Icon(Icons.select_all_rounded),
+          onPressed: onSelectAll,
+        ),
+        if (count == 1)
+          IconButton(
+            tooltip: 'Edit categories',
+            icon: const Icon(Icons.label_outline_rounded),
+            onPressed: onEditCategories,
+          ),
+        IconButton(
+          tooltip: 'Mark read',
+          icon: const Icon(Icons.done_all_rounded),
+          onPressed: onMarkRead,
+        ),
+        IconButton(
+          tooltip: 'Mark unread',
+          icon: const Icon(Icons.remove_done_rounded),
+          onPressed: onMarkUnread,
+        ),
+        IconButton(
+          tooltip: 'Keep offline (sync)',
+          icon: const Icon(Icons.download_for_offline_outlined),
+          onPressed: onKeepOffline,
+        ),
+        IconButton(
+          tooltip: 'Download to server',
+          icon: const Icon(Icons.cloud_download_outlined),
+          onPressed: onDownloadToServer,
+        ),
+      ],
     );
   }
 }

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -4,24 +4,44 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../../constants/db_keys.dart';
 import '../../../../../constants/enum.dart';
+import '../../../../../features/offline/data/offline_download_providers.dart';
+import '../../../../../features/offline/data/offline_repository.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../../utils/mixin/state_provider_mixin.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
+import '../../../../offline/data/offline_read_fallback.dart';
 import '../../../data/category_repository.dart';
 import '../../../domain/category/category_model.dart';
 
 part 'library_controller.g.dart';
 
 @riverpod
-Future<List<MangaDto>?> categoryMangaList(Ref ref, int categoryId) => ref
-    .watch(categoryRepositoryProvider)
-    .getMangasFromCategory(categoryId: categoryId);
+Future<List<MangaDto>?> categoryMangaList(Ref ref, int categoryId) async {
+  final list = await libraryWithOfflineFallback(
+    fetch: () => ref
+        .watch(categoryRepositoryProvider)
+        .getMangasFromCategory(categoryId: categoryId),
+    db: ref.watch(offlineDatabaseProvider),
+    offlineEnabled: ref.watch(offlineEnabledProvider),
+  );
+  // Mirror the category's manga into the offline catalog so the whole library
+  // is browsable offline (no-op on web/unset via the null offlineSync).
+  final sync = ref.read(offlineSyncProvider);
+  if (sync != null && list != null) {
+    for (final manga in list) {
+      unawaited(sync.syncManga(manga));
+    }
+  }
+  return list;
+}
 
 @riverpod
 class LibraryDisplayCategory extends _$LibraryDisplayCategory
@@ -44,6 +64,9 @@ class CategoryMangaListWithQueryAndFilter
     final mangaFilterStarted = ref.watch(libraryMangaFilterStartedProvider);
     final mangaFilterBookmarked =
         ref.watch(libraryMangaFilterBookmarkedProvider);
+    final mangaFilterOffline = ref.watch(libraryMangaFilterOfflineProvider);
+    final offlineMangaIds =
+        ref.watch(offlineDeviceMangaIdsProvider).valueOrNull ?? const <int>{};
     final MangaSort sortedBy =
         ref.watch(libraryMangaSortProvider) ?? DBKeys.mangaSort.initial;
     final sortedDirection =
@@ -72,6 +95,11 @@ class CategoryMangaListWithQueryAndFilter
 
       if (mangaFilterBookmarked != null &&
           (mangaFilterBookmarked ^ manga.bookmarkCount.isGreaterThan(0))) {
+        return false;
+      }
+
+      if (mangaFilterOffline != null &&
+          (mangaFilterOffline ^ offlineMangaIds.contains(manga.id))) {
         return false;
       }
 
@@ -134,6 +162,13 @@ class LibraryMangaFilterDownloaded extends _$LibraryMangaFilterDownloaded
     with SharedPreferenceClientMixin<bool> {
   @override
   bool? build() => initialize(DBKeys.mangaFilterDownloaded);
+}
+
+@riverpod
+class LibraryMangaFilterOffline extends _$LibraryMangaFilterOffline
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.mangaFilterOffline);
 }
 
 @riverpod

--- a/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
@@ -47,6 +47,12 @@ class LibraryMangaFilter extends ConsumerWidget {
           onChanged:
               ref.read(libraryMangaFilterDownloadedProvider.notifier).update,
         ),
+        CustomCheckboxListTile(
+          title: context.l10n.onDevice,
+          provider: libraryMangaFilterOfflineProvider,
+          onChanged:
+              ref.read(libraryMangaFilterOfflineProvider.notifier).update,
+        ),
       ],
     );
   }

--- a/lib/src/features/manga_book/domain/chapter_page/chapter_page_model.dart
+++ b/lib/src/features/manga_book/domain/chapter_page/chapter_page_model.dart
@@ -11,3 +11,5 @@ typedef ChapterPageDto = Fragment$ChapterPageDto;
 typedef ChapterPageWithMangaDto = Fragment$ChapterPageWithMangaDto;
 
 typedef ChapterPagesDto = Fragment$ChapterPagesDto;
+
+typedef ChapterPagesChapterDto = Fragment$ChapterPagesDto$chapter;

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -11,6 +11,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/emoticons.dart';
+import '../../../offline/presentation/offline_files_view.dart';
 import '../../data/downloads/downloads_repository.dart';
 import '../../domain/downloads/downloads_model.dart';
 import 'controller/downloads_controller.dart';
@@ -22,29 +23,63 @@ class DownloadsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final toast = ref.watch(toastProvider);
     final downloadsChapterIds = ref.watch(downloadsChapterIdsProvider);
     final downloadsGlobalStatus = ref.watch(downloaderStateProvider);
     final showDownloadsFAB = ref.watch(showDownloadsFABProvider);
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(context.l10n.downloads),
-        actions: [
-          if ((downloadsChapterIds).isNotBlank)
-            IconButton(
-              onPressed: () => AsyncValue.guard(
-                ref.read(downloadsRepositoryProvider).clearDownloads,
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(context.l10n.downloads),
+          bottom: TabBar(
+            tabs: [
+              Tab(text: context.l10n.downloadsServerTab),
+              Tab(text: context.l10n.downloadsOnDeviceTab),
+            ],
+          ),
+          actions: [
+            if ((downloadsChapterIds).isNotBlank)
+              IconButton(
+                onPressed: () => AsyncValue.guard(
+                  ref.read(downloadsRepositoryProvider).clearDownloads,
+                ),
+                icon: const Icon(Icons.delete_sweep_rounded),
               ),
-              icon: const Icon(Icons.delete_sweep_rounded),
+          ],
+        ),
+        floatingActionButton: showDownloadsFAB
+            ? DownloadsFab(
+                status: downloadsGlobalStatus.valueOrNull ??
+                    DownloaderState.STARTED)
+            : null,
+        body: TabBarView(
+          children: [
+            _ServerDownloads(
+              downloadsChapterIds: downloadsChapterIds,
+              downloadsGlobalStatus: downloadsGlobalStatus,
             ),
-        ],
+            const OfflineFilesView(),
+          ],
+        ),
       ),
-      floatingActionButton: showDownloadsFAB
-          ? DownloadsFab(
-              status:
-                  downloadsGlobalStatus.valueOrNull ?? DownloaderState.STARTED)
-          : null,
-      body: downloadsGlobalStatus.showUiWhenData(
+    );
+  }
+}
+
+/// The existing server download-queue view (the "Server" tab).
+class _ServerDownloads extends ConsumerWidget {
+  const _ServerDownloads({
+    required this.downloadsChapterIds,
+    required this.downloadsGlobalStatus,
+  });
+
+  final List<int> downloadsChapterIds;
+  final AsyncValue<DownloaderState?> downloadsGlobalStatus;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final toast = ref.watch(toastProvider);
+    return downloadsGlobalStatus.showUiWhenData(
         context,
         (data) {
           if (data == null) {
@@ -74,7 +109,6 @@ class DownloadsScreen extends ConsumerWidget {
           }
         },
         showGenericError: true,
-      ),
     );
   }
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -4,11 +4,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../../constants/db_keys.dart';
 import '../../../../../constants/enum.dart';
+import '../../../../../features/offline/data/offline_download_providers.dart';
+import '../../../../../features/offline/data/offline_read_fallback.dart';
+import '../../../../../features/offline/data/offline_repository.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../library/domain/category/category_model.dart';
@@ -21,8 +26,20 @@ part 'manga_details_controller.g.dart';
 @riverpod
 class MangaWithId extends _$MangaWithId {
   @override
-  Future<MangaDto?> build({required int mangaId}) =>
-      ref.watch(mangaBookRepositoryProvider).getManga(mangaId: mangaId);
+  Future<MangaDto?> build({required int mangaId}) async {
+    final manga = await mangaWithOfflineFallback(
+      fetch: () =>
+          ref.watch(mangaBookRepositoryProvider).getManga(mangaId: mangaId),
+      db: ref.watch(offlineDatabaseProvider),
+      offlineEnabled: ref.watch(offlineEnabledProvider),
+      mangaId: mangaId,
+    );
+    if (manga != null) {
+      unawaited(
+          ref.read(offlineSyncProvider)?.syncManga(manga) ?? Future.value());
+    }
+    return manga;
+  }
 
   Future<void> refresh() async {
     ref.invalidateSelf();
@@ -33,9 +50,20 @@ class MangaWithId extends _$MangaWithId {
 class MangaChapterList extends _$MangaChapterList {
   @override
   Future<List<ChapterDto>?> build({required int mangaId}) async {
-    final result =
-        await ref.watch(mangaBookRepositoryProvider).getChapterList(mangaId);
+    final result = await chaptersWithOfflineFallback(
+      fetch: () =>
+          ref.watch(mangaBookRepositoryProvider).getChapterList(mangaId),
+      db: ref.watch(offlineDatabaseProvider),
+      offlineEnabled: ref.watch(offlineEnabledProvider),
+      mangaId: mangaId,
+    );
     ref.keepAlive();
+    if (result != null) {
+      unawaited(
+          (ref.read(offlineSyncProvider)?.syncChapters(result) ??
+                  Future.value())
+              .then((_) => reconcileManga(ref, mangaId)));
+    }
     return result;
   }
 

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -309,13 +309,6 @@ class MangaDetailsScreen extends HookConsumerWidget {
             width: kDrawerWidth,
             child: MangaChapterOrganizer(mangaId: mangaId),
           ),
-          bottomSheet: selectedChapters.value.isNotEmpty
-              ? MultiChaptersActionsBottomAppBar(
-                  afterOptionSelected: chapterListRefresh,
-                  selectedChapters: selectedChapters,
-                  chapterList: filteredChapterList.value,
-                )
-              : null,
           floatingActionButton:
               firstUnreadChapter != null && selectedChapters.value.isEmpty
                   ? BrandFab(
@@ -334,7 +327,9 @@ class MangaDetailsScreen extends HookConsumerWidget {
                       },
                     )
                   : null,
-          body: NotificationListener<ScrollNotification>(
+          body: Stack(
+            children: [
+              NotificationListener<ScrollNotification>(
             onNotification: (n) {
               if (n.metrics.axis == Axis.vertical) {
                 scrollPx.value = n.metrics.pixels;
@@ -368,6 +363,19 @@ class MangaDetailsScreen extends HookConsumerWidget {
                     child: Text(context.l10n.refresh),
                   ),
                 ),
+          ),
+              if (selectedChapters.value.isNotEmpty)
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: MultiChaptersActionsBottomAppBar(
+                    afterOptionSelected: chapterListRefresh,
+                    selectedChapters: selectedChapters,
+                    chapterList: filteredChapterList.value,
+                  ),
+                ),
+            ],
           ),
         ),
         refresh: refresh,

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_list_tile.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_list_tile.dart
@@ -10,6 +10,7 @@ import 'package:gap/gap.dart';
 
 import '../../../../../routes/router_config.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../offline/presentation/offline_save_button.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/manga/manga_model.dart';
 import '../../../widgets/download_status_icon.dart';
@@ -86,11 +87,20 @@ class ChapterListTile extends StatelessWidget {
               ),
           ],
         ),
-        trailing: DownloadStatusIcon(
-          updateData: updateData,
-          chapter: chapter,
-          mangaId: manga.id,
-          isDownloaded: chapter.isDownloaded.ifNull(),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            OfflineSaveButton(
+              chapterId: chapter.id,
+              serverIsDownloaded: chapter.isDownloaded.ifNull(),
+            ),
+            DownloadStatusIcon(
+              updateData: updateData,
+              chapter: chapter,
+              mangaId: manga.id,
+              isDownloaded: chapter.isDownloaded.ifNull(),
+            ),
+          ],
         ),
         selectedColor: context.theme.colorScheme.onSurface,
         selectedTileColor:

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -19,6 +19,7 @@ import '../../../../../utils/misc/toast/toast.dart';
 import '../../../../../utils/theme/brand.dart';
 import '../../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart';
 import '../../../../../widgets/server_image.dart';
+import '../../../../offline/presentation/series_offline_button.dart';
 import '../../../domain/manga/manga_model.dart';
 
 class MangaDescription extends HookConsumerWidget {
@@ -131,17 +132,16 @@ class MangaDescription extends HookConsumerWidget {
                   },
                 ),
               ),
+              const SizedBox(width: 10),
+              Expanded(child: SeriesOfflineButton(mangaId: manga.id)),
               if (manga.realUrl.isNotBlank) ...[
                 const SizedBox(width: 10),
-                Expanded(
-                  child: BrandGlassButton(
-                    icon: const Icon(Icons.public_rounded),
-                    label: Text(context.l10n.webView),
-                    onPressed: () => launchUrlInWeb(
-                      context,
-                      (manga.realUrl ?? ""),
-                      ref.read(toastProvider),
-                    ),
+                BrandCircleButton(
+                  icon: Icons.public_rounded,
+                  onPressed: () => launchUrlInWeb(
+                    context,
+                    (manga.realUrl ?? ""),
+                    ref.read(toastProvider),
                   ),
                 ),
               ],

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/small_screen_manga_details.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/small_screen_manga_details.dart
@@ -106,7 +106,9 @@ class SmallScreenMangaDetails extends ConsumerWidget {
               ),
             ),
           ),
-          const SliverToBoxAdapter(child: ListTile()),
+          // Bottom spacer so the last chapter can scroll clear of the floating
+          // Resume button (which otherwise permanently covers its controls).
+          const SliverToBoxAdapter(child: SizedBox(height: 96)),
         ],
       ),
     );

--- a/lib/src/features/manga_book/presentation/reader/controller/reader_controller.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/reader_controller.dart
@@ -7,6 +7,8 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../../offline/data/offline_read_fallback.dart';
+import '../../../../offline/data/offline_repository.dart';
 import '../../../data/manga_book/manga_book_repository.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/chapter_page/chapter_page_model.dart';
@@ -18,9 +20,32 @@ FutureOr<ChapterDto?> chapter(
   Ref ref, {
   required int chapterId,
 }) =>
-    ref.watch(mangaBookRepositoryProvider).getChapter(chapterId: chapterId);
+    // Offline: a downloaded chapter must still open when the server is
+    // unreachable, so fall back to the on-device catalog row.
+    chapterMetaWithOfflineFallback(
+      fetch: () =>
+          ref.watch(mangaBookRepositoryProvider).getChapter(chapterId: chapterId),
+      db: ref.watch(offlineDatabaseProvider),
+      offlineEnabled: ref.watch(offlineEnabledProvider),
+      chapterId: chapterId,
+    );
 
 @riverpod
-Future<ChapterPagesDto?> chapterPages(Ref ref, {required int chapterId}) => ref
-    .watch(mangaBookRepositoryProvider)
-    .getChapterPages(chapterId: chapterId);
+Future<ChapterPagesDto?> chapterPages(Ref ref, {required int chapterId}) async {
+  // Offline: if this chapter is downloaded on-device, serve its pages from disk
+  // (as file:// URIs that ServerImage renders locally) instead of the server.
+  // Falls through to the network when not downloaded / offline is unavailable.
+  if (ref.watch(offlineEnabledProvider)) {
+    final local =
+        await ref.watch(offlineRepositoryProvider).localChapterPages(chapterId);
+    if (local != null && local.isNotEmpty) {
+      return ChapterPagesDto(
+        chapter: ChapterPagesChapterDto(id: chapterId, pageCount: local.length),
+        pages: [for (final path in local) Uri.file(path).toString()],
+      );
+    }
+  }
+  return ref
+      .watch(mangaBookRepositoryProvider)
+      .getChapterPages(chapterId: chapterId);
+}

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -14,10 +14,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../constants/enum.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../history/presentation/history_controller.dart';
+import '../../../offline/data/offline_download_providers.dart';
 import '../../../settings/presentation/reader/widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
 import '../../../settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart';
-import '../../data/manga_book/manga_book_repository.dart';
-import '../../domain/chapter_batch/chapter_batch_model.dart';
 import '../../domain/manga/manga_model.dart';
 import '../manga_details/controller/manga_details_controller.dart';
 import 'controller/reader_controller.dart';
@@ -45,6 +44,9 @@ class ReaderScreen extends HookConsumerWidget {
     final ignoreSafeArea = ref.watch(readerIgnoreSafeAreaProvider).ifNull();
 
     final debounce = useRef<Timer?>(null);
+    // Latest page reached, so we can flush it on exit (the debounce below would
+    // otherwise drop the last few pages if you back out before it fires).
+    final latestPage = useRef<int>(-1);
 
     final updateLastRead = useCallback((int currentPage) async {
       final chapterValue = chapter.valueOrNull;
@@ -58,14 +60,13 @@ class ReaderScreen extends HookConsumerWidget {
       final isReadingCompleted =
           (currentPage >= (actualPageCount - 1)) && actualPageCount > 0;
 
-      await AsyncValue.guard(
-        () => ref.read(mangaBookRepositoryProvider).putChapter(
-              chapterId: chapterValue.id,
-              patch: ChapterChange(
-                lastPageRead: isReadingCompleted ? 0 : currentPage,
-                isRead: isReadingCompleted,
-              ),
-            ),
+      // Persist locally first (survives offline + app restart), then push to
+      // the server; if offline it stays pending and up-syncs on reconnect.
+      await recordReadingProgress(
+        ref,
+        chapterId: chapterValue.id,
+        lastPageRead: isReadingCompleted ? 0 : currentPage,
+        isRead: isReadingCompleted,
       );
 
       // Invalidate history to refresh the reading progress
@@ -84,6 +85,7 @@ class ReaderScreen extends HookConsumerWidget {
           return;
         }
 
+        latestPage.value = index;
         final finalDebounce = debounce.value;
         if ((finalDebounce?.isActive).ifNull()) {
           finalDebounce?.cancel();
@@ -116,6 +118,12 @@ class ReaderScreen extends HookConsumerWidget {
     return PopScope(
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop) {
+          // Flush the latest page reached so progress isn't lost to a pending
+          // debounce when you back out (catalog write is synchronous here).
+          debounce.value?.cancel();
+          if (latestPage.value >= 0) {
+            updateLastRead(latestPage.value);
+          }
           ref.invalidate(chapterProviderWithIndex);
           ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
         }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -18,8 +18,6 @@ import '../../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../../utils/misc/app_utils.dart';
 import '../../../../../../../widgets/server_image.dart';
 import '../../../../../../../widgets/zoom/scroll_offset_to_scroll_controller.dart';
-import '../../../../../../history/presentation/history_controller.dart'
-    as history_ctrl;
 import '../../../../../../settings/presentation/reader/widgets/reader_pinch_to_zoom/reader_pinch_to_zoom.dart';
 import '../../../../../../settings/presentation/reader/widgets/reader_scroll_animation_tile/reader_scroll_animation_tile.dart';
 import '../../../../../data/manga_book/manga_book_repository.dart';
@@ -43,13 +41,12 @@ typedef _LoadedChapter = ({
 
 /// Multi-chapter webtoon reader built on ``ScrollablePositionedList``.
 ///
-/// Replaces the homegrown plain-``ListView`` reader. SPL anchors the
-/// scroll position to a page INDEX (not an absolute pixel offset), so
-/// when a lazily-loaded image above the viewport finishes decoding and
-/// changes height, the page the user is reading stays put — no backward
-/// "snap", no ever-growing extent. (Confirmed on-device 2026-06-17: the
-/// single-chapter SPL path is smooth on tall pages; the plain-ListView
-/// path jumped. See vault 2026-06-17-webtoon-reader-rebuild-decision.md.)
+/// Replaces the homegrown plain-``ListView`` reader. SPL gives us reliable
+/// index-based navigation and visible item reporting, but its underlying scroll
+/// position is still pixel based: when an async image above the viewport changes
+/// height, Flutter does not anchor the currently visible page for us. This
+/// widget records rendered page heights and compensates above-viewport resize
+/// deltas so the webtoon strip the user is reading stays visually pinned.
 ///
 /// Multi-chapter handling:
 ///   * Forward (next chapter) is APPENDED — front indices are unchanged,
@@ -111,6 +108,16 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // height in the placeholder on re-entry, so the strip never collapses and
     // the scroll stays put. Reader-scoped so it survives item dispose/rebuild.
     final pageHeights = useRef<Map<String, double>>(<String, double>{});
+    // Bumped each time a new ordered prefetch sweep starts, so a stale sweep
+    // (from before a seek / chapter load) cancels itself.
+    final prefetchGen = useRef<int>(0);
+    // True while a programmatic jump (seek / prepend re-anchor) is still
+    // settling. The position listener otherwise reads its transient positions
+    // as a user scroll and can auto-load a neighbour chapter mid-seek — which
+    // shifts every index and bounces the landing (the single-tap seek bug).
+    // Mangayomi guards its progress listener the same way (_isAdjustingScroll).
+    final isAdjustingScroll = useRef<bool>(false);
+    final adjustIdleTimer = useRef<Timer?>(null);
 
     final currentVisibleChapter = useState<ChapterDto>(chapter);
     final currentChapterPageIndex = useState<int>(
@@ -159,6 +166,102 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     final bool isPinchToZoomEnabled =
         ref.read(pinchToZoomProvider).ifNull(true);
 
+    // Decode a page's image off-screen AND record its true rendered height from
+    // the decoded aspect ratio (Mihon/Mangayomi technique). Caching the height
+    // is the load-bearing part: a page then ALWAYS lays out at its real height —
+    // even before its widget is built, and even if its bitmap was later evicted
+    // — so it never resizes on landing/scroll-in and never shoves the viewport.
+    Future<void> decodeAndCacheHeight(String url) async {
+      if (pageHeights.value.containsKey(url)) return;
+      final provider = serverPageImageProvider(ref, url);
+      final stream = provider.resolve(ImageConfiguration.empty);
+      final completer = Completer<ImageInfo>();
+      late final ImageStreamListener listener;
+      listener = ImageStreamListener((info, _) {
+        if (!completer.isCompleted) completer.complete(info);
+        stream.removeListener(listener);
+      }, onError: (e, st) {
+        if (!completer.isCompleted) completer.completeError(e);
+        stream.removeListener(listener);
+      });
+      stream.addListener(listener);
+      final info = await completer.future;
+      final w = info.image.width;
+      final h = info.image.height;
+      if (w > 0 && h > 0 && context.mounted) {
+        // Rendered height for a fitWidth strip spanning the viewport width.
+        pageHeights.value[url] =
+            MediaQuery.sizeOf(context).width * h / w;
+      }
+      info.dispose();
+    }
+
+    // Decode pages ONCE, off-screen and ahead of the viewport, in reading order
+    // — so a page is already decoded AND its height is known before it's
+    // reached/jumped-to; nothing resizes on/above screen. A generation token
+    // cancels an in-flight sweep when a new one starts (seek / chapter load).
+    void prefetchPagesFrom(int startGlobalIndex) {
+      final gen = ++prefetchGen.value;
+      Future(() async {
+        final urls = <String>[
+          for (final c in loadedRef.value) ...c.pages.pages,
+        ];
+        if (urls.isEmpty) return;
+        final start = startGlobalIndex.clamp(0, urls.length - 1);
+        final order = <int>[
+          for (var i = start; i < urls.length; i++) i,
+          for (var i = start - 1; i >= 0; i--) i,
+        ];
+        for (final i in order) {
+          if (!context.mounted || prefetchGen.value != gen) return;
+          try {
+            await decodeAndCacheHeight(urls[i]);
+          } catch (_) {}
+        }
+      });
+    }
+
+    // Global (across all loaded chapters) index of the page being read now.
+    int currentGlobalIndex() {
+      var cumulative = 0;
+      for (final c in loadedRef.value) {
+        if (c.chapterId == currentVisibleChapter.value.id) {
+          return cumulative + currentChapterPageIndex.value;
+        }
+        cumulative += c.pages.pages.length;
+      }
+      return currentChapterPageIndex.value;
+    }
+
+    // Start the ordered prefetch once, after the first layout.
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) prefetchPagesFrom(currentChapterPageIndex.value);
+      });
+      return () => adjustIdleTimer.value?.cancel();
+    }, const []);
+
+    // Open a short window during which the position listener won't auto-load a
+    // neighbour chapter. Called around programmatic jumps so their settle
+    // motion isn't mistaken for the user scrolling toward an edge.
+    void markScrollAdjusting() {
+      isAdjustingScroll.value = true;
+      adjustIdleTimer.value?.cancel();
+      adjustIdleTimer.value = Timer(
+        const Duration(milliseconds: 350),
+        () => isAdjustingScroll.value = false,
+      );
+    }
+
+    void jumpToIndex({required int index, double alignment = 0}) {
+      if (!itemScrollController.isAttached) return;
+      itemScrollController.jumpTo(index: index, alignment: alignment);
+      // Re-seed the decode order from the new position so the pages we just
+      // jumped onto (and the ones ahead) are decoded before they're scrolled
+      // past — otherwise a far jump lands on undecoded strips that resize.
+      prefetchPagesFrom(index);
+    }
+
     // --- chapter loading -------------------------------------------------
 
     Future<void> loadNextChapter(ChapterDto next) async {
@@ -181,6 +284,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           ...loadedChapters.value,
           (pages: pages, chapter: next, chapterId: next.id),
         ];
+        // Decode the appended chapter's pages ahead of the user reaching them.
+        prefetchPagesFrom(currentGlobalIndex());
         if (context.mounted) {
           InfinityContinuousFeedback.showNextChapterLoadedFeedback(
               context, next.name);
@@ -240,13 +345,11 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // new itemCount first). One frame, no animation, no second defer.
         if (anchorIndex != null) {
           final target = anchorIndex + newPageCount;
+          // Guard the re-anchor jump too: its settle motion must not be read
+          // as a scroll back to the top that prepends yet another chapter.
+          markScrollAdjusting();
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (itemScrollController.isAttached) {
-              itemScrollController.jumpTo(
-                index: target,
-                alignment: anchorAlignment,
-              );
-            }
+            jumpToIndex(index: target, alignment: anchorAlignment);
           });
         }
 
@@ -301,8 +404,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
             }
             if (currentVisibleChapter.value.id != ch.chapter.id) {
               final prevId = lastVisibleChapterId.value;
-              final prevPos =
-                  loaded.indexWhere((e) => e.chapterId == prevId);
+              final prevPos = loaded.indexWhere((e) => e.chapterId == prevId);
               final newPos =
                   loaded.indexWhere((e) => e.chapterId == ch.chapter.id);
               currentVisibleChapter.value = ch.chapter;
@@ -311,13 +413,23 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
               // finished → mark it read.
               if (prevPos >= 0 && newPos > prevPos) {
                 final left = loaded[prevPos].chapter;
-                _markChapterRead(ref, manga.id, left, completedChapterIds,
-                    context);
+                _markChapterRead(
+                    ref, manga.id, left, completedChapterIds, context);
               }
             }
             break;
           }
           cumulative += count;
+        }
+
+        // A programmatic jump (seek / prepend re-anchor) is still settling —
+        // its transient positions must not look like the user scrolling to an
+        // edge, or we'd auto-load a neighbour chapter and shift the indices
+        // out from under the jump. Skip edge handling until it settles, and
+        // drop the stale direction sample so the first real tick starts clean.
+        if (isAdjustingScroll.value) {
+          lastTop.value = null;
+          return;
         }
 
         // Boundary prefetch triggers — gated on scroll DIRECTION so that
@@ -329,8 +441,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         final maxIdx =
             positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
 
-        final top = positions
-            .reduce((a, b) => a.index <= b.index ? a : b);
+        final top = positions.reduce((a, b) => a.index <= b.index ? a : b);
         final prevTop = lastTop.value;
         lastTop.value = (index: top.index, edge: top.itemLeadingEdge);
         bool scrollingUp = false;
@@ -384,10 +495,22 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         currentVisibleChapter.value.id,
       );
       if (globalIndex < 0) return;
+      if (!itemScrollController.isAttached) return;
       currentChapterPageIndex.value = chapterIdx;
-      if (itemScrollController.isAttached) {
-        itemScrollController.jumpTo(index: globalIndex, alignment: 0.0);
-      }
+      // Jump IMMEDIATELY (Mangayomi parity: services/page_navigation_service.dart
+      // jumpToPage -> itemScrollController.jumpTo(index:), no await). The old
+      // path awaited ~10 sequential off-screen image decodes BEFORE jumping —
+      // a multi-second window (2.4s on-device, worse under download load) in
+      // which the position listener auto-loaded a neighbour chapter and shifted
+      // every index out from under the pending jump, so a single tap landed in
+      // the wrong chapter and bounced. Page heights are already estimated from
+      // measured siblings, so the landing is stable without pre-decoding.
+      markScrollAdjusting();
+      lastTop.value = null;
+      itemScrollController.jumpTo(index: globalIndex, alignment: 0);
+      // Decode forward from the new position in the background so the pages the
+      // user is about to scroll into are ready.
+      prefetchPagesFrom(globalIndex);
     }
 
     void handlePageNavigation({required bool isNext}) {
@@ -407,7 +530,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           curve: InfinityContinuousConfig.scrollAnimationCurve,
         );
       } else {
-        itemScrollController.jumpTo(index: globalIndex, alignment: 0.0);
+        jumpToIndex(index: globalIndex);
       }
     }
 
@@ -419,14 +542,27 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       final loc = _locate(index, loadedChapters.value);
       if (loc == null) {
         return SizedBox(
-          height: context.height *
-              InfinityContinuousConfig.verticalPageHeightRatio,
+          height:
+              context.height * InfinityContinuousConfig.verticalPageHeightRatio,
         );
       }
-      // Reserve the page's true height (once measured) so a re-entering strip
-      // never collapses to the small placeholder and snaps the scroll.
-      final reservedHeight = pageHeights.value[loc.imageUrl];
-      final placeholderHeight = reservedHeight ??
+      // Reserve the page's true height so a strip never grows on decode and
+      // shoves the scroll backward. Priority:
+      //   1. this exact page's measured height (re-entry), else
+      //   2. the AVERAGE of pages already measured in this session — manhwa
+      //      strips in a chapter are near-uniform, so this places an unloaded
+      //      page within a few px of its real height (the key fix: a page that
+      //      loads while ABOVE the viewport barely changes size, so it doesn't
+      //      push the reader back — the failure mode the 0.7-screen guess caused
+      //      when real strips are 2-4 screens tall), else
+      //   3. a one-screen fallback for the very first page (the anchor, which
+      //      grows downward and never jumps the reader).
+      final measured = pageHeights.value;
+      final double? avgHeight = measured.isEmpty
+          ? null
+          : measured.values.reduce((a, b) => a + b) / measured.length;
+      final placeholderHeight = measured[loc.imageUrl] ??
+          avgHeight ??
           context.height * InfinityContinuousConfig.verticalPageHeightRatio;
       return ServerImage(
         showReloadButton: true,
@@ -439,15 +575,31 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
             child: CircularProgressIndicator(value: progress.progress),
           ),
         ),
-        imageBuilder: (context, imageProvider) => MeasureSize(
-          onChange: (size) {
-            if (size.height > 0) pageHeights.value[loc.imageUrl] = size.height;
+        imageBuilder: (context, imageProvider) => Image(
+          image: imageProvider,
+          fit: BoxFit.fitWidth,
+          width: double.infinity,
+          // Reserve the page's height UNTIL the bitmap decodes. The network path
+          // gets this for free via progressIndicatorBuilder, but the offline
+          // (file://) ServerImage branch skips that and renders the bare Image —
+          // which is 0px tall until the local file decodes, then pops to full
+          // height. A wall of pages popping 0->real around a seek lands the jump
+          // on the wrong page (offline-only seek bug). Reserving placeholderHeight
+          // keeps every page size-stable, so jumpTo(index) lands true.
+          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+            if (frame == null && !wasSynchronouslyLoaded) {
+              return SizedBox(height: placeholderHeight, width: double.infinity);
+            }
+            // Only measure the REAL decoded image — never the placeholder — so a
+            // strip re-entering the viewport reserves its true height.
+            return MeasureSize(
+              onChange: (size) {
+                if (size.height <= 0) return;
+                pageHeights.value[loc.imageUrl] = size.height;
+              },
+              child: child,
+            );
           },
-          child: Image(
-            image: imageProvider,
-            fit: BoxFit.fitWidth,
-            width: double.infinity,
-          ),
         ),
       );
     }
@@ -536,11 +688,13 @@ void _markChapterRead(
     if (result.hasError) {
       completedChapterIds.value = {...completedChapterIds.value}
         ..remove(chapter.id);
-    } else {
-      ref.invalidate(chapterProvider(chapterId: chapter.id));
-      ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
-      ref.invalidate(history_ctrl.readingHistoryProvider);
     }
+    // NOTE: deliberately do NOT invalidate chapterProvider / mangaChapterList
+    // here. Doing so while reading rebuilds ReaderScreen through an async reload,
+    // which remounts this list and re-applies initialScrollIndex (now 0 from the
+    // mark-read above) — yanking the reader back to the start of the opening
+    // chapter. Read-state is tracked in-session via completedChapterIds, and
+    // ReaderScreen refreshes these providers on exit (its PopScope).
   });
 }
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -228,9 +228,17 @@ class ReaderWrapper extends HookConsumerWidget {
     );
 
     useEffect(() {
-      if (!visibility.value) {
-        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
-      }
+      // Match Komikku's ReaderActivity.setMenuVisibility: show the system bars
+      // (status bar/clock + navigation/gesture bar) WITH the reader menu, and
+      // hide them again when the menu is dismissed. The page content stays
+      // edge-to-edge under them either way. Previously only the hide branch
+      // existed, so once hidden the bars never came back on tap — leaving no
+      // clock and no gesture/nav controls while the menu was up.
+      SystemChrome.setEnabledSystemUIMode(
+        visibility.value
+            ? SystemUiMode.edgeToEdge
+            : SystemUiMode.immersiveSticky,
+      );
       return null;
     }, [visibility.value]);
 
@@ -445,9 +453,14 @@ class ReaderWrapper extends HookConsumerWidget {
         ),
         bottomSheet: visibility.value
             ? ExcludeFocus(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
+                // Reader is edge-to-edge now (no outer SafeArea), so pad the
+                // controls above the navigation / gesture bar — otherwise they
+                // sit under it when the menu is shown.
+                child: SafeArea(
+                  top: false,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
                     // Horizontal (manga): inline seek bar flanked by chapter
                     // prev/next arrows. Vertical (webtoon): the side bar carries
                     // the page count + chapter jumps, so this whole row (and its
@@ -541,6 +554,7 @@ class ReaderWrapper extends HookConsumerWidget {
                       ),
                     ),
                   ],
+                  ),
                 ),
               )
             : null,

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -8,10 +8,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../../../constants/app_sizes.dart';
-import '../../../../constants/gen/assets.gen.dart';
+import '../../../../features/offline/data/offline_download_providers.dart';
+import '../../../../features/offline/data/offline_repository.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
+import '../../../../widgets/selection_action_bar.dart';
 import '../../data/downloads/downloads_repository.dart';
 import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/chapter/chapter_model.dart';
@@ -31,8 +32,6 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
   final List<ChapterDto>? chapterList;
 
   List<int> get selectedChapterList => selectedChapters.value.keys.toList();
-  ChapterDto get firstChapter =>
-      selectedChapters.value[selectedChapterList.first]!;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -41,99 +40,114 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
       if (triggerAfterOption) await afterOptionSelected();
     }
 
-    final selectedList = selectedChapters.value.values;
-
-    // This bar is a Scaffold bottomSheet inside the shell navigation, which
-    // zeroes the bottom MediaQuery insets — BOTH padding and viewPadding — for
-    // its descendants (confirmed on-device: MediaQuery reports 0 while the
-    // system navigation bar is really 48dp). Read the inset straight from the
-    // FlutterView, which no MediaQuery ancestor can consume, so the bar clears
-    // the Android navigation buttons.
-    final view = View.of(context);
-    final bottomInset = view.viewPadding.bottom / view.devicePixelRatio;
-    return Padding(
-      padding: KEdgeInsets.a8.size.add(
-        EdgeInsets.only(bottom: bottomInset),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          if (selectedList.any((e) => e.isBookmarked.ifNull()))
-            MultiChaptersActionIcon(
-              iconData: Icons.bookmark_remove_rounded,
-              chapterList: selectedChapterList,
-              change: ChapterChange(isBookmarked: false),
-              refresh: refresh,
-            ),
-          if (selectedList.any((e) => !(e.isBookmarked.ifNull())))
-            MultiChaptersActionIcon(
-              iconData: Icons.bookmark_add_rounded,
-              chapterList: selectedChapterList,
-              change: ChapterChange(isBookmarked: true),
-              refresh: refresh,
-            ),
-          if (selectedList.isSingletonList && chapterList.isNotBlank)
-            MultiChaptersActionIcon(
-              chapterList: [
-                for (final chapter in chapterList!)
-                  if (firstChapter.index > chapter.index) chapter.id
-              ],
-              icon: ImageIcon(
-                Assets.icons.previousDone.provider(),
-                color: context.theme.cardTheme.color,
-              ),
-              change: ChapterChange(isRead: true),
-              refresh: refresh,
-            ),
-          if (selectedList.any((e) => !(e.isRead.ifNull())))
-            MultiChaptersActionIcon(
-              iconData: Icons.done_all_rounded,
-              chapterList: selectedChapterList,
-              change: ChapterChange(isRead: true, lastPageRead: 0),
-              refresh: refresh,
-            ),
-          if (selectedList.any((e) => e.isRead.ifNull()))
-            MultiChaptersActionIcon(
-              iconData: Icons.remove_done_rounded,
-              chapterList: selectedChapterList,
-              change: ChapterChange(isRead: false),
-              refresh: refresh,
-            ),
-          if (selectedList.any((e) => !(e.isDownloaded.ifNull())))
-            IconButton(
-              icon: Icon(Icons.download_rounded),
-              onPressed: () async {
-                final result = await AsyncValue.guard(
-                  () => ref
-                      .read(downloadsRepositoryProvider)
-                      .addChaptersBatchToDownloadQueue([
-                    for (var e in selectedList)
-                      if (!(e.isDownloaded.ifNull(true))) (e.id)
-                  ]),
-                );
-                if (context.mounted) {
-                  result.showToastOnError(ref.read(toastProvider));
-                }
-                await refresh(true);
-              },
-            ),
-          if (selectedList.any((e) => e.isDownloaded.ifNull()))
-            IconButton(
-              icon: Icon(Icons.delete_rounded),
-              onPressed: () async {
-                final result = await AsyncValue.guard(
-                  () => ref
-                      .read(mangaBookRepositoryProvider)
-                      .deleteChapters(selectedChapterList),
-                );
-                if (context.mounted) {
-                  result.showToastOnError(ref.read(toastProvider));
-                }
-                await refresh(true);
-              },
-            ),
-        ],
-      ),
+    // Same floating action bar as the library multi-select, with parity actions:
+    // a leading clear + count, then mark read / unread, download to device,
+    // download to server, and delete.
+    return SelectionActionBar(
+      clearsSystemNav: true,
+      leading: [
+        IconButton(
+          tooltip: 'Clear',
+          icon: const Icon(Icons.close_rounded),
+          onPressed: () => refresh(false),
+        ),
+        Text('${selectedChapters.value.length}',
+            style: context.textTheme.titleMedium),
+      ],
+      actions: [
+        IconButton(
+          tooltip: 'Select all',
+          icon: const Icon(Icons.select_all_rounded),
+          onPressed: chapterList == null
+              ? null
+              : () => selectedChapters.value = {
+                    for (final c in chapterList!) c.id: c,
+                  },
+        ),
+        MultiChaptersActionIcon(
+          iconData: Icons.done_all_rounded,
+          chapterList: selectedChapterList,
+          change: ChapterChange(isRead: true, lastPageRead: 0),
+          refresh: refresh,
+        ),
+        MultiChaptersActionIcon(
+          iconData: Icons.remove_done_rounded,
+          chapterList: selectedChapterList,
+          change: ChapterChange(isRead: false),
+          refresh: refresh,
+        ),
+        IconButton(
+          tooltip: context.l10n.keepOffline,
+          icon: const Icon(Icons.download_for_offline_outlined),
+          onPressed: () async {
+            // Download FIRST, clear selection AFTER: clearing selection disposes
+            // this bar, which would invalidate `ref` mid-loop and silently drop
+            // the remaining downloads.
+            final ids = selectedChapterList;
+            for (final id in ids) {
+              await saveChapterToDevice(ref, id);
+            }
+            await refresh(true);
+          },
+        ),
+        IconButton(
+          tooltip: context.l10n.downloads,
+          icon: const Icon(Icons.cloud_download_outlined),
+          onPressed: () async {
+            final result = await AsyncValue.guard(
+              () => ref
+                  .read(downloadsRepositoryProvider)
+                  .addChaptersBatchToDownloadQueue(selectedChapterList),
+            );
+            if (context.mounted) {
+              result.showToastOnError(ref.read(toastProvider));
+            }
+            await refresh(true);
+          },
+        ),
+        IconButton(
+          tooltip: context.l10n.delete,
+          icon: const Icon(Icons.delete_rounded),
+          onPressed: () async {
+            final repo = ref.read(offlineRepositoryProvider);
+            final onDevice =
+                await repo.deviceDownloadedCount(selectedChapterList);
+            if (onDevice > 0) {
+              if (!context.mounted) return;
+              final ok = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: Text(ctx.l10n.delete),
+                      content:
+                          Text(ctx.l10n.offlineBulkDeleteWarning(onDevice)),
+                      actions: [
+                        TextButton(
+                            onPressed: () => Navigator.pop(ctx, false),
+                            child: Text(ctx.l10n.cancel)),
+                        TextButton(
+                            onPressed: () => Navigator.pop(ctx, true),
+                            child: Text(ctx.l10n.delete)),
+                      ],
+                    ),
+                  ) ??
+                  false;
+              if (!ok) return;
+            }
+            final result = await AsyncValue.guard(
+              () => ref
+                  .read(mangaBookRepositoryProvider)
+                  .deleteChapters(selectedChapterList),
+            );
+            if (context.mounted) {
+              result.showToastOnError(ref.read(toastProvider));
+            }
+            if (!result.hasError) {
+              await cascadeServerDeleteToDevice(ref, selectedChapterList);
+            }
+            await refresh(true);
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/src/features/manga_book/widgets/download_status_icon.dart
+++ b/lib/src/features/manga_book/widgets/download_status_icon.dart
@@ -14,6 +14,7 @@ import '../../../utils/extensions/custom_extensions.dart';
 import '../../../utils/misc/toast/toast.dart';
 import '../../../utils/theme/brand.dart';
 import '../../../widgets/custom_circular_progress_indicator.dart';
+import '../../offline/data/offline_download_providers.dart';
 import '../data/downloads/downloads_repository.dart';
 import '../data/manga_book/manga_book_repository.dart';
 import '../domain/chapter/chapter_model.dart';
@@ -108,12 +109,15 @@ class DownloadStatusIcon extends HookConsumerWidget {
           return IconButton(
             icon: brandGradientIcon(context, Icons.check_circle_rounded),
             onPressed: () async {
-              (await AsyncValue.guard(
+              final result = await AsyncValue.guard(
                 () => ref
                     .read(mangaBookRepositoryProvider)
                     .deleteChapters([chapter.id]),
-              ))
-                  .showToastOnError(toast);
+              );
+              result.showToastOnError(toast);
+              if (!result.hasError) {
+                await cascadeServerDeleteToDevice(ref, [chapter.id]);
+              }
               await newUpdatePair(ref, (value) => isLoading.value = value);
             },
           );

--- a/lib/src/features/offline/data/chapter_download_engine.dart
+++ b/lib/src/features/offline/data/chapter_download_engine.dart
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'offline_page_store.dart';
+
+/// Thrown by a [PageFetcher] when the server rejects the request with 401.
+/// Signals the engine to refresh auth once and retry, rather than counting it
+/// as a normal transient failure.
+class PageAuthException implements Exception {
+  const PageAuthException();
+}
+
+/// One page to download: its server URL and its index within the chapter.
+typedef PageRef = ({int index, String url});
+
+/// Fetches one page's bytes over HTTP given the server page path/URL. The
+/// closure MUST resolve the server base AND the current auth (ui_login `?token=`
+/// query param, or basic/simple_login headers) itself, at call time — that's
+/// what makes auth run-time-fresh instead of baked at enqueue. It MUST throw
+/// [PageAuthException] on a 401 so the engine can refresh and retry; any other
+/// failure should throw a plain exception (treated as transient).
+typedef PageFetcher = Future<PageBytes> Function(String pageUrl);
+
+/// Refreshes auth after a 401. Returns true if a new credential is now
+/// available (retry worth attempting), false if auth is genuinely dead (give
+/// up). Single-flight is the caller's responsibility (AuthCoordinator handles
+/// it), so concurrent pages hitting 401 at once collapse to one refresh.
+typedef AuthRefresher = Future<bool> Function();
+
+/// Outcome of downloading one chapter's outstanding pages.
+class ChapterDownloadOutcome {
+  const ChapterDownloadOutcome({
+    required this.storedPages,
+    required this.cancelled,
+    required this.authFailed,
+    this.error,
+  });
+
+  /// Pages written to disk this run: pageIndex -> (relPath, bytes).
+  final Map<int, ({String relPath, int bytes})> storedPages;
+
+  /// True if the run stopped because [isCancelled] went true.
+  final bool cancelled;
+
+  /// True if a page 401'd and the refresh reported auth is dead — the chapter
+  /// can't proceed until the user re-authenticates.
+  final bool authFailed;
+
+  /// The first non-auth error that ended the run, if any.
+  final Object? error;
+
+  bool get succeeded => error == null && !cancelled && !authFailed;
+}
+
+/// Downloads a single chapter's pages, Komikku-style: up to
+/// [parallelPageLimit] pages in flight at once (default 5), each retried a few
+/// times with short backoff for transient blips, and auth refreshed once on a
+/// 401 before retrying. Pure Dart and dependency-injected so it runs the same
+/// on Android and the Linux desktop build and is testable without HTTP, dart:io
+/// or the real auth stack.
+///
+/// Deliberately does ONE chapter: like Komikku's single-source model, the
+/// orchestrator runs chapters one at a time (everything comes from our own
+/// server, so there's nothing to spread chapter-level load against). The win is
+/// page-level parallelism, which also hides the server's cold upstream-fetch
+/// latency for chapters it hasn't cached yet.
+class ChapterDownloadEngine {
+  ChapterDownloadEngine({
+    required this.fetchPage,
+    required this.writePage,
+    required this.refreshAuth,
+    this.parallelPageLimit = 5,
+    this.maxAttempts = 3,
+    this.backoff = _defaultBackoff,
+  });
+
+  final PageFetcher fetchPage;
+  final OfflinePageStore writePage;
+  final AuthRefresher refreshAuth;
+  final int parallelPageLimit;
+  final int maxAttempts;
+  final Duration Function(int attempt) backoff;
+
+  static Duration _defaultBackoff(int attempt) =>
+      Duration(milliseconds: 300 * (1 << (attempt - 1))); // 300ms, 600, 1200
+
+  /// Download [pages] for chapter [chapterId]. Returns when all are stored, the
+  /// run is cancelled, auth dies, or a page exhausts its retries. Calls
+  /// [onPageStored] as each page lands so the caller can persist its catalog row
+  /// and update progress incrementally.
+  Future<ChapterDownloadOutcome> download({
+    required int mangaId,
+    required int chapterId,
+    required List<PageRef> pages,
+    required bool Function() isCancelled,
+    Future<void> Function(int pageIndex, String relPath, int bytes)?
+        onPageStored,
+  }) async {
+    final stored = <int, ({String relPath, int bytes})>{};
+    if (pages.isEmpty) {
+      return ChapterDownloadOutcome(
+          storedPages: stored, cancelled: false, authFailed: false);
+    }
+
+    final queue = List<PageRef>.of(pages);
+    var cursor = 0;
+    var authFailed = false;
+    Object? fatalError;
+
+    Future<void> worker() async {
+      while (true) {
+        if (isCancelled() || authFailed || fatalError != null) return;
+        if (cursor >= queue.length) return;
+        final page = queue[cursor++];
+        final result = await _downloadOne(mangaId, chapterId, page);
+        switch (result) {
+          case _PageOk(:final relPath, :final bytes):
+            stored[page.index] = (relPath: relPath, bytes: bytes);
+            if (onPageStored != null) {
+              await onPageStored(page.index, relPath, bytes);
+            }
+          case _PageAuthDead():
+            authFailed = true;
+          case _PageError(:final error):
+            fatalError ??= error;
+        }
+      }
+    }
+
+    final workerCount =
+        parallelPageLimit < queue.length ? parallelPageLimit : queue.length;
+    await Future.wait([for (var i = 0; i < workerCount; i++) worker()]);
+
+    return ChapterDownloadOutcome(
+      storedPages: stored,
+      cancelled: isCancelled(),
+      authFailed: authFailed,
+      error: fatalError,
+    );
+  }
+
+  Future<_PageResult> _downloadOne(
+      int mangaId, int chapterId, PageRef page) async {
+    var refreshedForAuth = false;
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        final bytes = await fetchPage(page.url);
+        final written = await writePage.writePage(
+          mangaId,
+          chapterId,
+          page.index,
+          bytes.bytes,
+          bytes.ext,
+        );
+        return _PageOk(relPath: written.relPath, bytes: written.bytes);
+      } on PageAuthException {
+        // Refresh once; concurrent 401s collapse via the refresher's
+        // single-flight. If auth is dead, stop trying.
+        if (!refreshedForAuth) {
+          refreshedForAuth = true;
+          final ok = await refreshAuth();
+          if (!ok) return const _PageAuthDead();
+          continue; // retry immediately with the fresh token (doesn't count)
+        }
+        // Already refreshed once and still 401 → auth is dead for this run.
+        return const _PageAuthDead();
+      } catch (e) {
+        if (attempt >= maxAttempts) return _PageError(e);
+        await Future.delayed(backoff(attempt));
+      }
+    }
+    return const _PageError('exhausted retries');
+  }
+}
+
+sealed class _PageResult {
+  const _PageResult();
+}
+
+class _PageOk extends _PageResult {
+  const _PageOk({required this.relPath, required this.bytes});
+  final String relPath;
+  final int bytes;
+}
+
+class _PageError extends _PageResult {
+  const _PageError(this.error);
+  final Object error;
+}
+
+class _PageAuthDead extends _PageResult {
+  const _PageAuthDead();
+}

--- a/lib/src/features/offline/data/offline_background_downloads.dart
+++ b/lib/src/features/offline/data/offline_background_downloads.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../constants/endpoints.dart';
+import '../../../constants/enum.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/logger/logger.dart';
+import '../../auth/data/auth_coordinator.dart';
+import '../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+import 'chapter_download_engine.dart';
+import 'offline_database.dart';
+import 'offline_download_coordinator.dart';
+import 'offline_download_providers.dart';
+import 'offline_repository.dart';
+import 'offline_settings_providers.dart';
+
+part 'offline_background_downloads.g.dart';
+
+/// The chapter download engine wired with real deps: an auth'd HTTP page fetch
+/// (resolving the server base + current auth at request time), the on-disk page
+/// store, and a token refresher. Pure Dart — runs the same on Android and the
+/// Linux desktop build. Null on web / when offline storage is unavailable.
+@riverpod
+ChapterDownloadEngine? chapterDownloadEngine(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return null;
+  // Page-level parallelism (Komikku's parallelPageLimit). One chapter downloads
+  // at a time; this is how many of its pages are in flight at once.
+  final parallel = (ref.watch(offlineDownloadConcurrencyProvider) ??
+          DBKeys.offlineDownloadConcurrency.initial as int)
+      .clamp(1, 10);
+  return ChapterDownloadEngine(
+    fetchPage: (pageUrl) => fetchOfflinePageBytes(ref, pageUrl),
+    writePage: ref.watch(offlinePageStoreProvider),
+    parallelPageLimit: parallel,
+    refreshAuth: () async {
+      // Only ui_login has a refreshable rotating token. basic / simple_login /
+      // none don't rotate, so a 401 there means the credential is wrong — no
+      // point retrying.
+      if (ref.read(authTypeKeyProvider) != AuthType.uiLogin) return false;
+      // Refresh through a raw client (not the auth-linked one) so the refresh
+      // mutation itself can't recurse through SuwayomiAuthLink; the coordinator
+      // owns single-flight dedup, so concurrent 401s collapse to one refresh.
+      final rawClient = GraphQLClient(
+        link: HttpLink(Endpoints.baseApi(
+          baseUrl: ref.read(serverUrlProvider) ?? DBKeys.serverUrl.initial,
+          port: ref.read(serverPortProvider),
+          addPort: ref.read(serverPortToggleProvider).ifNull(),
+          isGraphQl: true,
+        )),
+        cache: GraphQLCache(),
+      );
+      final outcome = await ref
+          .read(authCoordinatorProvider.notifier)
+          .refreshUiAccessToken(gqlClient: rawClient);
+      return outcome is RefreshSuccess;
+    },
+  );
+}
+
+/// The offline download orchestrator (Komikku-style: one chapter at a time,
+/// page-parallel inside the engine, run-time auth). Null on web / when offline
+/// storage is unavailable.
+@riverpod
+OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return null;
+  final engine = ref.watch(chapterDownloadEngineProvider);
+  if (engine == null) return null;
+  final repo = ref.watch(mangaBookRepositoryProvider);
+  final store = ref.watch(offlinePageStoreProvider);
+  return OfflineDownloadCoordinator(
+    db: ref.watch(offlineDatabaseProvider),
+    engine: engine,
+    resolvePages: (chapterId) async =>
+        (await repo.getChapterPages(chapterId: chapterId))?.pages ??
+        const <String>[],
+    measureChapterBytes: store.chapterBytes,
+  );
+}
+
+/// Resume offline downloads at launch. Chapters left `downloading` by a previous
+/// run (the in-memory loop doesn't survive a process death) are stranded; the
+/// pump resumes them one at a time, re-fetching only pages not already on disk.
+/// Chapters previously marked `error` get one fresh attempt — most past errors
+/// were the stale-token 401s the run-time-auth engine now avoids.
+Future<void> initOfflineDownloads(ProviderContainer container) async {
+  if (!container.read(offlineEnabledProvider)) return;
+  final coord = container.read(offlineDownloadCoordinatorProvider);
+  if (coord == null) return;
+  final db = container.read(offlineDatabaseProvider);
+  final errored = await db.chaptersInState(OfflineDeviceState.error);
+  for (final c in errored) {
+    await db.setChapterDeviceState(c.id, OfflineDeviceState.queued);
+  }
+  if (errored.isNotEmpty) {
+    logger.i('Offline: requeued ${errored.length} previously-errored chapters');
+  }
+  await coord.pumpDownloads();
+}

--- a/lib/src/features/offline/data/offline_bootstrap.dart
+++ b/lib/src/features/offline/data/offline_bootstrap.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'offline_bootstrap_stub.dart'
+    if (dart.library.io) 'offline_bootstrap_io.dart' as platform;
+import 'offline_database.dart';
+import 'offline_page_store.dart';
+import 'offline_paths.dart';
+
+/// Open the on-device offline catalog at app startup.
+///
+/// Returns `null` on web (offline disabled there); on mobile/desktop returns the
+/// drift database, path resolver, and page store, which `main()` uses to
+/// override `offlineDatabaseProvider` / `offlinePathsProvider` /
+/// `offlinePageStoreProvider`.
+Future<({OfflineDatabase db, OfflinePaths paths, OfflinePageStore store})?>
+    initOfflineStorage() => platform.openOfflineStorage();

--- a/lib/src/features/offline/data/offline_bootstrap_io.dart
+++ b/lib/src/features/offline/data/offline_bootstrap_io.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'offline_database.dart';
+import 'offline_page_store.dart';
+import 'offline_page_store_io.dart';
+import 'offline_paths.dart';
+
+/// Native (mobile + desktop) implementation: open the drift catalog on a file
+/// under the app-support directory, plus the dart:io page store.
+Future<({OfflineDatabase db, OfflinePaths paths, OfflinePageStore store})?>
+    openOfflineStorage() async {
+  final support = await getApplicationSupportDirectory();
+  final baseDir = p.join(support.path, 'offline');
+  await Directory(baseDir).create(recursive: true);
+  final paths = OfflinePaths(baseDir);
+  final db = OfflineDatabase(
+    NativeDatabase.createInBackground(File(p.join(baseDir, 'catalog.sqlite'))),
+  );
+  return (db: db, paths: paths, store: IoOfflinePageStore(paths));
+}

--- a/lib/src/features/offline/data/offline_bootstrap_stub.dart
+++ b/lib/src/features/offline/data/offline_bootstrap_stub.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'offline_database.dart';
+import 'offline_page_store.dart';
+import 'offline_paths.dart';
+
+/// Web stub: offline storage is disabled on web (no bulk file storage), so the
+/// providers are never overridden and the offline UI stays hidden.
+Future<({OfflineDatabase db, OfflinePaths paths, OfflinePageStore store})?>
+    openOfflineStorage() async => null;

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:drift/drift.dart';
+
+part 'offline_database.g.dart';
+
+/// On-device state of a chapter's bytes.
+enum OfflineDeviceState { none, queued, downloading, downloaded, error, orphaned }
+
+/// How many of a series' chapters to keep on this device automatically.
+enum OfflineKeepRule { off, nUnread, allUnread, all }
+
+/// Library manga mirrored for offline browsing. Keyed by the server's stable
+/// manga id.
+class OfflineMangas extends Table {
+  IntColumn get id => integer()();
+  TextColumn get title => text()();
+  TextColumn get thumbnailUrl => text().nullable()();
+  TextColumn get thumbnailRelPath => text().nullable()();
+  DateTimeColumn get updatedAt => dateTime()();
+  TextColumn get keepRule =>
+      textEnum<OfflineKeepRule>().withDefault(Constant(OfflineKeepRule.off.name))();
+  IntColumn get keepUnreadCount => integer().withDefault(const Constant(3))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Chapter metadata + per-chapter device-download state. Keyed by the server's
+/// stable chapter id (NEVER chapterIndex/sourceOrder, which renumbers).
+///
+/// No FK to [OfflineMangas] by design: the server is canonical, and a chapter
+/// whose manga/chapter disappears server-side is reconciled in app logic via
+/// [OfflineDeviceState.orphaned] rather than cascade-deleted; `orphaned` is a
+/// transient reconciliation marker — server-gone chapters are evicted on the
+/// next reconcile pass, not kept indefinitely for explicit cleanup.
+@TableIndex(name: 'idx_offline_chapter_manga', columns: {#mangaId})
+class OfflineChapters extends Table {
+  IntColumn get id => integer()();
+  IntColumn get mangaId => integer()();
+  TextColumn get name => text()();
+  // The server's per-manga ordinal (sourceOrder). Stored for display/order only;
+  // never used as a stable key.
+  IntColumn get chapterIndex => integer()();
+  BoolColumn get isRead => boolean().withDefault(const Constant(false))();
+  IntColumn get lastPageRead => integer().withDefault(const Constant(0))();
+  BoolColumn get isBookmarked => boolean().withDefault(const Constant(false))();
+  BoolColumn get serverIsDownloaded =>
+      boolean().withDefault(const Constant(false))();
+  TextColumn get deviceState => textEnum<OfflineDeviceState>()
+      .withDefault(Constant(OfflineDeviceState.none.name))();
+  IntColumn get pageCount => integer().withDefault(const Constant(0))();
+  IntColumn get bytes => integer().withDefault(const Constant(0))();
+  DateTimeColumn get updatedAt => dateTime()();
+  BoolColumn get pinned => boolean().withDefault(const Constant(false))();
+  DateTimeColumn get downloadedAt => dateTime().nullable()();
+
+  /// True when this chapter's read progress was updated locally (e.g. read
+  /// offline) but not yet pushed to the server. Up-synced on reconnect.
+  BoolColumn get progressDirty =>
+      boolean().withDefault(const Constant(false))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+class OfflineCategories extends Table {
+  IntColumn get id => integer()();
+  TextColumn get name => text()();
+  IntColumn get sortOrder => integer().withDefault(const Constant(0))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+@TableIndex(name: 'idx_offline_manga_category_cat', columns: {#categoryId})
+class OfflineMangaCategories extends Table {
+  IntColumn get mangaId => integer()();
+  IntColumn get categoryId => integer()();
+
+  @override
+  Set<Column> get primaryKey => {mangaId, categoryId};
+}
+
+/// One page of a downloaded chapter → its relative file path under the offline
+/// base dir. Page order is the index returned by fetchChapterPages.
+class OfflinePages extends Table {
+  IntColumn get chapterId => integer()();
+  IntColumn get pageIndex => integer()();
+  TextColumn get relativePath => text()();
+
+  @override
+  Set<Column> get primaryKey => {chapterId, pageIndex};
+}
+
+@DriftDatabase(
+  tables: [
+    OfflineMangas,
+    OfflineChapters,
+    OfflineCategories,
+    OfflineMangaCategories,
+    OfflinePages,
+  ],
+)
+class OfflineDatabase extends _$OfflineDatabase {
+  OfflineDatabase(super.e);
+
+  @override
+  int get schemaVersion => 3;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+        onCreate: (m) => m.createAll(),
+        onUpgrade: (m, from, to) async {
+          if (from < 2) {
+            await m.addColumn(offlineMangas, offlineMangas.keepRule);
+            await m.addColumn(offlineMangas, offlineMangas.keepUnreadCount);
+            await m.addColumn(offlineChapters, offlineChapters.pinned);
+            await m.addColumn(offlineChapters, offlineChapters.downloadedAt);
+          }
+          if (from < 3) {
+            await m.addColumn(offlineChapters, offlineChapters.progressDirty);
+          }
+        },
+      );
+
+  // --- metadata down-sync upserts -------------------------------------------
+  // These set ONLY server-sourced columns, so device-managed columns
+  // (deviceState, bytes, thumbnailRelPath) are preserved on conflict and never
+  // clobbered by a metadata refresh.
+
+  Future<void> upsertMangaMetadata({
+    required int id,
+    required String title,
+    String? thumbnailUrl,
+    required DateTime updatedAt,
+  }) =>
+      into(offlineMangas).insertOnConflictUpdate(
+        OfflineMangasCompanion(
+          id: Value(id),
+          title: Value(title),
+          updatedAt: Value(updatedAt),
+          // Don't write NULL over a good URL on a partial refresh; absent when
+          // the caller has no URL. thumbnailRelPath stays absent (device-managed).
+          thumbnailUrl: thumbnailUrl == null
+              ? const Value.absent()
+              : Value(thumbnailUrl),
+        ),
+      );
+
+  Future<void> upsertChapterMetadata({
+    required int id,
+    required int mangaId,
+    required String name,
+    required int chapterIndex,
+    required bool isRead,
+    required int lastPageRead,
+    required bool isBookmarked,
+    required bool serverIsDownloaded,
+    required int pageCount,
+    required DateTime updatedAt,
+  }) =>
+      into(offlineChapters).insertOnConflictUpdate(
+        OfflineChaptersCompanion(
+          id: Value(id),
+          mangaId: Value(mangaId),
+          name: Value(name),
+          chapterIndex: Value(chapterIndex),
+          isRead: Value(isRead),
+          lastPageRead: Value(lastPageRead),
+          isBookmarked: Value(isBookmarked),
+          serverIsDownloaded: Value(serverIsDownloaded),
+          pageCount: Value(pageCount),
+          updatedAt: Value(updatedAt),
+          // deviceState + bytes intentionally absent — device-managed.
+        ),
+      );
+
+  Future<void> upsertCategory(int id, String name, int sortOrder) =>
+      into(offlineCategories).insertOnConflictUpdate(
+        OfflineCategoriesCompanion(
+          id: Value(id),
+          name: Value(name),
+          sortOrder: Value(sortOrder),
+        ),
+      );
+
+  // --- device-managed mutations ---------------------------------------------
+
+  Future<void> setMangaCoverPath(int mangaId, String relPath) =>
+      (update(offlineMangas)..where((t) => t.id.equals(mangaId)))
+          .write(OfflineMangasCompanion(thumbnailRelPath: Value(relPath)));
+
+  Future<void> setKeepRule(int mangaId, OfflineKeepRule rule, int count) =>
+      (update(offlineMangas)..where((t) => t.id.equals(mangaId))).write(
+        OfflineMangasCompanion(
+          keepRule: Value(rule),
+          keepUnreadCount: Value(count),
+        ),
+      );
+
+  Future<void> setChapterPinned(int chapterId, bool pinned) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
+          .write(OfflineChaptersCompanion(pinned: Value(pinned)));
+
+  Future<void> setChapterDeviceState(
+    int chapterId,
+    OfflineDeviceState state, {
+    int? bytes,
+    DateTime? downloadedAt,
+  }) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        OfflineChaptersCompanion(
+          deviceState: Value(state),
+          bytes: bytes == null ? const Value.absent() : Value(bytes),
+          downloadedAt:
+              downloadedAt == null ? const Value.absent() : Value(downloadedAt),
+        ),
+      );
+
+  /// Record local reading progress (read offline / always). Marks it
+  /// `progressDirty` so it's pushed to the server on the next online sync.
+  Future<void> setChapterProgress(
+    int chapterId, {
+    required int lastPageRead,
+    required bool isRead,
+  }) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        OfflineChaptersCompanion(
+          lastPageRead: Value(lastPageRead),
+          isRead: Value(isRead),
+          progressDirty: const Value(true),
+        ),
+      );
+
+  /// Clear the dirty flag after the progress was pushed to the server.
+  Future<void> clearProgressDirty(int chapterId) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
+          .write(const OfflineChaptersCompanion(progressDirty: Value(false)));
+
+  /// Chapters whose local read progress hasn't been pushed to the server.
+  Future<List<OfflineChapter>> dirtyProgressChapters() =>
+      (select(offlineChapters)..where((t) => t.progressDirty.equals(true)))
+          .get();
+
+  // --- offline queries -------------------------------------------------------
+
+  Future<OfflineManga?> mangaById(int mangaId) =>
+      (select(offlineMangas)..where((t) => t.id.equals(mangaId)))
+          .getSingleOrNull();
+
+  Future<OfflineChapter?> chapterById(int chapterId) =>
+      (select(offlineChapters)..where((t) => t.id.equals(chapterId)))
+          .getSingleOrNull();
+
+  Future<List<OfflineManga>> libraryManga() =>
+      (select(offlineMangas)..orderBy([(t) => OrderingTerm(expression: t.title)]))
+          .get();
+
+  Future<List<OfflineChapter>> chaptersForManga(int mangaId) =>
+      (select(offlineChapters)
+            ..where((t) => t.mangaId.equals(mangaId))
+            ..orderBy([(t) => OrderingTerm(expression: t.chapterIndex)]))
+          .get();
+
+  /// Live stream of a manga's chapter rows — drives the series download
+  /// progress UI (emits as device states change during a background download).
+  Stream<List<OfflineChapter>> watchChaptersForManga(int mangaId) =>
+      (select(offlineChapters)..where((t) => t.mangaId.equals(mangaId))).watch();
+
+  /// Live stream of every chapter that's downloaded OR actively
+  /// downloading/queued on this device — drives the Downloads → Offline files
+  /// tab (so it shows in-progress downloads, not just finished ones).
+  Stream<List<OfflineChapter>> watchOfflineChapters() => (select(offlineChapters)
+        ..where((t) => t.deviceState.isIn([
+              OfflineDeviceState.downloaded.name,
+              OfflineDeviceState.downloading.name,
+              OfflineDeviceState.queued.name,
+            ])))
+      .watch();
+
+  /// How many pages of a chapter are already on disk. Cheap COUNT (no row
+  /// materialisation) — called on the main isolate on every page completion.
+  Future<int> downloadedPageCount(int chapterId) async {
+    final cnt = offlinePages.pageIndex.count();
+    final row = await (selectOnly(offlinePages)
+          ..addColumns([cnt])
+          ..where(offlinePages.chapterId.equals(chapterId)))
+        .getSingle();
+    return row.read(cnt) ?? 0;
+  }
+
+  /// All chapters currently in a given device state (e.g. queued / downloading),
+  /// ordered by manga then chapter — drives the sequential download pump.
+  Future<List<OfflineChapter>> chaptersInState(OfflineDeviceState state) =>
+      (select(offlineChapters)
+            ..where((t) => t.deviceState.equalsValue(state))
+            ..orderBy([
+              (t) => OrderingTerm(expression: t.mangaId),
+              (t) => OrderingTerm(expression: t.chapterIndex),
+            ]))
+          .get();
+
+  /// The next chapter waiting in the queue (oldest by manga/chapter order), or
+  /// null if the queue is empty.
+  Future<OfflineChapter?> nextQueuedChapter() => (select(offlineChapters)
+        ..where((t) => t.deviceState.equalsValue(OfflineDeviceState.queued))
+        ..orderBy([
+          (t) => OrderingTerm(expression: t.mangaId),
+          (t) => OrderingTerm(expression: t.chapterIndex),
+        ])
+        ..limit(1))
+      .getSingleOrNull();
+
+  Future<List<OfflineChapter>> downloadedChaptersForManga(int mangaId) =>
+      (select(offlineChapters)
+            ..where((t) =>
+                t.mangaId.equals(mangaId) &
+                t.deviceState.equalsValue(OfflineDeviceState.downloaded)))
+          .get();
+
+  /// Manga ids that have at least one chapter with [OfflineDeviceState.downloaded]
+  /// on this device — used by the "On device" library filter.
+  Future<Set<int>> mangaIdsWithDeviceDownloads() async {
+    final rows = await (selectOnly(offlineChapters, distinct: true)
+          ..addColumns([offlineChapters.mangaId])
+          ..where(offlineChapters.deviceState
+              .equalsValue(OfflineDeviceState.downloaded)))
+        .get();
+    return {for (final r in rows) r.read(offlineChapters.mangaId)!};
+  }
+
+  /// Total bytes used by downloaded chapters — for the storage UI, without a
+  /// filesystem walk.
+  Future<int> totalDownloadedBytes() async {
+    final sum = offlineChapters.bytes.sum();
+    final row = await (selectOnly(offlineChapters)
+          ..addColumns([sum])
+          ..where(offlineChapters.deviceState
+              .equalsValue(OfflineDeviceState.downloaded)))
+        .getSingle();
+    return row.read(sum) ?? 0;
+  }
+}

--- a/lib/src/features/offline/data/offline_download_coordinator.dart
+++ b/lib/src/features/offline/data/offline_download_coordinator.dart
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import '../../../utils/logger/logger.dart';
+import 'chapter_download_engine.dart';
+import 'offline_database.dart';
+
+/// Resolves a chapter's page URLs (wraps the GraphQL fetchChapterPages call).
+typedef PageUrlsResolver = Future<List<String>> Function(int chapterId);
+
+/// Measures the total on-disk bytes of a downloaded chapter's pages.
+typedef ChapterBytesMeasurer = Future<int> Function(int mangaId, int chapterId);
+
+/// Orchestrates background chapter downloads on top of [ChapterDownloadEngine].
+///
+/// Komikku's model: download ONE chapter at a time (everything comes from our
+/// own server, so there's nothing to spread chapter-level load against), with
+/// page-level parallelism inside the engine. Auth is resolved at request time
+/// by the engine's fetcher and refreshed on a 401 — nothing is baked at enqueue,
+/// which is what stranded the old `background_downloader` tasks with expired
+/// tokens. Deps are injected so the flow is testable without GraphQL, HTTP or
+/// dart:io.
+class OfflineDownloadCoordinator {
+  OfflineDownloadCoordinator({
+    required this.db,
+    required this.resolvePages,
+    required this.engine,
+    required this.measureChapterBytes,
+  });
+
+  final OfflineDatabase db;
+  final PageUrlsResolver resolvePages;
+  final ChapterDownloadEngine engine;
+  final ChapterBytesMeasurer measureChapterBytes;
+
+  /// Chapter currently being downloaded by the engine (in-memory). One at a
+  /// time, so at most one entry.
+  final Set<int> _active = {};
+
+  /// Chapters asked to stop mid-download (delete / pause). Cleared once the
+  /// in-flight download observes it and unwinds.
+  final Set<int> _cancelled = {};
+
+  /// True while a pump loop is draining the queue. PROCESS-WIDE (static) so that
+  /// even if the provider rebuilds mid-drain (e.g. the concurrency setting
+  /// settles) and a second coordinator instance is created, only ONE loop ever
+  /// drains the shared DB queue — otherwise both race and re-download every
+  /// chapter. Mirrors the auth refresh single-flight.
+  static bool _pumping = false;
+
+  /// True if this chapter is actively downloading right now.
+  bool isActive(int chapterId) => _active.contains(chapterId);
+
+  /// Ask an in-flight chapter to stop; the pump leaves its already-stored pages
+  /// on disk so a later run resumes rather than restarts.
+  void cancel(int chapterId) {
+    if (_active.contains(chapterId)) _cancelled.add(chapterId);
+  }
+
+  /// Add a chapter to the persistent download queue (state `queued`). The pump
+  /// starts it when it reaches the front. Skips chapters already downloaded or
+  /// in flight.
+  Future<void> queueChapter(int chapterId) async {
+    final c = await db.chapterById(chapterId);
+    if (c == null) return;
+    if (c.deviceState == OfflineDeviceState.downloaded ||
+        c.deviceState == OfflineDeviceState.downloading ||
+        c.deviceState == OfflineDeviceState.queued) {
+      return;
+    }
+    await db.setChapterDeviceState(chapterId, OfflineDeviceState.queued);
+  }
+
+  /// Resolve + download a single chapter immediately (used by the pump and for
+  /// a direct save). Idempotent + resumable: an already-`downloaded` chapter is
+  /// skipped, pages already on disk are not re-fetched, and a chapter left
+  /// `downloading` by a previous run (e.g. an app kill) simply resumes.
+  Future<void> enqueueChapter(OfflineChapter chapter) async {
+    if (chapter.deviceState == OfflineDeviceState.downloaded) return;
+    if (_active.contains(chapter.id)) return;
+    _active.add(chapter.id);
+    try {
+      await db.setChapterDeviceState(
+          chapter.id, OfflineDeviceState.downloading);
+      final urls = await resolvePages(chapter.id);
+      if (urls.isEmpty) {
+        logger.e('Offline: no pages resolved for chapter ${chapter.id}; '
+            'marking error');
+        await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+        return;
+      }
+      final stored = (await (db.select(db.offlinePages)
+                ..where((t) => t.chapterId.equals(chapter.id)))
+              .get())
+          .map((p) => p.pageIndex)
+          .toSet();
+      final pages = <PageRef>[
+        for (var i = 0; i < urls.length; i++)
+          if (!stored.contains(i)) (index: i, url: urls[i]),
+      ];
+
+      final outcome = await engine.download(
+        mangaId: chapter.mangaId,
+        chapterId: chapter.id,
+        pages: pages,
+        isCancelled: () => _cancelled.contains(chapter.id),
+        onPageStored: (pageIndex, relPath, bytes) async {
+          await db.into(db.offlinePages).insertOnConflictUpdate(
+                OfflinePagesCompanion.insert(
+                  chapterId: chapter.id,
+                  pageIndex: pageIndex,
+                  relativePath: relPath,
+                ),
+              );
+        },
+      );
+
+      if (outcome.cancelled) return; // leave partial; resume later
+      if (outcome.authFailed) {
+        logger.e('Offline: chapter ${chapter.id} auth failed (token dead)');
+        await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+        return;
+      }
+      if (outcome.error != null) {
+        logger.e('Offline: chapter ${chapter.id} failed: ${outcome.error}');
+        await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+        return;
+      }
+      logger.i('Offline: enqueued ${pages.length} page tasks for chapter '
+          '${chapter.id} (manga ${chapter.mangaId})');
+      await _finalizeIfComplete(chapter.mangaId, chapter.id, urls.length);
+    } catch (e) {
+      logger.e('Offline: chapter ${chapter.id} download error: $e');
+      await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+    } finally {
+      _active.remove(chapter.id);
+      _cancelled.remove(chapter.id);
+    }
+  }
+
+  /// Mark a chapter `downloaded` (with measured bytes) once all its pages are on
+  /// disk. [expectedPages] is the resolved page count when known, else the
+  /// catalog's `pageCount`.
+  Future<bool> _finalizeIfComplete(
+      int mangaId, int chapterId, int? expectedPages) async {
+    final chapter = await db.chapterById(chapterId);
+    if (chapter == null) return false;
+    if (chapter.deviceState == OfflineDeviceState.downloaded) return true;
+    final target = expectedPages ?? chapter.pageCount;
+    if (target <= 0) return false;
+    if (await db.downloadedPageCount(chapterId) < target) return false;
+    final bytes = await measureChapterBytes(mangaId, chapterId);
+    await db.setChapterDeviceState(chapterId, OfflineDeviceState.downloaded,
+        bytes: bytes, downloadedAt: DateTime.now());
+    logger.i('Offline: chapter $chapterId downloaded ($target pages, '
+        '$bytes bytes)');
+    return true;
+  }
+
+  /// Drain the queue one chapter at a time: resume any chapter left
+  /// `downloading` (stranded by an app restart) first, then pull from the
+  /// `queued` backlog. Single-flight — a second call while running is a no-op;
+  /// the running loop picks up anything newly queued.
+  Future<void> pumpDownloads() async {
+    if (_pumping) return;
+    _pumping = true;
+    try {
+      while (true) {
+        final next = await _nextChapter();
+        if (next == null) break;
+        await enqueueChapter(next);
+      }
+    } finally {
+      _pumping = false;
+    }
+  }
+
+  /// The next chapter to work on: a stranded `downloading` chapter (state says
+  /// downloading but nothing is in flight — left over from a kill), else the
+  /// head of the `queued` backlog. Null when there's nothing to do.
+  Future<OfflineChapter?> _nextChapter() async {
+    final downloading =
+        await db.chaptersInState(OfflineDeviceState.downloading);
+    var stranded = 0;
+    for (final c in downloading) {
+      if (!_active.contains(c.id)) {
+        stranded++;
+      }
+    }
+    final firstStranded =
+        downloading.where((c) => !_active.contains(c.id)).firstOrNull;
+    logger.i('Offline pump: downloading=${downloading.length} '
+        'active=${_active.length} stranded=$stranded');
+    if (firstStranded != null) return firstStranded;
+    return db.nextQueuedChapter();
+  }
+}

--- a/lib/src/features/offline/data/offline_download_manager.dart
+++ b/lib/src/features/offline/data/offline_download_manager.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import '../../../utils/logger/logger.dart';
+import 'offline_database.dart';
+import 'offline_page_store.dart';
+
+/// Resolves a chapter's page URLs (wraps the GraphQL fetchChapterPages call).
+typedef PageUrlsFetcher = Future<List<String>> Function(int chapterId);
+
+/// Fetches one page URL's bytes + extension (wraps the auth'd HTTP GET).
+typedef PageBytesFetcher = Future<PageBytes> Function(String url);
+
+/// Orchestrates saving a chapter's pages to the device.
+///
+/// Platform-agnostic: the page-URL resolver, the byte fetcher, and the file
+/// store are injected, so the download flow is hermetically testable. The
+/// runtime wiring (GraphQL page URLs, auth'd HTTP, dart:io store, free-space
+/// guard) is provided on native platforms.
+class OfflineDownloadManager {
+  OfflineDownloadManager({
+    required this.db,
+    required this.store,
+    required this.fetchPageUrls,
+    required this.fetchBytes,
+  });
+
+  final OfflineDatabase db;
+  final OfflinePageStore store;
+  final PageUrlsFetcher fetchPageUrls;
+  final PageBytesFetcher fetchBytes;
+
+  /// Download every page of [chapter] to the device. Requires the chapter to be
+  /// server-downloaded (product policy). On any failure, partial files + page
+  /// rows are removed and the chapter is marked `error`, then the error
+  /// rethrows so the queue/UI can surface it.
+  Future<void> downloadChapter(OfflineChapter chapter, {bool force = false}) async {
+    if (!force && !chapter.serverIsDownloaded) {
+      throw StateError(
+          'Chapter ${chapter.id} is not downloaded server-side (server-first)');
+    }
+    await db.setChapterDeviceState(chapter.id, OfflineDeviceState.downloading);
+    var pageCount = 0;
+    var atPage = -1;
+    try {
+      final urls = await fetchPageUrls(chapter.id);
+      pageCount = urls.length;
+      logger.i('Offline: downloading chapter ${chapter.id} '
+          '(manga ${chapter.mangaId}, $pageCount pages)');
+      var totalBytes = 0;
+      for (var i = 0; i < urls.length; i++) {
+        atPage = i;
+        final page = await fetchBytes(urls[i]);
+        final stored = await store.writePage(
+            chapter.mangaId, chapter.id, i, page.bytes, page.ext);
+        totalBytes += stored.bytes;
+        await db.into(db.offlinePages).insertOnConflictUpdate(
+              OfflinePagesCompanion.insert(
+                chapterId: chapter.id,
+                pageIndex: i,
+                relativePath: stored.relPath,
+              ),
+            );
+      }
+      await db.setChapterDeviceState(chapter.id, OfflineDeviceState.downloaded,
+          bytes: totalBytes);
+      logger.i('Offline: chapter ${chapter.id} downloaded '
+          '($pageCount pages, $totalBytes bytes)');
+    } catch (e, st) {
+      logger.e(
+          'Offline: download FAILED for chapter ${chapter.id} '
+          '(manga ${chapter.mangaId}) at page ${atPage + 1}/$pageCount: $e',
+          error: e,
+          stackTrace: st);
+      await _purge(chapter);
+      await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+      rethrow;
+    }
+  }
+
+  /// Remove a chapter's device copy entirely and reset its state.
+  Future<void> deleteChapter(OfflineChapter chapter) async {
+    await _purge(chapter);
+    await db.setChapterDeviceState(chapter.id, OfflineDeviceState.none, bytes: 0);
+  }
+
+  /// On launch, reset chapters left mid-download (app killed) so they can be
+  /// retried cleanly instead of being stuck `downloading` forever.
+  Future<void> sweepInterrupted() async {
+    final stuck = await (db.select(db.offlineChapters)
+          ..where((t) =>
+              t.deviceState.equalsValue(OfflineDeviceState.downloading)))
+        .get();
+    for (final c in stuck) {
+      await deleteChapter(c);
+    }
+  }
+
+  Future<void> _purge(OfflineChapter chapter) async {
+    await store.deleteChapter(chapter.mangaId, chapter.id);
+    await (db.delete(db.offlinePages)
+          ..where((t) => t.chapterId.equals(chapter.id)))
+        .go();
+  }
+}

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -1,0 +1,437 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/endpoints.dart';
+import '../../../constants/enum.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/logger/logger.dart';
+import '../../auth/data/auth_credentials_store.dart';
+import 'chapter_download_engine.dart';
+import '../../manga_book/data/downloads/downloads_repository.dart';
+import '../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+import '../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
+import 'offline_background_downloads.dart';
+import 'offline_database.dart';
+import 'offline_download_coordinator.dart';
+import 'offline_download_manager.dart';
+import 'offline_page_store.dart';
+import 'offline_reconciler.dart';
+import 'offline_repository.dart';
+import 'offline_settings_providers.dart';
+import 'reconcile_types.dart';
+
+part 'offline_download_providers.g.dart';
+
+/// Live on-device download state for a chapter (none / queued / downloading /
+/// downloaded / error). Always `none` when offline is unavailable.
+@riverpod
+Stream<OfflineDeviceState> offlineChapterState(Ref ref, int chapterId) {
+  if (!ref.watch(offlineEnabledProvider)) {
+    return Stream.value(OfflineDeviceState.none);
+  }
+  return ref.watch(offlineRepositoryProvider).watchChapterState(chapterId);
+}
+
+/// Live download progress for a chapter as a fraction 0..1 (pages on disk /
+/// total pages), or null when the total isn't known yet — drives the
+/// determinate progress arc on a downloading chapter, like Mihon/Komikku.
+@riverpod
+Stream<double?> offlineChapterProgress(Ref ref, int chapterId) async* {
+  if (!ref.watch(offlineEnabledProvider)) {
+    yield null;
+    return;
+  }
+  final repo = ref.watch(offlineRepositoryProvider);
+  final total = (await repo.db.chapterById(chapterId))?.pageCount ?? 0;
+  if (total <= 0) {
+    yield null;
+    return;
+  }
+  yield* repo
+      .watchChapterDownloadedPages(chapterId)
+      .map((done) => (done / total).clamp(0.0, 1.0))
+      .distinct();
+}
+
+/// Save a chapter's pages to the device. Looks up the synced catalog row and
+/// hands it to the download manager. No-op if offline is unavailable or the
+/// chapter hasn't been synced (browse it online once first).
+///
+/// Manual save is sticky (pinned). If the chapter is not yet server-downloaded,
+/// enqueues a server download first so Suwayomi fetches the source pages, then
+/// pulls them immediately with `force: true` so the device copy is available as
+/// soon as the server completes its own fetch.
+Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
+  final coordinator = ref.read(offlineDownloadCoordinatorProvider);
+  if (coordinator == null) return;
+  final repo = ref.read(offlineRepositoryProvider);
+  final chapter = await repo.chapterById(chapterId);
+  if (chapter == null) return;
+  // Manual save is sticky.
+  await ref.read(offlineDatabaseProvider).setChapterPinned(chapterId, true);
+  if (!chapter.serverIsDownloaded) {
+    // Cascade: also commit a server download (grows the server library). The
+    // device copy doesn't wait on it — the server streams pages from source.
+    await ref
+        .read(downloadsRepositoryProvider)
+        .addChaptersBatchToDownloadQueue([chapterId]);
+  }
+  // Queue it and let the pump start it (one chapter at a time). Pages download
+  // in the background and survive the app being backgrounded.
+  await coordinator.queueChapter(chapterId);
+  await coordinator.pumpDownloads();
+}
+
+/// Record reading progress for a chapter. Persists it to the on-device catalog
+/// FIRST (so it survives offline + app restart — the bug where progress was
+/// lost reading offline), then pushes to the server; on a successful push the
+/// dirty flag is cleared, otherwise it stays pending for the next online sync.
+Future<void> recordReadingProgress(
+  WidgetRef ref, {
+  required int chapterId,
+  required int lastPageRead,
+  required bool isRead,
+}) async {
+  final offline = ref.read(offlineEnabledProvider);
+  if (offline) {
+    await ref.read(offlineDatabaseProvider).setChapterProgress(
+          chapterId,
+          lastPageRead: lastPageRead,
+          isRead: isRead,
+        );
+  }
+  final result = await AsyncValue.guard(
+    () => ref.read(mangaBookRepositoryProvider).putChapter(
+          chapterId: chapterId,
+          patch: ChapterChange(lastPageRead: lastPageRead, isRead: isRead),
+        ),
+  );
+  if (offline && !result.hasError) {
+    await ref.read(offlineDatabaseProvider).clearProgressDirty(chapterId);
+  }
+}
+
+/// Push any locally-recorded read progress that hasn't reached the server yet
+/// (e.g. read while offline). Run at launch + after a manga's chapters sync, so
+/// progress made offline syncs up once the connection returns.
+Future<void> pushPendingProgress(ProviderContainer container) async {
+  if (!container.read(offlineEnabledProvider)) return;
+  final db = container.read(offlineDatabaseProvider);
+  final repo = container.read(mangaBookRepositoryProvider);
+  for (final c in await db.dirtyProgressChapters()) {
+    final result = await AsyncValue.guard(
+      () => repo.putChapter(
+        chapterId: c.id,
+        patch: ChapterChange(lastPageRead: c.lastPageRead, isRead: c.isRead),
+      ),
+    );
+    if (!result.hasError) await db.clearProgressDirty(c.id);
+  }
+}
+
+/// Enforce device ⊆ server: when chapters are deleted on the server, drop any
+/// device copies too. Silent; no-op when offline is unavailable.
+Future<void> cascadeServerDeleteToDevice(
+    WidgetRef ref, List<int> chapterIds) async {
+  if (ref.read(offlineDownloadManagerProvider) == null) return;
+  for (final id in chapterIds) {
+    await deleteChapterFromDevice(ref, id);
+  }
+}
+
+/// Remove a chapter's device copy.
+Future<void> deleteChapterFromDevice(WidgetRef ref, int chapterId) async {
+  final manager = ref.read(offlineDownloadManagerProvider);
+  if (manager == null) return;
+  final chapter = await ref.read(offlineRepositoryProvider).chapterById(chapterId);
+  if (chapter != null) await manager.deleteChapter(chapter);
+  await ref.read(offlineDatabaseProvider).setChapterPinned(chapterId, false);
+}
+
+/// The offline download orchestrator, wired with real network dependencies:
+/// `fetchChapterPages` for the page URL list and an auth'd HTTP GET for each
+/// page's bytes. Null on web / when offline storage is unavailable, so callers
+/// can `ref.read(offlineDownloadManagerProvider)?.downloadChapter(c)`.
+@riverpod
+OfflineDownloadManager? offlineDownloadManager(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return null;
+  final repo = ref.watch(mangaBookRepositoryProvider);
+  return OfflineDownloadManager(
+    db: ref.watch(offlineDatabaseProvider),
+    store: ref.watch(offlinePageStoreProvider),
+    fetchPageUrls: (chapterId) async =>
+        (await repo.getChapterPages(chapterId: chapterId))?.pages ??
+        const <String>[],
+    fetchBytes: (url) => fetchOfflinePageBytes(ref, url),
+  );
+}
+
+/// Fetch one page image's bytes with the active auth, resolved at CALL time
+/// (never baked) — mirrors `ServerImage`'s request building: base API WITHOUT
+/// the `/api` suffix (page URLs already carry `/api/...`), ui_login token as a
+/// `?token=` query param, basic / simple_login via headers. Throws
+/// [PageAuthException] on 401 so the download engine refreshes the token and
+/// retries; any other non-200 is a plain (transient) exception.
+Future<PageBytes> fetchOfflinePageBytes(Ref ref, String pageUrl) async {
+  final authType = ref.read(authTypeKeyProvider);
+  final basicToken = ref.read(credentialsProvider).valueOrNull;
+  final creds = ref.read(authCredentialsStoreProvider).valueOrNull;
+  final base = Endpoints.baseApi(
+    baseUrl: ref.read(serverUrlProvider),
+    port: ref.read(serverPortProvider),
+    addPort: ref.read(serverPortToggleProvider).ifNull(),
+    appendApiToUrl: false,
+  );
+  var fetchUrl = '$base$pageUrl';
+
+  final headers = <String, String>{};
+  if (authType == AuthType.basic && basicToken != null) {
+    headers['Authorization'] = basicToken;
+  } else if (authType == AuthType.simpleLogin) {
+    final cookie = creds?.simpleLoginCookieHeader;
+    if (cookie != null) headers.addAll(cookie);
+  } else if (authType == AuthType.uiLogin &&
+      (creds?.uiAccessToken?.isNotEmpty ?? false)) {
+    final sep = fetchUrl.contains('?') ? '&' : '?';
+    fetchUrl =
+        '$fetchUrl${sep}token=${Uri.encodeQueryComponent(creds!.uiAccessToken!)}';
+  }
+
+  final res = await http.get(Uri.parse(fetchUrl), headers: headers);
+  if (res.statusCode == 401 || res.statusCode == 403) {
+    throw const PageAuthException();
+  }
+  if (res.statusCode != 200) {
+    throw Exception('offline page fetch failed ($pageUrl): ${res.statusCode}');
+  }
+  return (bytes: res.bodyBytes, ext: pageImageExt(res.headers['content-type'], res.bodyBytes));
+}
+
+/// Manga ids that have at least one chapter downloaded on this device — used
+/// by the "On device" library filter. Returns an empty set when offline is
+/// unavailable so the filter is a no-op.
+@riverpod
+Future<Set<int>> offlineDeviceMangaIds(Ref ref) async {
+  if (!ref.watch(offlineEnabledProvider)) return const {};
+  return ref.watch(offlineRepositoryProvider).deviceDownloadedMangaIds();
+}
+
+/// The keep-offline rule currently set for a manga — used by the popup button
+/// to show a checkmark on the active rule.
+@riverpod
+Future<OfflineKeepRule> mangaKeepRule(Ref ref, int mangaId) async {
+  if (!ref.watch(offlineEnabledProvider)) return OfflineKeepRule.off;
+  return ref.watch(offlineRepositoryProvider).keepRuleFor(mangaId);
+}
+
+/// How many of a manga's chapters are downloaded on this device — drives the
+/// series Download/On-device button label.
+@riverpod
+Future<int> mangaDownloadedCount(Ref ref, int mangaId) async {
+  if (!ref.watch(offlineEnabledProvider)) return 0;
+  return (await ref.watch(offlineDatabaseProvider).downloadedChaptersForManga(mangaId))
+      .length;
+}
+
+/// Live download progress for a series: how many chapters are downloaded vs
+/// currently downloading/queued. Drives the live "Downloading N" button state.
+@riverpod
+Stream<({int downloaded, int inFlight})> mangaOfflineProgress(
+    Ref ref, int mangaId) {
+  if (!ref.watch(offlineEnabledProvider)) {
+    return Stream.value((downloaded: 0, inFlight: 0));
+  }
+  return ref
+      .watch(offlineDatabaseProvider)
+      .watchChaptersForManga(mangaId)
+      .map((rows) {
+    var downloaded = 0;
+    var inFlight = 0;
+    for (final c in rows) {
+      if (c.deviceState == OfflineDeviceState.downloaded) {
+        downloaded++;
+      } else if (c.deviceState == OfflineDeviceState.downloading ||
+          c.deviceState == OfflineDeviceState.queued) {
+        inFlight++;
+      }
+    }
+    return (downloaded: downloaded, inFlight: inFlight);
+  }).distinct(); // only rebuild the button when the counts actually change
+}
+
+/// Series with chapters on this device — downloaded AND actively downloading /
+/// queued — with per-series counts + byte size. Drives the Downloads → Offline
+/// files tab; live (re-emits as downloads progress or are removed).
+@riverpod
+Stream<List<({OfflineManga manga, int count, int inFlight, int bytes})>>
+    offlineDownloadedSeries(Ref ref) async* {
+  if (!ref.watch(offlineEnabledProvider)) {
+    yield const [];
+    return;
+  }
+  final db = ref.watch(offlineDatabaseProvider);
+  final mangas = {for (final m in await db.libraryManga()) m.id: m};
+  await for (final chapters in db.watchOfflineChapters()) {
+    final done = <int, int>{};
+    final inFlight = <int, int>{};
+    final bytes = <int, int>{};
+    for (final c in chapters) {
+      if (c.deviceState == OfflineDeviceState.downloaded) {
+        done[c.mangaId] = (done[c.mangaId] ?? 0) + 1;
+        bytes[c.mangaId] = (bytes[c.mangaId] ?? 0) + c.bytes;
+      } else {
+        inFlight[c.mangaId] = (inFlight[c.mangaId] ?? 0) + 1;
+      }
+    }
+    final ids = {...done.keys, ...inFlight.keys};
+    final out = <({OfflineManga manga, int count, int inFlight, int bytes})>[];
+    for (final id in ids) {
+      final m = mangas[id];
+      if (m != null) {
+        out.add((
+          manga: m,
+          count: done[id] ?? 0,
+          inFlight: inFlight[id] ?? 0,
+          bytes: bytes[id] ?? 0,
+        ));
+      }
+    }
+    // Actively-downloading series first, then alphabetical.
+    out.sort((a, b) {
+      if ((a.inFlight > 0) != (b.inFlight > 0)) return a.inFlight > 0 ? -1 : 1;
+      return a.manga.title.toLowerCase().compareTo(b.manga.title.toLowerCase());
+    });
+    yield out;
+  }
+}
+
+/// Total bytes of on-device offline content — for the storage settings UI.
+@riverpod
+Future<int> offlineUsageBytes(Ref ref) async {
+  if (!ref.watch(offlineEnabledProvider)) return 0;
+  return ref.read(offlineRepositoryProvider).totalDownloadedBytes();
+}
+
+/// Device-wide safety nets — read from persisted user settings.
+@riverpod
+SafetyNetConfig safetyNetConfig(Ref ref) => SafetyNetConfig(
+      timeEvictEnabled:
+          ref.watch(offlineTimeEvictEnabledProvider) ?? false,
+      keepDays: ref.watch(offlineKeepDaysProvider) ?? 30,
+      storageCapEnabled:
+          ref.watch(offlineStorageCapEnabledProvider) ?? false,
+      storageCapBytes:
+          (ref.watch(offlineStorageCapMbProvider) ?? 2000) * 1024 * 1024,
+    );
+
+/// Concrete-deps core — no Ref/ProviderContainer in the signature, so the
+/// controller, the launch path, and tests can all call it.
+Future<void> reconcileMangaCore({
+  required OfflineDatabase db,
+  required OfflineRepository repo,
+  required OfflineDownloadManager manager,
+  required OfflineDownloadCoordinator coordinator,
+  required SafetyNetConfig nets,
+  required int mangaId,
+}) {
+  return OfflineReconciler(
+    db: db,
+    nets: nets,
+    now: DateTime.now(),
+    // Only QUEUE chapters here (mark them in the persistent backlog); the pump
+    // below starts them one at a time. This keeps the fragile in-memory holding
+    // queue down to a single chapter, so an app restart can't strand the whole
+    // library as "downloading". One failed queue-mark must NOT abort the rest.
+    onDownload: (id) async {
+      try {
+        await coordinator.queueChapter(id);
+      } catch (e) {
+        logger.e('Offline: reconcile queue skipped for chapter $id: $e');
+      }
+    },
+    onEvict: (id) async {
+      try {
+        final c = await repo.chapterById(id);
+        if (c != null) await manager.deleteChapter(c);
+      } catch (e) {
+        logger.e('Offline: reconcile evict skipped for chapter $id: $e');
+      }
+    },
+  ).reconcileManga(mangaId).then((_) => coordinator.pumpDownloads());
+}
+
+/// Controller / in-app entry point (generated Ref).
+Future<void> reconcileManga(Ref ref, int mangaId) async {
+  if (!ref.read(offlineEnabledProvider)) return;
+  final manager = ref.read(offlineDownloadManagerProvider);
+  final coordinator = ref.read(offlineDownloadCoordinatorProvider);
+  if (manager == null || coordinator == null) return;
+  await reconcileMangaCore(
+    db: ref.read(offlineDatabaseProvider),
+    repo: ref.read(offlineRepositoryProvider),
+    manager: manager,
+    coordinator: coordinator,
+    nets: ref.read(safetyNetConfigProvider),
+    mangaId: mangaId,
+  );
+}
+
+/// Widget entry point — same as [reconcileManga] but accepts a [WidgetRef].
+Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
+  if (!ref.read(offlineEnabledProvider)) return;
+  final manager = ref.read(offlineDownloadManagerProvider);
+  final coordinator = ref.read(offlineDownloadCoordinatorProvider);
+  if (manager == null || coordinator == null) return;
+  await reconcileMangaCore(
+    db: ref.read(offlineDatabaseProvider),
+    repo: ref.read(offlineRepositoryProvider),
+    manager: manager,
+    coordinator: coordinator,
+    nets: ref.read(safetyNetConfigProvider),
+    mangaId: mangaId,
+  );
+}
+
+/// Launch entry point (main.dart holds a ProviderContainer, not a Ref).
+Future<void> reconcileAllAtLaunch(ProviderContainer container) async {
+  if (!container.read(offlineEnabledProvider)) return;
+  final manager = container.read(offlineDownloadManagerProvider);
+  final coordinator = container.read(offlineDownloadCoordinatorProvider);
+  if (manager == null || coordinator == null) return;
+  final db = container.read(offlineDatabaseProvider);
+  final repo = container.read(offlineRepositoryProvider);
+  final nets = container.read(safetyNetConfigProvider);
+  for (final m in await db.libraryManga()) {
+    await reconcileMangaCore(
+        db: db, repo: repo, manager: manager, coordinator: coordinator,
+        nets: nets, mangaId: m.id);
+  }
+}
+
+/// Pick a file extension from the content-type, falling back to magic bytes.
+/// Rendering sniffs the bytes regardless, so this only keeps filenames sensible.
+String pageImageExt(String? contentType, List<int> bytes) {
+  final ct = contentType?.toLowerCase() ?? '';
+  if (ct.contains('png')) return 'png';
+  if (ct.contains('webp')) return 'webp';
+  if (ct.contains('gif')) return 'gif';
+  if (ct.contains('jpeg') || ct.contains('jpg')) return 'jpg';
+  if (bytes.length >= 12) {
+    if (bytes[0] == 0x89 && bytes[1] == 0x50) return 'png';
+    if (bytes[0] == 0x47 && bytes[1] == 0x49) return 'gif';
+    if (bytes[0] == 0xFF && bytes[1] == 0xD8) return 'jpg';
+    if (bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[8] == 0x57) return 'webp';
+  }
+  return 'jpg';
+}

--- a/lib/src/features/offline/data/offline_dto_mappers.dart
+++ b/lib/src/features/offline/data/offline_dto_mappers.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import '../../../graphql/__generated__/schema.graphql.dart';
+import '../../library/domain/category/category_model.dart';
+import '../../library/domain/category/graphql/__generated__/fragment.graphql.dart';
+import '../../manga_book/domain/chapter/chapter_model.dart';
+import '../../manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import '../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import '../../manga_book/domain/manga/manga_model.dart';
+import 'offline_database.dart';
+
+/// Build a [MangaDto] from an on-device catalog row. Used only as the offline
+/// fallback when the server is unreachable. Fields the catalog doesn't store
+/// (counts, genre, status, url) get safe defaults; the list UI reads cover +
+/// title + inLibrary, which are accurate.
+MangaDto offlineMangaToDto(OfflineManga m, {int chapterCount = 0}) =>
+    Fragment$MangaDto(
+      id: m.id,
+      title: m.title,
+      thumbnailUrl: m.thumbnailUrl,
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: chapterCount),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: const <Fragment$MangaDto$meta>[],
+      sourceId: '0',
+      status: Enum$MangaStatus.UNKNOWN,
+      unreadCount: 0,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '',
+    );
+
+/// Build a [ChapterDto] from an on-device catalog row (offline fallback).
+ChapterDto offlineChapterToDto(OfflineChapter c) => Fragment$ChapterDto(
+      id: c.id,
+      mangaId: c.mangaId,
+      name: c.name,
+      chapterNumber: c.chapterIndex.toDouble(),
+      sourceOrder: c.chapterIndex,
+      isRead: c.isRead,
+      isBookmarked: c.isBookmarked,
+      isDownloaded: c.serverIsDownloaded,
+      lastPageRead: c.lastPageRead,
+      pageCount: c.pageCount,
+      fetchedAt: '0',
+      uploadDate: '0',
+      lastReadAt: '0',
+      url: '',
+      meta: const <Fragment$ChapterDto$meta>[],
+    );
+
+/// A synthetic "Default" category used offline, when the server's category list
+/// is unreachable. Carries [mangaCount] so it survives the `mangas.totalCount >
+/// 0` filter (`nonZeroCategoryList`) and the library renders one flat tab of the
+/// on-device catalog.
+CategoryDto offlineDefaultCategoryDto(int mangaCount) => Fragment$CategoryDto(
+      defaultCategory: true,
+      id: 0,
+      includeInDownload: Enum$IncludeOrExclude.UNSET,
+      includeInUpdate: Enum$IncludeOrExclude.UNSET,
+      name: 'Default',
+      order: 0,
+      mangas: Fragment$CategoryDto$mangas(totalCount: mangaCount),
+      meta: const <Fragment$CategoryDto$meta>[],
+    );

--- a/lib/src/features/offline/data/offline_image_provider.dart
+++ b/lib/src/features/offline/data/offline_image_provider.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Resolves a local on-device page file to an [ImageProvider]. Native only
+// (dart:io `FileImage`); the web stub throws — offline is disabled on web, so
+// it is never called there, but this keeps `ServerImage` web-compilable.
+export 'offline_image_provider_stub.dart'
+    if (dart.library.io) 'offline_image_provider_io.dart';

--- a/lib/src/features/offline/data/offline_image_provider_io.dart
+++ b/lib/src/features/offline/data/offline_image_provider_io.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+
+/// Native: render a downloaded page straight off disk.
+ImageProvider offlineImageProvider(String path) => FileImage(File(path));

--- a/lib/src/features/offline/data/offline_image_provider_stub.dart
+++ b/lib/src/features/offline/data/offline_image_provider_stub.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/widgets.dart';
+
+/// Web stub: offline storage (and thus local page files) is disabled on web,
+/// so this is never reached; it exists only to keep `ServerImage` compiling.
+ImageProvider offlineImageProvider(String path) =>
+    throw UnsupportedError('Local page images are unavailable on web');

--- a/lib/src/features/offline/data/offline_page_store.dart
+++ b/lib/src/features/offline/data/offline_page_store.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Stores/removes a chapter's page image files on the device.
+///
+/// Abstract so the download orchestrator stays platform-agnostic and
+/// hermetically testable; the real implementation (dart:io, under the
+/// app-support dir) is provided at startup on native platforms.
+abstract class OfflinePageStore {
+  /// Persist one page's [bytes]; returns its stored relative path (for the
+  /// catalog) and the number of bytes written.
+  Future<({String relPath, int bytes})> writePage(
+    int mangaId,
+    int chapterId,
+    int pageIndex,
+    List<int> bytes,
+    String ext,
+  );
+
+  /// Remove all stored files for a chapter (used on delete, and to clean up a
+  /// failed/partial download).
+  Future<void> deleteChapter(int mangaId, int chapterId);
+
+  /// Total bytes of a chapter's stored page files (for the catalog's byte
+  /// count after a background download completes). 0 if nothing is stored.
+  Future<int> chapterBytes(int mangaId, int chapterId);
+}
+
+/// Image bytes + file extension fetched for a single page.
+typedef PageBytes = ({List<int> bytes, String ext});

--- a/lib/src/features/offline/data/offline_page_store_io.dart
+++ b/lib/src/features/offline/data/offline_page_store_io.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'offline_page_store.dart';
+import 'offline_paths.dart';
+
+/// Native (mobile + desktop) page store: writes page files under the app-support
+/// offline dir. dart:io — only constructed on native platforms (via the
+/// conditional-import bootstrap), never on web.
+class IoOfflinePageStore implements OfflinePageStore {
+  const IoOfflinePageStore(this.paths);
+
+  final OfflinePaths paths;
+
+  @override
+  Future<({String relPath, int bytes})> writePage(
+    int mangaId,
+    int chapterId,
+    int pageIndex,
+    List<int> bytes,
+    String ext,
+  ) async {
+    final rel = paths.pageRel(mangaId, chapterId, pageIndex, ext);
+    final abs = paths.absolute(rel);
+    final file = File(abs);
+    await file.parent.create(recursive: true);
+    // Atomic write: stage to a .part file, then rename into place so a crash
+    // mid-write never leaves a truncated page that looks complete.
+    final tmp = File('$abs.part');
+    await tmp.writeAsBytes(bytes, flush: true);
+    await tmp.rename(abs);
+    return (relPath: rel, bytes: bytes.length);
+  }
+
+  @override
+  Future<void> deleteChapter(int mangaId, int chapterId) async {
+    final dir = Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
+    if (await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+  }
+
+  @override
+  Future<int> chapterBytes(int mangaId, int chapterId) async {
+    final dir = Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
+    if (!await dir.exists()) return 0;
+    var total = 0;
+    await for (final e in dir.list()) {
+      if (e is File) total += await e.length();
+    }
+    return total;
+  }
+}

--- a/lib/src/features/offline/data/offline_paths.dart
+++ b/lib/src/features/offline/data/offline_paths.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:path/path.dart' as p;
+
+/// Resolves on-device offline storage paths.
+///
+/// Only **relative** paths are ever persisted (in the drift catalog). The
+/// absolute [baseDir] — `getApplicationSupportDirectory()/offline` — is resolved
+/// fresh at runtime, because iOS rewrites the app container path across installs
+/// and restores, so a persisted absolute path would dangle.
+///
+/// Relative paths always use forward slashes so they're stable across platforms;
+/// [absolute] converts them to a native path under [baseDir].
+class OfflinePaths {
+  const OfflinePaths(this.baseDir);
+
+  /// Absolute base directory for all offline files (app-private, not the OS
+  /// cache dir). Injected so the path logic is testable without path_provider.
+  final String baseDir;
+
+  /// `<mangaId>/<chapterId>` — the directory a chapter's page files live in.
+  String chapterDirRel(int mangaId, int chapterId) => '$mangaId/$chapterId';
+
+  /// `<mangaId>/<chapterId>/<NNN>.<ext>` — a single page file, zero-padded to 3.
+  String pageRel(int mangaId, int chapterId, int pageIndex, String ext) =>
+      '${chapterDirRel(mangaId, chapterId)}/'
+      '${pageIndex.toString().padLeft(3, '0')}.$ext';
+
+  /// `covers/<mangaId>.<ext>` — a manga's cached cover.
+  String coverRel(int mangaId, String ext) => 'covers/$mangaId.$ext';
+
+  /// Resolve a stored (forward-slash) relative path to a native absolute path
+  /// under [baseDir].
+  String absolute(String relPath) =>
+      p.joinAll([baseDir, ...p.posix.split(relPath)]);
+}

--- a/lib/src/features/offline/data/offline_read_fallback.dart
+++ b/lib/src/features/offline/data/offline_read_fallback.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import '../../library/domain/category/category_model.dart';
+import '../../manga_book/domain/chapter/chapter_model.dart';
+import '../../manga_book/domain/manga/manga_model.dart';
+import 'offline_database.dart';
+import 'offline_dto_mappers.dart';
+
+/// Network-first read with on-device catalog fallback. Tries [fetch]; if it
+/// throws and offline is available with catalog data, returns the catalog
+/// mapped to the server DTO type. Otherwise rethrows the original error.
+Future<List<MangaDto>?> libraryWithOfflineFallback({
+  required Future<List<MangaDto>?> Function() fetch,
+  required OfflineDatabase db,
+  required bool offlineEnabled,
+}) async {
+  try {
+    return await fetch();
+  } catch (_) {
+    if (!offlineEnabled) rethrow;
+    final rows = await db.libraryManga();
+    if (rows.isEmpty) rethrow;
+    return [for (final m in rows) offlineMangaToDto(m)];
+  }
+}
+
+Future<MangaDto?> mangaWithOfflineFallback({
+  required Future<MangaDto?> Function() fetch,
+  required OfflineDatabase db,
+  required bool offlineEnabled,
+  required int mangaId,
+}) async {
+  try {
+    return await fetch();
+  } catch (_) {
+    if (!offlineEnabled) rethrow;
+    final m = await db.mangaById(mangaId);
+    if (m == null) rethrow;
+    final count = (await db.chaptersForManga(mangaId)).length;
+    return offlineMangaToDto(m, chapterCount: count);
+  }
+}
+
+/// The reader fetches chapter metadata from the server. A downloaded chapter
+/// must still open offline, so fall back to the on-device catalog row.
+Future<ChapterDto?> chapterMetaWithOfflineFallback({
+  required Future<ChapterDto?> Function() fetch,
+  required OfflineDatabase db,
+  required bool offlineEnabled,
+  required int chapterId,
+}) async {
+  try {
+    return await fetch();
+  } catch (_) {
+    if (!offlineEnabled) rethrow;
+    final c = await db.chapterById(chapterId);
+    if (c == null) rethrow;
+    return offlineChapterToDto(c);
+  }
+}
+
+/// The library screen is gated on the category list (the tabs). Offline that
+/// server fetch fails before any per-category manga list runs, blanking the
+/// whole screen. Fall back to a single synthetic "Default" category so the
+/// library renders the on-device catalog as one flat tab.
+Future<List<CategoryDto>?> categoriesWithOfflineFallback({
+  required Future<List<CategoryDto>?> Function() fetch,
+  required OfflineDatabase db,
+  required bool offlineEnabled,
+}) async {
+  try {
+    return await fetch();
+  } catch (_) {
+    if (!offlineEnabled) rethrow;
+    final count = (await db.libraryManga()).length;
+    if (count == 0) rethrow;
+    return [offlineDefaultCategoryDto(count)];
+  }
+}
+
+Future<List<ChapterDto>?> chaptersWithOfflineFallback({
+  required Future<List<ChapterDto>?> Function() fetch,
+  required OfflineDatabase db,
+  required bool offlineEnabled,
+  required int mangaId,
+}) async {
+  try {
+    return await fetch();
+  } catch (_) {
+    if (!offlineEnabled) rethrow;
+    final rows = await db.chaptersForManga(mangaId);
+    if (rows.isEmpty) rethrow;
+    return [for (final c in rows) offlineChapterToDto(c)];
+  }
+}

--- a/lib/src/features/offline/data/offline_reconciler.dart
+++ b/lib/src/features/offline/data/offline_reconciler.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'offline_database.dart';
+import 'reconcile_logic.dart';
+import 'reconcile_types.dart';
+
+/// Rough per-page byte estimate used to bound cap-gated downloads before any
+/// real download sizes are known (cold start). Refined to real averages once
+/// chapters are on device.
+const _estimatedBytesPerPage = 256 * 1024;
+
+/// Orchestrates a single reconcile pass for one manga: reads the offline
+/// catalog, computes which chapters to download vs evict, invokes the injected
+/// callbacks, and returns the [ReconcilePlan].
+///
+/// Callbacks are injected so the reconciler is fully testable without a real
+/// download manager or filesystem.
+class OfflineReconciler {
+  OfflineReconciler({
+    required this.db,
+    required this.nets,
+    required this.onDownload,
+    required this.onEvict,
+    required this.now,
+  });
+
+  final OfflineDatabase db;
+  final SafetyNetConfig nets;
+  final Future<void> Function(int chapterId) onDownload;
+  final Future<void> Function(int chapterId) onEvict;
+  final DateTime now;
+
+  Future<ReconcilePlan> reconcileManga(int mangaId) async {
+    final manga = await (db.select(db.offlineMangas)
+          ..where((t) => t.id.equals(mangaId)))
+        .getSingleOrNull();
+    if (manga == null) return ReconcilePlan.empty;
+
+    final chapters = await db.chaptersForManga(mangaId);
+
+    // RC6: collect orphaned chapters (server-gone) — they must always be evicted.
+    final orphanedIds = {
+      for (final c in chapters)
+        if (c.deviceState == OfflineDeviceState.orphaned) c.id,
+    };
+
+    // Only chapters in `downloaded` state are considered by applySafetyNets.
+    final downloaded = chapters
+        .where((c) => c.deviceState == OfflineDeviceState.downloaded)
+        .toList();
+
+    final desired =
+        desiredChapterIds(chapters, manga.keepRule, manga.keepUnreadCount);
+
+    final ev = applySafetyNets(
+      downloaded: downloaded,
+      desired: desired,
+      nets: nets,
+      now: now,
+    );
+
+    // Merge orphaned ids into the evict set.
+    final toEvict = {...ev.evict, ...orphanedIds};
+
+    // Build the toDownload set.
+    // RC5: when the storage cap is active, do not emit downloads that would
+    // push retained bytes over the cap — this ensures reconcile converges (a
+    // fixed point) rather than triggering an evict→re-pull loop across passes.
+    final byId = {for (final c in chapters) c.id: c};
+
+    // Retained bytes after evictions (downloaded chapters not in toEvict).
+    final retainedBytes = downloaded
+        .where((c) => !toEvict.contains(c.id))
+        .fold<int>(0, (sum, c) => sum + c.bytes);
+
+    // Average byte size of currently-downloaded chapters — used to estimate
+    // each new download's footprint so we can stop before exceeding the cap.
+    final avgBytes = downloaded.isEmpty
+        ? 0
+        : downloaded.fold<int>(0, (s, c) => s + c.bytes) ~/ downloaded.length;
+
+    var projectedBytes = retainedBytes;
+    final toDownload = <int>{};
+
+    for (final id in desired) {
+      final c = byId[id];
+      if (c == null) continue;
+      // Unsatisfiable (design N3): server hasn't downloaded it yet — skip.
+      if (!c.serverIsDownloaded) continue;
+      // Already on device — nothing to do.
+      if (c.deviceState == OfflineDeviceState.downloaded) continue;
+
+      if (nets.storageCapEnabled) {
+        // RC5 convergence guard: stop adding if there is no room.
+        // If the cap is already met/exceeded by retained bytes, emit nothing.
+        if (projectedBytes >= nets.storageCapBytes) break;
+        // Cold-start fallback: when avgBytes is 0 (no chapters downloaded yet),
+        // use a pageCount-derived estimate so the guard still bounds first-pass
+        // downloads and avoids the evict↔re-pull oscillation the cap exists to
+        // prevent.
+        final estimate = avgBytes > 0
+            ? avgBytes
+            : c.pageCount * _estimatedBytesPerPage;
+        if (estimate > 0 && projectedBytes + estimate > nets.storageCapBytes) {
+          break;
+        }
+        projectedBytes += estimate;
+      }
+
+      toDownload.add(id);
+    }
+
+    for (final id in toEvict) {
+      await onEvict(id);
+    }
+    for (final id in toDownload) {
+      await onDownload(id);
+    }
+
+    return ReconcilePlan(
+      toDownload: toDownload,
+      toEvict: toEvict,
+      overCapWarning: ev.overCapWarning,
+    );
+  }
+}

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:drift/drift.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'offline_database.dart';
+import 'offline_page_store.dart';
+import 'offline_paths.dart';
+import 'offline_sync.dart';
+
+part 'offline_repository.g.dart';
+
+/// Single entry point the rest of the app uses for offline state. Keeps the
+/// drift database and path resolution behind one interface so callers never
+/// depend on drift directly.
+class OfflineRepository {
+  const OfflineRepository({required this.db, required this.paths});
+
+  final OfflineDatabase db;
+  final OfflinePaths paths;
+
+  /// Absolute on-disk path for a stored page, or null if not downloaded.
+  Future<String?> localPagePath(int chapterId, int pageIndex) async {
+    final rows = await (db.select(db.offlinePages)
+          ..where((t) =>
+              t.chapterId.equals(chapterId) & t.pageIndex.equals(pageIndex)))
+        .get();
+    if (rows.isEmpty) return null;
+    return paths.absolute(rows.single.relativePath);
+  }
+
+  /// Ordered absolute page paths for a chapter that is downloaded on-device, or
+  /// null when the chapter isn't fully downloaded — so the reader can serve it
+  /// from disk (offline) instead of the server.
+  Future<List<String>?> localChapterPages(int chapterId) async {
+    final ch = await (db.select(db.offlineChapters)
+          ..where((t) => t.id.equals(chapterId)))
+        .getSingleOrNull();
+    if (ch == null || ch.deviceState != OfflineDeviceState.downloaded) {
+      return null;
+    }
+    final rows = await (db.select(db.offlinePages)
+          ..where((t) => t.chapterId.equals(chapterId))
+          ..orderBy([(t) => OrderingTerm(expression: t.pageIndex)]))
+        .get();
+    if (rows.isEmpty) return null;
+    return [for (final r in rows) paths.absolute(r.relativePath)];
+  }
+
+  /// The catalog row for a manga — used when the server is unreachable so the
+  /// library screen can fall back to on-device data.
+  Future<OfflineManga?> mangaById(int mangaId) => db.mangaById(mangaId);
+
+  /// The catalog row for a chapter (needed to enqueue a device download), or
+  /// null if it hasn't been synced from an online read yet.
+  Future<OfflineChapter?> chapterById(int chapterId) =>
+      (db.select(db.offlineChapters)..where((t) => t.id.equals(chapterId)))
+          .getSingleOrNull();
+
+  /// How many of [chapterIds] currently have a device copy — for the bulk
+  /// delete confirm.
+  Future<int> deviceDownloadedCount(List<int> chapterIds) async {
+    if (chapterIds.isEmpty) return 0;
+    final rows = await (db.select(db.offlineChapters)
+          ..where((t) =>
+              t.id.isIn(chapterIds) &
+              t.deviceState.equalsValue(OfflineDeviceState.downloaded)))
+        .get();
+    return rows.length;
+  }
+
+  /// Live device-download state for a chapter, so the UI reflects progress.
+  Stream<OfflineDeviceState> watchChapterState(int chapterId) =>
+      (db.select(db.offlineChapters)..where((t) => t.id.equals(chapterId)))
+          .watchSingleOrNull()
+          .map((c) => c?.deviceState ?? OfflineDeviceState.none)
+          // drift re-fires every per-chapter stream on ANY chapters-table write;
+          // distinct() stops a row from rebuilding unless ITS state changed
+          // (avoids a 98-row rebuild storm while a series downloads).
+          .distinct();
+
+  /// Live count of pages already on disk for a chapter — drives the per-chapter
+  /// download progress arc (like Mihon/Komikku). distinct() so a row only
+  /// rebuilds when its page count actually advances.
+  Stream<int> watchChapterDownloadedPages(int chapterId) {
+    final cnt = db.offlinePages.pageIndex.count();
+    return (db.selectOnly(db.offlinePages)
+          ..addColumns([cnt])
+          ..where(db.offlinePages.chapterId.equals(chapterId)))
+        .watchSingle()
+        .map((r) => r.read(cnt) ?? 0)
+        .distinct();
+  }
+
+  /// The per-series keep-offline rule (defaults to off if the manga isn't
+  /// synced yet).
+  Future<OfflineKeepRule> keepRuleFor(int mangaId) async {
+    final m = await (db.select(db.offlineMangas)..where((t) => t.id.equals(mangaId)))
+        .getSingleOrNull();
+    return m?.keepRule ?? OfflineKeepRule.off;
+  }
+
+  /// Manga ids with at least one chapter downloaded to this device — for the
+  /// "On device" library filter.
+  Future<Set<int>> deviceDownloadedMangaIds() => db.mangaIdsWithDeviceDownloads();
+
+  /// Total bytes used by all downloaded chapters — for the storage settings UI.
+  Future<int> totalDownloadedBytes() => db.totalDownloadedBytes();
+}
+
+// These are overridden at app startup (like hiveStoreProvider) with the
+// runtime database + base dir resolved via path_provider on native platforms.
+// They are NOT read on web (offline is disabled there), so the throwing default
+// is never hit in that configuration.
+@riverpod
+OfflineDatabase offlineDatabase(Ref ref) => throw UnimplementedError(
+    'offlineDatabaseProvider must be overridden at startup');
+
+@riverpod
+OfflinePaths offlinePaths(Ref ref) => throw UnimplementedError(
+    'offlinePathsProvider must be overridden at startup');
+
+@riverpod
+OfflinePageStore offlinePageStore(Ref ref) => throw UnimplementedError(
+    'offlinePageStoreProvider must be overridden at startup');
+
+@riverpod
+OfflineRepository offlineRepository(Ref ref) => OfflineRepository(
+      db: ref.watch(offlineDatabaseProvider),
+      paths: ref.watch(offlinePathsProvider),
+    );
+
+/// Whether on-device offline storage is available. Defaults to false and is
+/// overridden to true at startup when the catalog opened (native platforms).
+/// Lets callers no-op cleanly on web / when init failed.
+@riverpod
+bool offlineEnabled(Ref ref) => false;
+
+/// The metadata down-sync, or null when offline storage is unavailable — so
+/// online controllers can call `ref.read(offlineSyncProvider)?.syncManga(m)`
+/// without caring about platform.
+@riverpod
+OfflineSync? offlineSync(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return null;
+  return OfflineSync(ref.watch(offlineDatabaseProvider));
+}

--- a/lib/src/features/offline/data/offline_settings_providers.dart
+++ b/lib/src/features/offline/data/offline_settings_providers.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'offline_settings_providers.g.dart';
+
+@riverpod
+class OfflineTimeEvictEnabled extends _$OfflineTimeEvictEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.offlineTimeEvictEnabled);
+}
+
+@riverpod
+class OfflineKeepDays extends _$OfflineKeepDays
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.offlineKeepDays);
+}
+
+@riverpod
+class OfflineStorageCapEnabled extends _$OfflineStorageCapEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.offlineStorageCapEnabled);
+}
+
+@riverpod
+class OfflineStorageCapMb extends _$OfflineStorageCapMb
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.offlineStorageCapMb);
+}
+
+/// Pages downloaded at once across all chapters. Kept low by default so a
+/// self-hosted server isn't saturated (it starts returning 500/503 under
+/// heavy parallelism). User-adjustable; applied live to the download queue.
+@riverpod
+class OfflineDownloadConcurrency extends _$OfflineDownloadConcurrency
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.offlineDownloadConcurrency);
+}

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import '../../manga_book/domain/chapter/chapter_model.dart';
+import '../../manga_book/domain/manga/manga_model.dart';
+import 'offline_database.dart';
+
+/// Mirrors server metadata into the offline catalog during normal online use.
+///
+/// Maps GraphQL DTOs onto the catalog's metadata upserts, which deliberately
+/// preserve device-managed columns (deviceState, bytes, thumbnailRelPath) — so
+/// a re-sync never clobbers what the user has downloaded. Called online only;
+/// a no-op offline (the caller guards via [offlineSyncProvider] being null).
+class OfflineSync {
+  const OfflineSync(this._db);
+
+  final OfflineDatabase _db;
+
+  Future<void> syncManga(MangaDto manga) => _db.upsertMangaMetadata(
+        id: manga.id,
+        title: manga.title,
+        thumbnailUrl: manga.thumbnailUrl,
+        updatedAt: DateTime.now(),
+      );
+
+  Future<void> syncChapters(List<ChapterDto> chapters) async {
+    final now = DateTime.now();
+    // Preserve read progress that was updated locally but not yet pushed to the
+    // server — otherwise a down-sync would overwrite it with the stale server
+    // value (the up-sync pushes it; this just stops it being lost in the gap).
+    final dirty = {
+      for (final c in await _db.dirtyProgressChapters()) c.id: c,
+    };
+    for (final c in chapters) {
+      final local = dirty[c.id];
+      await _db.upsertChapterMetadata(
+        id: c.id,
+        mangaId: c.mangaId,
+        name: c.name,
+        chapterIndex: c.sourceOrder,
+        isRead: local?.isRead ?? c.isRead,
+        lastPageRead: local?.lastPageRead ?? c.lastPageRead,
+        isBookmarked: c.isBookmarked,
+        serverIsDownloaded: c.isDownloaded,
+        pageCount: c.pageCount,
+        updatedAt: now,
+      );
+    }
+  }
+}

--- a/lib/src/features/offline/data/reconcile_logic.dart
+++ b/lib/src/features/offline/data/reconcile_logic.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'offline_database.dart';
+import 'reconcile_types.dart';
+
+/// Chapter ids that should be on-device for one manga, given its keep-rule.
+/// Always includes pinned chapters (manual saves are sticky, rule-independent).
+Set<int> desiredChapterIds(
+  List<OfflineChapter> chapters,
+  OfflineKeepRule rule,
+  int keepUnreadCount,
+) {
+  final pinned = {for (final c in chapters) if (c.pinned) c.id};
+  final ruleSet = switch (rule) {
+    OfflineKeepRule.off => <int>{},
+    OfflineKeepRule.all => {for (final c in chapters) c.id},
+    OfflineKeepRule.allUnread => {for (final c in chapters) if (!c.isRead) c.id},
+    OfflineKeepRule.nUnread => (chapters.where((c) => !c.isRead).toList()
+          ..sort((a, b) => a.chapterIndex.compareTo(b.chapterIndex)))
+        .take(keepUnreadCount)
+        .map((c) => c.id)
+        .toSet(),
+  };
+  return ruleSet..addAll(pinned);
+}
+
+/// Decide evictions over the currently-downloaded set, honoring precedence:
+/// pinned > safety-nets > rule. Pinned chapters are never evicted.
+({Set<int> evict, bool overCapWarning}) applySafetyNets({
+  required List<OfflineChapter> downloaded,
+  required Set<int> desired,
+  required SafetyNetConfig nets,
+  required DateTime now,
+}) {
+  final evict = <int>{};
+
+  // 1) Not wanted by any rule and not pinned.
+  for (final c in downloaded) {
+    if (!c.pinned && !desired.contains(c.id)) evict.add(c.id);
+  }
+
+  // 2) Time-net: non-pinned older than keepDays.
+  if (nets.timeEvictEnabled) {
+    for (final c in downloaded) {
+      final dt = c.downloadedAt;
+      if (!c.pinned && dt != null && now.difference(dt).inDays > nets.keepDays) {
+        evict.add(c.id);
+      }
+    }
+  }
+
+  // 3) Storage cap: evict oldest non-pinned until under cap.
+  var overCapWarning = false;
+  if (nets.storageCapEnabled) {
+    int total() => downloaded
+        .where((c) => !evict.contains(c.id))
+        .fold(0, (s, c) => s + c.bytes);
+    final candidates = downloaded
+        .where((c) => !c.pinned && !evict.contains(c.id))
+        .toList()
+      ..sort((a, b) => (a.downloadedAt ?? DateTime(0))
+          .compareTo(b.downloadedAt ?? DateTime(0)));
+    var i = 0;
+    while (total() > nets.storageCapBytes && i < candidates.length) {
+      evict.add(candidates[i++].id);
+    }
+    if (total() > nets.storageCapBytes) overCapWarning = true; // only pinned left
+  }
+
+  return (evict: evict, overCapWarning: overCapWarning);
+}

--- a/lib/src/features/offline/data/reconcile_types.dart
+++ b/lib/src/features/offline/data/reconcile_types.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Device-wide opt-in safety nets. Timestamp basis is downloadedAt (kept-N-days).
+class SafetyNetConfig {
+  const SafetyNetConfig({
+    required this.timeEvictEnabled,
+    required this.keepDays,
+    required this.storageCapEnabled,
+    required this.storageCapBytes,
+  });
+
+  final bool timeEvictEnabled;
+  final int keepDays;
+  final bool storageCapEnabled;
+  final int storageCapBytes;
+
+  static const off = SafetyNetConfig(
+    timeEvictEnabled: false,
+    keepDays: 30,
+    storageCapEnabled: false,
+    storageCapBytes: 0,
+  );
+}
+
+/// The outcome of a reconcile pass: chapters to fetch, chapters to evict, and
+/// whether the storage cap can't be met without removing pinned chapters.
+class ReconcilePlan {
+  const ReconcilePlan({
+    required this.toDownload,
+    required this.toEvict,
+    required this.overCapWarning,
+  });
+
+  final Set<int> toDownload;
+  final Set<int> toEvict;
+  final bool overCapWarning;
+
+  static const empty =
+      ReconcilePlan(toDownload: {}, toEvict: {}, overCapWarning: false);
+}

--- a/lib/src/features/offline/presentation/offline_files_view.dart
+++ b/lib/src/features/offline/presentation/offline_files_view.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../routes/router_config.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../widgets/emoticons.dart';
+import '../../../widgets/server_image.dart';
+import '../data/offline_download_providers.dart';
+import '../data/offline_repository.dart';
+import 'offline_settings_format.dart';
+
+/// The "On device" segment of the Downloads tab: every series with chapters
+/// saved on this device, with per-series chapter count + size, plus total
+/// usage. Live — updates as background downloads complete or are removed.
+class OfflineFilesView extends ConsumerWidget {
+  const OfflineFilesView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(offlineEnabledProvider)) {
+      return Center(child: Text(context.l10n.offlineNotAvailable));
+    }
+    final series =
+        ref.watch(offlineDownloadedSeriesProvider).valueOrNull ?? const [];
+    final totalBytes = ref.watch(offlineUsageBytesProvider).valueOrNull ?? 0;
+    if (series.isEmpty) {
+      return Emoticons(title: context.l10n.offlineNoFiles);
+    }
+    return ListView.builder(
+      itemCount: series.length + 1,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return ListTile(
+            dense: true,
+            leading: const Icon(Icons.sd_storage_outlined),
+            title: Text(context.l10n.offlineStorageUsage),
+            trailing: Text(formatBytes(totalBytes)),
+          );
+        }
+        final s = series[index - 1];
+        final downloading = s.inFlight > 0;
+        return ListTile(
+          leading: SizedBox(
+            width: 40,
+            height: 56,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: ServerImage(
+                imageUrl: s.manga.thumbnailUrl ?? '',
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          title: Text(s.manga.title,
+              maxLines: 1, overflow: TextOverflow.ellipsis),
+          subtitle: Text(downloading
+              ? '${context.l10n.offlineDownloadingCount(s.inFlight)} · ${context.l10n.nChapters(s.count)}'
+              : '${context.l10n.nChapters(s.count)} · ${formatBytes(s.bytes)}'),
+          trailing: downloading
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2))
+              : null,
+          onTap: () => MangaRoute(mangaId: s.manga.id).push(context),
+        );
+      },
+    );
+  }
+}

--- a/lib/src/features/offline/presentation/offline_save_button.dart
+++ b/lib/src/features/offline/presentation/offline_save_button.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../data/offline_database.dart';
+import '../data/offline_download_providers.dart';
+import '../data/offline_repository.dart';
+
+/// Save / on-device indicator for a chapter. Hidden on web / when offline is
+/// unavailable, and gated on the chapter being downloaded server-side (the
+/// product policy: we mirror the server's copy, we don't re-download sources).
+class OfflineSaveButton extends ConsumerWidget {
+  const OfflineSaveButton({
+    super.key,
+    required this.chapterId,
+    required this.serverIsDownloaded,
+  });
+
+  final int chapterId;
+  final bool serverIsDownloaded;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(offlineEnabledProvider) || !serverIsDownloaded) {
+      return const SizedBox.shrink();
+    }
+    final state = ref
+        .watch(offlineChapterStateProvider(chapterId))
+        .valueOrNull ??
+        OfflineDeviceState.none;
+    final cs = Theme.of(context).colorScheme;
+
+    return switch (state) {
+      OfflineDeviceState.queued || OfflineDeviceState.downloading =>
+        _DownloadingIndicator(chapterId: chapterId),
+      OfflineDeviceState.downloaded => IconButton(
+          tooltip: 'Remove from device',
+          icon: Icon(Icons.offline_pin_rounded, color: cs.primary),
+          onPressed: () => deleteChapterFromDevice(ref, chapterId),
+        ),
+      OfflineDeviceState.error => IconButton(
+          tooltip: 'Save failed — retry',
+          icon: Icon(Icons.error_outline_rounded, color: cs.error),
+          onPressed: () => _save(context, ref),
+        ),
+      OfflineDeviceState.none || OfflineDeviceState.orphaned => IconButton(
+          tooltip: 'Save to device',
+          icon: const Icon(Icons.save_alt_rounded),
+          onPressed: () => _save(context, ref),
+        ),
+    };
+  }
+
+  Future<void> _save(BuildContext context, WidgetRef ref) async {
+    try {
+      await saveChapterToDevice(ref, chapterId);
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Save failed: $e')),
+        );
+      }
+    }
+  }
+}
+
+/// Determinate download arc for a chapter, showing how many of its pages are
+/// on disk (Mihon/Komikku show the same). Falls back to an indeterminate
+/// spinner until the page total is known.
+class _DownloadingIndicator extends ConsumerWidget {
+  const _DownloadingIndicator({required this.chapterId});
+
+  final int chapterId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final progress =
+        ref.watch(offlineChapterProgressProvider(chapterId)).valueOrNull;
+    // Like Komikku: spin (indeterminate) while queued or at 0% so the icon is
+    // never invisible; switch to a determinate fill only once pages land.
+    final value = (progress == null || progress <= 0.0) ? null : progress;
+    return SizedBox(
+      width: 40,
+      height: 40,
+      child: Center(
+        child: SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2, value: value),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/offline/presentation/offline_settings_format.dart
+++ b/lib/src/features/offline/presentation/offline_settings_format.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Formats a byte count as a human-readable string (e.g. "1.5 GB").
+String formatBytes(int bytes) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  if (bytes <= 0) return '0 B';
+  var b = bytes.toDouble();
+  var i = 0;
+  while (b >= 1024 && i < units.length - 1) {
+    b /= 1024;
+    i++;
+  }
+  return i == 0 ? '${b.toInt()} B' : '${b.toStringAsFixed(1)} ${units[i]}';
+}

--- a/lib/src/features/offline/presentation/offline_settings_screen.dart
+++ b/lib/src/features/offline/presentation/offline_settings_screen.dart
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../widgets/input_popup/domain/settings_prop_type.dart';
+import '../../../widgets/input_popup/settings_prop_tile.dart';
+import '../../../widgets/section_title.dart';
+import '../data/offline_download_providers.dart';
+import '../data/offline_repository.dart';
+import '../data/offline_settings_providers.dart';
+import 'offline_settings_format.dart';
+
+class OfflineSettingsScreen extends ConsumerWidget {
+  const OfflineSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTileTheme(
+      data: const ListTileThemeData(
+        subtitleTextStyle: TextStyle(color: Colors.grey),
+      ),
+      child: Scaffold(
+        appBar: AppBar(title: Text(context.l10n.offline)),
+        body: ref.watch(offlineEnabledProvider)
+            ? ListView(
+                children: [
+                  SectionTitle(title: context.l10n.offlineStorageSection),
+                  ListTile(
+                    title: Text(context.l10n.offlineStorageUsage),
+                    subtitle: Text(
+                      formatBytes(
+                          ref.watch(offlineUsageBytesProvider).valueOrNull ??
+                              0),
+                    ),
+                  ),
+                  ListTile(
+                    title: Text(context.l10n.offlineRemoveAllDownloads),
+                    onTap: () async {
+                      final confirmed = await showDialog<bool>(
+                        context: context,
+                        builder: (ctx) => AlertDialog(
+                          content:
+                              Text(context.l10n.offlineRemoveAllConfirm),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, false),
+                              child: Text(context.l10n.cancel),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(ctx, true),
+                              child: Text(context.l10n.delete),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (confirmed != true) return;
+                      if (!context.mounted) return;
+                      final db = ref.read(offlineDatabaseProvider);
+                      try {
+                        for (final m in await db.libraryManga()) {
+                          for (final ch
+                              in await db.downloadedChaptersForManga(m.id)) {
+                            try {
+                              await deleteChapterFromDevice(ref, ch.id);
+                            } catch (_) {}
+                          }
+                        }
+                      } finally {
+                        ref.invalidate(offlineUsageBytesProvider);
+                      }
+                    },
+                  ),
+                  SectionTitle(title: context.l10n.offlineDownloadsSection),
+                  SettingsPropTile(
+                    title: context.l10n.offlineConcurrencyLabel,
+                    subtitle: context.l10n.offlineConcurrencyValue(
+                        ref.watch(offlineDownloadConcurrencyProvider) ?? 2),
+                    type: SettingsPropType.numberSlider(
+                      min: 1,
+                      max: 8,
+                      value:
+                          ref.watch(offlineDownloadConcurrencyProvider) ?? 2,
+                      onChanged: (v) async {
+                        ref
+                            .read(offlineDownloadConcurrencyProvider.notifier)
+                            .update(v);
+                        return null;
+                      },
+                    ),
+                  ),
+                  SectionTitle(title: context.l10n.offlineSafetyNets),
+                  SettingsPropTile(
+                    title: context.l10n.offlineStorageCapEnable,
+                    type: SettingsPropType.switchTile(
+                      value:
+                          ref.watch(offlineStorageCapEnabledProvider) ?? false,
+                      onChanged: (v) async {
+                        ref
+                            .read(offlineStorageCapEnabledProvider.notifier)
+                            .update(v);
+                        return null;
+                      },
+                    ),
+                  ),
+                  SettingsPropTile(
+                    title: context.l10n.offlineStorageCapLimit,
+                    subtitle: context.l10n.offlineMegabytes(
+                        ref.watch(offlineStorageCapMbProvider) ?? 2000),
+                    type: SettingsPropType.numberSlider(
+                      min: 100,
+                      max: 50000,
+                      value: ref.watch(offlineStorageCapMbProvider) ?? 2000,
+                      onChanged: (v) async {
+                        ref
+                            .read(offlineStorageCapMbProvider.notifier)
+                            .update(v);
+                        return null;
+                      },
+                    ),
+                  ),
+                  SettingsPropTile(
+                    title: context.l10n.offlineTimeEvictEnable,
+                    type: SettingsPropType.switchTile(
+                      value:
+                          ref.watch(offlineTimeEvictEnabledProvider) ?? false,
+                      onChanged: (v) async {
+                        ref
+                            .read(offlineTimeEvictEnabledProvider.notifier)
+                            .update(v);
+                        return null;
+                      },
+                    ),
+                  ),
+                  SettingsPropTile(
+                    title: context.l10n.offlineKeepDaysLabel,
+                    subtitle: context.l10n.offlineDays(
+                        ref.watch(offlineKeepDaysProvider) ?? 30),
+                    type: SettingsPropType.numberSlider(
+                      min: 1,
+                      max: 365,
+                      value: ref.watch(offlineKeepDaysProvider) ?? 30,
+                      onChanged: (v) async {
+                        ref
+                            .read(offlineKeepDaysProvider.notifier)
+                            .update(v);
+                        return null;
+                      },
+                    ),
+                  ),
+                ],
+              )
+            : Center(child: Text(context.l10n.offlineNotAvailable)),
+      ),
+    );
+  }
+}

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/theme/brand.dart';
+import '../data/offline_database.dart';
+import '../data/offline_download_providers.dart';
+import '../data/offline_repository.dart';
+
+/// The prominent per-series offline control that lives in the manga-details
+/// action row (beside "In Library"). Shows whether the series is on the device
+/// and opens an action sheet to download / auto-keep / remove it. Replaces the
+/// old buried app-bar pin.
+class SeriesOfflineButton extends ConsumerWidget {
+  const SeriesOfflineButton({super.key, required this.mangaId});
+
+  final int mangaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(offlineEnabledProvider)) return const SizedBox.shrink();
+    final progress =
+        ref.watch(mangaOfflineProgressProvider(mangaId)).valueOrNull;
+    final downloaded = progress?.downloaded ?? 0;
+    final inFlight = progress?.inFlight ?? 0;
+    final onDevice = downloaded > 0;
+    final downloading = inFlight > 0;
+    return BrandGlassButton(
+      icon: downloading
+          ? const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(strokeWidth: 2))
+          : Icon(onDevice
+              ? Icons.offline_pin_rounded
+              : Icons.download_rounded),
+      label: Text(downloading
+          ? context.l10n.offlineDownloadingCount(inFlight)
+          : onDevice
+              ? context.l10n.offlineOnDevice
+              : context.l10n.offlineDownloadAction),
+      onPressed: () => _openSheet(context, ref, onDevice),
+    );
+  }
+
+  void _openSheet(BuildContext context, WidgetRef ref, bool onDevice) {
+    final rule = ref.read(mangaKeepRuleProvider(mangaId)).valueOrNull ??
+        OfflineKeepRule.off;
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.download_rounded),
+              title: Text(sheetContext.l10n.offlineDownloadAll),
+              trailing: rule == OfflineKeepRule.all
+                  ? const Icon(Icons.check_rounded)
+                  : null,
+              onTap: () => _apply(sheetContext, ref, OfflineKeepRule.all),
+            ),
+            ListTile(
+              leading: const Icon(Icons.bookmark_added_outlined),
+              title: Text(sheetContext.l10n.keepOfflineNUnread),
+              trailing: rule == OfflineKeepRule.nUnread
+                  ? const Icon(Icons.check_rounded)
+                  : null,
+              onTap: () => _apply(sheetContext, ref, OfflineKeepRule.nUnread),
+            ),
+            ListTile(
+              leading: const Icon(Icons.menu_book_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAllUnread),
+              trailing: rule == OfflineKeepRule.allUnread
+                  ? const Icon(Icons.check_rounded)
+                  : null,
+              onTap: () => _apply(sheetContext, ref, OfflineKeepRule.allUnread),
+            ),
+            if (onDevice) ...[
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.delete_outline_rounded),
+                title: Text(sheetContext.l10n.offlineRemoveSeries),
+                onTap: () => _removeAll(sheetContext, ref),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _apply(
+      BuildContext sheetContext, WidgetRef ref, OfflineKeepRule rule) async {
+    final messenger = ScaffoldMessenger.of(sheetContext);
+    final toast = sheetContext.l10n.offlineDownloadingToast;
+    Navigator.of(sheetContext).pop();
+    await ref.read(offlineDatabaseProvider).setKeepRule(mangaId, rule, 3);
+    ref.invalidate(mangaKeepRuleProvider(mangaId));
+    messenger.showSnackBar(SnackBar(content: Text(toast)));
+    // The reconcile may pull many chapters; run it in the background and refresh
+    // the on-device count as it completes.
+    unawaited(reconcileMangaWidget(ref, mangaId)
+        .then((_) => ref.invalidate(mangaDownloadedCountProvider(mangaId))));
+  }
+
+  Future<void> _removeAll(BuildContext sheetContext, WidgetRef ref) async {
+    Navigator.of(sheetContext).pop();
+    final db = ref.read(offlineDatabaseProvider);
+    await db.setKeepRule(mangaId, OfflineKeepRule.off, 3);
+    for (final c in await db.downloadedChaptersForManga(mangaId)) {
+      await deleteChapterFromDevice(ref, c.id);
+    }
+    ref.invalidate(mangaKeepRuleProvider(mangaId));
+    ref.invalidate(mangaDownloadedCountProvider(mangaId));
+  }
+}

--- a/lib/src/features/settings/presentation/general/general_screen.dart
+++ b/lib/src/features/settings/presentation/general/general_screen.dart
@@ -14,6 +14,7 @@ import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../widgets/popup_widgets/radio_list_popup.dart';
 import 'quick_search_toggle/quick_search_toggle_tile.dart';
 import 'timeout_settings/timeout_settings_section.dart';
+import 'widgets/force_portrait_tile.dart';
 
 class GeneralScreen extends ConsumerWidget {
   const GeneralScreen({super.key});
@@ -57,6 +58,7 @@ class GeneralScreen extends ConsumerWidget {
           //   },
           // ),
           const QuickSearchToggleTile(),
+          const ForcePortraitTile(),
           const TimeoutSettingsSection(),
         ],
       ),

--- a/lib/src/features/settings/presentation/general/widgets/force_portrait_tile.dart
+++ b/lib/src/features/settings/presentation/general/widgets/force_portrait_tile.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../constants/db_keys.dart';
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'force_portrait_tile.g.dart';
+
+@riverpod
+class ForcePortrait extends _$ForcePortrait with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.forcePortrait);
+}
+
+/// Apply the portrait-lock preference to the system. Only phones honour it
+/// (landscape on a phone currently renders poorly); tablets, desktop and web
+/// always keep every orientation regardless of the setting.
+void applyForcePortrait(bool forcePortrait) {
+  final views = WidgetsBinding.instance.platformDispatcher.views;
+  final shortestSide = views.isEmpty
+      ? 0.0
+      : (views.first.physicalSize / views.first.devicePixelRatio).shortestSide;
+  final isPhone = !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS) &&
+      shortestSide > 0 &&
+      shortestSide < 600;
+  SystemChrome.setPreferredOrientations(
+    forcePortrait && isPhone
+        ? const [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]
+        : DeviceOrientation.values,
+  );
+}
+
+class ForcePortraitTile extends ConsumerWidget {
+  const ForcePortraitTile({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.screen_lock_portrait_rounded),
+      title: const Text('Lock to portrait'),
+      subtitle: const Text('Stop the app rotating to landscape on phones'),
+      onChanged: (value) {
+        ref.read(forcePortraitProvider.notifier).update(value);
+        applyForcePortrait(value);
+      },
+      value: ref.watch(forcePortraitProvider).ifNull(),
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/settings/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings/settings_screen.dart
@@ -41,6 +41,11 @@ class SettingsScreen extends StatelessWidget {
             onTap: () => const DownloadsSettingsRoute().go(context),
           ),
           ListTile(
+            title: Text(context.l10n.offline),
+            leading: const Icon(Icons.offline_pin_rounded),
+            onTap: () => const OfflineSettingsRoute().go(context),
+          ),
+          ListTile(
             title: Text(context.l10n.reader),
             leading: const Icon(Icons.chrome_reader_mode_rounded),
             onTap: () => const ReaderSettingsRoute().go(context),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1282,6 +1282,14 @@
     "nsfwInfo": "This does not prevent unofficial or potentially incorrectly flagged extensions from surfacing NSFW(18+) content within app",
     "numSelected": "{num} Selected",
     "obsolete": "Obsolete",
+    "onDevice": "On device",
+    "offlineBulkDeleteWarning": "{count} of these are saved on this device and will be removed here too.",
+    "@offlineBulkDeleteWarning": {
+        "description": "Bulk server-delete confirm: warns N selected chapters are also on this device",
+        "placeholders": {
+            "count": { "type": "int" }
+        }
+    },
     "openFlareSolverr": "Checkout FlareSolverr for information on how to set it up",
     "openInWeb": "Open In Web",
     "or": "or",
@@ -1511,5 +1519,139 @@
     "autoRefreshOnTimeoutDescription": "Automatically retries requests that timeout",
     "autoRefreshRetryDelay": "Auto-refresh Retry Delay",
     "@autoRefreshRetryDelay": {"description": "Delay between auto retry attempts in seconds"},
-    "autoRefreshRetryDelayDescription": "Delay between auto retry attempts (in seconds)"
+    "autoRefreshRetryDelayDescription": "Delay between auto retry attempts (in seconds)",
+    "offline": "Offline",
+    "@offline": {
+        "description": "Settings entry and screen title for offline downloads"
+    },
+    "offlineStorageSection": "Storage",
+    "@offlineStorageSection": {
+        "description": "Section header in Offline Settings"
+    },
+    "offlineStorageUsage": "Storage used",
+    "@offlineStorageUsage": {
+        "description": "Label for current offline storage usage tile"
+    },
+    "offlineRemoveAllDownloads": "Remove all downloads",
+    "@offlineRemoveAllDownloads": {
+        "description": "Label for the remove-all tile in Offline Settings"
+    },
+    "offlineRemoveAllConfirm": "Remove all downloaded chapters from this device? Your server library is untouched.",
+    "@offlineRemoveAllConfirm": {
+        "description": "Body text for remove-all confirmation dialog"
+    },
+    "offlineSafetyNets": "Safety nets",
+    "@offlineSafetyNets": {
+        "description": "Section header for safety net settings"
+    },
+    "offlineDownloadsSection": "Downloads",
+    "@offlineDownloadsSection": {
+        "description": "Section header for offline download behaviour settings"
+    },
+    "offlineConcurrencyLabel": "Simultaneous downloads",
+    "@offlineConcurrencyLabel": {
+        "description": "Label for the download concurrency slider"
+    },
+    "offlineConcurrencyValue": "{count} at a time",
+    "@offlineConcurrencyValue": {
+        "description": "Value subtitle for the download concurrency slider",
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "offlineStorageCapEnable": "Limit offline storage",
+    "@offlineStorageCapEnable": {
+        "description": "Toggle to enable the storage cap safety net"
+    },
+    "offlineStorageCapLimit": "Storage limit",
+    "@offlineStorageCapLimit": {
+        "description": "Label for the storage cap MB slider"
+    },
+    "offlineMegabytes": "{count} MB",
+    "@offlineMegabytes": {
+        "description": "Storage cap value shown as megabytes",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "offlineTimeEvictEnable": "Auto-remove old downloads",
+    "@offlineTimeEvictEnable": {
+        "description": "Toggle to enable time-based eviction"
+    },
+    "offlineKeepDaysLabel": "Keep downloads for",
+    "@offlineKeepDaysLabel": {
+        "description": "Label for the keep-days slider"
+    },
+    "offlineDays": "{count} days",
+    "@offlineDays": {
+        "description": "Keep-days value shown as days",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "offlineNotAvailable": "Offline downloads aren't available on this platform.",
+    "@offlineNotAvailable": {
+        "description": "Shown in Offline Settings when offline storage is unavailable"
+    },
+    "keepOffline": "Keep offline",
+    "@keepOffline": {
+        "description": "Tooltip for the per-series keep-offline popup button in manga details"
+    },
+    "keepOfflineOff": "Off",
+    "@keepOfflineOff": {
+        "description": "Keep-offline rule: disabled"
+    },
+    "keepOfflineNUnread": "Keep 3 unread",
+    "@keepOfflineNUnread": {
+        "description": "Keep-offline rule: keep the N most recent unread chapters on device"
+    },
+    "keepOfflineAllUnread": "Keep all unread",
+    "@keepOfflineAllUnread": {
+        "description": "Keep-offline rule: keep all unread chapters on device"
+    },
+    "keepOfflineAll": "Keep all",
+    "@keepOfflineAll": {
+        "description": "Keep-offline rule: keep every chapter on device"
+    },
+    "offlineDownloadAction": "Download",
+    "@offlineDownloadAction": {
+        "description": "Series offline button label when nothing is downloaded yet"
+    },
+    "offlineOnDevice": "On device",
+    "@offlineOnDevice": {
+        "description": "Series offline button label when the series has downloads on this device"
+    },
+    "offlineDownloadAll": "Download all chapters",
+    "@offlineDownloadAll": {
+        "description": "Series offline action: download every chapter to this device"
+    },
+    "offlineRemoveSeries": "Remove downloads",
+    "@offlineRemoveSeries": {
+        "description": "Series offline action: remove this series' downloads from the device"
+    },
+    "offlineDownloadingToast": "Downloading to this device…",
+    "@offlineDownloadingToast": {
+        "description": "Snackbar shown after starting a series download"
+    },
+    "offlineDownloadingCount": "Downloading {count}",
+    "@offlineDownloadingCount": {
+        "description": "Series button label while N chapters are downloading",
+        "placeholders": {
+            "count": { "type": "int" }
+        }
+    },
+    "downloadsServerTab": "Server",
+    "@downloadsServerTab": {
+        "description": "Downloads tab: the server download queue"
+    },
+    "downloadsOnDeviceTab": "On device",
+    "@downloadsOnDeviceTab": {
+        "description": "Downloads tab: files downloaded on this device"
+    },
+    "offlineNoFiles": "Nothing downloaded on this device yet",
+    "@offlineNoFiles": {
+        "description": "Empty state for the on-device downloads tab"
+    }
 }

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -25,6 +25,7 @@ import '../features/migration/presentation/screens/migration_preview_screen.dart
 import '../features/migration/presentation/screens/migration_progress_screen.dart';
 import '../features/migration/presentation/screens/migration_search_screen.dart';
 import '../features/migration/presentation/screens/migration_source_selection_screen.dart';
+import '../features/offline/presentation/offline_settings_screen.dart';
 import '../features/quick_open/presentation/search_stack/search_stack_screen.dart';
 import '../features/settings/presentation/appearance/appearance_screen.dart';
 import '../features/settings/presentation/backup/backup_screen.dart';
@@ -86,6 +87,7 @@ abstract class Routes {
   static const backup = 'backup';
   static const serverSettings = 'server';
   static const downloadsSettings = 'downloads';
+  static const offlineSettings = 'offline';
 
   // Commons
   static const mangaRoute = '/manga/:mangaId';
@@ -198,6 +200,8 @@ GoRouter routerConfig(ref) {
                     TypedGoRoute<BackupRoute>(path: Routes.backup),
                     TypedGoRoute<DownloadsSettingsRoute>(
                         path: Routes.downloadsSettings),
+                    TypedGoRoute<OfflineSettingsRoute>(
+                        path: Routes.offlineSettings),
                   ],
                 ),
               ],

--- a/lib/src/routes/sub_routes/more_routes.dart
+++ b/lib/src/routes/sub_routes/more_routes.dart
@@ -93,3 +93,10 @@ class DownloadsSettingsRoute extends GoRouteData {
   @override
   Widget build(context, state) => const DownloadsSettingsScreen();
 }
+
+class OfflineSettingsRoute extends GoRouteData {
+  const OfflineSettingsRoute();
+
+  @override
+  Widget build(context, state) => const OfflineSettingsScreen();
+}

--- a/lib/src/sorayomi.dart
+++ b/lib/src/sorayomi.dart
@@ -14,6 +14,7 @@ import 'constants/app_theme.dart';
 import 'features/auth/presentation/reauth_banner.dart';
 import 'features/settings/presentation/appearance/widgets/app_theme_selector/app_theme_providers.dart';
 import 'features/settings/presentation/appearance/widgets/is_true_black/is_true_black_tile.dart';
+import 'features/settings/presentation/general/widgets/force_portrait_tile.dart';
 import 'features/settings/widgets/app_theme_mode_tile/app_theme_mode_tile.dart';
 import 'global_providers/global_providers.dart';
 import 'l10n/generated/app_localizations.dart';
@@ -33,6 +34,9 @@ class Sorayomi extends ConsumerWidget {
     final customSeed = ref.watch(customThemeColorProvider);
     final isTrueBlack = ref.watch(isTrueBlackProvider).ifNull();
     final client = ref.watch(graphQlClientNotifierProvider);
+    // Honour the portrait-lock preference on launch and whenever it changes
+    // (phones only; idempotent so re-applying on rebuild is harmless).
+    applyForcePortrait(ref.watch(forcePortraitProvider).ifNull());
     return GraphQLProvider(
       client: client,
       child: MaterialApp.router(

--- a/lib/src/utils/theme/brand.dart
+++ b/lib/src/utils/theme/brand.dart
@@ -85,13 +85,20 @@ Widget _brandRow({
           ),
           const SizedBox(width: 8),
         ],
-        DefaultTextStyle.merge(
-          style: TextStyle(
-            color: content,
-            fontWeight: FontWeight.w700,
-            fontSize: 14,
+        // Flexible so a long label (e.g. "Downloading 14") ellipsises instead
+        // of overflowing the button's width.
+        Flexible(
+          child: DefaultTextStyle.merge(
+            style: TextStyle(
+              color: content,
+              fontWeight: FontWeight.w700,
+              fontSize: 14,
+            ),
+            maxLines: 1,
+            softWrap: false,
+            overflow: TextOverflow.ellipsis,
+            child: label,
           ),
-          child: label,
         ),
       ],
     );

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -24,6 +24,7 @@ class MangaCoverGridTile extends StatelessWidget {
     this.showBadges = true,
     this.showCountBadges = false,
     this.showDarkOverlay = true,
+    this.selected = false,
   });
   final MangaDto manga;
   final VoidCallback? onPressed;
@@ -32,6 +33,10 @@ class MangaCoverGridTile extends StatelessWidget {
   final bool showTitle;
   final bool showBadges;
   final bool showDarkOverlay;
+
+  /// Multi-select highlight: a primary-tinted border + check, like Komikku's
+  /// library selection.
+  final bool selected;
   @override
   Widget build(BuildContext context) {
     return InkResponse(
@@ -66,8 +71,34 @@ class MangaCoverGridTile extends StatelessWidget {
       onLongPress: onLongPress,
       child: Card(
         clipBehavior: Clip.antiAlias,
-        shape: RoundedRectangleBorder(borderRadius: KBorderRadius.r12.radius),
-        child: GridTile(
+        shape: RoundedRectangleBorder(
+          borderRadius: KBorderRadius.r12.radius,
+          side: selected
+              ? BorderSide(color: context.theme.colorScheme.primary, width: 3)
+              : BorderSide.none,
+        ),
+        child: Stack(
+          fit: StackFit.passthrough,
+          children: [
+            _selectableChild(context),
+            if (selected)
+              Positioned(
+                top: 4,
+                right: 4,
+                child: Icon(
+                  Icons.check_circle_rounded,
+                  color: context.theme.colorScheme.primary,
+                  shadows: const [Shadow(blurRadius: 4)],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _selectableChild(BuildContext context) {
+    return GridTile(
           header: showBadges
               ? MangaBadgesRow(manga: manga, showCountBadges: showCountBadges)
               : null,
@@ -118,8 +149,6 @@ class MangaCoverGridTile extends StatelessWidget {
                     size: context.height * .2,
                   ),
                 ),
-        ),
-      ),
-    );
+        );
   }
 }

--- a/lib/src/widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart
+++ b/lib/src/widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart
@@ -26,6 +26,7 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
     this.onTitleClicked,
     this.showBadges = true,
     this.showCountBadges = true,
+    this.selected = false,
   });
   final MangaDto manga;
   final bool showBadges;
@@ -33,12 +34,17 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
   final VoidCallback? onPressed;
   final VoidCallback? onLongPress;
   final ValueChanged<String?>? onTitleClicked;
+  final bool selected;
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onPressed,
-      onLongPress: onLongPress,
-      child: Padding(
+    return ColoredBox(
+      color: selected
+          ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.24)
+          : Colors.transparent,
+      child: InkWell(
+        onTap: onPressed,
+        onLongPress: onLongPress,
+        child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -152,6 +158,7 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
             ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
+++ b/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
@@ -19,6 +19,7 @@ class MangaCoverListTile extends StatelessWidget {
     this.onLongPress,
     this.showBadges = true,
     this.showCountBadges = false,
+    this.selected = false,
   });
 
   final MangaDto manga;
@@ -26,13 +27,18 @@ class MangaCoverListTile extends StatelessWidget {
   final VoidCallback? onLongPress;
   final bool showCountBadges;
   final bool showBadges;
+  final bool selected;
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onPressed,
-      onLongPress: onLongPress,
-      child: Row(
-        children: [
+    return ColoredBox(
+      color: selected
+          ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.24)
+          : Colors.transparent,
+      child: InkWell(
+        onTap: onPressed,
+        onLongPress: onLongPress,
+        child: Row(
+          children: [
           Padding(
             padding: KEdgeInsets.a8.size,
             child: ClipRRect(
@@ -53,9 +59,10 @@ class MangaCoverListTile extends StatelessWidget {
               ),
             ),
           ),
-          if (showBadges)
-            MangaBadgesRow(manga: manga, showCountBadges: showCountBadges),
-        ],
+            if (showBadges)
+              MangaBadgesRow(manga: manga, showCountBadges: showCountBadges),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/widgets/selection_action_bar.dart
+++ b/lib/src/widgets/selection_action_bar.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../constants/app_sizes.dart';
+import '../utils/extensions/custom_extensions.dart';
+
+/// Shared floating bottom action bar for multi-select modes (library manga and
+/// chapter selection use the same look). A translucent rounded [Card] holding an
+/// optional [leading] cluster (e.g. close + count + select-all) on the left and
+/// a row of action buttons on the right; when [leading] is empty the actions are
+/// spaced evenly (the chapter-selection layout, whose count/close/select-all
+/// live in the screen's app bar instead).
+///
+/// Reads the bottom inset straight from the [FlutterView]: this bar is rendered
+/// inside the shell navigation / a Scaffold bottomSheet, which zero out the
+/// bottom MediaQuery insets (both padding and viewPadding) for descendants, so a
+/// MediaQuery/SafeArea would not clear the Android navigation bar.
+class SelectionActionBar extends StatelessWidget {
+  const SelectionActionBar({
+    super.key,
+    this.leading = const [],
+    required this.actions,
+    this.clearsSystemNav = false,
+  });
+
+  final List<Widget> leading;
+  final List<Widget> actions;
+
+  /// Add the system navigation-bar inset below the card. True when the bar sits
+  /// directly over the system nav (a pushed screen's bottomSheet, e.g. chapter
+  /// selection). False when an app bottom NavigationBar already sits between
+  /// this bar and the system nav (the library tab) — otherwise the inset is
+  /// double-counted and the bar floats too high above the nav bar.
+  final bool clearsSystemNav;
+
+  @override
+  Widget build(BuildContext context) {
+    final view = View.of(context);
+    final bottomInset =
+        clearsSystemNav ? view.viewPadding.bottom / view.devicePixelRatio : 0.0;
+    return Padding(
+      padding: KEdgeInsets.a8.size.add(EdgeInsets.only(bottom: bottomInset)),
+      child: Card(
+        margin: EdgeInsets.zero,
+        color: context.theme.cardColor.withValues(alpha: 0.97),
+        shape: RoundedRectangleBorder(borderRadius: KBorderRadius.r12.radius),
+        child: Padding(
+          padding: KEdgeInsets.h8v4.size,
+          child: leading.isEmpty
+              ? Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: actions,
+                )
+              : Row(
+                  children: [
+                    ...leading,
+                    const Spacer(),
+                    ...actions,
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/server_image.dart
+++ b/lib/src/widgets/server_image.dart
@@ -17,6 +17,7 @@ import '../constants/endpoints.dart';
 import '../constants/enum.dart';
 import '../features/auth/data/auth_coordinator.dart';
 import '../features/auth/data/auth_credentials_store.dart';
+import '../features/offline/data/offline_image_provider.dart';
 import '../features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import '../features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
@@ -36,7 +37,13 @@ class ServerImage extends HookConsumerWidget {
     this.imageBuilder,
     this.wrapper,
     this.showReloadButton = false,
+    this.localFilePath,
   });
+
+  /// When set, the page is rendered straight off disk (downloaded chapter,
+  /// offline reading) instead of fetched from the server. The network path is
+  /// left untouched when this is null.
+  final String? localFilePath;
 
   final String imageUrl;
   final Size? size;
@@ -53,6 +60,35 @@ class ServerImage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final key = useState(UniqueKey());
+
+    // Offline: render the downloaded page from disk. Triggered either by an
+    // explicit localFilePath or by a `file://` imageUrl (the offline reader
+    // serves downloaded chapters as file URIs). Returned BEFORE any auth /
+    // server provider reads, so local pages never subscribe to token rotation
+    // (no rebuild storms) and need no network. Both inputs are immutable per
+    // widget instance, so this branch is consistent across rebuilds.
+    final localPath = localFilePath ??
+        (imageUrl.startsWith('file:') ? Uri.parse(imageUrl).toFilePath() : null);
+    if (localPath != null) {
+      final provider = offlineImageProvider(localPath);
+      if (imageBuilder != null) {
+        return AppUtils.wrapOn(wrapper, imageBuilder!(context, provider));
+      }
+      return AppUtils.wrapOn(
+        wrapper,
+        Image(
+          image: provider,
+          height: size?.height,
+          width: size?.width,
+          fit: fit ?? BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) => AppUtils.wrapOn(
+            wrapper,
+            const Icon(Icons.broken_image_rounded, color: Colors.grey),
+          ),
+        ),
+      );
+    }
+
     // Providers
     final authType = ref.watch(authTypeKeyProvider);
     final basicToken = ref.watch(credentialsProvider).valueOrNull;
@@ -246,4 +282,53 @@ class ServerImageWithCpi extends StatelessWidget {
       return ServerImage(imageUrl: url, size: outerSize);
     }
   }
+}
+
+/// The exact [ImageProvider] that [ServerImage] would render for [imageUrl],
+/// so callers (the reader's prefetcher) can `precacheImage` the SAME cache
+/// entry the on-screen widget will read — identical cacheKey and auth. This is
+/// the core of smooth webtoon scrolling: decode each page ONCE, off-screen and
+/// ahead of the viewport, so the on-screen build is instant and the page never
+/// resizes (and shoves the scroll) while it's above you. Mirrors the provider
+/// selection in [ServerImage.build]; reads creds non-reactively (ref.read).
+ImageProvider serverPageImageProvider(
+  WidgetRef ref,
+  String imageUrl, {
+  bool appendApiToUrl = false,
+}) {
+  final localPath =
+      imageUrl.startsWith('file:') ? Uri.parse(imageUrl).toFilePath() : null;
+  if (localPath != null) return offlineImageProvider(localPath);
+
+  final authType = ref.read(authTypeKeyProvider);
+  final basicToken = ref.read(credentialsProvider).valueOrNull;
+  final creds = ref.read(authCredentialsStoreProvider).valueOrNull;
+
+  final baseApi = "${Endpoints.baseApi(
+    baseUrl: ref.read(serverUrlProvider),
+    port: ref.read(serverPortProvider),
+    addPort: ref.read(serverPortToggleProvider).ifNull(),
+    appendApiToUrl: appendApiToUrl,
+  )}$imageUrl";
+
+  Map<String, String>? httpHeaders;
+  if (authType == AuthType.basic && basicToken != null) {
+    httpHeaders = {"Authorization": basicToken};
+  } else if (authType == AuthType.simpleLogin) {
+    httpHeaders = creds?.simpleLoginCookieHeader;
+  }
+
+  var fetchUrl = baseApi;
+  final uiToken = creds?.uiAccessToken;
+  if (authType == AuthType.uiLogin && uiToken != null && uiToken.isNotEmpty) {
+    final sep = fetchUrl.contains('?') ? '&' : '?';
+    fetchUrl = '$fetchUrl${sep}token=${Uri.encodeQueryComponent(uiToken)}';
+  }
+
+  return CachedNetworkImageProvider(
+    fetchUrl,
+    cacheKey: baseApi,
+    cacheManager: DefaultCacheManager(),
+    headers: httpHeaders,
+  );
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
+  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  sqlite3_flutter_libs
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
 import sqflite_darwin
+import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -24,5 +25,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,6 +166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -310,6 +318,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      sha256: b584ddeb2b74436735dd2cf746d2d021e19a9a6770f409212fd5cbc2814ada85
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.26.1"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      sha256: "0d3f8b33b76cf1c6a82ee34d9511c40957549c4674b8f1688609e6d6c7306588"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.26.0"
   extension_type_unions:
     dependency: "direct main"
     description:
@@ -396,6 +420,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_foreground_task:
+    dependency: "direct main"
+    description:
+      name: flutter_foreground_task
+      sha256: fc5c01a5e1b8f7bb51d0c737714f0c50440dbdf1aeddc5f8cbba313aa6fd4856
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.2"
   flutter_gen_core:
     dependency: transitive
     description:
@@ -1248,10 +1280,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "688ee90fbfb6989c980254a56cb26ebe9bb30a3a2dff439a78894211f73de67a"
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.1"
+    version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -1409,6 +1441,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  sqlite3:
+    dependency: "direct dev"
+    description:
+      name: sqlite3
+      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.42"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: "57090342af1ce32bb499aa641f4ecdd2d6231b9403cea537ac059e803cc20d67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.41.2"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   cached_network_image: ^3.2.2
   cached_network_image_platform_interface: ^4.0.0
   cupertino_icons: ^1.0.5
+  drift: ^2.20.0
   extension_type_unions: ^1.0.10
   file_picker: ^8.0.0+1
   flex_color_picker: 3.7.1
@@ -22,6 +23,7 @@ dependencies:
   flutter_android_volume_keydown:
     git: https://github.com/DattatreyaReddy/flutter_android_volume_keydown
   flutter_cache_manager: ^3.3.0
+  flutter_foreground_task: ^9.2.2
   flutter_hooks: ^0.20.0
   flutter_localizations:
     sdk: flutter
@@ -64,6 +66,7 @@ dependencies:
       ref: "4641e83"
   shared_preferences: ^2.0.15
   shimmer: ^3.0.0
+  sqlite3_flutter_libs: ^0.5.42
   url_launcher: ^6.1.6
   web_socket_channel: ^3.0.0
   zoom_view: ^1.0.2
@@ -71,6 +74,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.14
   # flutter_flavorizr: ^2.1.5
+  drift_dev: ^2.20.0
   flutter_gen_runner: ^5.1.0+1
   flutter_launcher_icons: ^0.14.1
   flutter_lints: ^5.0.0
@@ -83,6 +87,7 @@ dev_dependencies:
   json_serializable: ^6.5.4
   lints: ^5.0.0
   riverpod_generator: ^2.0.0
+  sqlite3: ^2.9.4
 
 flutter:
   uses-material-design: true

--- a/test/helpers/offline_test_db.dart
+++ b/test/helpers/offline_test_db.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:sqlite3/open.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+
+bool _configured = false;
+
+/// Point the `sqlite3` package at the versioned host library in tests.
+///
+/// On a device `sqlite3_flutter_libs` bundles the lib, but the Dart VM test
+/// host has only `libsqlite3.so.0` (no unversioned `libsqlite3.so`, which ships
+/// in the `-dev` package). Test-only workaround; no production effect.
+void _ensureSqlite() {
+  if (_configured) return;
+  _configured = true;
+  if (Platform.isLinux) {
+    open.overrideFor(
+      OperatingSystem.linux,
+      () => DynamicLibrary.open('libsqlite3.so.0'),
+    );
+  }
+}
+
+/// A fresh in-memory [OfflineDatabase] for tests.
+OfflineDatabase testOfflineDatabase() {
+  _ensureSqlite();
+  return OfflineDatabase(NativeDatabase.memory());
+}
+
+/// An on-disk [OfflineDatabase] at [path] — for migration tests that need
+/// close-and-reopen semantics. The sqlite3 host shim is applied so the same
+/// versioned library is used as in [testOfflineDatabase].
+OfflineDatabase testOfflineDatabaseFile(String path) {
+  _ensureSqlite();
+  return OfflineDatabase(NativeDatabase(File(path)));
+}

--- a/test/src/features/manga_book/reader/seekbar_landing_test.dart
+++ b/test/src/features/manga_book/reader/seekbar_landing_test.dart
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Reproduces the seek-bar landing bug WITHOUT a device. The webtoon reader is
+// a ScrollablePositionedList of variable-height pages. The seek bar calls
+// itemScrollController.jumpTo(index:). On-device, a single tap landed several
+// pages away from the target. These tests isolate the cause by modelling the
+// reader's item sizing in three escalating ways:
+//
+//   A. items have their real (variable) height from the first frame
+//   B. items start at a guessed placeholder height, then GROW to their real
+//      height one frame later (what MeasureSize + async image decode does)
+//   C. like B, but the placeholder is the running AVERAGE of already-measured
+//      pages (exactly what the live reader does)
+//
+// The first that fails tells us what actually breaks the landing.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+/// Real rendered heights for 40 pages — deliberately wildly variable, like
+/// real webtoon strips (some ~1 screen, some ~5 screens).
+List<double> _realHeights(double screen) => [
+      for (var i = 0; i < 40; i++)
+        screen * (i % 5 == 0 ? 5.0 : (i % 3 == 0 ? 3.0 : 1.2)),
+    ];
+
+/// Returns the index of the page currently pinned to the viewport top.
+int _topIndex(ItemPositionsListener listener) {
+  final positions = listener.itemPositions.value
+      .where((p) => p.itemTrailingEdge > 0)
+      .toList()
+    ..sort((a, b) => a.itemLeadingEdge.compareTo(b.itemLeadingEdge));
+  return positions.isEmpty ? -1 : positions.first.index;
+}
+
+void main() {
+  const screen = 800.0;
+
+  Future<void> pumpList(
+    WidgetTester tester, {
+    required ItemScrollController controller,
+    required ItemPositionsListener listener,
+    required Widget Function(BuildContext, int) itemBuilder,
+  }) async {
+    tester.view.physicalSize = const Size(400, screen);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ScrollablePositionedList.separated(
+            itemScrollController: controller,
+            itemPositionsListener: listener,
+            itemCount: 40,
+            minCacheExtent: screen * 3,
+            itemBuilder: itemBuilder,
+            separatorBuilder: (_, __) => const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('A: stable variable heights — jumpTo lands exactly',
+      (tester) async {
+    final controller = ItemScrollController();
+    final listener = ItemPositionsListener.create();
+    final heights = _realHeights(screen);
+
+    await pumpList(
+      tester,
+      controller: controller,
+      listener: listener,
+      itemBuilder: (_, i) => SizedBox(height: heights[i], width: 400),
+    );
+
+    controller.jumpTo(index: 20);
+    await tester.pumpAndSettle();
+
+    expect(_topIndex(listener), 20);
+  });
+
+  testWidgets('B: items grow after first layout — jumpTo landing',
+      (tester) async {
+    final controller = ItemScrollController();
+    final listener = ItemPositionsListener.create();
+    final heights = _realHeights(screen);
+
+    await pumpList(
+      tester,
+      controller: controller,
+      listener: listener,
+      itemBuilder: (_, i) => _GrowingPage(
+        placeholder: screen * 0.7,
+        real: heights[i],
+      ),
+    );
+
+    controller.jumpTo(index: 20);
+    await tester.pump(); // jump frame
+    await tester.pump(const Duration(milliseconds: 16)); // pages "decode"
+    await tester.pump(const Duration(milliseconds: 16));
+    await tester.pumpAndSettle();
+
+    expect(_topIndex(listener), 20);
+  });
+
+  // This is the offline seek bug AND its fix, captured off-device.
+  //
+  // The offline (file://) ServerImage branch skips progressIndicatorBuilder and
+  // renders a bare Image, which is ZERO px tall until the local file decodes and
+  // then pops to full height. With placeholder == 0 the jump lands on the wrong
+  // page; reserving the placeholder height first (what the frameBuilder fix in
+  // the reader does) makes the jump land true. If the reservation regresses,
+  // the `reserved` case below starts landing wrong and this test fails.
+  testWidgets('D: offline pages — zero-height pops mis-land; reserved lands true',
+      (tester) async {
+    final heights = _realHeights(screen);
+
+    Future<int> landingWith(double placeholder) async {
+      final controller = ItemScrollController();
+      final listener = ItemPositionsListener.create();
+      await pumpList(
+        tester,
+        controller: controller,
+        listener: listener,
+        itemBuilder: (_, i) => _GrowingPage(placeholder: placeholder, real: heights[i]),
+      );
+      controller.jumpTo(index: 20);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pump(const Duration(milliseconds: 16));
+      await tester.pumpAndSettle();
+      return _topIndex(listener);
+    }
+
+    // The bug: no reserved height -> jump does not land on the target.
+    expect(await landingWith(0), isNot(20));
+    // The fix: reserve the placeholder height first -> jump lands true.
+    expect(await landingWith(screen * 0.7), 20);
+  });
+
+  testWidgets('C: faithful mini-reader (rebuild on measure + on position)',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, screen);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final controller = ItemScrollController();
+    final key = GlobalKey<_MiniReaderState>();
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: _MiniReader(key: key, controller: controller))),
+    );
+    // let the initial pages "decode" and measure
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 30));
+    }
+
+    key.currentState!.seek(20);
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 30));
+    }
+    await tester.pumpAndSettle();
+
+    expect(_topIndex(key.currentState!.listener), 20);
+  });
+}
+
+/// A faithful miniature of MultiChapterContinuousReaderMode's sizing + listener
+/// loop: placeholder = measured[i] ?? average(measured) ?? 0.7-screen; each page
+/// measures its real height one frame after building (writes to the shared map
+/// and rebuilds); the position listener rebuilds on every change. The seek sets
+/// the current index then jumpTo(index:), exactly like the real onChanged.
+class _MiniReader extends StatefulWidget {
+  const _MiniReader({super.key, required this.controller});
+  final ItemScrollController controller;
+  @override
+  State<_MiniReader> createState() => _MiniReaderState();
+}
+
+class _MiniReaderState extends State<_MiniReader> {
+  final listener = ItemPositionsListener.create();
+  final Map<int, double> measured = {};
+  late final List<double> real;
+  static const screen = 800.0;
+  int currentIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    real = _realHeights(screen);
+    listener.itemPositions.addListener(_onPositions);
+  }
+
+  @override
+  void dispose() {
+    listener.itemPositions.removeListener(_onPositions);
+    super.dispose();
+  }
+
+  void _onPositions() {
+    final positions = listener.itemPositions.value
+        .where((p) => p.itemTrailingEdge > 0 && p.itemLeadingEdge < 1)
+        .toList()
+      ..sort((a, b) => a.itemLeadingEdge.compareTo(b.itemLeadingEdge));
+    if (positions.isEmpty) return;
+    final top = positions.first.index;
+    if (top != currentIndex && mounted) {
+      setState(() => currentIndex = top);
+    }
+  }
+
+  void seek(int index) {
+    setState(() => currentIndex = index);
+    widget.controller.jumpTo(index: index);
+  }
+
+  double _placeholder() {
+    if (measured.isEmpty) return screen * 0.7;
+    return measured.values.reduce((a, b) => a + b) / measured.length;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScrollablePositionedList.separated(
+      itemScrollController: widget.controller,
+      itemPositionsListener: listener,
+      itemCount: 40,
+      minCacheExtent: screen * 3,
+      separatorBuilder: (_, __) => const SizedBox.shrink(),
+      itemBuilder: (context, i) {
+        final h = measured[i] ?? _placeholder();
+        return _MeasuringPage(
+          height: h,
+          realHeight: real[i],
+          alreadyMeasured: measured.containsKey(i),
+          onMeasured: (rh) {
+            if (!measured.containsKey(i) && mounted) {
+              setState(() => measured[i] = rh);
+            }
+          },
+        );
+      },
+    );
+  }
+}
+
+/// Builds at [height]; one frame later reports its [realHeight] (decode) unless
+/// it was [alreadyMeasured]. Mirrors ServerImage + MeasureSize.
+class _MeasuringPage extends StatefulWidget {
+  const _MeasuringPage({
+    required this.height,
+    required this.realHeight,
+    required this.alreadyMeasured,
+    required this.onMeasured,
+  });
+  final double height;
+  final double realHeight;
+  final bool alreadyMeasured;
+  final ValueChanged<double> onMeasured;
+
+  @override
+  State<_MeasuringPage> createState() => _MeasuringPageState();
+}
+
+class _MeasuringPageState extends State<_MeasuringPage> {
+  @override
+  void initState() {
+    super.initState();
+    if (!widget.alreadyMeasured) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onMeasured(widget.realHeight);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      SizedBox(height: widget.height, width: 400);
+}
+
+/// A page that renders at [placeholder] height on its first build, then grows
+/// to [real] one frame later — exactly what an async image decode does to a
+/// page that was reserving a guessed height.
+class _GrowingPage extends StatefulWidget {
+  const _GrowingPage({required this.placeholder, required this.real});
+  final double placeholder;
+  final double real;
+
+  @override
+  State<_GrowingPage> createState() => _GrowingPageState();
+}
+
+class _GrowingPageState extends State<_GrowingPage> {
+  late double _height = widget.placeholder;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _height = widget.real);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) =>
+      SizedBox(height: _height, width: 400);
+}

--- a/test/src/features/offline/chapter_download_engine_test.dart
+++ b/test/src/features/offline/chapter_download_engine_test.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/chapter_download_engine.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+
+/// In-memory page store — records what was "written".
+class _FakeStore implements OfflinePageStore {
+  final written = <int, int>{}; // pageIndex -> bytes
+  @override
+  Future<({String relPath, int bytes})> writePage(
+      int mangaId, int chapterId, int pageIndex, List<int> bytes, String ext) async {
+    written[pageIndex] = bytes.length;
+    return (relPath: '$mangaId/$chapterId/$pageIndex.$ext', bytes: bytes.length);
+  }
+
+  @override
+  Future<void> deleteChapter(int mangaId, int chapterId) async {}
+  @override
+  Future<int> chapterBytes(int mangaId, int chapterId) async => 0;
+}
+
+List<PageRef> _pages(int n) =>
+    [for (var i = 0; i < n; i++) (index: i, url: 'http://s/p$i')];
+
+void main() {
+  const noBackoff = Duration.zero;
+
+  test('downloads all pages and reports each stored', () async {
+    final store = _FakeStore();
+    final engine = ChapterDownloadEngine(
+      fetchPage: (url) async => (bytes: [1, 2, 3], ext: 'jpg'),
+      writePage: store,
+      refreshAuth: () async => true,
+      backoff: (_) => noBackoff,
+    );
+    final reported = <int>[];
+    final out = await engine.download(
+      mangaId: 1,
+      chapterId: 2,
+      pages: _pages(10),
+      isCancelled: () => false,
+      onPageStored: (i, _, __) async => reported.add(i),
+    );
+    expect(out.succeeded, true);
+    expect(out.storedPages.length, 10);
+    expect(reported..sort(), List.generate(10, (i) => i));
+    expect(store.written.length, 10);
+  });
+
+  test('refreshes auth once on 401 then succeeds', () async {
+    var refreshes = 0;
+    var firstTry = true;
+    final engine = ChapterDownloadEngine(
+      fetchPage: (url) async {
+        // every page 401s once until a refresh happens
+        if (firstTry) {
+          firstTry = false;
+          throw const PageAuthException();
+        }
+        return (bytes: [0], ext: 'jpg');
+      },
+      writePage: _FakeStore(),
+      refreshAuth: () async {
+        refreshes++;
+        return true;
+      },
+      backoff: (_) => noBackoff,
+    );
+    final out = await engine.download(
+      mangaId: 1, chapterId: 1, pages: _pages(1), isCancelled: () => false);
+    expect(out.succeeded, true);
+    expect(refreshes, 1);
+  });
+
+  test('gives up with authFailed when refresh says auth is dead', () async {
+    final engine = ChapterDownloadEngine(
+      fetchPage: (url) async => throw const PageAuthException(),
+      writePage: _FakeStore(),
+      refreshAuth: () async => false, // auth dead
+      backoff: (_) => noBackoff,
+    );
+    final out = await engine.download(
+      mangaId: 1, chapterId: 1, pages: _pages(3), isCancelled: () => false);
+    expect(out.authFailed, true);
+    expect(out.succeeded, false);
+  });
+
+  test('retries transient failures up to maxAttempts then errors', () async {
+    var calls = 0;
+    final engine = ChapterDownloadEngine(
+      fetchPage: (url) async {
+        calls++;
+        throw Exception('boom');
+      },
+      writePage: _FakeStore(),
+      refreshAuth: () async => true,
+      maxAttempts: 3,
+      backoff: (_) => noBackoff,
+    );
+    final out = await engine.download(
+      mangaId: 1, chapterId: 1, pages: _pages(1), isCancelled: () => false);
+    expect(out.succeeded, false);
+    expect(out.error, isNotNull);
+    expect(calls, 3); // 3 attempts for the single page
+  });
+
+  test('never exceeds parallelPageLimit concurrent fetches', () async {
+    var inFlight = 0;
+    var peak = 0;
+    final engine = ChapterDownloadEngine(
+      parallelPageLimit: 5,
+      fetchPage: (url) async {
+        inFlight++;
+        peak = peak > inFlight ? peak : inFlight;
+        await Future.delayed(const Duration(milliseconds: 5));
+        inFlight--;
+        return (bytes: [0], ext: 'jpg');
+      },
+      writePage: _FakeStore(),
+      refreshAuth: () async => true,
+      backoff: (_) => noBackoff,
+    );
+    await engine.download(
+      mangaId: 1, chapterId: 1, pages: _pages(30), isCancelled: () => false);
+    expect(peak, lessThanOrEqualTo(5));
+    expect(peak, greaterThan(1)); // actually parallel
+  });
+
+  test('stops promptly when cancelled', () async {
+    var fetched = 0;
+    var cancel = false;
+    final engine = ChapterDownloadEngine(
+      parallelPageLimit: 2,
+      fetchPage: (url) async {
+        fetched++;
+        if (fetched >= 4) cancel = true;
+        return (bytes: [0], ext: 'jpg');
+      },
+      writePage: _FakeStore(),
+      refreshAuth: () async => true,
+      backoff: (_) => noBackoff,
+    );
+    final out = await engine.download(
+      mangaId: 1, chapterId: 1, pages: _pages(100), isCancelled: () => cancel);
+    expect(out.cancelled, true);
+    expect(fetched, lessThan(100));
+  });
+}

--- a/test/src/features/offline/data/offline_catalog_dao_test.dart
+++ b/test/src/features/offline/data/offline_catalog_dao_test.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seedChapter({
+    int id = 2000,
+    int mangaId = 552,
+    bool isRead = false,
+    int lastPageRead = 0,
+  }) =>
+      db.upsertChapterMetadata(
+        id: id,
+        mangaId: mangaId,
+        name: 'Chapter',
+        chapterIndex: 79,
+        isRead: isRead,
+        lastPageRead: lastPageRead,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 33,
+        updatedAt: DateTime.utc(2026),
+      );
+
+  test('metadata re-sync PRESERVES device-managed chapter fields', () async {
+    await seedChapter();
+    // Device marks it downloaded with a byte size.
+    await db.setChapterDeviceState(2000, OfflineDeviceState.downloaded,
+        bytes: 9999);
+
+    // A later metadata down-sync (server now says isRead=true) must NOT reset
+    // deviceState/bytes.
+    await seedChapter(isRead: true, lastPageRead: 5);
+
+    final c = (await db.chaptersForManga(552)).single;
+    expect(c.deviceState, OfflineDeviceState.downloaded, reason: 'preserved');
+    expect(c.bytes, 9999, reason: 'preserved');
+    expect(c.isRead, isTrue, reason: 'server field updated');
+    expect(c.lastPageRead, 5);
+  });
+
+  test('metadata re-sync PRESERVES a manga cover path', () async {
+    await db.upsertMangaMetadata(
+        id: 552, title: 'A', updatedAt: DateTime.utc(2026));
+    await db.setMangaCoverPath(552, 'covers/552.jpg');
+    await db.upsertMangaMetadata(
+        id: 552, title: 'A (renamed)', updatedAt: DateTime.utc(2026, 2));
+
+    final m = (await db.libraryManga()).single;
+    expect(m.thumbnailRelPath, 'covers/552.jpg', reason: 'preserved');
+    expect(m.title, 'A (renamed)', reason: 'server field updated');
+  });
+
+  test('downloadedChaptersForManga filters by device state', () async {
+    await seedChapter(id: 1, mangaId: 7);
+    await seedChapter(id: 2, mangaId: 7);
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloaded);
+    final dl = await db.downloadedChaptersForManga(7);
+    expect(dl.map((c) => c.id), [1]);
+  });
+
+  test('chaptersForManga is ordered by chapterIndex', () async {
+    await db.upsertChapterMetadata(
+        id: 10, mangaId: 7, name: 'b', chapterIndex: 2, isRead: false,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: false,
+        pageCount: 1, updatedAt: DateTime.utc(2026));
+    await db.upsertChapterMetadata(
+        id: 11, mangaId: 7, name: 'a', chapterIndex: 1, isRead: false,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: false,
+        pageCount: 1, updatedAt: DateTime.utc(2026));
+    final list = await db.chaptersForManga(7);
+    expect(list.map((c) => c.id), [11, 10]);
+  });
+
+  test('totalDownloadedBytes sums bytes', () async {
+    await seedChapter(id: 1, mangaId: 7);
+    await seedChapter(id: 2, mangaId: 7);
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 100);
+    await db.setChapterDeviceState(2, OfflineDeviceState.downloaded, bytes: 250);
+    expect(await db.totalDownloadedBytes(), 350);
+  });
+}

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  test('opens at schema version 3', () {
+    expect(db.schemaVersion, 3);
+  });
+
+  test('inserts and reads a manga', () async {
+    await db.into(db.offlineMangas).insert(
+          OfflineMangasCompanion.insert(
+            id: const Value(117),
+            title: 'Solo Leveling',
+            updatedAt: DateTime.utc(2026),
+          ),
+        );
+    final rows = await db.select(db.offlineMangas).get();
+    expect(rows.single.title, 'Solo Leveling');
+  });
+
+  test('chapter deviceState defaults to none and round-trips an enum', () async {
+    await db.into(db.offlineChapters).insert(
+          OfflineChaptersCompanion.insert(
+            id: const Value(2000),
+            mangaId: 552,
+            name: 'Chapter 79',
+            chapterIndex: 79,
+            updatedAt: DateTime.utc(2026),
+          ),
+        );
+    final c = await (db.select(db.offlineChapters)
+          ..where((t) => t.id.equals(2000)))
+        .getSingle();
+    expect(c.deviceState, OfflineDeviceState.none);
+
+    await (db.update(db.offlineChapters)..where((t) => t.id.equals(2000)))
+        .write(const OfflineChaptersCompanion(
+            deviceState: Value(OfflineDeviceState.downloaded)));
+    final c2 = await (db.select(db.offlineChapters)
+          ..where((t) => t.id.equals(2000)))
+        .getSingle();
+    expect(c2.deviceState, OfflineDeviceState.downloaded);
+  });
+
+  test('offline page maps (chapterId,pageIndex) -> relative path', () async {
+    await db.into(db.offlinePages).insert(
+          OfflinePagesCompanion.insert(
+            chapterId: 2000,
+            pageIndex: 0,
+            relativePath: '552/2000/000.jpg',
+          ),
+        );
+    final rows = await (db.select(db.offlinePages)
+          ..where((t) => t.chapterId.equals(2000)))
+        .get();
+    expect(rows.single.relativePath, '552/2000/000.jpg');
+  });
+}

--- a/test/src/features/offline/data/offline_device_manga_ids_test.dart
+++ b/test/src/features/offline/data/offline_device_manga_ids_test.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import '../../../../helpers/offline_test_db.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  test('returns manga ids with at least one downloaded chapter', () async {
+    await db.upsertChapterMetadata(id: 1, mangaId: 10, name: 'a', chapterIndex: 1,
+      isRead: false, lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+      pageCount: 1, updatedAt: DateTime(2026));
+    await db.upsertChapterMetadata(id: 2, mangaId: 20, name: 'b', chapterIndex: 1,
+      isRead: false, lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+      pageCount: 1, updatedAt: DateTime(2026));
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 5);
+    expect(await db.mangaIdsWithDeviceDownloads(), {10});
+  });
+}

--- a/test/src/features/offline/data/offline_download_coordinator_test.dart
+++ b/test/src/features/offline/data/offline_download_coordinator_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/chapter_download_engine.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_coordinator.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+/// In-memory page store — "writes" pages to a map keyed by chapter/page.
+class _FakeStore implements OfflinePageStore {
+  final pages = <String, int>{}; // '$chapter/$page' -> bytes
+  @override
+  Future<({String relPath, int bytes})> writePage(
+      int mangaId, int chapterId, int pageIndex, List<int> bytes, String ext) async {
+    pages['$chapterId/$pageIndex'] = bytes.length;
+    return (relPath: '$mangaId/$chapterId/$pageIndex.$ext', bytes: bytes.length);
+  }
+
+  @override
+  Future<void> deleteChapter(int mangaId, int chapterId) async {}
+  @override
+  Future<int> chapterBytes(int mangaId, int chapterId) async {
+    var total = 0;
+    for (final e in pages.entries) {
+      if (e.key.startsWith('$chapterId/')) total += e.value;
+    }
+    return total;
+  }
+}
+
+void main() {
+  late OfflineDatabase db;
+  late _FakeStore store;
+  setUp(() {
+    db = testOfflineDatabase();
+    store = _FakeStore();
+  });
+  tearDown(() => db.close());
+
+  Future<void> seedChapter(int id, int mangaId, int pageCount) =>
+      db.upsertChapterMetadata(
+          id: id, mangaId: mangaId, name: 'c$id', chapterIndex: 1,
+          isRead: false, lastPageRead: 0, isBookmarked: false,
+          serverIsDownloaded: true, pageCount: pageCount,
+          updatedAt: DateTime(2026));
+
+  /// Build a coordinator whose engine fetches with the given behaviour.
+  OfflineDownloadCoordinator coord({
+    List<String> pages = const ['/p/0', '/p/1', '/p/2'],
+    bool fail = false,
+    bool auth401 = false,
+    bool refreshOk = false,
+  }) {
+    final engine = ChapterDownloadEngine(
+      writePage: store,
+      maxAttempts: 2,
+      backoff: (_) => Duration.zero,
+      refreshAuth: () async => refreshOk,
+      fetchPage: (url) async {
+        if (auth401) throw const PageAuthException();
+        if (fail) throw Exception('boom');
+        return (bytes: [1, 2, 3], ext: 'jpg');
+      },
+    );
+    return OfflineDownloadCoordinator(
+      db: db,
+      engine: engine,
+      resolvePages: (_) async => pages,
+      measureChapterBytes: store.chapterBytes,
+    );
+  }
+
+  test('downloads every page, stores rows, marks downloaded with bytes', () async {
+    await seedChapter(1, 7, 3);
+    await coord().enqueueChapter((await db.chapterById(1))!);
+    final c = await db.chapterById(1);
+    expect(c!.deviceState, OfflineDeviceState.downloaded);
+    expect(await db.downloadedPageCount(1), 3);
+    expect(c.bytes, 9); // 3 pages x 3 bytes
+  });
+
+  test('no resolved pages -> error', () async {
+    await seedChapter(1, 7, 3);
+    await coord(pages: const []).enqueueChapter((await db.chapterById(1))!);
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.error);
+  });
+
+  test('resume only fetches pages not already on disk', () async {
+    await seedChapter(1, 7, 3);
+    await db.into(db.offlinePages).insert(OfflinePagesCompanion.insert(
+        chapterId: 1, pageIndex: 0, relativePath: '7/1/0.jpg'));
+    await coord().enqueueChapter((await db.chapterById(1))!);
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+    expect(store.pages.keys.toSet(), {'1/1', '1/2'}); // only the 2 missing
+  });
+
+  test('auth failure (401 + refresh dead) -> error', () async {
+    await seedChapter(1, 7, 3);
+    await coord(auth401: true, refreshOk: false)
+        .enqueueChapter((await db.chapterById(1))!);
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.error);
+  });
+
+  test('transient fetch failure exhausts retries -> error', () async {
+    await seedChapter(1, 7, 3);
+    await coord(fail: true).enqueueChapter((await db.chapterById(1))!);
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.error);
+  });
+
+  test('queueChapter marks queued without downloading', () async {
+    await seedChapter(1, 7, 3);
+    await coord().queueChapter(1);
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.queued);
+    expect(store.pages, isEmpty);
+  });
+
+  test('pump drains the queue one chapter at a time', () async {
+    await seedChapter(1, 7, 2);
+    await seedChapter(2, 7, 2);
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    await c.queueChapter(1);
+    await c.queueChapter(2);
+    await c.pumpDownloads();
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+    expect((await db.chapterById(2))!.deviceState, OfflineDeviceState.downloaded);
+  });
+
+  test('pump resumes a chapter stranded as downloading', () async {
+    await seedChapter(1, 7, 2);
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloading);
+    await coord(pages: const ['/p/0', '/p/1']).pumpDownloads();
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+  });
+}

--- a/test/src/features/offline/data/offline_download_manager_force_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_force_test.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_manager.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+class _FakeStore implements OfflinePageStore {
+  @override
+  Future<({String relPath, int bytes})> writePage(
+          int m, int c, int i, List<int> b, String e) async =>
+      (relPath: '$m/$c/$i.$e', bytes: b.length);
+  @override
+  Future<void> deleteChapter(int m, int c) async {}
+  @override
+  Future<int> chapterBytes(int m, int c) async => 0;
+}
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  OfflineChapter chap(bool serverDl) => OfflineChapter(
+        id: 1,
+        mangaId: 1,
+        name: 'c',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: serverDl,
+        deviceState: OfflineDeviceState.none,
+        pageCount: 1,
+        bytes: 0,
+        pinned: false,
+        downloadedAt: null,
+        progressDirty: false,
+        updatedAt: DateTime(2026),
+      );
+
+  OfflineDownloadManager manager() => OfflineDownloadManager(
+        db: db,
+        store: _FakeStore(),
+        fetchPageUrls: (id) async => ['/api/v1/x/0'],
+        fetchBytes: (u) async => (bytes: [1, 2, 3], ext: 'jpg'),
+      );
+
+  test('downloadChapter still refuses a not-server-downloaded chapter by default',
+      () async {
+    await expectLater(manager().downloadChapter(chap(false)), throwsStateError);
+  });
+
+  test('downloadChapter(force: true) downloads despite serverIsDownloaded=false',
+      () async {
+    await db.upsertChapterMetadata(
+        id: 1,
+        mangaId: 1,
+        name: 'c',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: false,
+        pageCount: 1,
+        updatedAt: DateTime(2026));
+    await manager().downloadChapter(chap(false), force: true);
+    final c = await (db.select(db.offlineChapters)
+          ..where((t) => t.id.equals(1)))
+        .getSingle();
+    expect(c.deviceState, OfflineDeviceState.downloaded);
+  });
+}

--- a/test/src/features/offline/data/offline_download_manager_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_test.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_manager.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+/// In-memory page store: records writes/deletes, no real file IO.
+class _FakeStore implements OfflinePageStore {
+  final Map<String, int> written = {};
+  final List<int> deletedChapters = [];
+
+  @override
+  Future<({String relPath, int bytes})> writePage(
+      int mangaId, int chapterId, int pageIndex, List<int> bytes, String ext) async {
+    final rel = '$mangaId/$chapterId/${pageIndex.toString().padLeft(3, '0')}.$ext';
+    written[rel] = bytes.length;
+    return (relPath: rel, bytes: bytes.length);
+  }
+
+  @override
+  Future<void> deleteChapter(int mangaId, int chapterId) async {
+    deletedChapters.add(chapterId);
+    written.removeWhere((k, _) => k.startsWith('$mangaId/$chapterId/'));
+  }
+
+  @override
+  Future<int> chapterBytes(int mangaId, int chapterId) async => written.entries
+      .where((e) => e.key.startsWith('$mangaId/$chapterId/'))
+      .fold<int>(0, (s, e) => s + e.value);
+}
+
+void main() {
+  late OfflineDatabase db;
+  late _FakeStore store;
+
+  setUp(() {
+    db = testOfflineDatabase();
+    store = _FakeStore();
+  });
+  tearDown(() => db.close());
+
+  Future<OfflineChapter> seedChapter({bool serverDownloaded = true}) async {
+    await db.upsertChapterMetadata(
+      id: 2000,
+      mangaId: 552,
+      name: 'Chapter 79',
+      chapterIndex: 79,
+      isRead: false,
+      lastPageRead: 0,
+      isBookmarked: false,
+      serverIsDownloaded: serverDownloaded,
+      pageCount: 3,
+      updatedAt: DateTime.utc(2026),
+    );
+    return (await db.chaptersForManga(552)).single;
+  }
+
+  OfflineDownloadManager managerWith({
+    PageUrlsFetcher? urls,
+    PageBytesFetcher? bytes,
+  }) =>
+      OfflineDownloadManager(
+        db: db,
+        store: store,
+        fetchPageUrls: urls ?? (id) async => ['u0', 'u1', 'u2'],
+        fetchBytes: bytes ?? (url) async => (bytes: [1, 2, 3], ext: 'jpg'),
+      );
+
+  test('downloadChapter stores all pages, records them, marks downloaded',
+      () async {
+    final chapter = await seedChapter();
+    await managerWith().downloadChapter(chapter);
+
+    expect(store.written.length, 3);
+    final pages = await (db.select(db.offlinePages)
+          ..where((t) => t.chapterId.equals(2000)))
+        .get();
+    expect(pages.length, 3);
+    expect(pages.map((p) => p.relativePath),
+        ['552/2000/000.jpg', '552/2000/001.jpg', '552/2000/002.jpg']);
+
+    final c = (await db.chaptersForManga(552)).single;
+    expect(c.deviceState, OfflineDeviceState.downloaded);
+    expect(c.bytes, 9); // 3 pages * 3 bytes
+  });
+
+  test('downloadChapter refuses a chapter not downloaded server-side', () async {
+    final chapter = await seedChapter(serverDownloaded: false);
+    expect(() => managerWith().downloadChapter(chapter), throwsStateError);
+    final c = (await db.chaptersForManga(552)).single;
+    expect(c.deviceState, OfflineDeviceState.none);
+  });
+
+  test('a failure mid-download cleans up and marks error', () async {
+    final chapter = await seedChapter();
+    var calls = 0;
+    final mgr = managerWith(bytes: (url) async {
+      if (calls++ == 1) throw Exception('network blip');
+      return (bytes: [1, 2, 3], ext: 'jpg');
+    });
+
+    await expectLater(mgr.downloadChapter(chapter), throwsException);
+
+    final c = (await db.chaptersForManga(552)).single;
+    expect(c.deviceState, OfflineDeviceState.error);
+    final pages = await (db.select(db.offlinePages)
+          ..where((t) => t.chapterId.equals(2000)))
+        .get();
+    expect(pages, isEmpty, reason: 'partial page rows purged');
+    expect(store.deletedChapters, contains(2000), reason: 'partial files purged');
+  });
+
+  test('deleteChapter removes files, page rows, and resets state', () async {
+    final chapter = await seedChapter();
+    await managerWith().downloadChapter(chapter);
+    final downloaded = (await db.chaptersForManga(552)).single;
+
+    await managerWith().deleteChapter(downloaded);
+
+    final c = (await db.chaptersForManga(552)).single;
+    expect(c.deviceState, OfflineDeviceState.none);
+    expect(c.bytes, 0);
+    final pages = await (db.select(db.offlinePages)
+          ..where((t) => t.chapterId.equals(2000)))
+        .get();
+    expect(pages, isEmpty);
+  });
+
+  test('sweepInterrupted resets chapters stuck downloading', () async {
+    final chapter = await seedChapter();
+    await db.setChapterDeviceState(chapter.id, OfflineDeviceState.downloading);
+
+    await managerWith().sweepInterrupted();
+
+    final c = (await db.chaptersForManga(552)).single;
+    expect(c.deviceState, OfflineDeviceState.none);
+  });
+}

--- a/test/src/features/offline/data/offline_download_providers_test.dart
+++ b/test/src/features/offline/data/offline_download_providers_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+
+void main() {
+  group('pageImageExt', () {
+    test('prefers the content-type', () {
+      expect(pageImageExt('image/jpeg', const []), 'jpg');
+      expect(pageImageExt('image/png', const []), 'png');
+      expect(pageImageExt('image/webp', const []), 'webp');
+      expect(pageImageExt('image/gif', const []), 'gif');
+    });
+
+    test('falls back to magic bytes when content-type is absent', () {
+      const z = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]; // padding to 12 bytes
+      expect(pageImageExt(null, [0x89, 0x50, ...z]), 'png');
+      expect(pageImageExt(null, [0xFF, 0xD8, ...z]), 'jpg');
+      expect(pageImageExt(null, [0x47, 0x49, ...z]), 'gif');
+      expect(pageImageExt(null, [0x52, 0x49, 0, 0, 0, 0, 0, 0, 0x57, 0, 0, 0]),
+          'webp');
+    });
+
+    test('defaults to jpg when unknown', () {
+      expect(pageImageExt(null, const [0, 0, 0, 0]), 'jpg');
+      expect(pageImageExt('application/octet-stream',
+          const [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]), 'jpg');
+    });
+  });
+
+  test('offlineDownloadManagerProvider is null when offline is disabled', () {
+    // Default config (web / offline unavailable): offlineEnabledProvider is
+    // false, so the manager provider must no-op to null without touching the
+    // (unoverridden, throwing) database/store/repo providers.
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    expect(container.read(offlineDownloadManagerProvider), isNull);
+  });
+
+  test('cascadeServerDeleteToDevice no-ops when offline disabled', () {
+    // cascadeServerDeleteToDevice guards on offlineDownloadManagerProvider == null.
+    // Assert the precondition: default container (offline disabled) yields null,
+    // so the helper exits before touching any device state.
+    // (cascadeServerDeleteToDevice takes WidgetRef; the guard path is tested by
+    //  confirming the provider it reads is null in the default config.)
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    expect(container.read(offlineDownloadManagerProvider), isNull);
+  });
+}

--- a/test/src/features/offline/data/offline_dto_mappers_test.dart
+++ b/test/src/features/offline/data/offline_dto_mappers_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_dto_mappers.dart';
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  test('offlineMangaToDto maps id/title/thumbnail and safe defaults', () async {
+    await db.upsertMangaMetadata(id: 7, title: 'Solo', thumbnailUrl: '/t.jpg',
+        updatedAt: DateTime(2026));
+    final m = await db.mangaById(7);
+    final dto = offlineMangaToDto(m!, chapterCount: 12);
+    expect(dto.id, 7);
+    expect(dto.title, 'Solo');
+    expect(dto.thumbnailUrl, '/t.jpg');
+    expect(dto.inLibrary, true);
+    expect(dto.unreadCount, 0);
+    expect(dto.downloadCount, 0);
+    expect(dto.chapters.totalCount, 12);
+  });
+
+  test('mangaById returns null for an unknown id', () async {
+    expect(await db.mangaById(999), isNull);
+  });
+
+  test('offlineChapterToDto maps fields from a catalog row', () async {
+    await db.upsertChapterMetadata(id: 3, mangaId: 7, name: 'Ch 3',
+        chapterIndex: 3, isRead: true, lastPageRead: 4, isBookmarked: false,
+        serverIsDownloaded: true, pageCount: 20, updatedAt: DateTime(2026));
+    final rows = await db.chaptersForManga(7);
+    final dto = offlineChapterToDto(rows.single);
+    expect(dto.id, 3);
+    expect(dto.mangaId, 7);
+    expect(dto.name, 'Ch 3');
+    expect(dto.sourceOrder, 3);
+    expect(dto.isRead, true);
+    expect(dto.isDownloaded, true); // from serverIsDownloaded
+    expect(dto.lastPageRead, 4);
+    expect(dto.pageCount, 20);
+  });
+}

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  test('opens at schema version 3', () {
+    expect(db.schemaVersion, 3);
+  });
+
+  test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',
+      () async {
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    var m = await (db.select(db.offlineMangas)
+          ..where((t) => t.id.equals(1)))
+        .getSingle();
+    expect(m.keepRule, OfflineKeepRule.off);
+    expect(m.keepUnreadCount, 3);
+
+    await db.setKeepRule(1, OfflineKeepRule.nUnread, 5);
+    m = await (db.select(db.offlineMangas)..where((t) => t.id.equals(1)))
+        .getSingle();
+    expect(m.keepRule, OfflineKeepRule.nUnread);
+    expect(m.keepUnreadCount, 5);
+  });
+
+  test(
+      'pinned defaults false; setChapterPinned persists; downloadedAt stamps on download',
+      () async {
+    await db.upsertChapterMetadata(
+      id: 10,
+      mangaId: 1,
+      name: 'c',
+      chapterIndex: 1,
+      isRead: false,
+      lastPageRead: 0,
+      isBookmarked: false,
+      serverIsDownloaded: true,
+      pageCount: 3,
+      updatedAt: DateTime(2026),
+    );
+    var c = await (db.select(db.offlineChapters)
+          ..where((t) => t.id.equals(10)))
+        .getSingle();
+    expect(c.pinned, false);
+    expect(c.downloadedAt, isNull);
+
+    await db.setChapterPinned(10, true);
+    await db.setChapterDeviceState(10, OfflineDeviceState.downloaded,
+        bytes: 100, downloadedAt: DateTime(2026, 2, 2));
+    c = await (db.select(db.offlineChapters)..where((t) => t.id.equals(10)))
+        .getSingle();
+    expect(c.pinned, true);
+    expect(c.downloadedAt, DateTime(2026, 2, 2));
+  });
+}

--- a/test/src/features/offline/data/offline_page_store_io_test.dart
+++ b/test/src/features/offline/data/offline_page_store_io_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:tsumiru/src/features/offline/data/offline_page_store_io.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+
+void main() {
+  late Directory tmp;
+  late IoOfflinePageStore store;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('offline_page_store_test');
+    store = IoOfflinePageStore(OfflinePaths(tmp.path));
+  });
+  tearDown(() async {
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  test('writes a page to <mangaId>/<chapterId>/<NNN>.<ext> and reads back', () async {
+    final r = await store.writePage(552, 2000, 0, [1, 2, 3, 4], 'jpg');
+    expect(r.relPath, '552/2000/000.jpg');
+    expect(r.bytes, 4);
+
+    final f = File(p.join(tmp.path, '552', '2000', '000.jpg'));
+    expect(await f.exists(), isTrue);
+    expect(await f.readAsBytes(), [1, 2, 3, 4]);
+  });
+
+  test('leaves no .part file behind (atomic rename)', () async {
+    await store.writePage(552, 2000, 1, [9], 'png');
+    final part = File(p.join(tmp.path, '552', '2000', '001.png.part'));
+    expect(await part.exists(), isFalse);
+  });
+
+  test('deleteChapter removes the chapter directory', () async {
+    await store.writePage(552, 2000, 0, [1], 'jpg');
+    await store.writePage(552, 2000, 1, [2], 'jpg');
+    await store.deleteChapter(552, 2000);
+    expect(await Directory(p.join(tmp.path, '552', '2000')).exists(), isFalse);
+  });
+
+  test('deleteChapter is a no-op when nothing was downloaded', () async {
+    await store.deleteChapter(999, 999); // must not throw
+  });
+}

--- a/test/src/features/offline/data/offline_paths_test.dart
+++ b/test/src/features/offline/data/offline_paths_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+
+void main() {
+  // Base dir is injected so the path logic is testable without path_provider /
+  // a real device. Production resolves the base at runtime; only RELATIVE paths
+  // are ever persisted (iOS rewrites the absolute container path across installs).
+  const base = '/app-support/offline';
+  const paths = OfflinePaths(base);
+
+  group('relative path generation', () {
+    test('pageRel is <mangaId>/<chapterId>/<NNN>.<ext>, zero-padded to 3', () {
+      expect(paths.pageRel(117, 2000, 0, 'jpg'), '117/2000/000.jpg');
+      expect(paths.pageRel(117, 2000, 5, 'png'), '117/2000/005.png');
+      expect(paths.pageRel(1, 1, 123, 'webp'), '1/1/123.webp');
+    });
+
+    test('chapterDirRel is <mangaId>/<chapterId>', () {
+      expect(paths.chapterDirRel(117, 2000), '117/2000');
+    });
+
+    test('coverRel is covers/<mangaId>.<ext>', () {
+      expect(paths.coverRel(552, 'jpg'), 'covers/552.jpg');
+    });
+
+    test('relative paths never contain the absolute base (no leak)', () {
+      expect(paths.pageRel(117, 2000, 0, 'jpg').contains(base), isFalse);
+      expect(paths.coverRel(552, 'jpg').contains(base), isFalse);
+    });
+
+    test('relative paths use forward slashes regardless of platform', () {
+      expect(paths.pageRel(117, 2000, 0, 'jpg').contains('\\'), isFalse);
+    });
+  });
+
+  group('absolute() resolves a relative path against the base', () {
+    test('joins base + relative segments natively', () {
+      expect(
+        paths.absolute('117/2000/000.jpg'),
+        p.join(base, '117', '2000', '000.jpg'),
+      );
+      expect(paths.absolute('covers/552.jpg'), p.join(base, 'covers', '552.jpg'));
+    });
+  });
+}

--- a/test/src/features/offline/data/offline_progress_test.dart
+++ b/test/src/features/offline/data/offline_progress_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_sync.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+ChapterDto serverChapter(int id,
+        {required int lastPageRead, required bool isRead}) =>
+    Fragment$ChapterDto(
+      id: id, mangaId: 1, name: 'c$id', chapterNumber: id.toDouble(),
+      sourceOrder: id, isRead: isRead, isBookmarked: false, isDownloaded: true,
+      lastPageRead: lastPageRead, pageCount: 30, fetchedAt: '0', uploadDate: '0',
+      lastReadAt: '0', url: '', meta: const <Fragment$ChapterDto$meta>[],
+    );
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seed(int id, {int lastPageRead = 0, bool isRead = false}) =>
+      db.upsertChapterMetadata(
+          id: id, mangaId: 1, name: 'c$id', chapterIndex: id, isRead: isRead,
+          lastPageRead: lastPageRead, isBookmarked: false,
+          serverIsDownloaded: true, pageCount: 30, updatedAt: DateTime(2026));
+
+  test('setChapterProgress records progress + marks dirty; clear clears it',
+      () async {
+    await seed(5);
+    await db.setChapterProgress(5, lastPageRead: 20, isRead: false);
+    final c = await db.chapterById(5);
+    expect(c!.lastPageRead, 20);
+    expect(c.progressDirty, true);
+    expect((await db.dirtyProgressChapters()).map((e) => e.id), [5]);
+    await db.clearProgressDirty(5);
+    expect(await db.dirtyProgressChapters(), isEmpty);
+    expect((await db.chapterById(5))!.lastPageRead, 20); // value kept
+  });
+
+  test('down-sync preserves dirty local progress (no stale-server overwrite)',
+      () async {
+    await seed(5, lastPageRead: 16);
+    await db.setChapterProgress(5, lastPageRead: 20, isRead: false); // read offline
+    await OfflineSync(db)
+        .syncChapters([serverChapter(5, lastPageRead: 16, isRead: false)]);
+    final c = await db.chapterById(5);
+    expect(c!.lastPageRead, 20); // local kept, not clobbered by server's 16
+    expect(c.progressDirty, true); // still pending up-sync
+  });
+
+  test('down-sync applies server progress for non-dirty chapters', () async {
+    await seed(6, lastPageRead: 0);
+    await OfflineSync(db)
+        .syncChapters([serverChapter(6, lastPageRead: 12, isRead: true)]);
+    final c = await db.chapterById(6);
+    expect(c!.lastPageRead, 12);
+    expect(c.isRead, true);
+  });
+}

--- a/test/src/features/offline/data/offline_read_fallback_test.dart
+++ b/test/src/features/offline/data/offline_read_fallback_test.dart
@@ -1,0 +1,61 @@
+// test/src/features/offline/data/offline_read_fallback_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_read_fallback.dart';
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<Never> boom() async => throw Exception('server unreachable');
+
+  test('library: returns server result when fetch succeeds', () async {
+    final r = await libraryWithOfflineFallback(
+        fetch: () async => null, db: db, offlineEnabled: true);
+    expect(r, isNull); // server returned null -> passed through, no fallback
+  });
+
+  test('library: falls back to catalog when fetch throws', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    await db.upsertMangaMetadata(id: 2, title: 'B', updatedAt: DateTime(2026));
+    final r = await libraryWithOfflineFallback(
+        fetch: boom, db: db, offlineEnabled: true);
+    expect(r!.map((m) => m.id).toSet(), {1, 2});
+  });
+
+  test('library: rethrows when offline disabled', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    expect(libraryWithOfflineFallback(fetch: boom, db: db, offlineEnabled: false),
+        throwsException);
+  });
+
+  test('library: rethrows when catalog empty', () async {
+    expect(libraryWithOfflineFallback(fetch: boom, db: db, offlineEnabled: true),
+        throwsException);
+  });
+
+  test('manga: falls back to the catalog row on throw', () async {
+    await db.upsertMangaMetadata(id: 5, title: 'M', updatedAt: DateTime(2026));
+    final r = await mangaWithOfflineFallback(
+        fetch: boom, db: db, offlineEnabled: true, mangaId: 5);
+    expect(r!.id, 5);
+  });
+
+  test('manga: rethrows when the manga is not in the catalog', () async {
+    expect(
+        mangaWithOfflineFallback(
+            fetch: boom, db: db, offlineEnabled: true, mangaId: 404),
+        throwsException);
+  });
+
+  test('chapters: falls back to catalog chapters on throw', () async {
+    await db.upsertChapterMetadata(id: 10, mangaId: 5, name: 'c10',
+        chapterIndex: 1, isRead: false, lastPageRead: 0, isBookmarked: false,
+        serverIsDownloaded: true, pageCount: 1, updatedAt: DateTime(2026));
+    final r = await chaptersWithOfflineFallback(
+        fetch: boom, db: db, offlineEnabled: true, mangaId: 5);
+    expect(r!.single.id, 10);
+  });
+}

--- a/test/src/features/offline/data/offline_read_providers_test.dart
+++ b/test/src/features/offline/data/offline_read_providers_test.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/library/data/category_repository.dart';
+import 'package:tsumiru/src/features/library/presentation/library/controller/library_controller.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import '../../../../helpers/offline_test_db.dart';
+
+class _ThrowingCategoryRepo implements CategoryRepository {
+  @override
+  Future<List<MangaDto>?> getMangasFromCategory({required int categoryId}) =>
+      throw Exception('offline');
+
+  @override
+  dynamic noSuchMethod(Invocation i) => throw Exception('offline');
+}
+
+void main() {
+  test('categoryMangaList falls back to the offline catalog on server error',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final db = testOfflineDatabase();
+    addTearDown(db.close);
+    await db.upsertMangaMetadata(
+        id: 1, title: 'Saved', updatedAt: DateTime(2026));
+
+    final c = ProviderContainer(overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      offlineDatabaseProvider.overrideWithValue(db),
+      offlineEnabledProvider.overrideWithValue(true),
+      categoryRepositoryProvider.overrideWithValue(_ThrowingCategoryRepo()),
+    ]);
+    addTearDown(c.dispose);
+
+    final list = await c.read(categoryMangaListProvider(0).future);
+    expect(list!.map((m) => m.id), [1]);
+  });
+}

--- a/test/src/features/offline/data/offline_reconcile_provider_test.dart
+++ b/test/src/features/offline/data/offline_reconcile_provider_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_types.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+void main() {
+  test('safetyNetConfigProvider defaults to off', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final c = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(c.dispose);
+    expect(c.read(safetyNetConfigProvider).storageCapEnabled, false);
+    expect(c.read(safetyNetConfigProvider).timeEvictEnabled, false);
+  });
+}

--- a/test/src/features/offline/data/offline_reconciler_test.dart
+++ b/test/src/features/offline/data/offline_reconciler_test.dart
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_reconciler.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_types.dart';
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seedChapter(int id, int idx, {
+    bool read = false,
+    bool serverDl = true,
+    OfflineDeviceState dev = OfflineDeviceState.none,
+    int bytes = 10,
+    DateTime? downloadedAt,
+    bool pinned = false,
+  }) async {
+    await db.upsertChapterMetadata(
+      id: id, mangaId: 1, name: 'c$id', chapterIndex: idx, isRead: read,
+      lastPageRead: 0, isBookmarked: false, serverIsDownloaded: serverDl,
+      pageCount: 1, updatedAt: DateTime(2026));
+    if (dev != OfflineDeviceState.none) {
+      await db.setChapterDeviceState(id, dev,
+          bytes: bytes, downloadedAt: downloadedAt ?? DateTime(2026, 1, 1));
+    }
+    if (pinned) await db.setChapterPinned(id, true);
+  }
+
+  // ── base brief tests ────────────────────────────────────────────────────────
+
+  test('downloads desired-but-missing on-server chapters; skips not-on-server', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.allUnread, 3);
+    await seedChapter(1, 1, read: false, serverDl: true);
+    await seedChapter(2, 2, read: false, serverDl: false); // unsatisfiable
+    final downloaded = <int>[]; final evicted = <int>[];
+    final r = await OfflineReconciler(
+      db: db, nets: SafetyNetConfig.off,
+      onDownload: (id) async => downloaded.add(id),
+      onEvict: (id) async => evicted.add(id),
+      now: DateTime(2026, 3, 1),
+    ).reconcileManga(1);
+    expect(downloaded, [1]);     // ch1 desired + on server
+    expect(evicted, isEmpty);
+    expect(r.toDownload, {1});
+  });
+
+  test('evicts a downloaded chapter no longer desired', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.allUnread, 3);
+    await seedChapter(1, 1, read: true, dev: OfflineDeviceState.downloaded); // read -> not desired
+    final downloaded = <int>[]; final evicted = <int>[];
+    await OfflineReconciler(
+      db: db, nets: SafetyNetConfig.off,
+      onDownload: (id) async => downloaded.add(id),
+      onEvict: (id) async => evicted.add(id),
+      now: DateTime(2026, 3, 1),
+    ).reconcileManga(1);
+    expect(evicted, [1]);
+    expect(downloaded, isEmpty);
+  });
+
+  // ── RC6: orphaned chapters are evicted ──────────────────────────────────────
+
+  test('RC6: orphaned chapter is included in evict and onEvict is called', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.allUnread, 3);
+    // An orphaned chapter (server-gone): was downloaded, now marked orphaned.
+    await seedChapter(10, 10, read: false, serverDl: false, dev: OfflineDeviceState.orphaned);
+    final evicted = <int>[];
+    final r = await OfflineReconciler(
+      db: db, nets: SafetyNetConfig.off,
+      onDownload: (id) async {},
+      onEvict: (id) async => evicted.add(id),
+      now: DateTime(2026, 3, 1),
+    ).reconcileManga(1);
+    expect(evicted, contains(10));
+    expect(r.toEvict, contains(10));
+  });
+
+  // ── RC5: convergence under storage cap ──────────────────────────────────────
+
+  // ── RC5-cold: cap gating works with zero downloaded chapters ───────────────
+
+  test('RC5-cold: cold-start cap hole — first pass queues only a bounded subset', () async {
+    // Bug: when avgBytes == 0 (no downloaded chapters yet), the estimate was
+    // always 0, so projectedBytes never grew and the cap guard was a no-op,
+    // causing EVERY chapter to be queued on the first pass.
+    //
+    // Fix: fall back to pageCount * _estimatedBytesPerPage (5 pages * 256 KB =
+    // 1.28 MB per chapter).  With a 600 KB cap, at most 0 chapters fit (the
+    // first candidate already exceeds the cap), so toDownload must be empty.
+    const kBytesPerPage = 256 * 1024; // must match _estimatedBytesPerPage
+    const pageCount = 5; // per chapter
+    const estimatedChapterBytes = pageCount * kBytesPerPage; // 1.28 MB
+    const cap = SafetyNetConfig(
+      timeEvictEnabled: false,
+      keepDays: 30,
+      storageCapEnabled: true,
+      storageCapBytes: 600 * 1024, // 600 KB — less than one estimated chapter
+    );
+
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.all, 0);
+
+    // 5 chapters: all on server, none on device yet.
+    for (var i = 1; i <= 5; i++) {
+      await db.upsertChapterMetadata(
+        id: i, mangaId: 1, name: 'c$i', chapterIndex: i,
+        isRead: false, lastPageRead: 0, isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: pageCount, updatedAt: DateTime(2026),
+      );
+    }
+
+    final downloaded1 = <int>[];
+    final r1 = await OfflineReconciler(
+      db: db, nets: cap,
+      onDownload: (id) async => downloaded1.add(id),
+      onEvict: (id) async {},
+      now: DateTime(2026, 3, 1),
+    ).reconcileManga(1);
+
+    // With a 600 KB cap and each chapter estimated at ~1.28 MB, none fit.
+    // Pre-fix this was 5 (all queued). The fix must make it 0.
+    expect(
+      r1.toDownload.length,
+      lessThan(5),
+      reason: 'cold-start cap guard must bound downloads below total chapter count',
+    );
+    // Specifically 0 chapters fit (cap < estimate).
+    expect(
+      r1.toDownload,
+      isEmpty,
+      reason: 'cap (600 KB) < one estimated chapter (${estimatedChapterBytes ~/ 1024} KB) — nothing fits',
+    );
+
+    // Second pass: state is unchanged (nothing was downloaded), so still empty.
+    final r2 = await OfflineReconciler(
+      db: db, nets: cap,
+      onDownload: (id) async {},
+      onEvict: (id) async {},
+      now: DateTime(2026, 3, 1),
+    ).reconcileManga(1);
+    expect(r2.toDownload, isEmpty, reason: 'no oscillation on second pass');
+  });
+
+  test('RC5: reconcile converges — second pass yields empty toDownload and toEvict', () async {
+    // Setup: storage cap of 50 bytes. Seed 6 chapters each 10 bytes = 60 bytes
+    // total downloaded, already over cap. Rule is "all" (all desired).
+    const cap = SafetyNetConfig(
+      timeEvictEnabled: false,
+      keepDays: 30,
+      storageCapEnabled: true,
+      storageCapBytes: 50,
+    );
+
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.all, 0);
+
+    // Seed 6 chapters as already-downloaded (60 bytes total > 50 cap).
+    for (var i = 1; i <= 6; i++) {
+      await seedChapter(i, i,
+          read: false, serverDl: true,
+          dev: OfflineDeviceState.downloaded, bytes: 10,
+          downloadedAt: DateTime(2026, 1, i));
+    }
+
+    final evicted1 = <int>[];
+    final downloaded1 = <int>[];
+    await OfflineReconciler(
+      db: db, nets: cap,
+      onDownload: (id) async => downloaded1.add(id),
+      onEvict: (id) async {
+        evicted1.add(id);
+        await db.setChapterDeviceState(id, OfflineDeviceState.none, bytes: 0);
+      },
+      now: DateTime(2026, 3, 1),
+    ).reconcileManga(1);
+
+    // First pass must evict to bring under cap — don't assert specifics here,
+    // just verify something happened (sanity).
+    expect(evicted1, isNotEmpty, reason: 'first pass should evict over-cap chapters');
+
+    // Second pass: state is now stable — no new downloads should be emitted
+    // because adding any chapter would exceed the cap, and no evictions because
+    // we're already at or under it.
+    final evicted2 = <int>[];
+    final downloaded2 = <int>[];
+    final r2 = await OfflineReconciler(
+      db: db, nets: cap,
+      onDownload: (id) async => downloaded2.add(id),
+      onEvict: (id) async => evicted2.add(id),
+      now: DateTime(2026, 3, 1),
+    ).reconcileManga(1);
+
+    expect(downloaded2, isEmpty, reason: 'second pass must not re-download (fixed point)');
+    expect(evicted2, isEmpty, reason: 'second pass must not evict (fixed point)');
+    expect(r2.toDownload, isEmpty);
+    expect(r2.toEvict, isEmpty);
+  });
+}

--- a/test/src/features/offline/data/offline_repository_test.dart
+++ b/test/src/features/offline/data/offline_repository_test.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineRepository repo;
+  setUp(() => repo = OfflineRepository(
+        db: testOfflineDatabase(),
+        paths: const OfflinePaths('/base/offline'),
+      ));
+  tearDown(() => repo.db.close());
+
+  test('localPagePath resolves a stored page to an absolute path', () async {
+    await repo.db.into(repo.db.offlinePages).insert(
+          OfflinePagesCompanion.insert(
+            chapterId: 2000,
+            pageIndex: 0,
+            relativePath: '552/2000/000.jpg',
+          ),
+        );
+    expect(
+      await repo.localPagePath(2000, 0),
+      p.join('/base/offline', '552', '2000', '000.jpg'),
+    );
+  });
+
+  test('localPagePath returns null for a page that is not downloaded', () async {
+    expect(await repo.localPagePath(2000, 0), isNull);
+  });
+
+  test('keepRuleFor returns the manga keep-rule (off by default)', () async {
+    await repo.db.upsertMangaMetadata(id: 5, title: 'M', updatedAt: DateTime(2026));
+    expect(await repo.keepRuleFor(5), OfflineKeepRule.off);
+    await repo.db.setKeepRule(5, OfflineKeepRule.all, 3);
+    expect(await repo.keepRuleFor(5), OfflineKeepRule.all);
+  });
+
+  test('deviceDownloadedCount counts only downloaded device copies', () async {
+    await repo.db.upsertChapterMetadata(
+        id: 1,
+        mangaId: 1,
+        name: 'a',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 1,
+        updatedAt: DateTime(2026));
+    await repo.db.upsertChapterMetadata(
+        id: 2,
+        mangaId: 1,
+        name: 'b',
+        chapterIndex: 2,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 1,
+        updatedAt: DateTime(2026));
+    await repo.db.setChapterDeviceState(1, OfflineDeviceState.downloaded,
+        bytes: 10);
+    expect(await repo.deviceDownloadedCount([1, 2]), 1);
+  });
+}

--- a/test/src/features/offline/data/offline_schema_migration_test.dart
+++ b/test/src/features/offline/data/offline_schema_migration_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  // Use a temp directory so each test run gets a fresh file and close/reopen
+  // semantics are real (not in-memory).
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('offline_migration_test_');
+  });
+
+  tearDown(() async {
+    await tmp.delete(recursive: true);
+  });
+
+  test(
+      'v2 schema persists keep-rule + pinned + downloadedAt across close/reopen',
+      () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    // Open, populate, close.
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      await db.upsertChapterMetadata(
+        id: 10,
+        mangaId: 1,
+        name: 'c',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 3,
+        updatedAt: DateTime(2026),
+      );
+      await db.setKeepRule(1, OfflineKeepRule.allUnread, 7);
+      await db.setChapterPinned(10, true);
+      await db.setChapterDeviceState(10, OfflineDeviceState.downloaded,
+          bytes: 512, downloadedAt: DateTime(2026, 3, 15));
+      await db.close();
+    }
+
+    // Reopen and assert the v2 columns persisted with the values we wrote.
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      final m = await (db.select(db.offlineMangas)
+            ..where((t) => t.id.equals(1)))
+          .getSingle();
+      expect(m.keepRule, OfflineKeepRule.allUnread);
+      expect(m.keepUnreadCount, 7);
+
+      final c = await (db.select(db.offlineChapters)
+            ..where((t) => t.id.equals(10)))
+          .getSingle();
+      expect(c.pinned, true);
+      expect(c.downloadedAt, DateTime(2026, 3, 15));
+      await db.close();
+    }
+  });
+}

--- a/test/src/features/offline/data/offline_screen_gates_test.dart
+++ b/test/src/features/offline/data/offline_screen_gates_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/library/data/category_repository.dart';
+import 'package:tsumiru/src/features/library/presentation/category/controller/edit_category_controller.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_dto_mappers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_read_fallback.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+class _ThrowingCategoryRepo implements CategoryRepository {
+  @override
+  dynamic noSuchMethod(Invocation i) => throw Exception('offline');
+}
+
+class _ThrowingMangaBookRepo implements MangaBookRepository {
+  @override
+  dynamic noSuchMethod(Invocation i) => throw Exception('offline');
+}
+
+Future<ProviderContainer> _container(
+    OfflineDatabase db, List<Override> extra) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final c = ProviderContainer(overrides: [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    offlineDatabaseProvider.overrideWithValue(db),
+    offlineEnabledProvider.overrideWithValue(true),
+    ...extra,
+  ]);
+  addTearDown(c.dispose);
+  return c;
+}
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  group('offlineDefaultCategoryDto', () {
+    test('carries the manga count so it survives the nonZero filter', () {
+      final cat = offlineDefaultCategoryDto(42);
+      expect(cat.id, 0);
+      expect(cat.mangas.totalCount, 42);
+      expect(cat.defaultCategory, true);
+    });
+  });
+
+  group('categoriesWithOfflineFallback', () {
+    Future<Never> boom() async => throw Exception('server down');
+
+    test('returns a single default category (count) when fetch throws', () async {
+      await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+      await db.upsertMangaMetadata(id: 2, title: 'B', updatedAt: DateTime(2026));
+      final cats = await categoriesWithOfflineFallback(
+          fetch: boom, db: db, offlineEnabled: true);
+      expect(cats!.length, 1);
+      expect(cats.single.mangas.totalCount, 2);
+    });
+
+    test('rethrows when the catalog is empty', () async {
+      expect(categoriesWithOfflineFallback(fetch: boom, db: db, offlineEnabled: true),
+          throwsException);
+    });
+
+    test('rethrows when offline disabled', () async {
+      await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+      expect(categoriesWithOfflineFallback(fetch: boom, db: db, offlineEnabled: false),
+          throwsException);
+    });
+  });
+
+  group('chapterMetaWithOfflineFallback', () {
+    Future<Never> boom() async => throw Exception('server down');
+
+    test('falls back to the catalog chapter row on throw', () async {
+      await db.upsertChapterMetadata(
+          id: 99, mangaId: 1, name: 'Ch99', chapterIndex: 5, isRead: false,
+          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+          pageCount: 10, updatedAt: DateTime(2026));
+      final ch = await chapterMetaWithOfflineFallback(
+          fetch: boom, db: db, offlineEnabled: true, chapterId: 99);
+      expect(ch!.id, 99);
+      expect(ch.name, 'Ch99');
+    });
+
+    test('rethrows when the chapter is not in the catalog', () async {
+      expect(
+          chapterMetaWithOfflineFallback(
+              fetch: boom, db: db, offlineEnabled: true, chapterId: 404),
+          throwsException);
+    });
+  });
+
+  // The bugs Aaron actually hit: the real gating providers must render offline,
+  // not just the helpers in isolation.
+  group('real gating providers offline', () {
+    test('CategoryController returns a default category when the server fails',
+        () async {
+      await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+      await db.upsertMangaMetadata(id: 2, title: 'B', updatedAt: DateTime(2026));
+      final c = await _container(db, [
+        categoryRepositoryProvider.overrideWithValue(_ThrowingCategoryRepo()),
+      ]);
+      final cats = await c.read(categoryControllerProvider.future);
+      expect(cats!.length, 1);
+      expect(cats.single.mangas.totalCount, 2);
+    });
+
+    test('reader chapter provider serves a downloaded chapter offline', () async {
+      await db.upsertChapterMetadata(
+          id: 99, mangaId: 1, name: 'Ch99', chapterIndex: 5, isRead: false,
+          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+          pageCount: 10, updatedAt: DateTime(2026));
+      final c = await _container(db, [
+        mangaBookRepositoryProvider.overrideWithValue(_ThrowingMangaBookRepo()),
+      ]);
+      final ch = await c.read(chapterProvider(chapterId: 99).future);
+      expect(ch!.id, 99);
+      expect(ch.name, 'Ch99');
+    });
+
+    test('mangaDownloadedCount counts only device-downloaded chapters', () async {
+      await db.upsertChapterMetadata(
+          id: 1, mangaId: 7, name: 'a', chapterIndex: 1, isRead: false,
+          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+          pageCount: 1, updatedAt: DateTime(2026));
+      await db.upsertChapterMetadata(
+          id: 2, mangaId: 7, name: 'b', chapterIndex: 2, isRead: false,
+          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+          pageCount: 1, updatedAt: DateTime(2026));
+      await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 5);
+      final c = await _container(db, const []);
+      expect(await c.read(mangaDownloadedCountProvider(7).future), 1);
+    });
+  });
+}

--- a/test/src/features/offline/data/offline_settings_providers_test.dart
+++ b/test/src/features/offline/data/offline_settings_providers_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+void main() {
+  test('safetyNetConfig reflects the persisted setting providers (defaults off)', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    final c = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(c.dispose);
+    final cfg = c.read(safetyNetConfigProvider);
+    expect(cfg.timeEvictEnabled, false);
+    expect(cfg.keepDays, 30);
+    expect(cfg.storageCapEnabled, false);
+    expect(cfg.storageCapBytes, 2000 * 1024 * 1024);
+  });
+}

--- a/test/src/features/offline/data/offline_sync_test.dart
+++ b/test/src/features/offline/data/offline_sync_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  test('offlineSync is null when offline is disabled (default / web)', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    expect(container.read(offlineSyncProvider), isNull);
+  });
+
+  test('offlineSync is provided when offline is enabled', () {
+    final db = testOfflineDatabase();
+    final container = ProviderContainer(overrides: [
+      offlineEnabledProvider.overrideWithValue(true),
+      offlineDatabaseProvider.overrideWithValue(db),
+    ]);
+    addTearDown(() {
+      container.dispose();
+      db.close();
+    });
+    expect(container.read(offlineSyncProvider), isNotNull);
+  });
+}

--- a/test/src/features/offline/data/reconcile_desired_set_test.dart
+++ b/test/src/features/offline/data/reconcile_desired_set_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_logic.dart';
+
+OfflineChapter ch(int id, int idx, {bool read = false, bool pinned = false}) =>
+    OfflineChapter(
+      id: id, mangaId: 1, name: 'c$id', chapterIndex: idx, isRead: read,
+      lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+      deviceState: OfflineDeviceState.none, pageCount: 1, bytes: 0,
+      pinned: pinned, downloadedAt: null, progressDirty: false,
+      updatedAt: DateTime(2026),
+    );
+
+void main() {
+  final chapters = [
+    ch(1, 1, read: true),
+    ch(2, 2, read: true),
+    ch(3, 3),            // unread
+    ch(4, 4),            // unread
+    ch(5, 5),            // unread
+  ];
+
+  test('off keeps nothing (except pinned)', () {
+    expect(desiredChapterIds(chapters, OfflineKeepRule.off, 3), isEmpty);
+    final withPin = [...chapters, ch(9, 9, read: true, pinned: true)];
+    expect(desiredChapterIds(withPin, OfflineKeepRule.off, 3), {9});
+  });
+
+  test('all keeps every chapter', () {
+    expect(desiredChapterIds(chapters, OfflineKeepRule.all, 3), {1, 2, 3, 4, 5});
+  });
+
+  test('allUnread keeps only unread', () {
+    expect(desiredChapterIds(chapters, OfflineKeepRule.allUnread, 3), {3, 4, 5});
+  });
+
+  test('nUnread keeps the N lowest-index unread', () {
+    expect(desiredChapterIds(chapters, OfflineKeepRule.nUnread, 2), {3, 4});
+  });
+
+  test('nUnread unions pinned even when read or beyond N', () {
+    final c = [...chapters, ch(1, 1, read: true, pinned: true)];
+    // id 1 already present but pinned; plus next-2-unread {3,4}
+    expect(desiredChapterIds(c, OfflineKeepRule.nUnread, 2), {1, 3, 4});
+  });
+}

--- a/test/src/features/offline/data/reconcile_eviction_test.dart
+++ b/test/src/features/offline/data/reconcile_eviction_test.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_logic.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_types.dart';
+
+OfflineChapter dl(int id, {int bytes = 100, DateTime? at, bool pinned = false}) =>
+    OfflineChapter(
+      id: id, mangaId: 1, name: 'c$id', chapterIndex: id, isRead: false,
+      lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+      deviceState: OfflineDeviceState.downloaded, pageCount: 1, bytes: bytes,
+      pinned: pinned, downloadedAt: at ?? DateTime(2026, 1, id),
+      progressDirty: false, updatedAt: DateTime(2026),
+    );
+
+void main() {
+  final now = DateTime(2026, 3, 1);
+
+  test('evicts downloaded chapters not in the desired set (non-pinned)', () {
+    final r = applySafetyNets(
+      downloaded: [dl(1), dl(2)], desired: {1}, nets: SafetyNetConfig.off, now: now);
+    expect(r.evict, {2});
+    expect(r.overCapWarning, false);
+  });
+
+  test('never evicts pinned, even if not desired', () {
+    final r = applySafetyNets(
+      downloaded: [dl(1, pinned: true)], desired: {}, nets: SafetyNetConfig.off, now: now);
+    expect(r.evict, isEmpty);
+  });
+
+  test('time-net evicts non-pinned older than keepDays', () {
+    final nets = SafetyNetConfig(timeEvictEnabled: true, keepDays: 10,
+        storageCapEnabled: false, storageCapBytes: 0);
+    final r = applySafetyNets(
+      downloaded: [dl(1, at: DateTime(2026, 1, 1)), dl(2, at: now)],
+      desired: {1, 2}, nets: nets, now: now);
+    expect(r.evict, {1}); // ch1 ~59 days old > 10
+  });
+
+  test('storage cap evicts oldest non-pinned first; warns if only pinned remain', () {
+    final nets = SafetyNetConfig(timeEvictEnabled: false, keepDays: 30,
+        storageCapEnabled: true, storageCapBytes: 150);
+    final r = applySafetyNets(
+      downloaded: [
+        dl(1, bytes: 100, at: DateTime(2026, 1, 1)),
+        dl(2, bytes: 100, at: DateTime(2026, 1, 2), pinned: true),
+      ],
+      desired: {1, 2}, nets: nets, now: now);
+    expect(r.evict, {1});          // evict oldest non-pinned to get under 150
+    expect(r.overCapWarning, false);
+  });
+
+  test('over cap with only pinned left -> warning, no eviction', () {
+    final nets = SafetyNetConfig(timeEvictEnabled: false, keepDays: 30,
+        storageCapEnabled: true, storageCapBytes: 50);
+    final r = applySafetyNets(
+      downloaded: [dl(1, bytes: 100, pinned: true)],
+      desired: {1}, nets: nets, now: now);
+    expect(r.evict, isEmpty);
+    expect(r.overCapWarning, true);
+  });
+}

--- a/test/src/features/offline/data/reconcile_types_test.dart
+++ b/test/src/features/offline/data/reconcile_types_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_types.dart';
+
+void main() {
+  test('SafetyNetConfig.off is all-disabled', () {
+    expect(SafetyNetConfig.off.timeEvictEnabled, false);
+    expect(SafetyNetConfig.off.storageCapEnabled, false);
+  });
+  test('ReconcilePlan.empty has empty sets and no warning', () {
+    expect(ReconcilePlan.empty.toDownload, isEmpty);
+    expect(ReconcilePlan.empty.toEvict, isEmpty);
+    expect(ReconcilePlan.empty.overCapWarning, false);
+  });
+}

--- a/test/src/features/offline/presentation/offline_bytes_format_test.dart
+++ b/test/src/features/offline/presentation/offline_bytes_format_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/presentation/offline_settings_format.dart';
+
+void main() {
+  test('formats bytes as human units', () {
+    expect(formatBytes(0), '0 B');
+    expect(formatBytes(1024), '1.0 KB');
+    expect(formatBytes(2 * 1024 * 1024), '2.0 MB');
+    expect(formatBytes(3 * 1024 * 1024 * 1024), '3.0 GB');
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -18,6 +19,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
   flutter_secure_storage_windows
   permission_handler_windows
+  sqlite3_flutter_libs
   url_launcher_windows
 )
 


### PR DESCRIPTION
## Offline reading
Keep a series on the device and read it with no server:
- Drift catalog mirrored from the library (manga/chapters/pages, keep-rules, pinned, byte sizes) + per-chapter device state; dart:io page store with atomic writes.
- Komikku-style download engine: one chapter at a time, pages fetched in parallel, **auth resolved per request and refreshed on 401** (no baked tokens), small retry. Coordinator drives the queue + finalize; reconciler applies per-series keep-rules (latest-N / all-unread / all) with `pinned > safety-nets > rule` precedence, plus device-wide time/size safety nets.
- `ServerImage` reads downloaded pages from disk; library / details / chapters / reader fall back to the catalog when the server is unreachable; reading progress persists locally and syncs up when back online.
- UI: per-series Keep-offline control, "On device" library filter, server/on-device Downloads tabs, Settings → Offline.

## Reader & library polish
- Webtoon: reserve each page's height before decode (fixes the offline seek-bar mis-landing), decode-ahead prefetch + sibling height estimate for smooth scroll, edge-to-edge fill + system bars shown with the menu.
- Unified library + chapter multi-select on one floating action bar (mark read/unread, download to device, download to server, edit categories, delete).
- Optional "Lock to portrait" for phones.

History was flattened from the development branch (many false starts removed). Downloads currently run while the app is open; a foreground-service/isolate **background-download worker is a planned follow-up** (`flutter_foreground_task` + FGS manifest are already in place for it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)