### PR TITLE
Offline downloads: background download engine

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'src/features/auth/data/auth_coordinator.dart';
 import 'src/features/auth/data/auth_credentials_store.dart';
 import 'src/features/auth/data/basic_auth_migration.dart';
 import 'src/features/auth/data/secure_credentials_provider.dart';
+import 'src/features/offline/data/background/background_download_controller_shim.dart';
 import 'src/features/offline/data/offline_background_downloads.dart';
 import 'src/features/offline/data/offline_bootstrap.dart';
 import 'src/features/offline/data/offline_download_providers.dart';
@@ -31,9 +32,13 @@ import 'src/features/settings/presentation/server/widget/credential_popup/creden
 import 'src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart';
 import 'src/global_providers/global_providers.dart';
 import 'src/sorayomi.dart';
+import 'src/utils/platform/is_android_native.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  // Initialise the foreground-task plugin (Android-only; no-op elsewhere) before
+  // any download service is started. Must run after the binding is ready.
+  initForegroundTaskService();
   final packageInfo = await PackageInfo.fromPlatform();
   final sharedPreferences = await SharedPreferences.getInstance();
   await initHiveForFlutter();
@@ -126,7 +131,16 @@ Future<void> main() async {
     unawaited(Future(() async {
       await pushPendingProgress(container);
       await reconcileAllAtLaunch(container);
-      await initOfflineDownloads(container);
+      if (isAndroidNative) {
+        // Android: the foreground-service worker owns downloads. Register the
+        // lifecycle/connectivity hooks, replay any leftover completion log into
+        // drift, and restart the service if the queue is non-empty.
+        final controller = container.read(backgroundDownloadControllerProvider);
+        controller.register();
+        await controller.replayAtLaunchAndMaybeStart();
+      } else {
+        await initOfflineDownloads(container);
+      }
     }));
   }
 

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -77,6 +77,8 @@ enum DBKeys {
   // How many chapter pages download at once. Low by default: a self-hosted
   // server saturates fast and starts returning 500/503 under heavy parallelism.
   offlineDownloadConcurrency(2),
+  // Restrict background downloads to Wi-Fi connections only.
+  downloadOnlyOverWifi(false),
   // Lock phones to portrait (landscape on a phone currently looks broken). Off
   // by default — many readers prefer landscape; tablets/desktop ignore it.
   forcePortrait(false),

--- a/lib/src/features/offline/data/background/background_completion_log.dart
+++ b/lib/src/features/offline/data/background/background_completion_log.dart
@@ -7,6 +7,9 @@
 import 'dart:convert';
 import 'dart:io';
 
+import '../offline_database.dart';
+import '../offline_paths.dart';
+
 sealed class LogEntry {
   const LogEntry();
 }
@@ -87,4 +90,77 @@ class BackgroundCompletionLog {
   Future<void> truncate() async {
     if (await file.exists()) await file.writeAsString('', flush: true);
   }
+}
+
+typedef ChapterBytesMeasurer = Future<int> Function(int mangaId, int chapterId);
+
+Future<void> replayCompletionLog({
+  required OfflineDatabase db,
+  required OfflinePaths paths,
+  required BackgroundCompletionLog log,
+  required ChapterBytesMeasurer measureBytes,
+}) async {
+  final entries = await log.parse();
+  if (entries.isEmpty) return;
+
+  // Which chapters were touched + their terminal status (last one wins).
+  final touched = <int, int>{}; // chapterId -> mangaId
+  final terminal = <int, String>{};
+  for (final e in entries) {
+    switch (e) {
+      case PageEntry(:final chapterId, :final mangaId):
+        touched[chapterId] = mangaId;
+      case ChapterEntry(:final chapterId, :final status):
+        terminal[chapterId] = status;
+        // mangaId for a chapter-only entry comes from drift below
+      case DrainedEntry():
+        break;
+    }
+  }
+
+  for (final chapterId in {...touched.keys, ...terminal.keys}) {
+    final ch = await db.chapterById(chapterId);
+    // Skip deleted/cleared chapters — never resurrect (design: filesystem is
+    // subordinate to drift authority here).
+    if (ch == null || ch.deviceState == OfflineDeviceState.none) continue;
+    final mangaId = touched[chapterId] ?? ch.mangaId;
+
+    // Filesystem is truth: upsert a row for every page file on disk.
+    final dir = Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
+    if (await dir.exists()) {
+      await for (final f in dir.list()) {
+        if (f is! File) continue;
+        final name = f.uri.pathSegments.last; // e.g. 003.jpg
+        final dot = name.indexOf('.');
+        if (dot <= 0) continue;
+        final idx = int.tryParse(name.substring(0, dot));
+        if (idx == null) continue;
+        await db.into(db.offlinePages).insertOnConflictUpdate(
+              OfflinePagesCompanion.insert(
+                chapterId: chapterId,
+                pageIndex: idx,
+                relativePath: paths.pageRel(mangaId, chapterId, idx,
+                    name.substring(dot + 1)),
+              ),
+            );
+      }
+    }
+
+    // Apply terminal state.
+    switch (terminal[chapterId]) {
+      case 'downloaded':
+        final bytes = await measureBytes(mangaId, chapterId);
+        await db.setChapterDeviceState(chapterId, OfflineDeviceState.downloaded,
+            bytes: bytes, downloadedAt: DateTime.now());
+      case 'error':
+      case 'authFailed':
+        await db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
+      case 'offline':
+      case null:
+        // leave downloading — resumed later by the pump/worker
+        break;
+    }
+  }
+
+  await log.truncate();
 }

--- a/lib/src/features/offline/data/background/background_completion_log.dart
+++ b/lib/src/features/offline/data/background/background_completion_log.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+import 'dart:io';
+
+sealed class LogEntry {
+  const LogEntry();
+}
+
+class PageEntry extends LogEntry {
+  const PageEntry(this.chapterId, this.mangaId, this.pageIndex, this.relPath, this.bytes);
+  final int chapterId, mangaId, pageIndex, bytes;
+  final String relPath;
+}
+
+class ChapterEntry extends LogEntry {
+  const ChapterEntry(this.chapterId, this.status, this.pages, this.bytes);
+  final int chapterId, pages, bytes;
+  final String status; // downloaded | error | authFailed | offline
+}
+
+class DrainedEntry extends LogEntry {
+  const DrainedEntry();
+}
+
+/// Append-only JSONL record of background-download progress. The DURABLE source
+/// of truth the main isolate replays into drift on resume/launch. One JSON object
+/// per line, flushed. A torn final line (process killed mid-write) is silently
+/// discarded on parse; page files are independently crash-safe (atomic write).
+class BackgroundCompletionLog {
+  BackgroundCompletionLog(this.file);
+  final File file;
+
+  Future<void> _append(Map<String, Object?> obj) async {
+    await file.parent.create(recursive: true);
+    await file.writeAsString('${jsonEncode(obj)}\n',
+        mode: FileMode.append, flush: true);
+  }
+
+  Future<void> appendPage({
+    required int chapterId,
+    required int mangaId,
+    required int pageIndex,
+    required String relPath,
+    required int bytes,
+  }) =>
+      _append({'t': 'page', 'c': chapterId, 'm': mangaId, 'i': pageIndex, 'p': relPath, 'b': bytes});
+
+  Future<void> appendChapter({
+    required int chapterId,
+    required String status,
+    required int pages,
+    required int bytes,
+  }) =>
+      _append({'t': 'chapter', 'c': chapterId, 's': status, 'pages': pages, 'bytes': bytes});
+
+  Future<void> appendDrained() => _append({'t': 'drained'});
+
+  Future<List<LogEntry>> parse() async {
+    if (!await file.exists()) return const [];
+    final lines = await file.readAsLines();
+    final out = <LogEntry>[];
+    for (final line in lines) {
+      if (line.trim().isEmpty) continue;
+      Map<String, Object?> j;
+      try {
+        j = jsonDecode(line) as Map<String, Object?>;
+      } catch (_) {
+        continue; // torn/partial line — discard
+      }
+      switch (j['t']) {
+        case 'page':
+          out.add(PageEntry(j['c'] as int, j['m'] as int, j['i'] as int, j['p'] as String, j['b'] as int));
+        case 'chapter':
+          out.add(ChapterEntry(j['c'] as int, j['s'] as String, j['pages'] as int, j['bytes'] as int));
+        case 'drained':
+          out.add(const DrainedEntry());
+      }
+    }
+    return out;
+  }
+
+  Future<void> truncate() async {
+    if (await file.exists()) await file.writeAsString('', flush: true);
+  }
+}

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -74,12 +74,14 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// replay). Idempotent.
   void register() {
     if (!Platform.isAndroid) return;
+    WidgetsBinding.instance.addObserver(this);
     _workerEventCallback ??= _onWorkerEvent;
     FlutterForegroundTask.addTaskDataCallback(_workerEventCallback!);
     _connSub ??= Connectivity().onConnectivityChanged.listen(_onConnectivityChanged);
   }
 
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     final cb = _workerEventCallback;
     if (cb != null) FlutterForegroundTask.removeTaskDataCallback(cb);
     unawaited(_connSub?.cancel());
@@ -421,4 +423,33 @@ class BackgroundDownloadController with WidgetsBindingObserver {
             key: kTokenRecordKey, value: jsonEncode(r.toJson())),
         refreshFn: refreshFn,
       );
+}
+
+/// App-lifetime singleton driving the foreground-service downloads on Android.
+/// Read it at launch (to `register()` + replay) and from the enqueue/delete
+/// sites. Self-gates to Android; a no-op on iOS/desktop (main-isolate pump used
+/// there). On web this file is never compiled — the conditional-import shim
+/// (`background_download_controller_shim.dart`) swaps in a no-op stub.
+final backgroundDownloadControllerProvider =
+    Provider<BackgroundDownloadController>(
+        (ref) => BackgroundDownloadController(ref));
+
+/// Initialise `flutter_foreground_task` (communication port + notification
+/// channel/options). Call once early in `main()`. Android-only; no-op elsewhere.
+void initForegroundTaskService() {
+  if (!Platform.isAndroid) return;
+  FlutterForegroundTask.initCommunicationPort();
+  FlutterForegroundTask.init(
+    androidNotificationOptions: AndroidNotificationOptions(
+      channelId: 'tsumiru_downloads',
+      channelName: 'Downloads',
+      channelImportance: NotificationChannelImportance.LOW,
+      priority: NotificationPriority.LOW,
+    ),
+    iosNotificationOptions: const IOSNotificationOptions(),
+    foregroundTaskOptions: ForegroundTaskOptions(
+      eventAction: ForegroundTaskEventAction.nothing(),
+      allowWifiLock: true,
+    ),
+  );
 }

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -217,8 +217,24 @@ class BackgroundDownloadController with WidgetsBindingObserver {
 
   void _onWorkerEvent(Object data) {
     if (data is! Map) return;
-    if (data['kind'] == 'chapterDone') {
-      unawaited(_onChapterDone(data));
+    switch (data['kind']) {
+      // Live foreground UI: mark the chapter downloading + accumulate page rows
+      // as the worker reports them, so the per-chapter progress arc animates.
+      // (Only meaningful while the app is foreground; the durable record is the
+      // completion log, replayed on resume.)
+      case 'chapterStart':
+        unawaited(_db.setChapterDeviceState(
+            data['chapterId'] as int, OfflineDeviceState.downloading));
+      case 'page':
+        unawaited(_db.into(_db.offlinePages).insertOnConflictUpdate(
+              OfflinePagesCompanion.insert(
+                chapterId: data['chapterId'] as int,
+                pageIndex: data['pageIndex'] as int,
+                relativePath: data['relPath'] as String,
+              ),
+            ));
+      case 'chapterDone':
+        unawaited(_onChapterDone(data));
     }
   }
 

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -1,0 +1,424 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../constants/enum.dart';
+import '../../../../global_providers/global_providers.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../utils/logger/logger.dart';
+import '../../../auth/data/auth_credentials_store.dart';
+import '../../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import '../../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+import '../../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
+import '../offline_database.dart';
+import '../offline_page_store.dart';
+import '../offline_paths.dart';
+import '../offline_repository.dart';
+import '../offline_settings_providers.dart';
+import 'background_completion_log.dart';
+import 'background_token_record.dart';
+import 'background_work_order.dart';
+import 'download_task_handler.dart';
+
+/// Owns the Android foreground-service download worker from the MAIN isolate:
+/// starts/stops it at the right moments, mirrors drift into the worker via
+/// messages, applies the worker's events + the durable completion log back into
+/// drift, and recovers correctly after backgrounding / a kill.
+///
+/// Single-owner invariant: while the queue is non-empty on Android, exactly one
+/// background isolate downloads (foreground + background). The main-isolate
+/// file-writing pump must NOT run on Android — that gate lives in
+/// `initOfflineDownloads` (wired in a later task), not here.
+///
+/// This controller is a no-op on non-Android platforms; desktop/iOS keep the
+/// existing main-isolate pump.
+class BackgroundDownloadController with WidgetsBindingObserver {
+  BackgroundDownloadController(this._ref);
+
+  final Ref _ref;
+
+  /// Registered as the FFT task-data callback; held so we can deregister.
+  DataCallback? _workerEventCallback;
+
+  /// Connectivity listener used to enforce Wi-Fi-only while the app is alive.
+  StreamSubscription<List<ConnectivityResult>>? _connSub;
+
+  /// Guards [ensureServiceRunning] against overlapping invocations (it does
+  /// several awaited steps; concurrent enqueue + resume could double-start).
+  bool _ensuring = false;
+
+  OfflineDatabase get _db => _ref.read(offlineDatabaseProvider);
+  OfflinePaths get _paths => _ref.read(offlinePathsProvider);
+  OfflinePageStore get _store => _ref.read(offlinePageStoreProvider);
+
+  BackgroundCompletionLog get _log =>
+      BackgroundCompletionLog(File('${_paths.baseDir}/.bg_completion.log'));
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle registration
+  // ---------------------------------------------------------------------------
+
+  /// Wire up the worker-event callback + the Wi-Fi-only connectivity listener.
+  /// Call once at startup (after FFT.initCommunicationPort, before/at launch
+  /// replay). Idempotent.
+  void register() {
+    if (!Platform.isAndroid) return;
+    _workerEventCallback ??= _onWorkerEvent;
+    FlutterForegroundTask.addTaskDataCallback(_workerEventCallback!);
+    _connSub ??= Connectivity().onConnectivityChanged.listen(_onConnectivityChanged);
+  }
+
+  void dispose() {
+    final cb = _workerEventCallback;
+    if (cb != null) FlutterForegroundTask.removeTaskDataCallback(cb);
+    unawaited(_connSub?.cancel());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Service start (heart of single-owner)
+  // ---------------------------------------------------------------------------
+
+  /// Ensure the foreground service owns the current queue. Idempotent: if it's
+  /// already running, the pending ids are messaged in (the worker merges them);
+  /// otherwise the service is started with a freshly-built work order.
+  ///
+  /// Wi-Fi-only is enforced HERE (main isolate): if the setting is on and the
+  /// active connection is metered, the service is not started.
+  Future<void> ensureServiceRunning() async {
+    if (!Platform.isAndroid) return;
+    if (_ensuring) return;
+    _ensuring = true;
+    try {
+      final pending = await _pendingChapters();
+      if (pending.isEmpty) return;
+
+      if (await FlutterForegroundTask.isRunningService) {
+        // Already owned — just merge the new ids into the worker's queue.
+        for (final c in pending) {
+          FlutterForegroundTask.sendDataToTask(
+              {'op': 'add', 'chapterId': c.id, 'mangaId': c.mangaId});
+        }
+        return;
+      }
+
+      // Start gate: don't bring up the service on a metered connection when
+      // Wi-Fi-only is on. The queue stays in drift; a later Wi-Fi reconnect (or
+      // the next foreground) starts it.
+      if (await _wifiOnlyBlocks()) {
+        logger.i('Offline: Wi-Fi-only on + metered — deferring service start');
+        return;
+      }
+
+      await _ensureNotificationPermission();
+      await _writeWorkOrder(pending);
+      final res = await FlutterForegroundTask.startService(
+        serviceTypes: [ForegroundServiceTypes.dataSync],
+        notificationTitle: 'Downloading chapters',
+        notificationText: 'Starting…',
+        callback: backgroundDownloadCallback,
+      );
+      if (res is ServiceRequestFailure) {
+        logger.e('Offline: foreground service failed to start: ${res.error}');
+      }
+    } finally {
+      _ensuring = false;
+    }
+  }
+
+  /// drift is queue authority: queued + (resumable) downloading chapters.
+  Future<List<OfflineChapter>> _pendingChapters() async {
+    final queued = await _db.chaptersInState(OfflineDeviceState.queued);
+    final downloading =
+        await _db.chaptersInState(OfflineDeviceState.downloading);
+    return [...queued, ...downloading];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Enqueue / remove / wifi-only changes
+  // ---------------------------------------------------------------------------
+
+  /// Called after the caller has written drift `queued` for [chapterIds]. Just
+  /// ensures the service owns the queue (it reads drift, not the argument).
+  Future<void> onEnqueued(List<int> chapterIds) => ensureServiceRunning();
+
+  /// Tell the worker to drop a chapter (delete/cancel). The caller still does
+  /// the actual drift/file delete; this only stops the in-flight download.
+  Future<void> onRemoved(int chapterId) async {
+    if (!Platform.isAndroid) return;
+    if (await FlutterForegroundTask.isRunningService) {
+      FlutterForegroundTask.sendDataToTask(
+          {'op': 'remove', 'chapterId': chapterId});
+    }
+  }
+
+  /// Push a Wi-Fi-only setting change to the worker, and enforce it from the
+  /// main side: if it's now on + we're metered, stop the running service.
+  Future<void> onWifiOnlyChanged(bool value) async {
+    if (!Platform.isAndroid) return;
+    if (await FlutterForegroundTask.isRunningService) {
+      FlutterForegroundTask.sendDataToTask({'op': 'setWifiOnly', 'value': value});
+      if (value && await _isMetered()) {
+        await FlutterForegroundTask.stopService();
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // App lifecycle
+  // ---------------------------------------------------------------------------
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!Platform.isAndroid) return;
+    if (state == AppLifecycleState.resumed) {
+      // Catch drift up from the durable log for live UI. No ownership change —
+      // the worker still owns the queue.
+      unawaited(replayOnResume());
+    }
+    // paused/hidden/detached: NOTHING — the FGS already owns the queue.
+  }
+
+  /// Replay the completion log into drift (live-UI catch-up on resume).
+  Future<void> replayOnResume() => _replay();
+
+  /// At launch: replay any log left by a previous run, then — if drift still has
+  /// a non-empty queue — (re)start the service to finish it.
+  Future<void> replayAtLaunchAndMaybeStart() async {
+    if (!Platform.isAndroid) return;
+    await _replay();
+    final pending = await _pendingChapters();
+    if (pending.isNotEmpty) await ensureServiceRunning();
+  }
+
+  Future<void> _replay() => replayCompletionLog(
+        db: _db,
+        paths: _paths,
+        log: _log,
+        measureBytes: (mangaId, chapterId) =>
+            _store.chapterBytes(mangaId, chapterId),
+      );
+
+  // ---------------------------------------------------------------------------
+  // Worker events + drain handshake (CRITICAL-1)
+  // ---------------------------------------------------------------------------
+
+  void _onWorkerEvent(Object data) {
+    if (data is! Map) return;
+    if (data['kind'] == 'chapterDone') {
+      unawaited(_onChapterDone(data));
+    }
+  }
+
+  Future<void> _onChapterDone(Map data) async {
+    final chapterId = data['chapterId'] as int?;
+    final status = data['status'] as String?;
+    if (chapterId != null && status != null) {
+      // Foreground live UI: apply the terminal state immediately (the durable
+      // log is still the source of truth and is reconciled on the next replay).
+      switch (status) {
+        case 'downloaded':
+          final ch = await _db.chapterById(chapterId);
+          if (ch != null && ch.deviceState != OfflineDeviceState.none) {
+            final bytes = await _store.chapterBytes(ch.mangaId, chapterId);
+            await _db.setChapterDeviceState(
+                chapterId, OfflineDeviceState.downloaded,
+                bytes: bytes, downloadedAt: DateTime.now());
+          }
+        case 'error':
+        case 'authFailed':
+          await _db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
+        // 'offline' / null: leave `downloading` so it resumes.
+      }
+    }
+
+    // Drain handshake: if the worker just self-stopped (queue empty), do the
+    // post-stop reconciliation + a drift requery in case work was enqueued
+    // during the async stop window (CRITICAL-1).
+    if (!await FlutterForegroundTask.isRunningService) {
+      await _onServiceStopped();
+    }
+  }
+
+  Future<void> _onServiceStopped() async {
+    await _replay(); // final log replay → drift
+    await _wipeWorkOrderAuth();
+    // Anything queued during the async stop? Restart to pick it up.
+    final pending = await _pendingChapters();
+    if (pending.isNotEmpty) await ensureServiceRunning();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Work order + auth snapshot / write-back
+  // ---------------------------------------------------------------------------
+
+  Future<void> _writeWorkOrder(List<OfflineChapter> pending) async {
+    final auth = _snapshotAuth();
+    final order = BackgroundWorkOrder(
+      chapterIds: [for (final c in pending) c.id],
+      mangaIdByChapter: {for (final c in pending) c.id: c.mangaId},
+      serverBase: _ref.read(serverUrlProvider) ?? '',
+      port: _ref.read(serverPortProvider),
+      addPort: _ref.read(serverPortToggleProvider).ifNull(),
+      wifiOnly: _ref.read(offlineWifiOnlyProvider) ?? false,
+      auth: auth,
+      baseDir: _paths.baseDir,
+    );
+    await FlutterForegroundTask.saveData(
+        key: kWorkOrderKey, value: jsonEncode(order.toJson()));
+    // Seed the shared token record so the worker's broker reads/writes the same
+    // gen-versioned record we'll read back on stop.
+    await FlutterForegroundTask.saveData(
+        key: kTokenRecordKey, value: jsonEncode(auth.toJson()));
+  }
+
+  /// Snapshot the current auth into the cross-isolate record. The worker uses
+  /// only the fields relevant to the active auth type.
+  BackgroundTokenRecord _snapshotAuth() {
+    final authType = _ref.read(authTypeKeyProvider) ?? AuthType.none;
+    final basicToken = _ref.read(credentialsProvider).valueOrNull;
+    final creds = _ref.read(authCredentialsStoreProvider).valueOrNull;
+    return BackgroundTokenRecord(
+      gen: 0,
+      authType: authType.name,
+      accessToken: creds?.uiAccessToken,
+      refreshToken: creds?.uiRefreshToken,
+      basicCredential: basicToken,
+      simpleCookie: creds?.simpleLoginCookie,
+    );
+  }
+
+  /// After the worker stops, copy any rotated ui_login tokens it persisted back
+  /// into the app's [AuthCredentialsStore], then clear the FFT auth keys so a
+  /// stale token snapshot never lingers in plugin storage.
+  Future<void> _wipeWorkOrderAuth() async {
+    final raw =
+        await FlutterForegroundTask.getData<String>(key: kTokenRecordKey);
+    if (raw != null) {
+      try {
+        final record = BackgroundTokenRecord.fromJson(
+            jsonDecode(raw) as Map<String, Object?>);
+        // gen > 0 means the worker rotated the token at least once.
+        if (record.gen > 0 &&
+            record.authType == 'uiLogin' &&
+            record.accessToken != null) {
+          final store = _ref.read(authCredentialsStoreProvider.notifier);
+          if (record.refreshToken != null) {
+            await store.saveUiLoginTokens(
+              accessToken: record.accessToken!,
+              refreshToken: record.refreshToken!,
+            );
+          } else {
+            await store.updateUiLoginAccessToken(record.accessToken!);
+          }
+        }
+      } catch (e) {
+        logger.e('Offline: failed to read back worker token record: $e');
+      }
+    }
+    await FlutterForegroundTask.removeData(key: kTokenRecordKey);
+    await FlutterForegroundTask.removeData(key: kWorkOrderKey);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Wi-Fi-only main-side enforcement
+  // ---------------------------------------------------------------------------
+
+  /// True when Wi-Fi-only is set AND the active connection is metered — the
+  /// condition under which we won't start the service.
+  Future<bool> _wifiOnlyBlocks() async {
+    if (!(_ref.read(offlineWifiOnlyProvider) ?? false)) return false;
+    return _isMetered();
+  }
+
+  /// True when the active connection is metered (no Wi-Fi and no ethernet).
+  /// `connectivity_plus` returns a list; an empty/none list is treated as
+  /// metered-ish (no usable unmetered link), so we don't start a wifi-only batch.
+  Future<bool> _isMetered() async {
+    final result = await Connectivity().checkConnectivity();
+    final hasUnmetered = result.contains(ConnectivityResult.wifi) ||
+        result.contains(ConnectivityResult.ethernet);
+    return !hasUnmetered;
+  }
+
+  /// React to connectivity changes while the app is alive: if Wi-Fi-only is on
+  /// and we drop to metered, stop the running service (the chapters stay
+  /// `downloading` and resume on Wi-Fi). If we (re)gain Wi-Fi and there's
+  /// pending work, start it.
+  ///
+  /// v1 LIMITATION: a Wi-Fi→mobile switch that happens ENTIRELY while the app is
+  /// backgrounded isn't caught here (no listener runs) — it's only reconciled on
+  /// the next foreground/launch. The worker carries the wifiOnly flag for a
+  /// future in-worker gate but does not act on connection type today.
+  void _onConnectivityChanged(List<ConnectivityResult> result) {
+    if (!Platform.isAndroid) return;
+    final wifiOnly = _ref.read(offlineWifiOnlyProvider) ?? false;
+    if (!wifiOnly) return;
+    final hasUnmetered = result.contains(ConnectivityResult.wifi) ||
+        result.contains(ConnectivityResult.ethernet);
+    unawaited(() async {
+      if (!hasUnmetered) {
+        if (await FlutterForegroundTask.isRunningService) {
+          logger.i('Offline: dropped to metered with Wi-Fi-only — stopping FGS');
+          await FlutterForegroundTask.stopService();
+        }
+      } else {
+        // Back on an unmetered link — resume any pending work.
+        final pending = await _pendingChapters();
+        if (pending.isNotEmpty) await ensureServiceRunning();
+      }
+    }());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Permissions
+  // ---------------------------------------------------------------------------
+
+  /// Request POST_NOTIFICATIONS (Android 13+) before starting the service —
+  /// `startService` fails without it. Best-effort: a denial is logged; the start
+  /// attempt still proceeds (the OS will simply suppress the notification).
+  Future<void> _ensureNotificationPermission() async {
+    final current = await FlutterForegroundTask.checkNotificationPermission();
+    if (current == NotificationPermission.granted) return;
+    final result = await FlutterForegroundTask.requestNotificationPermission();
+    if (result != NotificationPermission.granted) {
+      logger.i('Offline: notification permission not granted ($result)');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // TokenBroker adapter (main side)
+  // ---------------------------------------------------------------------------
+
+  /// A [TokenBroker] backed by FFT storage for the main side, sharing the same
+  /// gen-versioned record the worker uses. Provided for callers/tests that need
+  /// to coordinate a refresh from the main isolate against the worker's record.
+  /// Only ui_login refreshes; the network refresh is delegated to [refreshFn].
+  TokenBroker mainSideBroker({
+    required Future<RefreshResult?> Function(String refreshToken) refreshFn,
+  }) =>
+      TokenBroker(
+        read: () async {
+          final raw = await FlutterForegroundTask.getData<String>(
+              key: kTokenRecordKey);
+          if (raw != null) {
+            return BackgroundTokenRecord.fromJson(
+                jsonDecode(raw) as Map<String, Object?>);
+          }
+          return _snapshotAuth();
+        },
+        write: (r) => FlutterForegroundTask.saveData(
+            key: kTokenRecordKey, value: jsonEncode(r.toJson())),
+        refreshFn: refreshFn,
+      );
+}

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -251,7 +251,23 @@ class BackgroundDownloadController with WidgetsBindingObserver {
             ));
       case 'chapterDone':
         unawaited(_onChapterDone(data));
+      case 'drained':
+        unawaited(_onDrained());
     }
+  }
+
+  /// The worker drained its queue and is self-stopping. Anything enqueued during
+  /// that shutdown window is in drift `queued` but stranded in the dying worker
+  /// (the "tap download, nothing happens until reopen" bug). So: wait for the
+  /// service to actually stop (stopService is async), then re-check the catalog
+  /// and restart if work remains. ensureServiceRunning is idempotent.
+  Future<void> _onDrained() async {
+    for (var i = 0; i < 20; i++) {
+      if (!await FlutterForegroundTask.isRunningService) break;
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+    }
+    final pending = await _pendingChapters();
+    if (pending.isNotEmpty) await ensureServiceRunning();
   }
 
   Future<void> _onChapterDone(Map data) async {

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -192,7 +192,16 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   }
 
   /// Replay the completion log into drift (live-UI catch-up on resume).
-  Future<void> replayOnResume() => _replay();
+  Future<void> replayOnResume() async {
+    await _replay();
+    // The foreground service may have been killed while we were backgrounded (OS
+    // memory pressure, the dataSync time cap, a swipe-away). If drift still has
+    // pending chapters, (re)start it — ensureServiceRunning is idempotent, so
+    // it's a no-op when the worker is still alive. Without this, downloads only
+    // resumed when the user reopened a manga's details (which calls it too).
+    final pending = await _pendingChapters();
+    if (pending.isNotEmpty) await ensureServiceRunning();
+  }
 
   /// At launch: replay any log left by a previous run, then — if drift still has
   /// a non-empty queue — (re)start the service to finish it.
@@ -223,8 +232,15 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       // (Only meaningful while the app is foreground; the durable record is the
       // completion log, replayed on resume.)
       case 'chapterStart':
-        unawaited(_db.setChapterDeviceState(
-            data['chapterId'] as int, OfflineDeviceState.downloading));
+        final id = data['chapterId'] as int;
+        unawaited(_db.setChapterDeviceState(id, OfflineDeviceState.downloading));
+        // Record the resolved page total so the progress arc can show a real
+        // fraction (only when known + currently unset/0, to avoid clobbering a
+        // good catalog value).
+        final total = data['total'] as int?;
+        if (total != null && total > 0) {
+          unawaited(_db.setChapterPageCount(id, total));
+        }
       case 'page':
         unawaited(_db.into(_db.offlinePages).insertOnConflictUpdate(
               OfflinePagesCompanion.insert(

--- a/lib/src/features/offline/data/background/background_download_controller_shim.dart
+++ b/lib/src/features/offline/data/background/background_download_controller_shim.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Web-safe entry point for the background-download controller.
+//
+// The real controller (`background_download_controller.dart`) pulls in
+// `dart:io` + `flutter_foreground_task` and only compiles on native platforms;
+// on web this exports a no-op stub instead. Web-compiled code
+// (`offline_download_providers.dart`, `main.dart`) must import THIS shim, never
+// the controller directly.
+export 'background_download_controller_stub.dart'
+    if (dart.library.io) 'background_download_controller.dart';

--- a/lib/src/features/offline/data/background/background_download_controller_stub.dart
+++ b/lib/src/features/offline/data/background/background_download_controller_stub.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Web stub for [BackgroundDownloadController]. The real controller depends on
+/// `dart:io` + `flutter_foreground_task` (native-only), which don't compile for
+/// web. The conditional-import shim swaps this no-op in on web, so the
+/// web-compiled call sites (`offline_download_providers.dart`, `main.dart`)
+/// still build. Offline is disabled on web, so none of these are ever reached
+/// at runtime there anyway.
+class BackgroundDownloadController {
+  BackgroundDownloadController(this._ref);
+
+  // ignore: unused_field
+  final Ref _ref;
+
+  void register() {}
+  void dispose() {}
+  Future<void> ensureServiceRunning() async {}
+  Future<void> onEnqueued(List<int> chapterIds) async {}
+  Future<void> onRemoved(int chapterId) async {}
+  Future<void> onWifiOnlyChanged(bool value) async {}
+  Future<void> replayAtLaunchAndMaybeStart() async {}
+}
+
+/// Web no-op mirror of the native provider.
+final backgroundDownloadControllerProvider =
+    Provider<BackgroundDownloadController>(
+        (ref) => BackgroundDownloadController(ref));
+
+/// Web no-op: there is no foreground task service to initialise.
+void initForegroundTaskService() {}

--- a/lib/src/features/offline/data/background/background_token_record.dart
+++ b/lib/src/features/offline/data/background/background_token_record.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+typedef RefreshResult = ({String access, String refresh});
+
+class BackgroundTokenRecord {
+  const BackgroundTokenRecord({
+    required this.gen,
+    required this.authType,
+    this.accessToken,
+    this.refreshToken,
+    this.password,
+    this.basicCredential,
+    this.simpleCookie,
+  });
+
+  final int gen;
+  final String authType; // basic | simpleLogin | uiLogin | none
+  final String? accessToken, refreshToken, password, basicCredential, simpleCookie;
+
+  BackgroundTokenRecord copyWith({int? gen, String? accessToken, String? refreshToken}) =>
+      BackgroundTokenRecord(
+        gen: gen ?? this.gen,
+        authType: authType,
+        accessToken: accessToken ?? this.accessToken,
+        refreshToken: refreshToken ?? this.refreshToken,
+        password: password,
+        basicCredential: basicCredential,
+        simpleCookie: simpleCookie,
+      );
+
+  Map<String, Object?> toJson() => {
+        'gen': gen, 'authType': authType, 'accessToken': accessToken,
+        'refreshToken': refreshToken, 'password': password,
+        'basicCredential': basicCredential, 'simpleCookie': simpleCookie,
+      };
+
+  factory BackgroundTokenRecord.fromJson(Map<String, Object?> j) =>
+      BackgroundTokenRecord(
+        gen: j['gen'] as int,
+        authType: j['authType'] as String,
+        accessToken: j['accessToken'] as String?,
+        refreshToken: j['refreshToken'] as String?,
+        password: j['password'] as String?,
+        basicCredential: j['basicCredential'] as String?,
+        simpleCookie: j['simpleCookie'] as String?,
+      );
+}
+
+/// Coordinates token refresh across the main and worker isolates against ONE
+/// gen-versioned record, so a rotating refresh token is never lost-updated by two
+/// holders. Pure logic: storage + the actual refresh network call are injected.
+class TokenBroker {
+  TokenBroker({required this.read, required this.write, required this.refreshFn});
+  final Future<BackgroundTokenRecord> Function() read;
+  final Future<void> Function(BackgroundTokenRecord) write;
+  final Future<RefreshResult?> Function(String refreshToken) refreshFn;
+
+  /// Returns a usable access token to retry with, or null if auth is dead.
+  Future<String?> resolveAfter401(String tokenThat401d) async {
+    final current = await read();
+    // Someone already refreshed to a different access token — use it, no refresh.
+    if (current.accessToken != null && current.accessToken != tokenThat401d) {
+      return current.accessToken;
+    }
+    final rt = current.refreshToken;
+    if (rt == null) return null;
+    final res = await refreshFn(rt);
+    if (res == null) return null;
+    await write(current.copyWith(
+        gen: current.gen + 1, accessToken: res.access, refreshToken: res.refresh));
+    return res.access;
+  }
+}

--- a/lib/src/features/offline/data/background/background_work_order.dart
+++ b/lib/src/features/offline/data/background/background_work_order.dart
@@ -15,7 +15,8 @@ class BackgroundWorkOrder {
     required this.addPort,
     required this.wifiOnly,
     required this.auth,
-    required this.rootIsolateToken,
+    required this.baseDir,
+    this.rootIsolateToken = 0,
   });
 
   final List<int> chapterIds;
@@ -25,6 +26,17 @@ class BackgroundWorkOrder {
   final bool addPort;
   final bool wifiOnly;
   final BackgroundTokenRecord auth;
+
+  /// Absolute offline base directory (`<appSupport>/offline`), resolved by the
+  /// MAIN isolate via path_provider and handed to the worker so the worker
+  /// itself stays plugin-free: it builds [OfflinePaths]/[IoOfflinePageStore]
+  /// from this string with only dart:io.
+  final String baseDir;
+
+  /// Vestigial — the plugin-free worker no longer reconstructs a
+  /// [RootIsolateToken] (it touches no platform channels), so this is unused.
+  /// Kept on the model so the JSON shape stays backward-compatible; defaults
+  /// to 0 and is ignored by the worker.
   final int rootIsolateToken;
 
   Map<String, Object?> toJson() => {
@@ -36,6 +48,7 @@ class BackgroundWorkOrder {
         'addPort': addPort,
         'wifiOnly': wifiOnly,
         'auth': auth.toJson(),
+        'baseDir': baseDir,
         'rootIsolateToken': rootIsolateToken,
       };
 
@@ -50,6 +63,7 @@ class BackgroundWorkOrder {
         wifiOnly: j['wifiOnly'] as bool,
         auth: BackgroundTokenRecord.fromJson(
             j['auth'] as Map<String, Object?>),
-        rootIsolateToken: j['rootIsolateToken'] as int,
+        baseDir: j['baseDir'] as String? ?? '',
+        rootIsolateToken: j['rootIsolateToken'] as int? ?? 0,
       );
 }

--- a/lib/src/features/offline/data/background/background_work_order.dart
+++ b/lib/src/features/offline/data/background/background_work_order.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'background_token_record.dart';
+
+class BackgroundWorkOrder {
+  const BackgroundWorkOrder({
+    required this.chapterIds,
+    required this.mangaIdByChapter,
+    required this.serverBase,
+    required this.port,
+    required this.addPort,
+    required this.wifiOnly,
+    required this.auth,
+    required this.rootIsolateToken,
+  });
+
+  final List<int> chapterIds;
+  final Map<int, int> mangaIdByChapter;
+  final String serverBase;
+  final int? port;
+  final bool addPort;
+  final bool wifiOnly;
+  final BackgroundTokenRecord auth;
+  final int rootIsolateToken;
+
+  Map<String, Object?> toJson() => {
+        'chapterIds': chapterIds,
+        'mangaIdByChapter':
+            mangaIdByChapter.map((k, v) => MapEntry(k.toString(), v)),
+        'serverBase': serverBase,
+        'port': port,
+        'addPort': addPort,
+        'wifiOnly': wifiOnly,
+        'auth': auth.toJson(),
+        'rootIsolateToken': rootIsolateToken,
+      };
+
+  factory BackgroundWorkOrder.fromJson(Map<String, Object?> j) =>
+      BackgroundWorkOrder(
+        chapterIds: (j['chapterIds'] as List).cast<int>(),
+        mangaIdByChapter: (j['mangaIdByChapter'] as Map)
+            .map((k, v) => MapEntry(int.parse(k as String), v as int)),
+        serverBase: j['serverBase'] as String,
+        port: j['port'] as int?,
+        addPort: j['addPort'] as bool,
+        wifiOnly: j['wifiOnly'] as bool,
+        auth: BackgroundTokenRecord.fromJson(
+            j['auth'] as Map<String, Object?>),
+        rootIsolateToken: j['rootIsolateToken'] as int,
+      );
+}

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -1,0 +1,448 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:http/http.dart' as http;
+
+import '../../../../constants/endpoints.dart';
+import '../chapter_download_engine.dart';
+import '../offline_download_providers.dart' show pageImageExt;
+import '../offline_page_store_io.dart';
+import '../offline_paths.dart';
+import 'background_completion_log.dart';
+import 'background_token_record.dart';
+import 'background_work_order.dart';
+
+/// Foreground-service entry point. MUST be a top-level function annotated
+/// `@pragma('vm:entry-point')` so the AOT compiler keeps it and the plugin can
+/// re-enter it in the background isolate. Registers the handler and returns;
+/// the actual work runs in [DownloadTaskHandler.onStart].
+@pragma('vm:entry-point')
+void backgroundDownloadCallback() {
+  FlutterForegroundTask.setTaskHandler(DownloadTaskHandler());
+}
+
+/// Storage key under which the main isolate stashes the JSON-encoded
+/// [BackgroundWorkOrder] for the worker to pick up in [DownloadTaskHandler.onStart].
+const String kWorkOrderKey = 'work_order';
+
+/// Storage key for the gen-versioned [BackgroundTokenRecord] shared across the
+/// main + worker isolates (so a rotated refresh token survives a worker
+/// rotation and is read back by the main side on stop).
+const String kTokenRecordKey = 'token_record';
+
+/// The background-download worker. Runs entirely inside the foreground-service
+/// isolate, which is PLUGIN-FREE by design: it uses only `dart:io`,
+/// `package:http`, and `flutter_foreground_task`'s own storage/messaging. It
+/// never touches path_provider / secure_storage / connectivity_plus, so it
+/// needs no [RootIsolateToken] / [BackgroundIsolateBinaryMessenger] init.
+///
+/// Single-owner model: while the queue is non-empty this isolate owns ALL
+/// downloading (foreground and background), reusing the pure-Dart
+/// [ChapterDownloadEngine]. Progress is appended to a durable JSONL log
+/// ([BackgroundCompletionLog]) — the real source of truth — while
+/// `sendDataToMain` events are foreground-only cosmetics.
+class DownloadTaskHandler extends TaskHandler {
+  /// chapterIds still to download, in order.
+  final List<int> _queue = <int>[];
+
+  /// chapterId -> mangaId, needed to build page paths.
+  final Map<int, int> _mangaOf = <int, int>{};
+
+  /// chapters the main isolate asked to drop (delete/cancel).
+  final Set<int> _cancelled = <int>{};
+
+  /// Total chapters seen across this service lifetime (for the notification
+  /// "done/total"). Seeded from the work order, grows as `add` ops arrive.
+  int _total = 0;
+
+  /// Chapters that reached a terminal state (for the notification counter).
+  int _done = 0;
+
+  /// Wi-Fi-only flag carried from the main isolate. v1 LIMITATION: the worker
+  /// records and live-updates it but does NOT itself gate on connection type —
+  /// Wi-Fi-only is enforced by the MAIN isolate (it won't start/keep the service
+  /// on a metered connection). Kept here for a future in-worker connectivity
+  /// gate; currently informational only.
+  // ignore: unused_field
+  var _wifiOnly = false;
+
+  /// Set when an `add` op merges new work while the drain loop is between
+  /// chapters, so the drain loop re-checks before self-stopping.
+  var _sawNewWork = false;
+
+  /// True once onDestroy fires (timeout / external stop) — the drain loop and
+  /// the in-flight chapter observe it and unwind.
+  var _stopping = false;
+
+  BackgroundWorkOrder? _order;
+  late BackgroundCompletionLog _log;
+  late OfflinePaths _paths;
+  late IoOfflinePageStore _store;
+  late BackgroundTokenRecord _record;
+  late TokenBroker _broker;
+
+  @override
+  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {
+    final raw = await FlutterForegroundTask.getData<String>(key: kWorkOrderKey);
+    if (raw == null) {
+      // Nothing to do — self-stop so we don't sit as a zombie notification.
+      await FlutterForegroundTask.stopService();
+      return;
+    }
+    _order = BackgroundWorkOrder.fromJson(
+        jsonDecode(raw) as Map<String, Object?>);
+    final order = _order!;
+
+    // Plugin-free path building: the main isolate already resolved the offline
+    // base dir (path_provider lives in the root isolate), so we just wrap it.
+    _paths = OfflinePaths(order.baseDir);
+    _store = IoOfflinePageStore(_paths);
+    _log = BackgroundCompletionLog(File('${order.baseDir}/.bg_completion.log'));
+
+    _wifiOnly = order.wifiOnly;
+    _record = order.auth;
+    _broker = _buildBroker();
+
+    _queue.addAll(order.chapterIds);
+    _mangaOf.addAll(order.mangaIdByChapter);
+    _total = _queue.length;
+
+    await _drain();
+  }
+
+  @override
+  void onReceiveData(Object data) {
+    if (data is! Map) return;
+    switch (data['op']) {
+      case 'add':
+        final id = data['chapterId'] as int;
+        if (!_queue.contains(id) &&
+            !_cancelled.contains(id) &&
+            !_mangaOf.containsKey(id)) {
+          _queue.add(id);
+          _mangaOf[id] = data['mangaId'] as int;
+          _total++;
+          _sawNewWork = true;
+        } else if (!_queue.contains(id) && !_cancelled.contains(id)) {
+          // Known manga mapping but not currently queued (e.g. re-add of a
+          // chapter whose row we still remember): requeue it.
+          _queue.add(id);
+          _sawNewWork = true;
+        }
+      case 'remove':
+        final id = data['chapterId'] as int;
+        _cancelled.add(id);
+        _queue.remove(id);
+      case 'setWifiOnly':
+        _wifiOnly = data['value'] as bool;
+    }
+  }
+
+  @override
+  void onRepeatEvent(DateTime timestamp) {}
+
+  @override
+  Future<void> onDestroy(DateTime timestamp, bool isTimeout) async {
+    // The drain loop + the in-flight chapter both observe this and unwind. The
+    // log is flushed per page, so nothing is lost on an abrupt stop.
+    _stopping = true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Drain loop
+  // ---------------------------------------------------------------------------
+
+  Future<void> _drain() async {
+    while (!_stopping) {
+      final next = _queue.where((c) => !_cancelled.contains(c)).firstOrNull;
+      if (next == null) {
+        if (_sawNewWork) {
+          _sawNewWork = false;
+          continue;
+        }
+        // Queue genuinely empty — record the drain marker and self-stop.
+        await _log.appendDrained();
+        await FlutterForegroundTask.stopService();
+        return;
+      }
+      _queue.remove(next);
+      await _downloadChapter(next, _mangaOf[next]!);
+    }
+  }
+
+  Future<void> _downloadChapter(int chapterId, int mangaId) async {
+    final urls = await _resolvePageUrls(chapterId);
+    if (urls.isEmpty) {
+      // Could not resolve pages (terminal): a server with no pages or a hard
+      // failure even after a token refresh. Mark error, keep draining.
+      await _log.appendChapter(
+          chapterId: chapterId, status: 'error', pages: 0, bytes: 0);
+      _done++;
+      _afterChapter(chapterId, 'error');
+      return;
+    }
+
+    final engine = _buildEngine();
+    final pages = [
+      for (var i = 0; i < urls.length; i++) (index: i, url: urls[i]),
+    ];
+    final outcome = await engine.download(
+      mangaId: mangaId,
+      chapterId: chapterId,
+      pages: pages,
+      isCancelled: () => _cancelled.contains(chapterId) || _stopping,
+      onPageStored: (i, rel, bytes) => _log.appendPage(
+        chapterId: chapterId,
+        mangaId: mangaId,
+        pageIndex: i,
+        relPath: rel,
+        bytes: bytes,
+      ),
+    );
+
+    final String? status = outcome.succeeded
+        ? 'downloaded'
+        : outcome.offline
+            ? 'offline'
+            : outcome.authFailed
+                ? 'authFailed'
+                // cancelled → no terminal line; leave it `downloading` so a
+                // later replay/worker can pick it up (delete cleans it up).
+                : outcome.cancelled
+                    ? null
+                    : 'error';
+
+    if (status != null) {
+      final bytes = await _store.chapterBytes(mangaId, chapterId);
+      await _log.appendChapter(
+        chapterId: chapterId,
+        status: status,
+        pages: urls.length,
+        bytes: bytes,
+      );
+      _done++;
+    }
+    _afterChapter(chapterId, status);
+  }
+
+  /// Notification + main-isolate notification after each chapter settles.
+  void _afterChapter(int chapterId, String? status) {
+    FlutterForegroundTask.sendDataToMain(
+        {'kind': 'chapterDone', 'chapterId': chapterId, 'status': status});
+    FlutterForegroundTask.updateService(
+      notificationTitle: 'Downloading chapters',
+      notificationText: 'Downloading — $_done/$_total',
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Page-list resolution (hand-rolled GraphQL POST, pure http)
+  // ---------------------------------------------------------------------------
+
+  /// Resolves a chapter's page URLs via the `fetchChapterPages` mutation. On a
+  /// 401/403 it runs the [TokenBroker] refresh once and retries; on any other
+  /// failure (or an empty result) it returns an empty list (terminal error).
+  Future<List<String>> _resolvePageUrls(int chapterId) async {
+    var result = await _postChapterPages(chapterId, _record.accessToken);
+    if (result == _gqlAuthError && _record.authType == 'uiLogin') {
+      final newAccess = await _broker.resolveAfter401(_record.accessToken ?? '');
+      if (newAccess != null) {
+        result = await _postChapterPages(chapterId, newAccess);
+      }
+    }
+    if (result is List<String>) return result;
+    return const <String>[];
+  }
+
+  /// Sentinel returned by [_postChapterPages] to signal an auth (401/403)
+  /// failure distinctly from "no pages / other error" (an empty list).
+  static const Object _gqlAuthError = Object();
+
+  /// Returns the page-URL list on success, [_gqlAuthError] on 401/403, or an
+  /// empty list on any other failure.
+  Future<Object> _postChapterPages(int chapterId, String? accessToken) async {
+    final order = _order!;
+    final endpoint = Endpoints.baseApi(
+      baseUrl: order.serverBase,
+      port: order.port,
+      addPort: order.addPort,
+      isGraphQl: true,
+    );
+    final headers = <String, String>{'Content-Type': 'application/json'};
+    _applyAuthHeaders(headers, accessToken);
+    final body = jsonEncode({
+      'query':
+          'mutation GetChapterPages(\$input: FetchChapterPagesInput!){ fetchChapterPages(input: \$input){ pages } }',
+      'variables': {
+        'input': {'chapterId': chapterId},
+      },
+    });
+    try {
+      final res = await http.post(Uri.parse(endpoint),
+          headers: headers, body: body);
+      if (res.statusCode == 401 || res.statusCode == 403) return _gqlAuthError;
+      if (res.statusCode != 200) return const <String>[];
+      final decoded = jsonDecode(res.body) as Map<String, Object?>;
+      final data = decoded['data'] as Map<String, Object?>?;
+      final fetch = data?['fetchChapterPages'] as Map<String, Object?>?;
+      final pages = fetch?['pages'];
+      if (pages is List) return pages.cast<String>();
+      return const <String>[];
+    } on SocketException {
+      // No network for the page-list POST: treat as a transient empty so the
+      // batch isn't poisoned. (Per-page fetches surface offline via the engine.)
+      return const <String>[];
+    } catch (_) {
+      return const <String>[];
+    }
+  }
+
+  /// Applies the in-isolate auth to a GraphQL/REST request's headers, mirroring
+  /// the app's auth modes (uiLogin Bearer, basic, simpleLogin cookie).
+  void _applyAuthHeaders(Map<String, String> headers, String? accessToken) {
+    switch (_record.authType) {
+      case 'uiLogin':
+        if (accessToken != null && accessToken.isNotEmpty) {
+          headers['Authorization'] = 'Bearer $accessToken';
+        }
+      case 'basic':
+        final cred = _record.basicCredential;
+        if (cred != null && cred.isNotEmpty) headers['Authorization'] = cred;
+      case 'simpleLogin':
+        final cookie = _record.simpleCookie;
+        if (cookie != null && cookie.isNotEmpty) headers['Cookie'] = cookie;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Engine wiring (in-isolate deps)
+  // ---------------------------------------------------------------------------
+
+  ChapterDownloadEngine _buildEngine() => ChapterDownloadEngine(
+        writePage: _store,
+        parallelPageLimit: 5,
+        fetchPage: (pageUrl) async {
+          final (url, headers) = _authedPageRequest(pageUrl);
+          final http.Response res;
+          try {
+            res = await http.get(Uri.parse(url), headers: headers);
+          } on SocketException {
+            // Device offline (connection refused / unreachable host / DNS).
+            throw const PageOfflineException();
+          }
+          if (res.statusCode == 401 || res.statusCode == 403) {
+            throw const PageAuthException();
+          }
+          if (res.statusCode != 200) {
+            throw Exception('page fetch failed ($pageUrl): ${res.statusCode}');
+          }
+          return (
+            bytes: res.bodyBytes,
+            ext: pageImageExt(res.headers['content-type'], res.bodyBytes),
+          );
+        },
+        refreshAuth: () async {
+          // Only ui_login rotates; basic/simple credentials are static.
+          if (_record.authType != 'uiLogin') return false;
+          final newAccess =
+              await _broker.resolveAfter401(_record.accessToken ?? '');
+          return newAccess != null;
+        },
+      );
+
+  /// Builds the page-image GET URL + headers — mirrors
+  /// `fetchOfflinePageBytes`: base API WITHOUT the `/api` suffix (page URLs
+  /// already carry `/api/...`); ui_login as a `?token=` query param;
+  /// basic/simpleLogin via headers. Reads the CURRENT in-isolate [_record]
+  /// (kept fresh by the broker), not Riverpod.
+  (String, Map<String, String>) _authedPageRequest(String pageUrl) {
+    final order = _order!;
+    final base = Endpoints.baseApi(
+      baseUrl: order.serverBase,
+      port: order.port,
+      addPort: order.addPort,
+      appendApiToUrl: false,
+    );
+    var fetchUrl = '$base$pageUrl';
+    final headers = <String, String>{};
+    switch (_record.authType) {
+      case 'basic':
+        final cred = _record.basicCredential;
+        if (cred != null && cred.isNotEmpty) headers['Authorization'] = cred;
+      case 'simpleLogin':
+        final cookie = _record.simpleCookie;
+        if (cookie != null && cookie.isNotEmpty) headers['Cookie'] = cookie;
+      case 'uiLogin':
+        final token = _record.accessToken;
+        if (token != null && token.isNotEmpty) {
+          final sep = fetchUrl.contains('?') ? '&' : '?';
+          fetchUrl = '$fetchUrl${sep}token=${Uri.encodeQueryComponent(token)}';
+        }
+    }
+    return (fetchUrl, headers);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Token broker (in-isolate, FFT-storage-backed)
+  // ---------------------------------------------------------------------------
+
+  TokenBroker _buildBroker() => TokenBroker(
+        read: () async {
+          final raw =
+              await FlutterForegroundTask.getData<String>(key: kTokenRecordKey);
+          if (raw == null) return _record;
+          _record = BackgroundTokenRecord.fromJson(
+              jsonDecode(raw) as Map<String, Object?>);
+          return _record;
+        },
+        write: (r) async {
+          _record = r;
+          await FlutterForegroundTask.saveData(
+              key: kTokenRecordKey, value: jsonEncode(r.toJson()));
+        },
+        refreshFn: (refreshToken) async {
+          // Only ui_login refreshes; basic/simple return null.
+          if (_record.authType != 'uiLogin') return null;
+          final order = _order!;
+          final endpoint = Endpoints.baseApi(
+            baseUrl: order.serverBase,
+            port: order.port,
+            addPort: order.addPort,
+            isGraphQl: true,
+          );
+          final body = jsonEncode({
+            'query':
+                'mutation RefreshToken(\$input: RefreshTokenInput!){ refreshToken(input: \$input){ accessToken } }',
+            'variables': {
+              'input': {'refreshToken': refreshToken},
+            },
+          });
+          try {
+            final res = await http.post(
+              Uri.parse(endpoint),
+              headers: const {'Content-Type': 'application/json'},
+              body: body,
+            );
+            if (res.statusCode != 200) return null;
+            final decoded = jsonDecode(res.body) as Map<String, Object?>;
+            final data = decoded['data'] as Map<String, Object?>?;
+            final refreshed =
+                data?['refreshToken'] as Map<String, Object?>?;
+            final access = refreshed?['accessToken'] as String?;
+            if (access == null || access.isEmpty) return null;
+            // Suwayomi's refresh doesn't rotate the refresh token, so reuse the
+            // input one (the broker persists it back as the current refresh).
+            return (access: access, refresh: refreshToken);
+          } catch (_) {
+            return null;
+          }
+        },
+      );
+}

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -167,8 +167,11 @@ class DownloadTaskHandler extends TaskHandler {
           _sawNewWork = false;
           continue;
         }
-        // Queue genuinely empty — record the drain marker and self-stop.
+        // Queue genuinely empty — record the drain marker, tell the main isolate
+        // we're stopping (so it can re-check the catalog for anything enqueued
+        // during this shutdown window and restart us), then self-stop.
         await _log.appendDrained();
+        FlutterForegroundTask.sendDataToMain({'kind': 'drained'});
         await FlutterForegroundTask.stopService();
         return;
       }

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -192,8 +192,13 @@ class DownloadTaskHandler extends TaskHandler {
     // Tell the UI this chapter is now downloading, so the live progress arc
     // shows while the app is in the foreground (the main isolate applies it to
     // the catalog; while backgrounded it's dropped and the log replay covers it).
-    FlutterForegroundTask.sendDataToMain(
-        {'kind': 'chapterStart', 'chapterId': chapterId});
+    FlutterForegroundTask.sendDataToMain({
+      'kind': 'chapterStart',
+      'chapterId': chapterId,
+      // The resolved page count — lets the UI show a determinate progress arc
+      // (webtoon chapters don't know their page total until resolved here).
+      'total': urls.length,
+    });
 
     final engine = _buildEngine();
     final pages = [

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -189,6 +189,12 @@ class DownloadTaskHandler extends TaskHandler {
       return;
     }
 
+    // Tell the UI this chapter is now downloading, so the live progress arc
+    // shows while the app is in the foreground (the main isolate applies it to
+    // the catalog; while backgrounded it's dropped and the log replay covers it).
+    FlutterForegroundTask.sendDataToMain(
+        {'kind': 'chapterStart', 'chapterId': chapterId});
+
     final engine = _buildEngine();
     final pages = [
       for (var i = 0; i < urls.length; i++) (index: i, url: urls[i]),
@@ -198,13 +204,23 @@ class DownloadTaskHandler extends TaskHandler {
       chapterId: chapterId,
       pages: pages,
       isCancelled: () => _cancelled.contains(chapterId) || _stopping,
-      onPageStored: (i, rel, bytes) => _log.appendPage(
-        chapterId: chapterId,
-        mangaId: mangaId,
-        pageIndex: i,
-        relPath: rel,
-        bytes: bytes,
-      ),
+      onPageStored: (i, rel, bytes) {
+        // Live per-page progress for the foreground UI (drift row applied by the
+        // main isolate). The durable record is still the completion log.
+        FlutterForegroundTask.sendDataToMain({
+          'kind': 'page',
+          'chapterId': chapterId,
+          'pageIndex': i,
+          'relPath': rel,
+        });
+        return _log.appendPage(
+          chapterId: chapterId,
+          mangaId: mangaId,
+          pageIndex: i,
+          relPath: rel,
+          bytes: bytes,
+        );
+      },
     );
 
     final String? status = outcome.succeeded

--- a/lib/src/features/offline/data/chapter_download_engine.dart
+++ b/lib/src/features/offline/data/chapter_download_engine.dart
@@ -15,6 +15,13 @@ class PageAuthException implements Exception {
   const PageAuthException();
 }
 
+/// Thrown by a [PageFetcher] when the device is offline, or Wi-Fi-only is on and
+/// the active connection is metered. Signals the engine to stop this chapter and
+/// report it as paused-offline (leave it resumable), NOT as an error.
+class PageOfflineException implements Exception {
+  const PageOfflineException();
+}
+
 /// One page to download: its server URL and its index within the chapter.
 typedef PageRef = ({int index, String url});
 
@@ -38,6 +45,7 @@ class ChapterDownloadOutcome {
     required this.storedPages,
     required this.cancelled,
     required this.authFailed,
+    required this.offline,
     this.error,
   });
 
@@ -51,10 +59,15 @@ class ChapterDownloadOutcome {
   /// can't proceed until the user re-authenticates.
   final bool authFailed;
 
+  /// True if the run stopped because the device went offline / Wi-Fi-only
+  /// blocked it. The chapter is left resumable (NOT an error).
+  final bool offline;
+
   /// The first non-auth error that ended the run, if any.
   final Object? error;
 
-  bool get succeeded => error == null && !cancelled && !authFailed;
+  bool get succeeded =>
+      error == null && !cancelled && !authFailed && !offline;
 }
 
 /// Downloads a single chapter's pages, Komikku-style: up to
@@ -104,17 +117,23 @@ class ChapterDownloadEngine {
     final stored = <int, ({String relPath, int bytes})>{};
     if (pages.isEmpty) {
       return ChapterDownloadOutcome(
-          storedPages: stored, cancelled: false, authFailed: false);
+          storedPages: stored,
+          cancelled: false,
+          authFailed: false,
+          offline: false);
     }
 
     final queue = List<PageRef>.of(pages);
     var cursor = 0;
     var authFailed = false;
+    var offline = false;
     Object? fatalError;
 
     Future<void> worker() async {
       while (true) {
-        if (isCancelled() || authFailed || fatalError != null) return;
+        if (isCancelled() || authFailed || offline || fatalError != null) {
+          return;
+        }
         if (cursor >= queue.length) return;
         final page = queue[cursor++];
         final result = await _downloadOne(mangaId, chapterId, page);
@@ -126,6 +145,8 @@ class ChapterDownloadEngine {
             }
           case _PageAuthDead():
             authFailed = true;
+          case _PageOffline():
+            offline = true;
           case _PageError(:final error):
             fatalError ??= error;
         }
@@ -140,6 +161,7 @@ class ChapterDownloadEngine {
       storedPages: stored,
       cancelled: isCancelled(),
       authFailed: authFailed,
+      offline: offline,
       error: fatalError,
     );
   }
@@ -158,6 +180,10 @@ class ChapterDownloadEngine {
           bytes.ext,
         );
         return _PageOk(relPath: written.relPath, bytes: written.bytes);
+      } on PageOfflineException {
+        // Device went offline / Wi-Fi-only blocked it — stop this chapter and
+        // leave it resumable. No retry (retrying offline just burns backoff).
+        return const _PageOffline();
       } on PageAuthException {
         // Refresh once; concurrent 401s collapse via the refresher's
         // single-flight. If auth is dead, stop trying.
@@ -195,4 +221,8 @@ class _PageError extends _PageResult {
 
 class _PageAuthDead extends _PageResult {
   const _PageAuthDead();
+}
+
+class _PageOffline extends _PageResult {
+  const _PageOffline();
 }

--- a/lib/src/features/offline/data/offline_background_downloads.dart
+++ b/lib/src/features/offline/data/offline_background_downloads.dart
@@ -14,6 +14,7 @@ import '../../../constants/enum.dart';
 import '../../../global_providers/global_providers.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../../utils/logger/logger.dart';
+import '../../../utils/platform/is_android_native.dart';
 import '../../auth/data/auth_coordinator.dart';
 import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
@@ -95,6 +96,10 @@ OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
 /// were the stale-token 401s the run-time-auth engine now avoids.
 Future<void> initOfflineDownloads(ProviderContainer container) async {
   if (!container.read(offlineEnabledProvider)) return;
+  // On Android the foreground-service worker owns downloads (see the corruption
+  // gate in pumpDownloads + BackgroundDownloadController); the launch path calls
+  // the controller instead.
+  if (isAndroidNative) return;
   final coord = container.read(offlineDownloadCoordinatorProvider);
   if (coord == null) return;
   final db = container.read(offlineDatabaseProvider);

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -207,6 +207,13 @@ class OfflineDatabase extends _$OfflineDatabase {
       (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
           .write(OfflineChaptersCompanion(pinned: Value(pinned)));
 
+  /// Set a chapter's resolved page count (used to drive the determinate
+  /// download progress arc for chapters whose total wasn't known until the
+  /// downloader resolved their pages — e.g. webtoon chapters).
+  Future<void> setChapterPageCount(int chapterId, int pageCount) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
+          .write(OfflineChaptersCompanion(pageCount: Value(pageCount)));
+
   Future<void> setChapterDeviceState(
     int chapterId,
     OfflineDeviceState state, {

--- a/lib/src/features/offline/data/offline_download_coordinator.dart
+++ b/lib/src/features/offline/data/offline_download_coordinator.dart
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import '../../../utils/logger/logger.dart';
+import '../../../utils/platform/is_android_native.dart';
 import 'chapter_download_engine.dart';
 import 'offline_database.dart';
 
@@ -172,6 +173,11 @@ class OfflineDownloadCoordinator {
   /// `queued` backlog. Single-flight — a second call while running is a no-op;
   /// the running loop picks up anything newly queued.
   Future<void> pumpDownloads() async {
+    // CORRUPTION GATE: on Android the foreground-service worker isolate is the
+    // sole downloader; the main-isolate pump must NEVER write page files there
+    // (two isolates writing the same files/catalog corrupts it). Downloads on
+    // Android are driven by BackgroundDownloadController instead.
+    if (isAndroidNative) return;
     if (_pumping) return;
     _pumping = true;
     try {

--- a/lib/src/features/offline/data/offline_download_coordinator.dart
+++ b/lib/src/features/offline/data/offline_download_coordinator.dart
@@ -119,6 +119,13 @@ class OfflineDownloadCoordinator {
       );
 
       if (outcome.cancelled) return; // leave partial; resume later
+      if (outcome.offline) {
+        // No network / Wi-Fi-only blocked it — leave the chapter `downloading`
+        // so it resumes on reconnect, NOT `error`.
+        logger.i('Offline: chapter ${chapter.id} paused (no network); '
+            'leaving downloading for resume');
+        return;
+      }
       if (outcome.authFailed) {
         logger.e('Offline: chapter ${chapter.id} auth failed (token dead)');
         await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -13,7 +13,9 @@ import '../../../constants/enum.dart';
 import '../../../global_providers/global_providers.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../../utils/logger/logger.dart';
+import '../../../utils/platform/is_android_native.dart';
 import '../../auth/data/auth_credentials_store.dart';
+import 'background/background_download_controller_shim.dart';
 import 'chapter_download_engine.dart';
 import '../../manga_book/data/downloads/downloads_repository.dart';
 import '../../manga_book/data/manga_book/manga_book_repository.dart';
@@ -32,6 +34,10 @@ import 'offline_settings_providers.dart';
 import 'reconcile_types.dart';
 
 part 'offline_download_providers.g.dart';
+
+/// True only on Android native, where the foreground-service worker owns
+/// downloads (web-safe + correct in unit tests — see [isAndroidNative]).
+bool get _useBgService => isAndroidNative;
 
 /// Live on-device download state for a chapter (none / queued / downloading /
 /// downloaded / error). Always `none` when offline is unavailable.
@@ -87,10 +93,15 @@ Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue([chapterId]);
   }
-  // Queue it and let the pump start it (one chapter at a time). Pages download
-  // in the background and survive the app being backgrounded.
+  // Queue it (drift `queued` is the single source of truth). On Android the
+  // foreground-service worker owns the downloading; elsewhere the main-isolate
+  // pump drains it.
   await coordinator.queueChapter(chapterId);
-  await coordinator.pumpDownloads();
+  if (_useBgService) {
+    await ref.read(backgroundDownloadControllerProvider).onEnqueued([chapterId]);
+  } else {
+    await coordinator.pumpDownloads();
+  }
 }
 
 /// Record reading progress for a chapter. Persists it to the on-device catalog
@@ -154,6 +165,12 @@ Future<void> cascadeServerDeleteToDevice(
 Future<void> deleteChapterFromDevice(WidgetRef ref, int chapterId) async {
   final manager = ref.read(offlineDownloadManagerProvider);
   if (manager == null) return;
+  // If the FGS worker is mid-download of this chapter, stop it first so it can't
+  // resurrect files we're about to delete (the worker honours `remove` via the
+  // engine's per-chapter cancel).
+  if (_useBgService) {
+    await ref.read(backgroundDownloadControllerProvider).onRemoved(chapterId);
+  }
   final chapter = await ref.read(offlineRepositoryProvider).chapterById(chapterId);
   if (chapter != null) await manager.deleteChapter(chapter);
   await ref.read(offlineDatabaseProvider).setChapterPinned(chapterId, false);
@@ -385,6 +402,12 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
     nets: ref.read(safetyNetConfigProvider),
     mangaId: mangaId,
   );
+  // Keep-rule sync just queued any missing chapters into drift. On Android make
+  // sure the foreground-service worker is running to pick them up (the pump
+  // no-ops there).
+  if (_useBgService) {
+    await ref.read(backgroundDownloadControllerProvider).ensureServiceRunning();
+  }
 }
 
 /// Widget entry point — same as [reconcileManga] but accepts a [WidgetRef].

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -70,21 +70,19 @@ Stream<OfflineDeviceState> offlineChapterState(Ref ref, int chapterId) {
 /// total pages), or null when the total isn't known yet — drives the
 /// determinate progress arc on a downloading chapter, like Mihon/Komikku.
 @riverpod
-Stream<double?> offlineChapterProgress(Ref ref, int chapterId) async* {
+Stream<double?> offlineChapterProgress(Ref ref, int chapterId) {
   if (!ref.watch(offlineEnabledProvider)) {
-    yield null;
-    return;
+    return Stream.value(null);
   }
   final repo = ref.watch(offlineRepositoryProvider);
-  final total = (await repo.db.chapterById(chapterId))?.pageCount ?? 0;
-  if (total <= 0) {
-    yield null;
-    return;
-  }
-  yield* repo
-      .watchChapterDownloadedPages(chapterId)
-      .map((done) => (done / total).clamp(0.0, 1.0))
-      .distinct();
+  // Re-read the page total on every downloaded-page tick (instead of once up
+  // front) so the arc flips from indeterminate to a real fraction the moment the
+  // total becomes known — webtoon chapters only learn their page count when the
+  // downloader resolves their pages mid-download.
+  return repo.watchChapterDownloadedPages(chapterId).asyncMap((done) async {
+    final total = (await repo.db.chapterById(chapterId))?.pageCount ?? 0;
+    return total <= 0 ? null : (done / total).clamp(0.0, 1.0);
+  }).distinct();
 }
 
 /// Save a chapter's pages to the device. Looks up the synced catalog row and

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -39,6 +39,23 @@ part 'offline_download_providers.g.dart';
 /// downloads (web-safe + correct in unit tests — see [isAndroidNative]).
 bool get _useBgService => isAndroidNative;
 
+/// THE single entry point that kicks off downloading after chapters have been
+/// queued into drift. EVERY download trigger must call this — on Android it
+/// starts the foreground-service worker, elsewhere it drains via the
+/// main-isolate pump. Centralised (and overridable in tests) so no trigger can
+/// ever again silently rely on the Android-disabled pump.
+final downloadStarterProvider = Provider<Future<void> Function()>((ref) {
+  return () async {
+    if (isAndroidNative) {
+      await ref
+          .read(backgroundDownloadControllerProvider)
+          .ensureServiceRunning();
+    } else {
+      await ref.read(offlineDownloadCoordinatorProvider)?.pumpDownloads();
+    }
+  };
+});
+
 /// Live on-device download state for a chapter (none / queued / downloading /
 /// downloaded / error). Always `none` when offline is unavailable.
 @riverpod
@@ -97,11 +114,7 @@ Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
   // foreground-service worker owns the downloading; elsewhere the main-isolate
   // pump drains it.
   await coordinator.queueChapter(chapterId);
-  if (_useBgService) {
-    await ref.read(backgroundDownloadControllerProvider).onEnqueued([chapterId]);
-  } else {
-    await coordinator.pumpDownloads();
-  }
+  await ref.read(downloadStarterProvider)();
 }
 
 /// Record reading progress for a chapter. Persists it to the on-device catalog
@@ -366,10 +379,10 @@ Future<void> reconcileMangaCore({
     db: db,
     nets: nets,
     now: DateTime.now(),
-    // Only QUEUE chapters here (mark them in the persistent backlog); the pump
-    // below starts them one at a time. This keeps the fragile in-memory holding
-    // queue down to a single chapter, so an app restart can't strand the whole
-    // library as "downloading". One failed queue-mark must NOT abort the rest.
+    // Only QUEUE chapters here (mark them in the persistent backlog). Starting
+    // the download is the caller's job (via downloadStarterProvider) — this core
+    // must NOT start anything itself, so the Ref-less launch path and tests stay
+    // in control. One failed queue-mark must NOT abort the rest.
     onDownload: (id) async {
       try {
         await coordinator.queueChapter(id);
@@ -385,7 +398,7 @@ Future<void> reconcileMangaCore({
         logger.e('Offline: reconcile evict skipped for chapter $id: $e');
       }
     },
-  ).reconcileManga(mangaId).then((_) => coordinator.pumpDownloads());
+  ).reconcileManga(mangaId);
 }
 
 /// Controller / in-app entry point (generated Ref).
@@ -402,12 +415,8 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
     nets: ref.read(safetyNetConfigProvider),
     mangaId: mangaId,
   );
-  // Keep-rule sync just queued any missing chapters into drift. On Android make
-  // sure the foreground-service worker is running to pick them up (the pump
-  // no-ops there).
-  if (_useBgService) {
-    await ref.read(backgroundDownloadControllerProvider).ensureServiceRunning();
-  }
+  // Keep-rule sync queued any missing chapters; now start downloading them.
+  await ref.read(downloadStarterProvider)();
 }
 
 /// Widget entry point — same as [reconcileManga] but accepts a [WidgetRef].
@@ -424,6 +433,9 @@ Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
     nets: ref.read(safetyNetConfigProvider),
     mangaId: mangaId,
   );
+  // Start downloading the freshly-queued chapters. THIS was the missing wire
+  // that made "Download all / unread" silently do nothing on Android.
+  await ref.read(downloadStarterProvider)();
 }
 
 /// Launch entry point (main.dart holds a ProviderContainer, not a Ref).

--- a/lib/src/features/offline/data/offline_settings_providers.dart
+++ b/lib/src/features/offline/data/offline_settings_providers.dart
@@ -48,3 +48,10 @@ class OfflineDownloadConcurrency extends _$OfflineDownloadConcurrency
   @override
   int? build() => initialize(DBKeys.offlineDownloadConcurrency);
 }
+
+@riverpod
+class OfflineWifiOnly extends _$OfflineWifiOnly
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.downloadOnlyOverWifi);
+}

--- a/lib/src/features/offline/presentation/offline_settings_screen.dart
+++ b/lib/src/features/offline/presentation/offline_settings_screen.dart
@@ -78,6 +78,19 @@ class OfflineSettingsScreen extends ConsumerWidget {
                   ),
                   SectionTitle(title: context.l10n.offlineDownloadsSection),
                   SettingsPropTile(
+                    title: context.l10n.downloadOverWifiOnly,
+                    type: SettingsPropType.switchTile(
+                      value:
+                          ref.watch(offlineWifiOnlyProvider) ?? false,
+                      onChanged: (v) async {
+                        ref
+                            .read(offlineWifiOnlyProvider.notifier)
+                            .update(v);
+                        return null;
+                      },
+                    ),
+                  ),
+                  SettingsPropTile(
                     title: context.l10n.offlineConcurrencyLabel,
                     subtitle: context.l10n.offlineConcurrencyValue(
                         ref.watch(offlineDownloadConcurrencyProvider) ?? 2),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1548,6 +1548,10 @@
     "@offlineDownloadsSection": {
         "description": "Section header for offline download behaviour settings"
     },
+    "downloadOverWifiOnly": "Download over Wi-Fi only",
+    "@downloadOverWifiOnly": {
+        "description": "Toggle to restrict background downloads to Wi-Fi connections"
+    },
     "offlineConcurrencyLabel": "Simultaneous downloads",
     "@offlineConcurrencyLabel": {
         "description": "Label for the download concurrency slider"

--- a/lib/src/utils/platform/is_android_native.dart
+++ b/lib/src/utils/platform/is_android_native.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// True only when running natively on Android. Unlike `defaultTargetPlatform`
+// (which reports `android` inside `flutter test` and on Android browsers), this
+// reads `dart:io`'s `Platform.isAndroid` on native and is hard-coded `false` on
+// web — so it's correct on real Android, in unit tests (host is Linux/macOS),
+// and web, all at once. Used to gate the Android-only foreground-service
+// download path against the desktop/web main-isolate pump.
+export 'is_android_native_stub.dart'
+    if (dart.library.io) 'is_android_native_io.dart';

--- a/lib/src/utils/platform/is_android_native_io.dart
+++ b/lib/src/utils/platform/is_android_native_io.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+/// Native implementation: true only on a real Android device/emulator.
+bool get isAndroidNative => Platform.isAndroid;

--- a/lib/src/utils/platform/is_android_native_stub.dart
+++ b/lib/src/utils/platform/is_android_native_stub.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Web implementation: there is no Android foreground service on web.
+bool get isAndroidNative => false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -210,13 +210,13 @@ packages:
     source: hosted
     version: "1.19.1"
   connectivity_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "6.1.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -706,10 +706,10 @@ packages:
     dependency: "direct main"
     description:
       name: graphql_flutter
-      sha256: "4164962170998bc88bed833d1aa6efc5c3a85cbc8e66a8e62f790b43f4953980"
+      sha256: "0fef9dc2483c4f21c6ac93cd2ef0b820542fc0ce6db6efa87367326d7f36ade4"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.2.1"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   built_collection: ^5.1.1
   cached_network_image: ^3.2.2
   cached_network_image_platform_interface: ^4.0.0
+  connectivity_plus: ^6.1.3
   cupertino_icons: ^1.0.5
   drift: ^2.20.0
   extension_type_unions: ^1.0.10

--- a/test/offline/background/background_completion_log_replay_test.dart
+++ b/test/offline/background/background_completion_log_replay_test.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/background/background_completion_log.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+
+import '../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  late Directory tmp;
+  late OfflinePaths paths;
+  late BackgroundCompletionLog log;
+
+  setUp(() async {
+    db = testOfflineDatabase();
+    tmp = await Directory.systemTemp.createTemp('replay');
+    paths = OfflinePaths(tmp.path);
+    log = BackgroundCompletionLog(File('${tmp.path}/.bg_completion.log'));
+    // a manga + a downloading chapter exist in drift:
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.upsertChapterMetadata(
+        id: 5, mangaId: 1, name: 'c', chapterIndex: 0, isRead: false,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 2, updatedAt: DateTime(2026));
+    await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+  });
+  tearDown(() async {
+    await db.close();
+    await tmp.delete(recursive: true);
+  });
+
+  Future<void> writePageFile(int m, int c, int i) async {
+    final f = File(paths.absolute(paths.pageRel(m, c, i, 'jpg')));
+    await f.parent.create(recursive: true);
+    await f.writeAsBytes(List.filled(10, 0));
+  }
+
+  test('a page on disk with NO log line still gets a drift row (filesystem truth)',
+      () async {
+    await writePageFile(1, 5, 0);
+    await writePageFile(1, 5, 1);
+    // log only recorded page 0 + a downloaded terminal (page 1 line was lost):
+    await log.appendPage(chapterId: 5, mangaId: 1, pageIndex: 0, relPath: paths.pageRel(1, 5, 0, 'jpg'), bytes: 10);
+    await log.appendChapter(chapterId: 5, status: 'downloaded', pages: 2, bytes: 20);
+
+    await replayCompletionLog(
+        db: db, paths: paths, log: log,
+        measureBytes: (m, c) async => 20);
+
+    expect(await db.downloadedPageCount(5), 2); // both pages, from the filesystem
+    final ch = await db.chapterById(5);
+    expect(ch!.deviceState, OfflineDeviceState.downloaded);
+    expect(await log.parse(), isEmpty); // truncated
+  });
+
+  test('a deleted chapter (drift row gone) is NOT resurrected', () async {
+    await writePageFile(1, 5, 0);
+    await log.appendPage(chapterId: 5, mangaId: 1, pageIndex: 0, relPath: paths.pageRel(1, 5, 0, 'jpg'), bytes: 10);
+    // user deleted it: state -> none
+    await db.setChapterDeviceState(5, OfflineDeviceState.none);
+
+    await replayCompletionLog(
+        db: db, paths: paths, log: log, measureBytes: (m, c) async => 10);
+
+    expect(await db.downloadedPageCount(5), 0); // no rows added
+    final ch = await db.chapterById(5);
+    expect(ch!.deviceState, OfflineDeviceState.none);
+  });
+
+  test('double-replay is idempotent', () async {
+    await writePageFile(1, 5, 0);
+    await writePageFile(1, 5, 1);
+    await log.appendChapter(chapterId: 5, status: 'downloaded', pages: 2, bytes: 20);
+    await replayCompletionLog(db: db, paths: paths, log: log, measureBytes: (m, c) async => 20);
+    // replay again on the (now empty) log — must not throw or change counts
+    await replayCompletionLog(db: db, paths: paths, log: log, measureBytes: (m, c) async => 20);
+    expect(await db.downloadedPageCount(5), 2);
+  });
+}

--- a/test/offline/background/background_completion_log_test.dart
+++ b/test/offline/background/background_completion_log_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/background/background_completion_log.dart';
+
+void main() {
+  late Directory tmp;
+  late File logFile;
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('bglog');
+    logFile = File('${tmp.path}/.bg_completion.log');
+  });
+  tearDown(() async => tmp.delete(recursive: true));
+
+  test('append + parse round-trips pages, chapter, drained', () async {
+    final log = BackgroundCompletionLog(logFile);
+    await log.appendPage(chapterId: 5, mangaId: 1, pageIndex: 0, relPath: '1/5/000.jpg', bytes: 1234);
+    await log.appendPage(chapterId: 5, mangaId: 1, pageIndex: 1, relPath: '1/5/001.jpg', bytes: 2345);
+    await log.appendChapter(chapterId: 5, status: 'downloaded', pages: 2, bytes: 3579);
+    await log.appendDrained();
+
+    final entries = await log.parse();
+    expect(entries.length, 4);
+    expect(entries[0], isA<PageEntry>());
+    expect((entries[0] as PageEntry).relPath, '1/5/000.jpg');
+    expect((entries[2] as ChapterEntry).status, 'downloaded');
+    expect(entries[3], isA<DrainedEntry>());
+  });
+
+  test('a torn final line (crash mid-write) is discarded, earlier lines kept',
+      () async {
+    final log = BackgroundCompletionLog(logFile);
+    await log.appendPage(chapterId: 5, mangaId: 1, pageIndex: 0, relPath: '1/5/000.jpg', bytes: 1234);
+    // simulate a partial trailing write (no newline, invalid json)
+    await logFile.writeAsString('{"t":"page","c":5,"m":1,"i":1,"p":"1/5/0',
+        mode: FileMode.append);
+    final entries = await log.parse();
+    expect(entries.length, 1);
+    expect((entries.single as PageEntry).pageIndex, 0);
+  });
+
+  test('parse on a missing file returns empty', () async {
+    final log = BackgroundCompletionLog(logFile);
+    expect(await log.parse(), isEmpty);
+  });
+
+  test('truncate empties the log', () async {
+    final log = BackgroundCompletionLog(logFile);
+    await log.appendDrained();
+    await log.truncate();
+    expect(await log.parse(), isEmpty);
+  });
+}

--- a/test/offline/background/background_token_record_test.dart
+++ b/test/offline/background/background_token_record_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/background/background_token_record.dart';
+
+void main() {
+  test('a newer record gen is used WITHOUT calling refresh', () async {
+    var record = const BackgroundTokenRecord(
+        gen: 1, authType: 'uiLogin', accessToken: 'OLD', refreshToken: 'R0');
+    var refreshCalls = 0;
+    final broker = TokenBroker(
+      read: () async => record,
+      write: (r) async => record = r,
+      refreshFn: (_) async {
+        refreshCalls++;
+        return (access: 'NEW', refresh: 'R1');
+      },
+    );
+    // someone else already advanced the record:
+    record = const BackgroundTokenRecord(
+        gen: 2, authType: 'uiLogin', accessToken: 'NEWER', refreshToken: 'R9');
+    final token = await broker.resolveAfter401('OLD');
+    expect(token, 'NEWER');
+    expect(refreshCalls, 0);
+  });
+
+  test('refresh rotates BOTH tokens and bumps gen', () async {
+    var record = const BackgroundTokenRecord(
+        gen: 1, authType: 'uiLogin', accessToken: 'OLD', refreshToken: 'R0');
+    final broker = TokenBroker(
+      read: () async => record,
+      write: (r) async => record = r,
+      refreshFn: (rt) async {
+        expect(rt, 'R0');
+        return (access: 'NEW', refresh: 'R1');
+      },
+    );
+    final token = await broker.resolveAfter401('OLD');
+    expect(token, 'NEW');
+    expect(record.gen, 2);
+    expect(record.accessToken, 'NEW');
+    expect(record.refreshToken, 'R1'); // rotated refresh persisted (fixes C4)
+  });
+
+  test('a dead refresh returns null', () async {
+    var record = const BackgroundTokenRecord(
+        gen: 1, authType: 'uiLogin', accessToken: 'OLD', refreshToken: 'R0');
+    final broker = TokenBroker(
+      read: () async => record,
+      write: (r) async => record = r,
+      refreshFn: (_) async => null,
+    );
+    expect(await broker.resolveAfter401('OLD'), isNull);
+  });
+}

--- a/test/offline/background/background_work_order_test.dart
+++ b/test/offline/background/background_work_order_test.dart
@@ -13,6 +13,7 @@ void main() {
       wifiOnly: true,
       auth: const BackgroundTokenRecord(
           gen: 3, authType: 'uiLogin', accessToken: 'A', refreshToken: 'R'),
+      baseDir: '/data/app/offline',
       rootIsolateToken: 99887766,
     );
     final restored = BackgroundWorkOrder.fromJson(order.toJson());
@@ -22,6 +23,24 @@ void main() {
     expect(restored.wifiOnly, isTrue);
     expect(restored.auth.gen, 3);
     expect(restored.auth.accessToken, 'A');
+    expect(restored.baseDir, '/data/app/offline');
     expect(restored.rootIsolateToken, 99887766);
+  });
+
+  test('baseDir defaults to empty when absent (back-compat decode)', () {
+    final order = BackgroundWorkOrder(
+      chapterIds: const [1],
+      mangaIdByChapter: const {1: 1},
+      serverBase: 'https://s.example',
+      port: null,
+      addPort: false,
+      wifiOnly: false,
+      auth: const BackgroundTokenRecord(gen: 0, authType: 'none'),
+      baseDir: '/x',
+    );
+    final json = order.toJson()..remove('baseDir');
+    final restored = BackgroundWorkOrder.fromJson(json);
+    expect(restored.baseDir, '');
+    expect(restored.rootIsolateToken, 0);
   });
 }

--- a/test/offline/background/background_work_order_test.dart
+++ b/test/offline/background/background_work_order_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/background/background_token_record.dart';
+import 'package:tsumiru/src/features/offline/data/background/background_work_order.dart';
+
+void main() {
+  test('work order round-trips through json incl. int-keyed maps', () {
+    final order = BackgroundWorkOrder(
+      chapterIds: const [5, 6, 7],
+      mangaIdByChapter: const {5: 1, 6: 1, 7: 2},
+      serverBase: 'https://suwayomi.example',
+      port: 4567,
+      addPort: false,
+      wifiOnly: true,
+      auth: const BackgroundTokenRecord(
+          gen: 3, authType: 'uiLogin', accessToken: 'A', refreshToken: 'R'),
+      rootIsolateToken: 99887766,
+    );
+    final restored = BackgroundWorkOrder.fromJson(order.toJson());
+    expect(restored.chapterIds, [5, 6, 7]);
+    expect(restored.mangaIdByChapter[6], 1);
+    expect(restored.mangaIdByChapter[7], 2);
+    expect(restored.wifiOnly, isTrue);
+    expect(restored.auth.gen, 3);
+    expect(restored.auth.accessToken, 'A');
+    expect(restored.rootIsolateToken, 99887766);
+  });
+}

--- a/test/offline/background/chapter_download_engine_offline_test.dart
+++ b/test/offline/background/chapter_download_engine_offline_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/chapter_download_engine.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+
+class _NoopStore implements OfflinePageStore {
+  @override
+  Future<({String relPath, int bytes})> writePage(
+          int m, int c, int i, List<int> b, String e) async =>
+      (relPath: 'x', bytes: b.length);
+  @override
+  Future<void> deleteChapter(int m, int c) async {}
+  @override
+  Future<int> chapterBytes(int m, int c) async => 0;
+}
+
+void main() {
+  test('a PageOfflineException yields outcome.offline, not error/authFailed',
+      () async {
+    final engine = ChapterDownloadEngine(
+      fetchPage: (_) async => throw const PageOfflineException(),
+      writePage: _NoopStore(),
+      refreshAuth: () async => true,
+    );
+    final outcome = await engine.download(
+      mangaId: 1,
+      chapterId: 2,
+      pages: const [(index: 0, url: 'u0')],
+      isCancelled: () => false,
+    );
+    expect(outcome.offline, isTrue);
+    expect(outcome.error, isNull);
+    expect(outcome.authFailed, isFalse);
+    expect(outcome.succeeded, isFalse);
+    expect(outcome.storedPages, isEmpty);
+  });
+
+  test('offline short-circuits immediately (no retry/backoff burn)', () async {
+    var calls = 0;
+    final engine = ChapterDownloadEngine(
+      fetchPage: (_) async {
+        calls++;
+        throw const PageOfflineException();
+      },
+      writePage: _NoopStore(),
+      refreshAuth: () async => true,
+      maxAttempts: 3,
+    );
+    await engine.download(
+      mangaId: 1,
+      chapterId: 2,
+      pages: const [(index: 0, url: 'u0')],
+      isCancelled: () => false,
+    );
+    expect(calls, 1); // not retried 3x
+  });
+}

--- a/test/src/features/offline/data/offline_download_triggers_test.dart
+++ b/test/src/features/offline/data/offline_download_triggers_test.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Regression guard for the bug where "Download all / unread" silently did
+// nothing on Android: the trigger queued chapters but never started the
+// download service. Every download trigger MUST go through
+// downloadStarterProvider — these tests fail if one forgets to.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/offline/data/chapter_download_engine.dart';
+import 'package:tsumiru/src/features/offline/data/offline_background_downloads.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_coordinator.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_manager.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+class _FakeStore implements OfflinePageStore {
+  @override
+  Future<({String relPath, int bytes})> writePage(
+          int m, int c, int i, List<int> b, String e) async =>
+      (relPath: '$m/$c/$i.$e', bytes: b.length);
+  @override
+  Future<void> deleteChapter(int m, int c) async {}
+  @override
+  Future<int> chapterBytes(int m, int c) async => 0;
+}
+
+void main() {
+  late OfflineDatabase db;
+  final store = _FakeStore();
+
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  // Minimal non-null deps so the triggers reach the start step instead of
+  // bailing on a null coordinator/manager.
+  OfflineDownloadCoordinator buildCoordinator() => OfflineDownloadCoordinator(
+        db: db,
+        engine: ChapterDownloadEngine(
+          fetchPage: (_) async => throw UnimplementedError(),
+          writePage: store,
+          refreshAuth: () async => false,
+        ),
+        resolvePages: (_) async => const [],
+        measureChapterBytes: (_, __) async => 0,
+      );
+
+  OfflineDownloadManager buildManager() => OfflineDownloadManager(
+        db: db,
+        store: store,
+        fetchPageUrls: (_) async => const [],
+        fetchBytes: (_) async => throw UnimplementedError(),
+      );
+
+  /// Pump a ProviderScope with offline "enabled" + fake deps, a spy
+  /// downloadStarter, and hand back the captured [WidgetRef] + the spy counter.
+  Future<({WidgetRef ref, int Function() starts})> harness(
+      WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    var startCalls = 0;
+    late WidgetRef captured;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          offlineEnabledProvider.overrideWithValue(true),
+          offlineDatabaseProvider.overrideWithValue(db),
+          offlinePathsProvider.overrideWithValue(const OfflinePaths('/tmp/x')),
+          offlinePageStoreProvider.overrideWithValue(store),
+          offlineDownloadCoordinatorProvider
+              .overrideWithValue(buildCoordinator()),
+          offlineDownloadManagerProvider.overrideWithValue(buildManager()),
+          downloadStarterProvider.overrideWithValue(() async => startCalls++),
+        ],
+        child: Consumer(builder: (_, ref, __) {
+          captured = ref;
+          return const SizedBox();
+        }),
+      ),
+    );
+    return (ref: captured, starts: () => startCalls);
+  }
+
+  testWidgets('reconcileMangaWidget (Download all / unread) starts downloads',
+      (tester) async {
+    final h = await harness(tester);
+    await reconcileMangaWidget(h.ref, 1);
+    expect(h.starts(), 1,
+        reason: 'the keep-rule trigger must invoke downloadStarterProvider — '
+            'this is the bug where "Download all" did nothing on Android');
+  });
+
+  testWidgets('saveChapterToDevice (single chapter) starts downloads',
+      (tester) async {
+    await db.upsertMangaMetadata(
+        id: 7, title: 'M', updatedAt: DateTime(2026));
+    await db.upsertChapterMetadata(
+        id: 1, mangaId: 7, name: 'c1', chapterIndex: 1, isRead: false,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026));
+    final h = await harness(tester);
+    await saveChapterToDevice(h.ref, 1);
+    expect(h.starts(), 1,
+        reason: 'the single-chapter save must invoke downloadStarterProvider');
+  });
+}


### PR DESCRIPTION
## Background / offline downloads

Adds a real background download engine so chapters keep downloading when the app is backgrounded or closed, with durable state that survives a cold restart.

### What it does
- **Foreground-service worker isolate** does the actual downloading off the main isolate, so progress continues when the app is backgrounded.
- **Main-isolate controller** issues typed work orders to the worker and tracks live state.
- **Single start chokepoint** — every download trigger (manual, queue, resume) routes through one path, so nothing can start a download by a side door. Covered by a regression test.
- **Durable JSONL completion log** + filesystem-truth replay: on reopen we reconcile what actually landed on disk against the log, so a download interrupted mid-flight isn't lost or double-counted.
- **Resume on reopen** — in-flight downloads pick back up automatically on app restart; no longer need to reopen manga details to kick them.
- **Determinate per-chapter progress arc** restored on the chapter rows.
- **"Download over Wi-Fi only" setting**.
- **No-network pause vs. error** are distinguished, so losing signal pauses cleanly instead of failing.
- **Drain-race fix** — a download started during shutdown is no longer stranded.
- **Gen-versioned token record + shared refresh protocol** so the worker isolate stays authenticated.

### Tests
Adds coverage for the completion log + replay, token record, work order, the offline engine's no-network handling, and the all-triggers-start regression.
