### PR TITLE
Manga details: 'Soon' next-release estimate + Komikku-style action row

### DIFF
--- a/lib/src/features/manga_book/domain/next_update/next_update_predictor.dart
+++ b/lib/src/features/manga_book/domain/next_update/next_update_predictor.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:math' as math;
+
+/// Maximum predicted interval, in days (Komikku `FetchInterval.MAX_INTERVAL`).
+const int kMaxFetchIntervalDays = 28;
+
+/// One chapter's relevant timestamps, epoch milliseconds (0 = absent).
+typedef ChapterRelease = ({int uploadMs, int fetchMs});
+
+/// Result of [predictNextUpdate]: the estimated release [intervalDays] and the
+/// projected [nextUpdate] (null when there's no usable date history).
+class NextUpdatePrediction {
+  const NextUpdatePrediction({required this.intervalDays, this.nextUpdate});
+
+  final int intervalDays;
+  final DateTime? nextUpdate;
+
+  /// Whole days from [now] until the next expected chapter, floored at 0.
+  /// Null when there's no prediction.
+  int? daysUntil(DateTime now) {
+    final next = nextUpdate;
+    if (next == null) return null;
+    return math.max(0, next.difference(now).inDays);
+  }
+}
+
+/// Predict when a manga's next chapter is due, from its own release history.
+///
+/// The release [intervalDays] is computed exactly like Komikku/Mihon
+/// `tachiyomi.domain.manga.interactor.FetchInterval.calculateInterval`: the
+/// median gap between recent distinct release days (upload dates, falling back
+/// to fetch dates, else a 7-day default), clamped to 1..28 days.
+///
+/// The next date is simply `latestRelease + interval`. (Komikku projects
+/// forward whole cycles, but that only ever reads "Soon" because it *stores*
+/// the value and counts down to a stale one; computed live, latest+interval
+/// gives the intended "In N days" while pending and "Soon" once due/overdue.)
+NextUpdatePrediction predictNextUpdate(
+  List<ChapterRelease> chapters, {
+  DateTime? now,
+}) {
+  final interval = _calculateInterval(chapters);
+
+  final latestDate = _latestReleaseStartOfDay(chapters);
+  if (latestDate == null) {
+    // No dated chapters at all → no estimate.
+    return NextUpdatePrediction(intervalDays: interval, nextUpdate: null);
+  }
+
+  return NextUpdatePrediction(
+    intervalDays: interval,
+    nextUpdate: latestDate.add(Duration(days: interval)),
+  );
+}
+
+int _calculateInterval(List<ChapterRelease> chapters) {
+  // Wider sampling window once there's a decent backlog (Komikku: 3 vs 10).
+  final window = chapters.length <= 8 ? 3 : 10;
+
+  final uploadDays = _recentDistinctDays(
+    chapters,
+    (c) => c.uploadMs,
+    window,
+  );
+  final fetchDays = _recentDistinctDays(
+    chapters,
+    (c) => c.fetchMs,
+    window,
+  );
+
+  final fromUpload = _medianGapDays(uploadDays);
+  final fromFetch = _medianGapDays(fetchDays);
+
+  final interval = fromUpload ?? fromFetch ?? 7;
+  return interval.clamp(1, kMaxFetchIntervalDays);
+}
+
+/// Most recent [window] distinct release days (start-of-day, descending) for a
+/// given timestamp, ignoring absent (<= 0) values.
+List<DateTime> _recentDistinctDays(
+  List<ChapterRelease> chapters,
+  int Function(ChapterRelease) pick,
+  int window,
+) {
+  final sorted = [...chapters]..sort((a, b) => pick(b).compareTo(pick(a)));
+  final seen = <int>{};
+  final days = <DateTime>[];
+  for (final c in sorted) {
+    final ms = pick(c);
+    if (ms <= 0) continue;
+    final d = DateTime.fromMillisecondsSinceEpoch(ms);
+    final startOfDay = DateTime(d.year, d.month, d.day);
+    if (seen.add(startOfDay.millisecondsSinceEpoch)) {
+      days.add(startOfDay);
+      if (days.length >= window) break;
+    }
+  }
+  return days;
+}
+
+/// Median gap (days) between consecutive [days] (descending). Needs >= 3 days
+/// (i.e. >= 2 gaps) to be meaningful; null otherwise. Matches Komikku's
+/// `ranges[(ranges.size - 1) / 2]` lower-median.
+int? _medianGapDays(List<DateTime> days) {
+  if (days.length < 3) return null;
+  final gaps = <int>[
+    for (var i = 0; i < days.length - 1; i++) days[i].difference(days[i + 1]).inDays,
+  ]..sort();
+  return gaps[(gaps.length - 1) ~/ 2];
+}
+
+DateTime? _latestReleaseStartOfDay(List<ChapterRelease> chapters) {
+  var latest = 0;
+  for (final c in chapters) {
+    if (c.uploadMs > latest) latest = c.uploadMs;
+  }
+  if (latest == 0) {
+    // No upload dates — fall back to the newest fetch date.
+    for (final c in chapters) {
+      if (c.fetchMs > latest) latest = c.fetchMs;
+    }
+  }
+  if (latest == 0) return null;
+  final d = DateTime.fromMillisecondsSinceEpoch(latest);
+  return DateTime(d.year, d.month, d.day);
+}

--- a/lib/src/features/manga_book/presentation/manga_details/controller/next_update_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/next_update_controller.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../domain/next_update/next_update_predictor.dart';
+import 'manga_details_controller.dart';
+
+part 'next_update_controller.g.dart';
+
+/// Predicted next-chapter date for a manga, derived from its loaded chapter
+/// list (upload/fetch timestamps). Null when there are no chapters yet.
+@riverpod
+NextUpdatePrediction? mangaNextUpdate(Ref ref, {required int mangaId}) {
+  final chapters =
+      ref.watch(mangaChapterListProvider(mangaId: mangaId)).valueOrNull;
+  if (chapters == null || chapters.isEmpty) return null;
+  final releases = <ChapterRelease>[
+    for (final c in chapters)
+      (
+        uploadMs: int.tryParse(c.uploadDate) ?? 0,
+        fetchMs: int.tryParse(c.fetchedAt) ?? 0,
+      ),
+  ];
+  return predictNextUpdate(releases);
+}

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_action_button.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_action_button.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+
+/// Compact icon-over-label action button for the manga-details action row,
+/// matching Komikku's `MangaActionButton` (MangaInfoHeader.kt:1014): a
+/// weight-1 TextButton wrapping a centered Column of a 20dp icon, a 4dp gap and
+/// a 12sp centered label. Active items use the primary color; the rest recede.
+///
+/// Put each in an [Expanded] so the row's items share width evenly.
+class MangaActionButton extends StatelessWidget {
+  const MangaActionButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    this.onPressed,
+    this.active = false,
+  });
+
+  /// Usually an [Icon]; may be any widget (e.g. a progress spinner). Its colour
+  /// and 20dp size are applied via [IconTheme].
+  final Widget icon;
+  final String label;
+  final VoidCallback? onPressed;
+
+  /// Highlight (primary colour) when the action's state is "on".
+  final bool active;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    final color = active ? cs.primary : cs.onSurfaceVariant;
+    return TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconTheme.merge(
+            data: IconThemeData(size: 20, color: color),
+            child: icon,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(fontSize: 12, color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -12,6 +12,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../../constants/app_sizes.dart';
+import '../../../../../graphql/__generated__/schema.graphql.dart';
 import '../../../../../routes/router_config.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/launch_url_in_web.dart';
@@ -19,8 +20,11 @@ import '../../../../../utils/misc/toast/toast.dart';
 import '../../../../../utils/theme/brand.dart';
 import '../../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart';
 import '../../../../../widgets/server_image.dart';
+import '../../../../offline/data/offline_repository.dart';
 import '../../../../offline/presentation/series_offline_button.dart';
 import '../../../domain/manga/manga_model.dart';
+import '../controller/next_update_controller.dart';
+import 'manga_action_button.dart';
 
 class MangaDescription extends HookConsumerWidget {
   const MangaDescription({
@@ -103,51 +107,72 @@ class MangaDescription extends HookConsumerWidget {
             ),
           ],
         ),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: BrandButton(
-                  icon: Icon(
-                    inLibrary
-                        ? Icons.favorite_rounded
-                        : Icons.favorite_border_rounded,
-                  ),
-                  label: Text(
-                    inLibrary ? context.l10n.inLibrary : context.l10n.addToLibrary,
-                  ),
-                  onPressed: () async {
-                    final val = await AsyncValue.guard(() async {
-                      if (inLibrary) {
-                        await removeMangaFromLibrary();
-                      } else {
-                        await addMangaToLibrary();
+        Builder(builder: (context) {
+          // Komikku-style action row: equal-width icon-over-label columns.
+          final offlineEnabled = ref.watch(offlineEnabledProvider);
+          final prediction =
+              ref.watch(mangaNextUpdateProvider(mangaId: manga.id));
+          final soonDays = manga.status == Enum$MangaStatus.COMPLETED
+              ? null
+              : prediction?.daysUntil(DateTime.now());
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: MangaActionButton(
+                    active: inLibrary,
+                    icon: Icon(
+                      inLibrary
+                          ? Icons.favorite_rounded
+                          : Icons.favorite_border_rounded,
+                    ),
+                    label: inLibrary
+                        ? context.l10n.inLibrary
+                        : context.l10n.addToLibrary,
+                    onPressed: () async {
+                      final val = await AsyncValue.guard(() async {
+                        if (inLibrary) {
+                          await removeMangaFromLibrary();
+                        } else {
+                          await addMangaToLibrary();
+                        }
+                        await refresh();
+                      });
+                      if (context.mounted) {
+                        val.showToastOnError(ref.read(toastProvider));
                       }
-                      await refresh();
-                    });
-                    if (context.mounted) {
-                      val.showToastOnError(ref.read(toastProvider));
-                    }
-                  },
-                ),
-              ),
-              const SizedBox(width: 10),
-              Expanded(child: SeriesOfflineButton(mangaId: manga.id)),
-              if (manga.realUrl.isNotBlank) ...[
-                const SizedBox(width: 10),
-                BrandCircleButton(
-                  icon: Icons.public_rounded,
-                  onPressed: () => launchUrlInWeb(
-                    context,
-                    (manga.realUrl ?? ""),
-                    ref.read(toastProvider),
+                    },
                   ),
                 ),
+                if (offlineEnabled)
+                  Expanded(child: SeriesOfflineButton(mangaId: manga.id)),
+                if (soonDays != null)
+                  Expanded(
+                    child: MangaActionButton(
+                      active: soonDays <= 1,
+                      icon: const Icon(Icons.hourglass_empty_rounded),
+                      label: soonDays == 0
+                          ? context.l10n.soon
+                          : context.l10n.inNDays(soonDays),
+                    ),
+                  ),
+                if (manga.realUrl.isNotBlank)
+                  Expanded(
+                    child: MangaActionButton(
+                      icon: const Icon(Icons.public_rounded),
+                      label: context.l10n.webView,
+                      onPressed: () => launchUrlInWeb(
+                        context,
+                        (manga.realUrl ?? ""),
+                        ref.read(toastProvider),
+                      ),
+                    ),
+                  ),
               ],
-            ],
-          ),
-        ),
+            ),
+          );
+        }),
         if (manga.description.isNotBlank)
           Padding(
             padding: KEdgeInsets.a16.size,

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../utils/extensions/custom_extensions.dart';
-import '../../../utils/theme/brand.dart';
+import '../../manga_book/presentation/manga_details/widgets/manga_action_button.dart';
 import '../data/offline_database.dart';
 import '../data/offline_download_providers.dart';
 import '../data/offline_repository.dart';
@@ -33,7 +33,8 @@ class SeriesOfflineButton extends ConsumerWidget {
     final inFlight = progress?.inFlight ?? 0;
     final onDevice = downloaded > 0;
     final downloading = inFlight > 0;
-    return BrandGlassButton(
+    return MangaActionButton(
+      active: onDevice || downloading,
       icon: downloading
           ? const SizedBox(
               width: 18,
@@ -42,11 +43,11 @@ class SeriesOfflineButton extends ConsumerWidget {
           : Icon(onDevice
               ? Icons.offline_pin_rounded
               : Icons.download_rounded),
-      label: Text(downloading
+      label: downloading
           ? context.l10n.offlineDownloadingCount(inFlight)
           : onDevice
               ? context.l10n.offlineOnDevice
-              : context.l10n.offlineDownloadAction),
+              : context.l10n.offlineDownloadAction,
       onPressed: () => _openSheet(context, ref, onDevice),
     );
   }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1257,6 +1257,14 @@
     "moveToTop": "Move to top",
     "nChapters": "{n, plural, =0{None} =1{1 Chapter} other{{n} Chapters}}",
     "nDays": "{count, select, 01{01 Day} other{{count} Days}}",
+    "soon": "Soon",
+    "inNDays": "{days, plural, =1{In 1 day} other{In {days} days}}",
+    "@inNDays": {
+        "description": "Next-chapter estimate on the manga details page",
+        "placeholders": {
+            "days": { "type": "int" }
+        }
+    },
     "nHours": "{n, plural, =1{1 hour} other{{n} hours}}",
     "nMinutes": "{n, plural, =1{1 Minute} other{{n} Minutes}}",
     "nRepo": "{n, plural, =1{1 Repo} other{{n} Repos}}",

--- a/test/manga_book/next_update_predictor_test.dart
+++ b/test/manga_book/next_update_predictor_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/domain/next_update/next_update_predictor.dart';
+
+void main() {
+  final now = DateTime(2026, 6, 23);
+  int daysAgoMs(int d) =>
+      now.subtract(Duration(days: d)).millisecondsSinceEpoch;
+
+  ChapterRelease up(int d) => (uploadMs: daysAgoMs(d), fetchMs: daysAgoMs(d));
+
+  group('predictNextUpdate interval', () {
+    test('weekly cadence → interval 7', () {
+      final p = predictNextUpdate(
+        [up(2), up(9), up(16), up(23)],
+        now: now,
+      );
+      expect(p.intervalDays, 7);
+      // latest 2 days ago + 7 → 5 days out.
+      expect(p.daysUntil(now), 5);
+    });
+
+    test('biweekly cadence → interval 14', () {
+      final p = predictNextUpdate(
+        [up(1), up(15), up(29), up(43)],
+        now: now,
+      );
+      expect(p.intervalDays, 14);
+    });
+
+    test('huge gaps clamp at 28', () {
+      final p = predictNextUpdate(
+        [up(1), up(60), up(120), up(180)],
+        now: now,
+      );
+      expect(p.intervalDays, 28);
+    });
+
+    test('fewer than 3 dated chapters → default 7', () {
+      final p = predictNextUpdate([up(0), up(40)], now: now);
+      expect(p.intervalDays, 7);
+    });
+
+    test('falls back to fetch dates when upload dates are absent', () {
+      final c = <ChapterRelease>[
+        for (final d in [2, 9, 16, 23]) (uploadMs: 0, fetchMs: daysAgoMs(d)),
+      ];
+      final p = predictNextUpdate(c, now: now);
+      expect(p.intervalDays, 7);
+    });
+  });
+
+  group('predictNextUpdate days/Soon', () {
+    test('not yet due → positive days', () {
+      // weekly, latest 3 days ago → due in 4.
+      final p = predictNextUpdate([up(3), up(10), up(17), up(24)], now: now);
+      expect(p.daysUntil(now), 4);
+    });
+
+    test('overdue → Soon (0)', () {
+      // weekly, latest 10 days ago → 3 days overdue → 0.
+      final p = predictNextUpdate([up(10), up(17), up(24), up(31)], now: now);
+      expect(p.daysUntil(now), 0);
+    });
+
+    test('no chapters → null prediction', () {
+      final p = predictNextUpdate(const [], now: now);
+      expect(p.nextUpdate, isNull);
+      expect(p.daysUntil(now), isNull);
+    });
+
+    test('duplicate same-day releases do not skew the gap', () {
+      // Three chapters on the same day shouldn't read as a 0-day cadence.
+      final c = <ChapterRelease>[
+        up(2), up(2), up(2), up(9), up(16), up(23),
+      ];
+      final p = predictNextUpdate(c, now: now);
+      expect(p.intervalDays, 7);
+    });
+  });
+}


### PR DESCRIPTION
Komikku parity: a next-release estimate on the manga-details page, plus a tidy-up of the action row.

## "Soon" estimate
- Computed entirely on-device from the chapter list — **no server changes**. tsumiru already fetches per-chapter `uploadDate`/`fetchedAt`.
- Faithful port of Komikku's `FetchInterval`: the interval is the median gap between recent distinct release days (upload dates → fetch dates → 7-day default), clamped to 1..28 days.
- Reads **"In N days"** while pending and **"Soon"** once due/overdue. Hidden for completed series or when there's no usable history.
- Pure predictor with 9 unit tests covering cadence, clamp, fallback, overdue, and empty cases.

## Action row
- Reworked to Komikku's compact icon-over-label columns (`MangaActionButton`): **In library · On device · Soon · Web View** — equal width, active items in the accent colour. Replaces the previous mixed pill/circle buttons.

Verified on-device (Pixel 9 Pro): a weekly manhwa shows "In 3 days"; the row renders as four even columns. `flutter analyze` clean.

Deferred (noted in the vault spec): tapping "Soon" to manually override the interval.
