### PR TITLE
Add first-time onboarding wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ design/qa-*.png
 flatpak/bundle/
 .flatpak-out/
 .flatpak-builder/
+
+# Claude Code local settings (personal hooks/config)
+.claude/settings.local.json

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,6 +54,16 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        manifestPlaceholders += [appLabel: "Tsumiru"]
+
+        // Opt-in side-by-side test build — leaves the daily driver untouched.
+        // Build with: ORG_GRADLE_PROJECT_devBuild=1 flutter build apk --debug
+        // Installs as a separate app id (…tsumiru.dev) named "Tsumiru Dev".
+        if (project.hasProperty('devBuild')) {
+            applicationIdSuffix ".dev"
+            versionNameSuffix "-dev"
+            manifestPlaceholders += [appLabel: "Tsumiru Dev"]
+        }
     }
 
    signingConfigs {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
      <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
      <uses-permission android:name="android.permission.WAKE_LOCK" />
    <application
-        android:label="Tsumiru"
+        android:label="${appLabel}"
         android:name="${applicationName}"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@ import 'src/features/offline/data/offline_background_downloads.dart';
 import 'src/features/offline/data/offline_bootstrap.dart';
 import 'src/features/offline/data/offline_download_providers.dart';
 import 'src/features/offline/data/offline_repository.dart';
+import 'src/features/onboarding/data/onboarding_complete.dart';
 import 'src/features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import 'src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import 'src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
@@ -100,7 +101,21 @@ Future<void> main() async {
     debugPrint('readerIgnoreSafeArea migration failed: $e\n$st');
   }
 
-  // 3) Preload both auth providers BEFORE the first frame so synchronous reads
+  // 3) One-time: an install that already points at a real server has already
+  //    "onboarded" — seed the flag so the new first-run wizard never shows for
+  //    existing users. Only run when the flag is unset; treat the default
+  //    loopback URL (and no URL) as not-configured.
+  try {
+    if (sharedPreferences.getBool('onboardingComplete') == null) {
+      final url = sharedPreferences.getString('serverUrl');
+      await sharedPreferences.setBool(
+          'onboardingComplete', serverConfiguredForOnboarding(url));
+    }
+  } catch (e, st) {
+    debugPrint('onboarding migration failed: $e\n$st');
+  }
+
+  // 4) Preload both auth providers BEFORE the first frame so synchronous reads
   //    (image widgets, GraphQL links) get populated state instead of
   //    AsyncLoading — which would produce tokenless requests that get cached
   //    as 401 failures by cached_network_image.
@@ -114,7 +129,7 @@ Future<void> main() async {
     // Both notifiers will re-attempt on first widget read. App still launches.
   }
 
-  // 3) Eagerly instantiate the AuthCoordinator so its build() runs and
+  // 5) Eagerly instantiate the AuthCoordinator so its build() runs and
   //    sets up the proactive-refresh listener BEFORE any image request
   //    can see an expired token. Without this, the Coordinator stays
   //    lazy until something hits a 401 — which for an existing logged-in
@@ -128,7 +143,7 @@ Future<void> main() async {
     // Non-fatal: reactive 401-refresh path still works on first use.
   }
 
-  // 4) Debug-only: auto-connect + auto-login from a local --dart-define test
+  // 6) Debug-only: auto-connect + auto-login from a local --dart-define test
   //    config (see scripts/run-test.sh). No-op in release builds or when
   //    TEST_SERVER_URL isn't provided, so it never affects real users.
   try {
@@ -137,7 +152,7 @@ Future<void> main() async {
     debugPrint('test-config seed failed: $e\n$st');
   }
 
-  // 5) Sweep any chapter left mid-download by a prior crash/kill back to a
+  // 7) Sweep any chapter left mid-download by a prior crash/kill back to a
   //    clean state so it can be retried. Fire-and-forget; native only.
   if (offlineStorage != null) {
     // Push read progress made offline, re-apply keep-rules (queues anything

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -13,6 +13,9 @@ enum DBKeys {
   serverUrl('http://127.0.0.1'),
   serverPort(4567),
   serverPortToggle(true),
+  // First-time onboarding: false until the wizard is finished. A one-time
+  // migration seeds it true for installs that already have a server configured.
+  onboardingComplete(false),
   sourceLanguageFilter(["all", "lastUsed", "en", "localsourcelang"]),
   extensionLanguageFilter(["installed", "update", "en", "all"]),
   sourceLastUsed(null),

--- a/lib/src/features/onboarding/data/onboarding_complete.dart
+++ b/lib/src/features/onboarding/data/onboarding_complete.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'onboarding_complete.g.dart';
+
+/// Whether the first-time onboarding wizard has been finished. While false, the
+/// router sends every route to `/onboarding`. Persisted in SharedPreferences;
+/// a one-time launch migration seeds it true for already-configured installs.
+@riverpod
+class OnboardingComplete extends _$OnboardingComplete
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.onboardingComplete);
+}
+
+/// Whether a saved server URL counts as "already configured" for the one-time
+/// onboarding migration — anything but unset/empty or the default loopback.
+/// Existing installs that pass this are seeded onboarded so the wizard never
+/// shows for them.
+bool serverConfiguredForOnboarding(String? serverUrl) =>
+    serverUrl != null &&
+    serverUrl.isNotEmpty &&
+    serverUrl != DBKeys.serverUrl.initial;

--- a/lib/src/features/onboarding/data/server_discovery.dart
+++ b/lib/src/features/onboarding/data/server_discovery.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:network_info_plus/network_info_plus.dart';
+
+/// LAN discovery for the onboarding "Search my network" action.
+///
+/// Sweeps the device's Wi-Fi /24 subnet looking for a Suwayomi server on its
+/// default port (4567) — the same approach as the existing ServerSearchButton,
+/// extracted so onboarding can drive it. The Wi-Fi-IP lookup and the per-host
+/// ping are injectable so the sweep logic is unit-testable without a network.
+
+const int kSuwayomiScanPort = 4567;
+
+/// Every host to probe for [ip]'s /24 subnet (`x.y.z.1` … `x.y.z.254`), plus
+/// [ip] itself, de-duplicated and order-preserving.
+List<String> subnetHosts(String ip) {
+  final dot = ip.lastIndexOf('.');
+  if (dot < 0) return [ip];
+  final subnet = ip.substring(0, dot);
+  return <String>{ip, for (var i = 1; i < 255; i++) '$subnet.$i'}.toList();
+}
+
+/// Scans the Wi-Fi subnet for a Suwayomi server on :4567. Returns
+/// `http://<ip>:4567` for the first host that accepts a TCP connection there,
+/// or null if none (or there's no Wi-Fi IP). Probes in concurrent batches so a
+/// full /24 sweep finishes quickly.
+Future<String?> discoverServerOnLan({
+  Future<String?> Function()? wifiIp,
+  Future<bool> Function(String host, int port)? ping,
+  int batchSize = 48,
+}) async {
+  final ip = await (wifiIp ?? () => NetworkInfo().getWifiIP())();
+  if (ip == null || ip.isEmpty) return null;
+
+  final doPing = ping ?? _ping;
+  final hosts = subnetHosts(ip);
+  for (var start = 0; start < hosts.length; start += batchSize) {
+    final end =
+        (start + batchSize) < hosts.length ? start + batchSize : hosts.length;
+    final batch = hosts.sublist(start, end);
+    final results = await Future.wait(
+        batch.map((h) async => (await doPing(h, kSuwayomiScanPort)) ? h : null));
+    for (final h in results) {
+      if (h != null) return 'http://$h:$kSuwayomiScanPort';
+    }
+  }
+  return null;
+}
+
+Future<bool> _ping(String host, int port) async {
+  try {
+    final socket = await Socket.connect(host, port,
+        timeout: const Duration(milliseconds: 120));
+    socket.destroy();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/lib/src/features/onboarding/data/server_resolver.dart
+++ b/lib/src/features/onboarding/data/server_resolver.dart
@@ -1,0 +1,797 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// "Find server" connection resolver.
+///
+/// The onboarding Step 2 lets a user type a half-remembered address — a bare
+/// host, `host:port`, a full `https://…/suwayomi` URL, an IPv6 literal — and
+/// have the app figure out the working base URL (and whether it needs auth)
+/// without making them understand schemes/ports. This file is the PURE,
+/// testable core of that:
+///
+///   * [connectionCandidates] turns one fuzzy input into an ordered ladder of
+///     concrete base URLs to try.
+///   * [classifyProbeBody] reads a probe response body into a [ProbeResult].
+///   * [probeServer] runs ONE candidate over the network (short timeout,
+///     redirects OFF, lightweight http client) using the two-request protocol.
+///   * [resolveServer] walks the ladder and returns the best [ResolvedServer].
+///
+/// The network bits take their `http.Client` and timeout by parameter so the
+/// resolver can be driven entirely in-memory from unit tests.
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Per-candidate auth posture, derived from the two-request probe.
+enum ProbeAuthMode {
+  /// `aboutServer` returned data AND the @RequireAuth probe returned data —
+  /// the server is reachable with no auth (or we're already authorised).
+  open,
+
+  /// `aboutServer` returned data but the @RequireAuth probe came back
+  /// "Unauthorized" — a real Suwayomi server that needs credentials.
+  authRequired,
+}
+
+/// The classified outcome of probing one candidate URL.
+///
+/// `confirmed` is the strong signal: we saw a real Suwayomi `aboutServer`
+/// payload. `reached` means the host answered with *something* HTTP-shaped but
+/// not a Suwayomi GraphQL body (could be a reverse proxy login page, a 401
+/// HTML page, the wrong service, …). `basicGated` is the special case where
+/// the transport itself is gated by HTTP Basic auth (a 401 with a
+/// `WWW-Authenticate: Basic` challenge) — we cannot see past it to confirm
+/// Suwayomi, so per spec it must NEVER short-circuit and NEVER read as found.
+class ProbeResult {
+  const ProbeResult({
+    required this.url,
+    required this.confirmed,
+    required this.reached,
+    required this.basicGated,
+    this.authMode,
+    this.serverName,
+    this.serverVersion,
+  });
+
+  /// Nothing answered at this candidate (socket error / timeout / no body).
+  const ProbeResult.notReached(this.url)
+      : confirmed = false,
+        reached = false,
+        basicGated = false,
+        authMode = null,
+        serverName = null,
+        serverVersion = null;
+
+  /// The host answered but it was not a confirmable Suwayomi GraphQL body.
+  const ProbeResult.reachedUnconfirmed(this.url)
+      : confirmed = false,
+        reached = true,
+        basicGated = false,
+        authMode = null,
+        serverName = null,
+        serverVersion = null;
+
+  /// The transport is behind HTTP Basic auth — opaque, cannot confirm.
+  const ProbeResult.basicGatedResult(this.url)
+      : confirmed = false,
+        reached = true,
+        basicGated = true,
+        authMode = null,
+        serverName = null,
+        serverVersion = null;
+
+  final String url;
+
+  /// We saw a genuine Suwayomi `aboutServer` payload at this URL.
+  final bool confirmed;
+
+  /// The host responded with *something* (not a transport failure).
+  final bool reached;
+
+  /// A 401 + `WWW-Authenticate: Basic` challenge fronts this URL.
+  final bool basicGated;
+
+  /// When [confirmed], whether the server's @RequireAuth surface needs creds.
+  final ProbeAuthMode? authMode;
+
+  /// `aboutServer.name`, when present in the body (read independently of
+  /// the `errors[]` array — a partial/errored response can still carry it).
+  final String? serverName;
+
+  /// `aboutServer.version`, when present in the body.
+  final String? serverVersion;
+}
+
+/// The final answer the UI consumes.
+class ResolvedServer {
+  const ResolvedServer({
+    required this.baseUrl,
+    required this.outcome,
+    this.authMode,
+    this.serverName,
+    this.serverVersion,
+  });
+
+  /// The base URL the UI should adopt (no `/api/graphql` suffix).
+  final String baseUrl;
+
+  /// How strong the match is — see [ResolveOutcome].
+  final ResolveOutcome outcome;
+
+  /// For a [ResolveOutcome.found] result, whether the server needs auth.
+  final ProbeAuthMode? authMode;
+
+  final String? serverName;
+  final String? serverVersion;
+
+  bool get isFound => outcome == ResolveOutcome.found;
+}
+
+/// Strength of the resolver's best result, in descending confidence.
+enum ResolveOutcome {
+  /// Confirmed Suwayomi server (`aboutServer` payload seen).
+  found,
+
+  /// Best we could reach is behind HTTP Basic auth — can't confirm Suwayomi,
+  /// but there IS a server here. The UI prompts for basic creds.
+  basicGated,
+
+  /// Something answered but we couldn't confirm it's Suwayomi.
+  reachedUnconfirmed,
+
+  /// Nothing answered at any candidate.
+  notReached,
+}
+
+// ---------------------------------------------------------------------------
+// Candidate ladder + normalisation
+// ---------------------------------------------------------------------------
+
+/// Default Suwayomi port, surfaced on bare hosts so the user sees/edits it.
+const int kDefaultSuwayomiPort = 4567;
+
+/// Builds the ordered list of concrete base URLs to try for [rawInput].
+///
+/// Rules (red-teamed):
+///   * Trim, and treat blank as no candidates.
+///   * IPv6 literals are detected FIRST (bracketed `[::1]` or a bare literal
+///     that [Uri.parseIPv6Address] accepts) BEFORE any `host:port` split, so a
+///     bare `::1` / `fe80::1` is never mistaken for `host` + `port`.
+///   * An explicit scheme (`http://` / `https://`) is honoured verbatim and
+///     yields exactly ONE candidate — the user told us what they want.
+///   * A scheme-less input with NO typed port fans out http-first (spec
+///     decision #2, the LAN fast-path):
+///       http://host:4567, https://host, http://host
+///   * A scheme-less input WITH a typed port keeps that port on both schemes
+///     and skips the default-port / bare-host variants (spec Part A):
+///       http://host:port, https://host:port
+///   * Any base path the user typed is preserved on every candidate.
+///   * URLs are assembled via [Uri] (never string concatenation); a part that
+///     can't form a valid URL is dropped (never throws); the list is
+///     de-duplicated, order-preserving.
+List<String> connectionCandidates(String rawInput) {
+  final input = rawInput.trim();
+  if (input.isEmpty) return const [];
+
+  // --- Explicit scheme. ---
+  final lower = input.toLowerCase();
+  if (lower.startsWith('http://') || lower.startsWith('https://')) {
+    final uri = Uri.tryParse(input);
+    if (uri == null || uri.host.isEmpty) return const [];
+    if (uri.hasPort) {
+      // Scheme AND port → fully specified; honour it verbatim (custom ports).
+      return _dedup([_assemble(uri.scheme, uri.host, uri.port, uri.path)]);
+    }
+    // Scheme but NO port → the user named a host, not a full address. Try the
+    // default Suwayomi port FIRST (a server is rarely on :80/:443 bare), then
+    // the scheme's bare port as a fallback.
+    return _dedup([
+      _assemble(uri.scheme, uri.host, kDefaultSuwayomiPort, uri.path),
+      _assemble(uri.scheme, uri.host, null, uri.path),
+    ]);
+  }
+
+  // Split off any base path the user typed (everything from the first '/').
+  String authority = input;
+  String path = '';
+  final slash = input.indexOf('/');
+  if (slash >= 0) {
+    authority = input.substring(0, slash);
+    path = input.substring(slash); // keeps the leading '/'
+  }
+  if (authority.isEmpty) return const [];
+
+  final (host, port) = _splitHostPort(authority);
+  if (host.isEmpty) return const [];
+
+  if (port != null) {
+    // Explicit port: only the two scheme variants on that exact port; the
+    // 4567/443/80 substitutions are skipped (spec Part A, round-3 fix).
+    return _dedup([
+      _assemble('http', host, port, path),
+      _assemble('https', host, port, path),
+    ]);
+  }
+
+  // No port: http on the default Suwayomi port first (LAN), then bare https
+  // (:443, reverse-proxy), then bare http (:80).
+  return _dedup([
+    _assemble('http', host, kDefaultSuwayomiPort, path),
+    _assemble('https', host, null, path),
+    _assemble('http', host, null, path),
+  ]);
+}
+
+/// Splits a scheme-less authority into `(host, port?)`, handling IPv6 FIRST so
+/// a bare IPv6 literal's colons are never read as a port separator.
+(String, int?) _splitHostPort(String authority) {
+  // Bracketed IPv6: [::1] or [fe80::1]:4568
+  if (authority.startsWith('[')) {
+    final close = authority.indexOf(']');
+    if (close < 0) return (authority, null); // malformed; pass through
+    final host = authority.substring(1, close); // inner literal, no brackets
+    final rest = authority.substring(close + 1);
+    if (rest.startsWith(':')) {
+      final p = int.tryParse(rest.substring(1));
+      return (host, p);
+    }
+    return (host, null);
+  }
+
+  // Bare IPv6 literal (e.g. `::1`, `fe80::1`) — accepted by parseIPv6Address.
+  // Detect BEFORE the host:port split: such a literal has 2+ colons and must
+  // not be split on its last colon.
+  if (_isBareIpv6(authority)) {
+    return (authority, null);
+  }
+
+  // IPv4 / hostname: split on the single (last) colon if present.
+  final colon = authority.lastIndexOf(':');
+  if (colon >= 0) {
+    final host = authority.substring(0, colon);
+    final p = int.tryParse(authority.substring(colon + 1));
+    // Only treat the suffix as a port when it's numeric AND in range. A
+    // non-numeric ('host:abc') or out-of-range ('host:99999') suffix is not a
+    // port — return the whole authority as host so the bad candidate is
+    // dropped by [_assemble] rather than wasting a probe on a default port.
+    if (p == null || p < 1 || p > 65535) return (authority, null);
+    return (host, p);
+  }
+  return (authority, null);
+}
+
+bool _isBareIpv6(String s) {
+  // A valid bare IPv6 literal contains '::' or has multiple ':' segments.
+  // parseIPv6Address is the authority; guard it with a try.
+  if (!s.contains(':')) return false;
+  try {
+    Uri.parseIPv6Address(s);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Assembles a base URL from parts via [Uri] — never string concatenation.
+/// [host] may be an IPv6 literal WITHOUT brackets; [Uri] re-brackets it.
+///
+/// Returns `null` (rather than throwing) when the parts can't form a valid URL
+/// — e.g. a host still carrying a stray `:` or userinfo `@` from a malformed
+/// input like `host:abc` or `user@host:4567`. [connectionCandidates] filters
+/// these out, so arbitrary user text never crashes the resolver.
+String? _assemble(String scheme, String host, int? port, String path) {
+  // Normalise the path: drop a lone trailing slash so `host/` and `host`
+  // produce the same candidate, but keep a real base path (e.g. `/suwayomi`).
+  var p = path;
+  if (p == '/') p = '';
+  if (p.length > 1 && p.endsWith('/')) p = p.substring(0, p.length - 1);
+
+  try {
+    final uri = Uri(
+      scheme: scheme,
+      host: host,
+      port: port,
+      path: p.isEmpty ? '' : p,
+    );
+    // Uri.toString() omits a default port for the scheme; that's fine — it
+    // keeps explicit non-default ports and drops redundant ones, de-dups well.
+    return uri.toString();
+  } on FormatException {
+    return null;
+  }
+}
+
+List<String> _dedup(List<String?> urls) {
+  final seen = <String>{};
+  final out = <String>[];
+  for (final u in urls) {
+    if (u != null && seen.add(u)) out.add(u);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Probe queries
+// ---------------------------------------------------------------------------
+
+/// Auth-exempt confirmation query: a real Suwayomi server answers this with
+/// `data.aboutServer{name,version}` whether or not auth is configured.
+const String kAboutProbeQuery = 'query { aboutServer { name version } }';
+
+/// @RequireAuth probe: `downloadStatus` is gated server-side. Unauthenticated,
+/// the server returns an `errors[]` entry whose message is exactly
+/// "Unauthorized"; authenticated (or auth-disabled) it returns data.
+const String kAuthProbeQuery = 'query { downloadStatus { __typename } }';
+
+// ---------------------------------------------------------------------------
+// Classifier
+// ---------------------------------------------------------------------------
+
+/// Reads the [aboutBody] (response body of [kAboutProbeQuery]) and the
+/// [authBody] (response body of [kAuthProbeQuery]) into a [ProbeResult].
+///
+/// KEY RULES (red-teamed):
+///   * `aboutServer.name`/`.version` are read INDEPENDENTLY of `errors[]`: a
+///     response can carry partial data alongside errors and we still treat a
+///     present `aboutServer` as confirmation.
+///   * `authRequired` is "does the auth-probe body contain (case-insensitive)
+///     the substring 'unauthor' in its errors". This catches both
+///     "Unauthorized" and "Unauthorised"/"unauthorized access".
+///   * If the about-probe doesn't yield an `aboutServer` object, the candidate
+///     is NOT confirmed (returns null here → caller treats as reached-unconfirmed).
+ProbeResult? classifyProbeBody({
+  required String url,
+  required String aboutBody,
+  required String authBody,
+}) {
+  final about = _tryDecode(aboutBody);
+  if (about == null) return null;
+
+  final aboutServer = _readAboutServer(about);
+  if (aboutServer == null) return null; // not a Suwayomi GraphQL body
+
+  final name = aboutServer['name'];
+  final version = aboutServer['version'];
+
+  final authRequired = _bodyIndicatesUnauthorised(authBody);
+
+  return ProbeResult(
+    url: url,
+    confirmed: true,
+    reached: true,
+    basicGated: false,
+    authMode: authRequired ? ProbeAuthMode.authRequired : ProbeAuthMode.open,
+    serverName: name is String ? name : null,
+    serverVersion: version is String ? version : null,
+  );
+}
+
+Map<String, dynamic>? _tryDecode(String body) {
+  if (body.isEmpty) return null;
+  try {
+    final decoded = json.decode(body);
+    return decoded is Map<String, dynamic> ? decoded : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Pulls `data.aboutServer` out of a decoded GraphQL body, independently of
+/// the presence of `errors[]`. Returns null if absent.
+Map<String, dynamic>? _readAboutServer(Map<String, dynamic> body) {
+  final data = body['data'];
+  if (data is! Map<String, dynamic>) return null;
+  final about = data['aboutServer'];
+  return about is Map<String, dynamic> ? about : null;
+}
+
+/// True when the auth-probe body's `errors[]` contains a message with the
+/// case-insensitive substring 'unauthor'.
+bool _bodyIndicatesUnauthorised(String authBody) {
+  final decoded = _tryDecode(authBody);
+  if (decoded == null) {
+    // Couldn't parse — fall back to a raw substring scan so a non-JSON 401
+    // page ("401 Unauthorized") still trips the flag.
+    return authBody.toLowerCase().contains('unauthor');
+  }
+  final errors = decoded['errors'];
+  if (errors is! List) return false;
+  for (final e in errors) {
+    if (e is Map) {
+      final msg = e['message'];
+      if (msg is String && msg.toLowerCase().contains('unauthor')) return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Network probe (one candidate)
+// ---------------------------------------------------------------------------
+
+/// Builds the `/api/graphql` URL for a candidate base URL, via [Uri] so a
+/// base path is preserved and the segment is appended structurally.
+Uri graphqlUriFor(String baseUrl) {
+  final base = Uri.parse(baseUrl);
+  return base.replace(pathSegments: [...base.pathSegments, 'api', 'graphql']);
+}
+
+/// Inverse of [graphqlUriFor]: given a redirect destination that points at a
+/// GraphQL endpoint, recover the server's base URL by stripping a trailing
+/// `api/graphql`. A destination that ISN'T a graphql endpoint (e.g. an SSO
+/// `/login`) is returned as-is — re-probing it will simply not confirm.
+String _baseFromGraphqlUri(Uri g) {
+  var segs = g.pathSegments.toList();
+  if (segs.length >= 2 &&
+      segs[segs.length - 1] == 'graphql' &&
+      segs[segs.length - 2] == 'api') {
+    segs = segs.sublist(0, segs.length - 2);
+  }
+  // Rebuild from parts so query/fragment are dropped without leaving a stray
+  // "?#" in the string form.
+  return Uri(
+    scheme: g.scheme,
+    host: g.host,
+    port: g.hasPort ? g.port : null,
+    pathSegments: segs,
+  ).toString();
+}
+
+/// Probes ONE candidate base URL using the two-request protocol with a short
+/// [timeout] and redirects OFF (so an https→http downgrade or a proxy login
+/// redirect can't masquerade as a reachable Suwayomi server). [client] is
+/// injected for testability.
+///
+/// Request A confirms Suwayomi (`aboutServer`); request B detects auth
+/// (`downloadStatus`). A 401 with a `WWW-Authenticate: Basic` challenge on
+/// request A short-circuits to a [ProbeResult.basicGatedResult] — we cannot
+/// see past Basic auth to confirm Suwayomi.
+Future<ProbeResult> probeServer(
+  String baseUrl, {
+  required http.Client client,
+  Duration timeout = const Duration(seconds: 4),
+  int redirectBudget = 1,
+}) async {
+  final uri = graphqlUriFor(baseUrl);
+
+  final http.StreamedResponse aboutResp;
+  final String aboutBody;
+  try {
+    final (resp, body) = await _sendNoRedirect(
+      client,
+      uri,
+      kAboutProbeQuery,
+      timeout,
+    );
+    aboutResp = resp;
+    aboutBody = body;
+  } catch (_) {
+    return ProbeResult.notReached(baseUrl);
+  }
+
+  // HTTP Basic auth fronting the transport: opaque, can't confirm Suwayomi.
+  if (aboutResp.statusCode == 401 &&
+      (aboutResp.headers['www-authenticate']?.toLowerCase().contains('basic') ??
+          false)) {
+    return ProbeResult.basicGatedResult(baseUrl);
+  }
+
+  // A redirect: follow ONE hop to the destination (a proxy bouncing the API to
+  // its real origin is legitimate), but NEVER chase an https→http downgrade and
+  // NEVER chase a second hop (an SSO portal that keeps bouncing). On the single
+  // hop we persist the DESTINATION base on confirm, not the redirecting URL.
+  if (aboutResp.statusCode >= 300 && aboutResp.statusCode < 400) {
+    final loc = aboutResp.headers['location'];
+    if (loc != null && loc.isNotEmpty && redirectBudget > 0) {
+      Uri? dest;
+      try {
+        dest = uri.resolveUri(Uri.parse(loc));
+      } catch (_) {
+        dest = null;
+      }
+      if (dest != null && !(uri.isScheme('https') && dest.isScheme('http'))) {
+        return probeServer(
+          _baseFromGraphqlUri(dest),
+          client: client,
+          timeout: timeout,
+          redirectBudget: redirectBudget - 1,
+        );
+      }
+    }
+    return ProbeResult.reachedUnconfirmed(baseUrl);
+  }
+
+  // Auth probe (request B). Failure here doesn't sink the candidate — we can
+  // still confirm Suwayomi from request A and assume auth-required if B is
+  // unreadable.
+  String authBody = '';
+  try {
+    final (_, body) = await _sendNoRedirect(
+      client,
+      uri,
+      kAuthProbeQuery,
+      timeout,
+    );
+    authBody = body;
+  } catch (_) {
+    authBody = '';
+  }
+
+  final classified =
+      classifyProbeBody(url: baseUrl, aboutBody: aboutBody, authBody: authBody);
+  if (classified != null) return classified;
+
+  return ProbeResult.reachedUnconfirmed(baseUrl);
+}
+
+/// Sends one POST with redirects disabled and a hard timeout, returning the
+/// streamed response plus its decoded body string.
+Future<(http.StreamedResponse, String)> _sendNoRedirect(
+  http.Client client,
+  Uri uri,
+  String query,
+  Duration timeout,
+) async {
+  final request = http.Request('POST', uri)
+    ..followRedirects = false
+    ..headers['Content-Type'] = 'application/json'
+    ..body = jsonEncode({'query': query});
+  final streamed = await client.send(request).timeout(timeout);
+  final body = await streamed.stream.bytesToString().timeout(timeout);
+  return (streamed, body);
+}
+
+// ---------------------------------------------------------------------------
+// Resolve (walk the ladder)
+// ---------------------------------------------------------------------------
+
+/// Walks [connectionCandidates] for [rawInput] in order and returns the best
+/// [ResolvedServer].
+///
+/// Short-circuit + fallback rules (red-teamed):
+///   * A CONFIRMED candidate short-circuits immediately — first confirmed wins.
+///     Ladder order is http-first (spec decision #2, the LAN fast-path); the
+///     resolved URL is surfaced for the user to confirm, so the http-first
+///     pick is visible rather than a silent downgrade.
+///   * A basic-gated candidate NEVER short-circuits and is NEVER reported as
+///     `found`: we keep walking in case a LATER candidate is a confirmable
+///     Suwayomi server (e.g. http:4567 is basic-gated but https is the real one).
+///   * If no candidate is confirmed, fall back by priority:
+///       basicGated > reachedUnconfirmed > notReached.
+Future<ResolvedServer> resolveServer(
+  String rawInput, {
+  required http.Client client,
+  Duration perCandidateTimeout = const Duration(seconds: 4),
+  Future<ProbeResult> Function(String url)? probe,
+}) async {
+  final candidates = connectionCandidates(rawInput);
+  if (candidates.isEmpty) {
+    // Unparseable input (e.g. a typo'd port): nothing to probe. Hand back a
+    // best-effort scheme-bearing URL so the "use this address anyway" escape
+    // never persists raw schemeless text (spec Part D).
+    return ResolvedServer(
+      baseUrl: normalisedFallbackUrl(rawInput),
+      outcome: ResolveOutcome.notReached,
+    );
+  }
+
+  final doProbe = probe ??
+      (url) => probeServer(url, client: client, timeout: perCandidateTimeout);
+
+  ProbeResult? bestBasicGated;
+  ProbeResult? bestReached;
+
+  for (final candidate in candidates) {
+    final result = await doProbe(candidate);
+
+    if (result.confirmed) {
+      // First confirmed candidate wins outright.
+      return ResolvedServer(
+        baseUrl: result.url,
+        outcome: ResolveOutcome.found,
+        authMode: result.authMode,
+        serverName: result.serverName,
+        serverVersion: result.serverVersion,
+      );
+    }
+    if (result.basicGated) {
+      bestBasicGated ??= result; // remember, but keep walking
+      continue;
+    }
+    if (result.reached) {
+      bestReached ??= result;
+    }
+  }
+
+  if (bestBasicGated != null) {
+    return ResolvedServer(
+      baseUrl: bestBasicGated.url,
+      outcome: ResolveOutcome.basicGated,
+    );
+  }
+  if (bestReached != null) {
+    return ResolvedServer(
+      baseUrl: bestReached.url,
+      outcome: ResolveOutcome.reachedUnconfirmed,
+    );
+  }
+  return ResolvedServer(
+    baseUrl: candidates.first,
+    outcome: ResolveOutcome.notReached,
+  );
+}
+
+/// Renders a base URL with its port ALWAYS explicit, so result messages can be
+/// unambiguous about exactly where (and on which port) a server was reached —
+/// e.g. `http://192.168.0.10` becomes `http://192.168.0.10:80`. Dart's `Uri`
+/// hides scheme-default ports; this surfaces them. IPv6 hosts are bracketed.
+String displayAddress(String baseUrl) {
+  final u = Uri.tryParse(baseUrl);
+  if (u == null || u.host.isEmpty) return baseUrl;
+  final host = u.host.contains(':') ? '[${u.host}]' : u.host;
+  return '${u.scheme}://$host:${u.port}${u.path}';
+}
+
+/// Whether a failed resolve should suggest "try its https address" — true only
+/// when NO https candidate was tried (the user pinned an explicit `http://`).
+/// A bare host already includes an https candidate, so we don't nag.
+bool shouldSuggestHttps(String rawInput) => !connectionCandidates(rawInput)
+    .any((c) => c.toLowerCase().startsWith('https://'));
+
+/// Best-effort scheme-bearing form of [rawInput] for the "use this address
+/// anyway" escape — guarantees a scheme so we never persist raw schemeless
+/// text. Prefers the first real candidate; otherwise prefixes `http://`.
+String normalisedFallbackUrl(String rawInput) {
+  final input = rawInput.trim();
+  if (input.isEmpty) return input;
+  final lower = input.toLowerCase();
+  // Explicit scheme → "use this address anyway" means EXACTLY what they typed.
+  if (lower.startsWith('http://') || lower.startsWith('https://')) return input;
+  // No scheme → first candidate (scheme + default port), else http:// prefix.
+  final first = connectionCandidates(input);
+  if (first.isNotEmpty) return first.first;
+  return 'http://$input';
+}
+
+// ---------------------------------------------------------------------------
+// VERIFIED try-both (submit-time auth resolution)
+// ---------------------------------------------------------------------------
+
+/// The auth mode whose credential ACTUALLY authorised an `@RequireAuth` API
+/// call — the only trustworthy signal for simple-vs-ui (round-4 fix).
+enum VerifiedAuthMode { simpleLogin, uiLogin }
+
+/// Sends the `@RequireAuth` probe ([kAuthProbeQuery]) carrying a credential and
+/// reports whether the server ACTUALLY authorised it.
+///
+/// This is the heart of the round-4 fix: Suwayomi's `POST /login.html` returns
+/// 303 + a session cookie in EVERY auth mode — including `ui_login`, where that
+/// cookie is then ignored. So a successful simple-login is NOT proof the server
+/// is in simple_login mode. We must push the obtained credential through a real
+/// protected query and let the server's own `getUserFromContext` be the judge:
+/// authorised (data, no "unauthorized") → the credential is the right kind.
+///
+/// Pass EXACTLY one of [cookie] / [bearer] / [basic]. [basic] is the raw
+/// `username:password` pair (base64-encoded here into a `Basic` header) — used
+/// to prove a basic_auth credential ACTUALLY authorises the @RequireAuth
+/// surface, not just the public `aboutServer`. Redirects are disabled and any
+/// transport failure reads as "not authorised" (false), never a throw.
+Future<bool> authProbeAuthorized(
+  String baseUrl, {
+  required http.Client client,
+  String? cookie,
+  String? bearer,
+  String? basic,
+  Duration timeout = const Duration(seconds: 4),
+}) async {
+  final uri = graphqlUriFor(baseUrl);
+  try {
+    final request = http.Request('POST', uri)
+      ..followRedirects = false
+      ..headers['Content-Type'] = 'application/json'
+      ..body = jsonEncode({'query': kAuthProbeQuery});
+    if (cookie != null) request.headers['Cookie'] = cookie;
+    if (bearer != null) request.headers['Authorization'] = 'Bearer $bearer';
+    if (basic != null) {
+      request.headers['Authorization'] =
+          'Basic ${base64Encode(utf8.encode(basic))}';
+    }
+    final streamed = await client.send(request).timeout(timeout);
+    final body = await streamed.stream.bytesToString().timeout(timeout);
+    if (streamed.statusCode == 401 || streamed.statusCode == 403) return false;
+    // Authorised iff the body does not carry an "unauthorized" GraphQL error.
+    return !_bodyIndicatesUnauthorised(body);
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Re-probes `aboutServer` carrying an HTTP Basic `Authorization` header and
+/// reports whether it confirms a Suwayomi server. This is the basic_auth
+/// equivalent of the simple/ui verified sign-in: a basic-gated host is opaque
+/// until we send credentials, so submit re-probes WITH the Basic header —
+/// 200 + a real `aboutServer` shape means the creds are valid AND it's really
+/// Suwayomi (closes the "random 401 host" trap on the basic path). Any other
+/// outcome (still 401, non-Suwayomi body, transport failure) → false.
+Future<bool> basicAuthConfirms(
+  String baseUrl, {
+  required http.Client client,
+  required String username,
+  required String password,
+  Duration timeout = const Duration(seconds: 4),
+}) async {
+  final uri = graphqlUriFor(baseUrl);
+  try {
+    final cred = base64Encode(utf8.encode('$username:$password'));
+    final request = http.Request('POST', uri)
+      ..followRedirects = false
+      ..headers['Content-Type'] = 'application/json'
+      ..headers['Authorization'] = 'Basic $cred'
+      ..body = jsonEncode({'query': kAboutProbeQuery});
+    final streamed = await client.send(request).timeout(timeout);
+    final body = await streamed.stream.bytesToString().timeout(timeout);
+    if (streamed.statusCode != 200) return false;
+    final decoded = _tryDecode(body);
+    return decoded != null && _readAboutServer(decoded) != null;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Runs the VERIFIED try-both for a server that we already confirmed is
+/// Suwayomi-with-auth-required. [obtainSimpleCookie] performs the `/login.html`
+/// POST and returns the session cookie (throws/returns null on rejection);
+/// [obtainUiBearer] runs the `login` mutation and returns the access token.
+/// Each obtained credential is VERIFIED via [authProbeAuthorized] before we
+/// trust it, so a `ui_login` server (whose cookie is inert) never gets
+/// mis-tagged simple_login.
+///
+/// Returns the verified mode, or null when neither credential authorises
+/// (wrong password, or not really a Suwayomi auth server).
+Future<VerifiedAuthMode?> verifyAuthMode({
+  required String baseUrl,
+  required http.Client client,
+  required Future<String?> Function() obtainSimpleCookie,
+  required Future<String?> Function() obtainUiBearer,
+  Duration timeout = const Duration(seconds: 4),
+}) async {
+  // 1. simple-login → cookie → re-probe carrying ONLY that cookie.
+  String? cookie;
+  try {
+    cookie = await obtainSimpleCookie();
+  } catch (_) {
+    cookie = null;
+  }
+  if (cookie != null &&
+      cookie.isNotEmpty &&
+      await authProbeAuthorized(baseUrl,
+          client: client, cookie: cookie, timeout: timeout)) {
+    return VerifiedAuthMode.simpleLogin;
+  }
+
+  // 2. ui-login → bearer → re-probe carrying ONLY that bearer (a fresh request,
+  //    no stale cookie from step 1 — see [authProbeAuthorized]).
+  String? bearer;
+  try {
+    bearer = await obtainUiBearer();
+  } catch (_) {
+    bearer = null;
+  }
+  if (bearer != null &&
+      bearer.isNotEmpty &&
+      await authProbeAuthorized(baseUrl,
+          client: client, bearer: bearer, timeout: timeout)) {
+    return VerifiedAuthMode.uiLogin;
+  }
+
+  return null;
+}

--- a/lib/src/features/onboarding/presentation/onboarding_screen.dart
+++ b/lib/src/features/onboarding/presentation/onboarding_screen.dart
@@ -1,0 +1,811 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import '../../../constants/db_keys.dart';
+import '../../../constants/enum.dart';
+import '../../../constants/gen/assets.gen.dart';
+import '../../../constants/urls.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../../routes/router_config.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/launch_url_in_web.dart';
+import '../../../utils/misc/toast/toast.dart';
+import '../../../utils/theme/brand.dart';
+import '../../about/data/about_repository.dart';
+import '../../auth/data/auth_coordinator.dart';
+import '../../settings/presentation/appearance/widgets/app_theme_selector/app_theme_selector.dart';
+import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+import '../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
+import '../data/onboarding_complete.dart';
+import '../data/server_discovery.dart';
+import '../data/server_resolver.dart';
+
+/// First-time onboarding wizard: pick a theme, connect a Suwayomi server, done.
+/// Shown by the router until [OnboardingComplete] is set true. Matches the
+/// approved Indigo Night mockups.
+class OnboardingScreen extends HookConsumerWidget {
+  const OnboardingScreen({super.key});
+
+  static const _stepCount = 3;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final step = useState(0);
+    final serverVerified = useState(false);
+
+    bool stepComplete(int i) => switch (i) {
+          1 => serverVerified.value,
+          _ => true,
+        };
+
+    final isLast = step.value == _stepCount - 1;
+
+    void finish() {
+      ref.read(onboardingCompleteProvider.notifier).update(true);
+      const LibraryRoute(categoryId: 0).go(context);
+    }
+
+    final cs = context.theme.colorScheme;
+
+    return Scaffold(
+      body: Stack(
+        children: [
+          // Brand backdrop: indigo glow at the top fading into the scaffold.
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.center,
+                  colors: [
+                    cs.primary.withValues(alpha: 0.20),
+                    context.theme.scaffoldBackgroundColor.withValues(alpha: 0),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          SafeArea(
+            child: Column(
+              children: [
+                const SizedBox(height: 12),
+                // Brand wordmark, centered, with a top-right "Skip" escape on
+                // every step except the final one (nothing left to skip there).
+                Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    const _BrandHeader(),
+                    if (step.value < _stepCount - 1)
+                      Positioned(
+                        right: 4,
+                        child: TextButton(
+                          onPressed: finish,
+                          child: Text(context.l10n.onboardingSkip),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                _StepDots(count: _stepCount, active: step.value),
+                Expanded(
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 250),
+                    child: SingleChildScrollView(
+                      key: ValueKey(step.value),
+                      padding: const EdgeInsets.fromLTRB(24, 8, 24, 8),
+                      child: switch (step.value) {
+                        0 => const _ThemeStep(),
+                        1 => _ServerStep(
+                            onVerifiedChanged: (v) => serverVerified.value = v),
+                        _ => const _FinishStep(),
+                      },
+                    ),
+                  ),
+                ),
+                _NavBar(
+                  showBack: step.value > 0,
+                  canAdvance: stepComplete(step.value),
+                  isLast: isLast,
+                  onBack: () => step.value--,
+                  onNext: () => isLast ? finish() : step.value++,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The swirl logo + "Tsumiru" wordmark shown at the top of every step.
+class _BrandHeader extends StatelessWidget {
+  const _BrandHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Image.asset(Assets.icons.darkIcon.path, height: 26),
+        const SizedBox(width: 8),
+        Text(
+          'Tsumiru',
+          style: context.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.2,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StepDots extends StatelessWidget {
+  const _StepDots({required this.count, required this.active});
+  final int count;
+  final int active;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        for (var i = 0; i < count; i++)
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 12),
+            width: i == active ? 22 : 8,
+            height: 8,
+            decoration: BoxDecoration(
+              color:
+                  i == active ? cs.primary : cs.onSurface.withValues(alpha: 0.22),
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _NavBar extends StatelessWidget {
+  const _NavBar({
+    required this.showBack,
+    required this.canAdvance,
+    required this.isLast,
+    required this.onBack,
+    required this.onNext,
+  });
+  final bool showBack;
+  final bool canAdvance;
+  final bool isLast;
+  final VoidCallback onBack;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    final next = BrandButton(
+      label: Text(isLast ? context.l10n.finish : context.l10n.next),
+      onPressed: canAdvance ? onNext : null,
+    );
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 4, 24, 20),
+      // Back + Next share one row (Next wider) so the nav takes less vertical
+      // space; on the first step there's no Back, so Next fills the row.
+      child: showBack
+          ? Row(
+              children: [
+                Expanded(
+                  child: BrandGlassButton(
+                    label: Text(context.l10n.back),
+                    onPressed: onBack,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(flex: 2, child: next),
+              ],
+            )
+          : next,
+    );
+  }
+}
+
+// --- Step 1: theme ----------------------------------------------------------
+
+class _ThemeStep extends StatelessWidget {
+  const _ThemeStep();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 12),
+        // The big brand mark — the swirl logo above the welcome heading.
+        Center(child: Image.asset(Assets.icons.darkIcon.path, height: 160)),
+        const SizedBox(height: 24),
+        Text(context.l10n.onboardingWelcomeTitle,
+            style: context.textTheme.headlineMedium
+                ?.copyWith(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Text(context.l10n.onboardingWelcomeSubtitle,
+            style: TextStyle(color: cs.onSurfaceVariant)),
+        const SizedBox(height: 28),
+        Text(context.l10n.onboardingChooseTheme,
+            style: context.textTheme.titleMedium),
+        const ThemeSelector(),
+      ],
+    );
+  }
+}
+
+// --- Step 2: server ---------------------------------------------------------
+
+/// Outcome of "Test connection" (and the in-flight states for both actions).
+enum _TestState {
+  idle,
+  searching,
+  testing,
+  connected,
+
+  /// Reachable Suwayomi whose API is gated — reveal the auth sub-form.
+  needsLogin,
+
+  /// Couldn't reach the address at all.
+  failed,
+
+  /// Reached something, but it isn't a Suwayomi server.
+  notSuwayomi,
+}
+
+/// Factory for the throwaway HTTP client the resolver probes use. Overridable
+/// in widget tests so the connection flow can be driven against a MockClient.
+final onboardingHttpClientProvider =
+    Provider<http.Client Function()>((ref) => http.Client.new);
+
+class _ServerStep extends HookConsumerWidget {
+  const _ServerStep({required this.onVerifiedChanged});
+  final ValueChanged<bool> onVerifiedChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cs = context.theme.colorScheme;
+    final urlController = useTextEditingController(
+      text: () {
+        final stored = ref.read(serverUrlProvider);
+        return (stored == null || stored == DBKeys.serverUrl.initial)
+            ? ''
+            : stored;
+      }(),
+    );
+    final state = useState(_TestState.idle);
+    final version = useState<String?>(null);
+    final errorDetail = useState<String?>(null);
+    // The base URL we resolved to (after auto-fallback) — shown + persisted.
+    final resolvedUrl = useState<String?>(null);
+    // Credentials + chosen auth type, revealed when the server needs a login.
+    final userController = useTextEditingController();
+    final passController = useTextEditingController();
+    final authChoice = useState(AuthType.basic);
+    final credsRejected = useState(false);
+
+    // The URL field carries the full address (scheme + host + port), so never
+    // let the client auto-append a port.
+    useEffect(() {
+      Future.microtask(
+          () => ref.read(serverPortToggleProvider.notifier).update(false));
+      return null;
+    }, const []);
+
+    void resetToIdle() {
+      if (state.value != _TestState.idle) {
+        state.value = _TestState.idle;
+        onVerifiedChanged(false);
+      }
+    }
+
+    // Persist a resolved/typed base URL as the active server URL.
+    void adopt(String url) {
+      resolvedUrl.value = url;
+      ref.read(serverPortToggleProvider.notifier).update(false);
+      ref.read(serverUrlProvider.notifier).update(url);
+      if (urlController.text != url) urlController.text = url;
+    }
+
+    // Validate the entered credentials against [base] using [authChoice].
+    // Persists and returns true on success.
+    Future<bool> validateCredentials(String base, http.Client client) async {
+      final user = userController.text.trim();
+      final pass = passController.text;
+      if (user.isEmpty || pass.isEmpty) return false;
+      final coord = ref.read(authCoordinatorProvider.notifier);
+      try {
+        switch (authChoice.value) {
+          case AuthType.basic:
+            // Two gates: basicAuthConfirms proves it's really Suwayomi AND the
+            // Basic creds pass the transport (closes the "random 401 host"
+            // trap); authProbeAuthorized proves those creds actually authorise
+            // the @RequireAuth API. The second gate is what stops a wrong auth
+            // type "succeeding" against a ui_login/simple_login server, whose
+            // public aboutServer answers regardless of credentials.
+            if (!await basicAuthConfirms(base,
+                client: client, username: user, password: pass)) {
+              return false;
+            }
+            if (!await authProbeAuthorized(base,
+                client: client, basic: '$user:$pass')) {
+              return false;
+            }
+            await ref.read(credentialsProvider.notifier).set(
+                'Basic ${base64.encode(utf8.encode('$user:$pass'))}');
+          case AuthType.simpleLogin:
+            final cookie = await coord.verifySimpleCredentials(
+                serverBaseUrl: base, username: user, password: pass);
+            if (!await authProbeAuthorized(base,
+                client: client, cookie: cookie)) {
+              return false;
+            }
+            await coord.loginSimple(
+                serverBaseUrl: base, username: user, password: pass);
+          case AuthType.uiLogin:
+            final tokens = await coord.verifyUiCredentials(
+                gqlClient: ref.read(graphQlClientProvider),
+                username: user,
+                password: pass);
+            if (!await authProbeAuthorized(base,
+                client: client, bearer: tokens.accessToken)) {
+              return false;
+            }
+            await coord.loginUi(
+                gqlClient: ref.read(graphQlClientProvider),
+                username: user,
+                password: pass);
+          case AuthType.none:
+            return false;
+        }
+      } catch (_) {
+        return false;
+      }
+      ref.read(authTypeKeyProvider.notifier).update(authChoice.value);
+      return true;
+    }
+
+    // Web can't run the redirect-OFF/short-timeout probe (CORS), so test
+    // exactly what's typed via the about/version query.
+    Future<void> testWeb() async {
+      final url = urlController.text.trim();
+      if (url.isBlank) return;
+      state.value = _TestState.testing;
+      onVerifiedChanged(false);
+      ref.read(serverPortToggleProvider.notifier).update(false);
+      ref.read(serverUrlProvider.notifier).update(url);
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      final result = await AsyncValue.guard(
+          () => ref.read(aboutRepositoryProvider).getAbout());
+      if (result.hasError || result.valueOrNull == null) {
+        errorDetail.value = result.error?.toString();
+        state.value = _TestState.failed;
+        onVerifiedChanged(false);
+      } else {
+        version.value = result.value?.version;
+        resolvedUrl.value = url;
+        state.value = _TestState.connected;
+        onVerifiedChanged(true);
+      }
+    }
+
+    // "Test connection": validate the address. Auto-fallback (scheme/port) runs
+    // under the hood. The first press detects whether a login is needed; once
+    // credentials are entered, pressing again validates them.
+    Future<void> testConnection() async {
+      final input = urlController.text.trim();
+      if (input.isBlank) {
+        errorDetail.value = context.l10n.onboardingEnterAddress;
+        state.value = _TestState.failed;
+        onVerifiedChanged(false);
+        return;
+      }
+      if (kIsWeb) return testWeb();
+
+      state.value = _TestState.testing;
+      version.value = null;
+      errorDetail.value = null;
+      credsRejected.value = false;
+      onVerifiedChanged(false);
+
+      final client = ref.read(onboardingHttpClientProvider)();
+      try {
+        final result = await resolveServer(input, client: client);
+        switch (result.outcome) {
+          case ResolveOutcome.notReached:
+            state.value = _TestState.failed;
+            onVerifiedChanged(false);
+          case ResolveOutcome.reachedUnconfirmed:
+            resolvedUrl.value = result.baseUrl;
+            state.value = _TestState.notSuwayomi;
+            onVerifiedChanged(false);
+          case ResolveOutcome.found:
+          case ResolveOutcome.basicGated:
+            adopt(result.baseUrl);
+            version.value = result.serverVersion;
+            final needsLogin = result.outcome == ResolveOutcome.basicGated ||
+                result.authMode == ProbeAuthMode.authRequired;
+            if (!needsLogin) {
+              state.value = _TestState.connected;
+              onVerifiedChanged(true);
+            } else {
+              final hasCreds = userController.text.trim().isNotEmpty &&
+                  passController.text.isNotEmpty;
+              if (hasCreds &&
+                  await validateCredentials(result.baseUrl, client)) {
+                state.value = _TestState.connected;
+                onVerifiedChanged(true);
+              } else {
+                if (hasCreds) credsRejected.value = true;
+                state.value = _TestState.needsLogin;
+                onVerifiedChanged(false);
+              }
+            }
+        }
+      } catch (e) {
+        errorDetail.value = e.toString();
+        state.value = _TestState.failed;
+        onVerifiedChanged(false);
+      } finally {
+        client.close();
+      }
+    }
+
+    // "Search my network": scan the LAN for a Suwayomi server on :4567, fill
+    // the field, then test it.
+    Future<void> searchNetwork() async {
+      if (kIsWeb) return;
+      final noServerMsg = context.l10n.onboardingNoServerFound;
+      state.value = _TestState.searching;
+      errorDetail.value = null;
+      onVerifiedChanged(false);
+      String? found;
+      try {
+        found = await discoverServerOnLan();
+      } catch (_) {
+        found = null;
+      }
+      if (found == null) {
+        errorDetail.value = noServerMsg;
+        state.value = _TestState.failed;
+        onVerifiedChanged(false);
+        return;
+      }
+      urlController.text = found;
+      await testConnection();
+    }
+
+    // "Sign in": validate the entered credentials against the resolved server
+    // and, on success, unlock Next. Clear, dedicated action that lives right
+    // under the credential fields.
+    Future<void> signIn() async {
+      final base = resolvedUrl.value ?? urlController.text.trim();
+      final user = userController.text.trim();
+      final pass = passController.text;
+      if (base.isEmpty || user.isEmpty || pass.isEmpty) {
+        credsRejected.value = true;
+        return;
+      }
+      credsRejected.value = false;
+      state.value = _TestState.testing;
+      final client = ref.read(onboardingHttpClientProvider)();
+      bool ok = false;
+      try {
+        ok = await validateCredentials(base, client);
+      } catch (_) {
+        ok = false;
+      } finally {
+        client.close();
+      }
+      if (ok) {
+        state.value = _TestState.connected;
+        onVerifiedChanged(true);
+      } else {
+        credsRejected.value = true;
+        state.value = _TestState.needsLogin;
+        onVerifiedChanged(false);
+      }
+    }
+
+    final busy = state.value == _TestState.testing ||
+        state.value == _TestState.searching;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 16),
+        Text(context.l10n.onboardingServerStepLabel,
+            style: TextStyle(
+                color: cs.primary, fontSize: 12, fontWeight: FontWeight.w600)),
+        const SizedBox(height: 4),
+        Text(context.l10n.onboardingServerTitle,
+            style: context.textTheme.headlineSmall
+                ?.copyWith(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Text(context.l10n.onboardingServerSubtitle,
+            style: TextStyle(color: cs.onSurfaceVariant)),
+        const SizedBox(height: 20),
+        TextField(
+          controller: urlController,
+          keyboardType: TextInputType.url,
+          autocorrect: false,
+          decoration: InputDecoration(
+            labelText: context.l10n.serverUrl,
+            hintText: 'http://192.168.0.10:4567',
+            border: const OutlineInputBorder(),
+            prefixIcon: const Icon(Icons.dns_rounded),
+          ),
+          onChanged: (_) => resetToIdle(),
+        ),
+        // Discover: scan the LAN and fill the address.
+        if (!kIsWeb)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: busy ? null : searchNetwork,
+              icon: const Icon(Icons.search_rounded, size: 18),
+              label: Text(context.l10n.onboardingSearchNetwork),
+            ),
+          ),
+        Text(context.l10n.onboardingServerPortHint,
+            style: TextStyle(color: cs.onSurfaceVariant, fontSize: 12)),
+        const SizedBox(height: 12),
+        // Validate: test the connection.
+        FilledButton.tonalIcon(
+          onPressed: busy ? null : testConnection,
+          icon: busy
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2))
+              : const Icon(Icons.wifi_tethering_rounded),
+          label: Text(state.value == _TestState.searching
+              ? context.l10n.onboardingSearching
+              : context.l10n.onboardingTestConnection),
+          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(46)),
+        ),
+        const SizedBox(height: 12),
+        ..._buildTestStatus(context, cs, state.value, resolvedUrl.value,
+            version.value, errorDetail.value,
+            shouldSuggestHttps(urlController.text.trim())),
+        // Auth sub-form, revealed only when the server needs a login.
+        if (state.value == _TestState.needsLogin) ...[
+          const SizedBox(height: 12),
+          DropdownButtonFormField<AuthType>(
+            initialValue: authChoice.value,
+            decoration: InputDecoration(
+              labelText: context.l10n.onboardingAuthMode,
+              border: const OutlineInputBorder(),
+              prefixIcon: const Icon(Icons.shield_rounded),
+            ),
+            items: [
+              DropdownMenuItem(
+                  value: AuthType.basic,
+                  child: Text(context.l10n.onboardingAuthModeBasic)),
+              DropdownMenuItem(
+                  value: AuthType.simpleLogin,
+                  child: Text(context.l10n.onboardingAuthModeSimple)),
+              DropdownMenuItem(
+                  value: AuthType.uiLogin,
+                  child: Text(context.l10n.onboardingAuthModeUi)),
+            ],
+            onChanged: (m) {
+              if (m != null) {
+                authChoice.value = m;
+                credsRejected.value = false;
+              }
+            },
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: userController,
+            autocorrect: false,
+            enableSuggestions: false,
+            decoration: InputDecoration(
+              labelText: context.l10n.userName,
+              border: const OutlineInputBorder(),
+              prefixIcon: const Icon(Icons.person_rounded),
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: passController,
+            obscureText: true,
+            decoration: InputDecoration(
+              labelText: context.l10n.password,
+              border: const OutlineInputBorder(),
+              prefixIcon: const Icon(Icons.lock_rounded),
+            ),
+            onSubmitted: (_) => signIn(),
+          ),
+          if (credsRejected.value) ...[
+            const SizedBox(height: 8),
+            _StatusRow(
+              color: cs.error,
+              icon: Icons.error_rounded,
+              text: context.l10n.onboardingCredsRejected,
+            ),
+          ],
+          const SizedBox(height: 12),
+          // The clear, dedicated action right under the credentials.
+          FilledButton.icon(
+            onPressed: busy ? null : signIn,
+            icon: busy
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2))
+                : const Icon(Icons.login_rounded),
+            label: Text(context.l10n.onboardingSignIn),
+            style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(46)),
+          ),
+        ],
+        const SizedBox(height: 8),
+        // No server yet? Open the setup docs and let them proceed — Library then
+        // shows the friendly "set up a server" empty state.
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: () {
+              launchUrlInWeb(
+                  context, AppUrls.tachideskHelp.url, ref.read(toastProvider));
+              onVerifiedChanged(true);
+            },
+            icon: const Icon(Icons.open_in_new_rounded, size: 18),
+            label: Text(context.l10n.onboardingNoServerLink),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Renders the Test-connection outcome row(s) — always naming the exact
+/// address (with explicit port) we reached.
+List<Widget> _buildTestStatus(
+  BuildContext context,
+  ColorScheme cs,
+  _TestState state,
+  String? url,
+  String? version,
+  String? errorDetail,
+  bool suggestHttps,
+) {
+  final addr = (url != null && url.isNotEmpty) ? displayAddress(url) : null;
+  switch (state) {
+    case _TestState.idle:
+    case _TestState.testing:
+    case _TestState.searching:
+      return const [SizedBox.shrink()];
+
+    case _TestState.connected:
+      return [
+        _StatusRow(
+          color: Colors.green,
+          icon: Icons.check_circle_rounded,
+          text: (version != null && version.isNotEmpty)
+              ? context.l10n.onboardingConnected(version)
+              : context.l10n.onboardingResolvedAddress(addr ?? ''),
+        ),
+        if (addr != null) ...[
+          const SizedBox(height: 6),
+          _StatusRow(
+            color: cs.onSurfaceVariant,
+            icon: Icons.dns_rounded,
+            text: context.l10n.onboardingFoundAt(addr),
+          ),
+        ],
+      ];
+
+    case _TestState.needsLogin:
+      return [
+        _StatusRow(
+          color: cs.tertiary,
+          icon: Icons.lock_rounded,
+          text: context.l10n.onboardingNeedsLogin,
+        ),
+        if (addr != null) ...[
+          const SizedBox(height: 6),
+          _StatusRow(
+            color: cs.onSurfaceVariant,
+            icon: Icons.dns_rounded,
+            text: context.l10n.onboardingFoundAt(addr),
+          ),
+        ],
+      ];
+
+    case _TestState.notSuwayomi:
+      return [
+        _StatusRow(
+          color: cs.tertiary,
+          icon: Icons.help_outline_rounded,
+          text: context.l10n.onboardingResolvedUnconfirmed(addr ?? ''),
+        ),
+      ];
+
+    case _TestState.failed:
+      return [
+        _StatusRow(
+          color: cs.error,
+          icon: Icons.error_rounded,
+          text: (errorDetail?.isNotEmpty ?? false)
+              ? errorDetail!
+              : context.l10n.onboardingNotReached,
+        ),
+        if (suggestHttps) ...[
+          const SizedBox(height: 6),
+          _StatusRow(
+            color: cs.onSurfaceVariant,
+            icon: Icons.lightbulb_outline_rounded,
+            text: context.l10n.onboardingNotReachedHttpsHint,
+          ),
+        ],
+      ];
+  }
+}
+
+class _StatusRow extends StatelessWidget {
+  const _StatusRow(
+      {required this.color, required this.icon, required this.text});
+  final Color color;
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, color: color, size: 18),
+        const SizedBox(width: 8),
+        Expanded(child: Text(text, style: TextStyle(color: color))),
+      ],
+    );
+  }
+}
+
+// --- Step 3: finish ---------------------------------------------------------
+
+class _FinishStep extends StatelessWidget {
+  const _FinishStep();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        const SizedBox(height: 48),
+        Icon(Icons.rocket_launch_rounded, size: 64, color: cs.primary),
+        const SizedBox(height: 24),
+        Text(context.l10n.onboardingDoneTitle,
+            textAlign: TextAlign.center,
+            style: context.textTheme.headlineSmall
+                ?.copyWith(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Text(context.l10n.onboardingDoneSubtitle,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: cs.onSurfaceVariant)),
+      ],
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1131,6 +1131,74 @@
     "createBackupDescription": "Backup library as a Tachidesk backup",
     "createBackupTitle": "Create Backup",
     "credentials": "Credentials",
+    "back": "Back",
+    "next": "Next",
+    "finish": "Finish",
+    "onboardingSkip": "Skip",
+    "onboardingWelcomeTitle": "Welcome to Tsumiru",
+    "onboardingWelcomeSubtitle": "A reader for your Suwayomi library.",
+    "onboardingChooseTheme": "Choose your theme",
+    "onboardingServerTitle": "Connect your server",
+    "onboardingServerSubtitle": "Tsumiru reads from your Suwayomi server.",
+    "onboardingServerPortHint": "Suwayomi runs on port 4567 by default.",
+    "onboardingServerStepLabel": "STEP 2 OF 3",
+    "onboardingServerOnNetwork": "On this network",
+    "onboardingServerRemote": "Remote",
+    "onboardingServerNone": "No server yet",
+    "onboardingNoServerHelp": "No problem — you can set up a Suwayomi server and connect it later in Settings.",
+    "onboardingNoServerLink": "How to set up a server",
+    "onboardingTestConnection": "Test connection",
+    "onboardingFindServer": "Find server",
+    "onboardingResolvedAddress": "Found your server at {url}",
+    "@onboardingResolvedAddress": {
+        "placeholders": {
+            "url": { "type": "String" }
+        }
+    },
+    "onboardingFoundAt": "at {address}",
+    "@onboardingFoundAt": {
+        "placeholders": {
+            "address": { "type": "String" }
+        }
+    },
+    "onboardingResolvedNoAuth": "This server is ready — no sign-in needed.",
+    "onboardingResolvedNeedsAuth": "This server needs a sign-in. Add your username and password below.",
+    "onboardingSearchNetwork": "Search my network",
+    "onboardingSearching": "Searching your network…",
+    "onboardingNoServerFound": "No server found on your network — enter the address manually.",
+    "onboardingNeedsLogin": "This server needs a login",
+    "onboardingEnterAddress": "Enter your server's address, or tap Search my network.",
+    "onboardingSignIn": "Sign in",
+    "onboardingCredsRejected": "Those credentials didn't work. Double-check your username, password, and sign-in method.",
+    "onboardingNotReachedHttpsHint": "If it's behind a reverse proxy, try its https address instead.",
+    "onboardingAuthMode": "Sign-in method",
+    "onboardingAuthModeAuto": "Username & password (auto)",
+    "onboardingAuthModeBasic": "Basic auth",
+    "onboardingAuthModeSimple": "Simple login",
+    "onboardingAuthModeUi": "UI login",
+    "onboardingResolvedBasicGated": "Something answered at {url} but it's behind a sign-in we can't read past. Pick 'Username & password' and enter your credentials.",
+    "@onboardingResolvedBasicGated": {
+        "placeholders": {
+            "url": { "type": "String" }
+        }
+    },
+    "onboardingResolvedUnconfirmed": "Reached {url}, but it didn't respond as a Suwayomi server — often that's a router or another app, not your server. Double-check the address and port, or use it anyway.",
+    "@onboardingResolvedUnconfirmed": {
+        "placeholders": {
+            "url": { "type": "String" }
+        }
+    },
+    "onboardingNotReached": "Couldn't reach a server at that address. Check it's running and reachable from this device.",
+    "onboardingUseAddressAnyway": "Use this address anyway",
+    "onboardingConnected": "Connected — Suwayomi v{version}",
+    "@onboardingConnected": {
+        "placeholders": {
+            "version": { "type": "String" }
+        }
+    },
+    "onboardingConnectFailed": "Couldn't reach that server. Check the address (and login, if it needs one).",
+    "onboardingDoneTitle": "You're all set",
+    "onboardingDoneSubtitle": "Browse sources to start adding manga to your library.",
     "current": "Current",
     "daysAgo": "{days} days ago",
     "debugLogs": "Debug logs",

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -26,6 +26,8 @@ import '../features/migration/presentation/screens/migration_progress_screen.dar
 import '../features/migration/presentation/screens/migration_search_screen.dart';
 import '../features/migration/presentation/screens/migration_source_selection_screen.dart';
 import '../features/offline/presentation/offline_settings_screen.dart';
+import '../features/onboarding/data/onboarding_complete.dart';
+import '../features/onboarding/presentation/onboarding_screen.dart';
 import '../features/quick_open/presentation/search_stack/search_stack_screen.dart';
 import '../features/settings/presentation/appearance/appearance_screen.dart';
 import '../features/settings/presentation/backup/backup_screen.dart';
@@ -95,6 +97,7 @@ abstract class Routes {
   static const updateStatus = "/update-status";
   static const about = 'about';
   static const globalSearch = '/global-search';
+  static const onboarding = '/onboarding';
 
   // Migration
   static const migrationGlobalSearch = '/migration/global-search';
@@ -111,6 +114,18 @@ GoRouter routerConfig(ref) {
     debugLogDiagnostics: true,
     initialLocation: const LibraryRoute(categoryId: 0).location,
     navigatorKey: rootNavigatorKey,
+    redirect: (context, state) {
+      // First-run gate: until onboarding is finished, send everything to the
+      // wizard (and keep finished users out of it).
+      final complete = ref.read(onboardingCompleteProvider) ?? false;
+      final atOnboarding =
+          state.matchedLocation == const OnboardingRoute().location;
+      if (!complete && !atOnboarding) return const OnboardingRoute().location;
+      if (complete && atOnboarding) {
+        return const LibraryRoute(categoryId: 0).location;
+      }
+      return null;
+    },
   );
 }
 

--- a/lib/src/routes/sub_routes/common_routes.dart
+++ b/lib/src/routes/sub_routes/common_routes.dart
@@ -75,3 +75,14 @@ class GlobalSearchRoute extends GoRouteData {
   Widget build(BuildContext context, GoRouterState state) =>
       GlobalSearchScreen(key: ValueKey(query), initialQuery: query);
 }
+
+@TypedGoRoute<OnboardingRoute>(path: Routes.onboarding)
+class OnboardingRoute extends GoRouteData {
+  const OnboardingRoute();
+
+  static final $parentNavigatorKey = rootNavigatorKey;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const OnboardingScreen();
+}

--- a/lib/src/utils/extensions/custom_extensions/string_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions/string_extensions.dart
@@ -113,7 +113,10 @@ extension StringExtensions on String? {
 
   String? get toWebSocket {
     if (isBlank) return null;
-    return this!.replaceFirst(RegExp('http', caseSensitive: false), 'ws');
+    // Anchor to the START so only the scheme is rewritten (http→ws,
+    // https→wss). An un-anchored 'http' would also rewrite a path segment
+    // that happens to contain "http" (e.g. a base path like /proxy/http).
+    return this!.replaceFirst(RegExp('^http', caseSensitive: false), 'ws');
   }
 
   TimeOfDay? get toTimeOfDay {

--- a/test/onboarding/onboarding_flow_test.dart
+++ b/test/onboarding/onboarding_flow_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/onboarding/presentation/onboarding_screen.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+void main() {
+  testWidgets(
+      'wizard advances theme→server, gates Next until verified, Back returns',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(sp)],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const OnboardingScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Step 1: welcome + theme. The big brand logo sits above the heading
+    // (header swirl + the large logo → two brand images on this step), and a
+    // top-right Skip escape is offered.
+    expect(find.text('Welcome to Tsumiru'), findsOneWidget);
+    expect(find.text('Next'), findsOneWidget);
+    expect(find.text('Skip'), findsOneWidget);
+    expect(find.byType(Image), findsNWidgets(2));
+
+    // Advance to step 2 (theme step is always completable).
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+    expect(find.text('Connect your server'), findsOneWidget);
+    // Skip is still offered on the server step.
+    expect(find.text('Skip'), findsOneWidget);
+
+    // Next is gated until a connection verifies — tapping must NOT finish.
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+    expect(find.text("You're all set"), findsNothing);
+    expect(find.text('Connect your server'), findsOneWidget);
+
+    // Back returns to the theme step.
+    await tester.tap(find.text('Back'));
+    await tester.pumpAndSettle();
+    expect(find.text('Welcome to Tsumiru'), findsOneWidget);
+  });
+}

--- a/test/onboarding/onboarding_test.dart
+++ b/test/onboarding/onboarding_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/onboarding/data/onboarding_complete.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+Future<ProviderContainer> _container(Map<String, Object> prefs) async {
+  SharedPreferences.setMockInitialValues(prefs);
+  final sp = await SharedPreferences.getInstance();
+  final c = ProviderContainer(
+    overrides: [sharedPreferencesProvider.overrideWithValue(sp)],
+  );
+  addTearDown(c.dispose);
+  return c;
+}
+
+void main() {
+  group('serverConfiguredForOnboarding (migration predicate)', () {
+    test('unset / empty / default loopback → not configured', () {
+      expect(serverConfiguredForOnboarding(null), isFalse);
+      expect(serverConfiguredForOnboarding(''), isFalse);
+      expect(serverConfiguredForOnboarding('http://127.0.0.1'), isFalse);
+    });
+
+    test('a real server URL → configured (existing installs skip the wizard)',
+        () {
+      expect(serverConfiguredForOnboarding('http://192.168.0.10:4567'), isTrue);
+      expect(
+          serverConfiguredForOnboarding('https://suwayomi.example.com'), isTrue);
+    });
+  });
+
+  group('onboardingCompleteProvider', () {
+    test('defaults to false on a fresh install (so the wizard shows)', () async {
+      final c = await _container({});
+      expect(c.read(onboardingCompleteProvider) ?? false, isFalse);
+    });
+
+    test('reads a persisted true (finished / migrated installs skip it)',
+        () async {
+      final c = await _container({'flutter.onboardingComplete': true});
+      expect(c.read(onboardingCompleteProvider), isTrue);
+    });
+  });
+}

--- a/test/onboarding/server_discovery_test.dart
+++ b/test/onboarding/server_discovery_test.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// Unit tests for LAN server discovery (the "Search my network" sweep).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/onboarding/data/server_discovery.dart';
+
+void main() {
+  group('subnetHosts', () {
+    test('generates the /24 sweep including the ip, de-duped', () {
+      final hosts = subnetHosts('192.168.1.50');
+      expect(hosts, contains('192.168.1.1'));
+      expect(hosts, contains('192.168.1.254'));
+      expect(hosts.first, '192.168.1.50'); // ip probed first
+      expect(hosts.where((h) => h == '192.168.1.50').length, 1); // de-duped
+      expect(hosts.length, 254);
+    });
+
+    test('malformed ip → just itself', () {
+      expect(subnetHosts('not-an-ip'), ['not-an-ip']);
+    });
+  });
+
+  group('discoverServerOnLan', () {
+    test('returns http://<ip>:4567 for the first responder on :4567', () async {
+      final found = await discoverServerOnLan(
+        wifiIp: () async => '192.168.1.50',
+        ping: (host, port) async => host == '192.168.1.7' && port == 4567,
+      );
+      expect(found, 'http://192.168.1.7:4567');
+    });
+
+    test('no Wi-Fi IP → null', () async {
+      expect(await discoverServerOnLan(wifiIp: () async => null), isNull);
+    });
+
+    test('nothing responds → null', () async {
+      final found = await discoverServerOnLan(
+        wifiIp: () async => '192.168.1.50',
+        ping: (_, __) async => false,
+      );
+      expect(found, isNull);
+    });
+  });
+}

--- a/test/onboarding/server_resolver_live_test.dart
+++ b/test/onboarding/server_resolver_live_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// LIVE test — runs the REAL resolver against a REAL Suwayomi server over the
+// network (no mocks). The server address is NEVER hard-coded: it is read from
+// the TSUMIRU_LIVE_SERVER environment variable and the test skips when unset,
+// so no address or credential is ever committed.
+//
+// Run:  TSUMIRU_LIVE_SERVER=host:port flutter test test/onboarding/server_resolver_live_test.dart
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:tsumiru/src/features/onboarding/data/server_resolver.dart';
+
+void main() {
+  final host = Platform.environment['TSUMIRU_LIVE_SERVER'];
+
+  test('LIVE: resolves a real Suwayomi server as found', () async {
+    if (host == null || host.isEmpty) {
+      // ignore: avoid_print
+      print('SKIP: set TSUMIRU_LIVE_SERVER=host:port to run the live test.');
+      return;
+    }
+
+    final client = http.Client();
+    final result = await resolveServer(host, client: client);
+    client.close();
+
+    if (result.outcome == ResolveOutcome.notReached) {
+      // ignore: avoid_print
+      print('SKIP: $host not reachable from this machine.');
+      return;
+    }
+
+    // A reachable Suwayomi confirms with a real name + version.
+    expect(result.outcome, ResolveOutcome.found,
+        reason: 'a real Suwayomi server should be confirmed');
+    expect(result.serverName, isNotEmpty);
+    expect(result.serverVersion, isNotNull);
+    // Auth mode is whatever the server is configured for; just assert we read one.
+    expect(result.authMode, isNotNull);
+  }, timeout: const Timeout(Duration(seconds: 30)));
+}

--- a/test/onboarding/server_resolver_test.dart
+++ b/test/onboarding/server_resolver_test.dart
@@ -1,0 +1,605 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// Unit tests for the "Find server" connection resolver.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:tsumiru/src/features/onboarding/data/server_resolver.dart';
+
+// ---------------------------------------------------------------------------
+// Canned GraphQL bodies
+// ---------------------------------------------------------------------------
+
+const _aboutOk =
+    '{"data":{"aboutServer":{"name":"Suwayomi-Server","version":"1.0.0"}}}';
+const _authOpen = '{"data":{"downloadStatus":{"__typename":"DownloadStatus"}}}';
+const _authUnauthorized =
+    '{"data":null,"errors":[{"message":"Unauthorized"}]}';
+
+/// The null-bubbling case the recon warned about: a COMBINED query would null
+/// the entire `data` object because the non-null @RequireAuth field's error
+/// propagates to the root. We must still read aboutServer from a SEPARATE
+/// request — but if someone *did* combine, `data` is null and we must NOT
+/// crash; the about-only request is what confirms.
+const _nullBubbledCombined =
+    '{"data":null,"errors":[{"message":"Unauthorized"}]}';
+
+void main() {
+  group('connectionCandidates — ordering & normalisation', () {
+    test('bare host: http-first on :4567, then bare https, then bare http', () {
+      expect(connectionCandidates('192.168.0.10'), [
+        'http://192.168.0.10:4567',
+        'https://192.168.0.10',
+        'http://192.168.0.10',
+      ]);
+    });
+
+    test('host + explicit port: only the two scheme variants on that port', () {
+      expect(connectionCandidates('myserver.local:4568'), [
+        'http://myserver.local:4568',
+        'https://myserver.local:4568',
+      ]);
+    });
+
+    test('malformed host:port (non-numeric port) never throws', () {
+      expect(() => connectionCandidates('host:abc'), returnsNormally);
+      expect(connectionCandidates('host:abc'), isEmpty);
+    });
+
+    test('userinfo (user@host) never throws', () {
+      expect(() => connectionCandidates('user@host:4567'), returnsNormally);
+    });
+
+    test('out-of-range port is rejected (fail-fast, no candidates)', () {
+      expect(connectionCandidates('host:99999'), isEmpty);
+    });
+
+    test('explicit scheme WITH port → single candidate (fully specified)', () {
+      expect(connectionCandidates('http://10.0.0.5:4567'),
+          ['http://10.0.0.5:4567']);
+    });
+
+    test('explicit http scheme, NO port → still tries the default :4567', () {
+      // A scheme without a port is NOT a complete address — the user named a
+      // host, so we must still try Suwayomi's default port, then bare :80.
+      expect(connectionCandidates('http://192.168.0.10'), [
+        'http://192.168.0.10:4567',
+        'http://192.168.0.10',
+      ]);
+    });
+
+    test('explicit https scheme, NO port → default :4567 first, then bare', () {
+      expect(connectionCandidates('https://suwayomi.example.com'), [
+        'https://suwayomi.example.com:4567',
+        'https://suwayomi.example.com',
+      ]);
+    });
+
+    test('bracketed IPv6 with port: two scheme variants on that port', () {
+      expect(connectionCandidates('[fe80::1]:4568'), [
+        'http://[fe80::1]:4568',
+        'https://[fe80::1]:4568',
+      ]);
+    });
+
+    test('bare IPv6 literal is NOT mistaken for host:port', () {
+      // `::1` must keep its colons as the address, not split `:1` as a port.
+      final candidates = connectionCandidates('::1');
+      expect(candidates, [
+        'http://[::1]:4567',
+        'https://[::1]',
+        'http://[::1]',
+      ]);
+    });
+
+    test('longer bare IPv6 literal (fe80::1) is detected', () {
+      final candidates = connectionCandidates('fe80::1');
+      expect(candidates.first, 'http://[fe80::1]:4567');
+      expect(candidates, contains('http://[fe80::1]'));
+    });
+
+    test('base path is preserved (explicit port → two variants)', () {
+      expect(connectionCandidates('host.example:8080/suwayomi'), [
+        'http://host.example:8080/suwayomi',
+        'https://host.example:8080/suwayomi',
+      ]);
+    });
+
+    test('trailing slash is normalised away (no duplicates)', () {
+      // bare host with trailing slash should equal bare host.
+      expect(connectionCandidates('myhost/'), connectionCandidates('myhost'));
+    });
+
+    test('explicit scheme + port + base path → single candidate, path kept', () {
+      expect(connectionCandidates('https://host.example:8080/suwayomi/'),
+          ['https://host.example:8080/suwayomi']);
+    });
+
+    test('blank input yields no candidates', () {
+      expect(connectionCandidates('   '), isEmpty);
+    });
+
+    test('explicit scheme-default port (:80) reads as no port → fans to :4567',
+        () {
+      // Dart's Uri treats a scheme-default port as "no port", so http://host:80
+      // is indistinguishable from http://host — we fan out to the default :4567
+      // first (a server is rarely on :80), then bare.
+      expect(connectionCandidates('http://host.example:80'),
+          ['http://host.example:4567', 'http://host.example']);
+    });
+  });
+
+  group('classifyProbeBody', () {
+    test('confirmed + open when auth probe returns data', () {
+      final r = classifyProbeBody(
+        url: 'http://h:4567',
+        aboutBody: _aboutOk,
+        authBody: _authOpen,
+      );
+      expect(r, isNotNull);
+      expect(r!.confirmed, isTrue);
+      expect(r.authMode, ProbeAuthMode.open);
+      expect(r.serverName, 'Suwayomi-Server');
+      expect(r.serverVersion, '1.0.0');
+    });
+
+    test('confirmed + authRequired when auth probe says Unauthorized', () {
+      final r = classifyProbeBody(
+        url: 'http://h:4567',
+        aboutBody: _aboutOk,
+        authBody: _authUnauthorized,
+      );
+      expect(r!.confirmed, isTrue);
+      expect(r.authMode, ProbeAuthMode.authRequired);
+    });
+
+    test('reads aboutServer name/version INDEPENDENTLY of errors[]', () {
+      // Partial data: aboutServer present AND an errors array present.
+      const partial =
+          '{"data":{"aboutServer":{"name":"S","version":"9"}},"errors":[{"message":"something else"}]}';
+      final r = classifyProbeBody(
+        url: 'http://h',
+        aboutBody: partial,
+        authBody: _authUnauthorized,
+      );
+      expect(r!.confirmed, isTrue);
+      expect(r.serverName, 'S');
+      expect(r.serverVersion, '9');
+    });
+
+    test('null-bubbled combined response does NOT confirm (no aboutServer)',
+        () {
+      // If the about request itself came back null-bubbled, there's no
+      // aboutServer object → not confirmed.
+      final r = classifyProbeBody(
+        url: 'http://h',
+        aboutBody: _nullBubbledCombined,
+        authBody: _authUnauthorized,
+      );
+      expect(r, isNull);
+    });
+
+    test('case-insensitive "unauthor" substring trips authRequired', () {
+      const weird = '{"errors":[{"message":"UNAUTHORISED access denied"}]}';
+      final r = classifyProbeBody(
+        url: 'http://h',
+        aboutBody: _aboutOk,
+        authBody: weird,
+      );
+      expect(r!.authMode, ProbeAuthMode.authRequired);
+    });
+
+    test('non-JSON / html body is not confirmed', () {
+      final r = classifyProbeBody(
+        url: 'http://h',
+        aboutBody: '<html>login</html>',
+        authBody: '',
+      );
+      expect(r, isNull);
+    });
+  });
+
+  group('resolveServer — ladder walk', () {
+    test('first confirmed candidate (http:4567) short-circuits', () async {
+      final tried = <String>[];
+      final r = await resolveServer(
+        '192.168.0.10',
+        client: MockClient((_) async => http.Response('', 200)),
+        probe: (url) async {
+          tried.add(url);
+          return ProbeResult(
+            url: url,
+            confirmed: true,
+            reached: true,
+            basicGated: false,
+            authMode: ProbeAuthMode.open,
+            serverName: 'Suwayomi-Server',
+            serverVersion: '1.0.0',
+          );
+        },
+      );
+      expect(r.isFound, isTrue);
+      // http-first: the LAN candidate is tried first and wins.
+      expect(r.baseUrl, 'http://192.168.0.10:4567');
+      expect(tried, ['http://192.168.0.10:4567']); // stopped at first
+    });
+
+    test('basic-gated NEVER wins over a LATER confirmed candidate', () async {
+      // The first candidate (http:4567) is basic-gated; a later one (https) is
+      // the real confirmable server. Must resolve to the confirmed https, NOT
+      // the basic-gated http.
+      final r = await resolveServer(
+        'myserver',
+        client: MockClient((_) async => http.Response('', 200)),
+        probe: (url) async {
+          if (url.startsWith('http://')) {
+            return ProbeResult.basicGatedResult(url);
+          }
+          return ProbeResult(
+            url: url,
+            confirmed: true,
+            reached: true,
+            basicGated: false,
+            authMode: ProbeAuthMode.open,
+            serverName: 'S',
+            serverVersion: '1',
+          );
+        },
+      );
+      expect(r.isFound, isTrue);
+      expect(r.outcome, ResolveOutcome.found);
+      expect(r.baseUrl, startsWith('https://'));
+    });
+
+    test('basic-gated is the best fallback when nothing confirms', () async {
+      final r = await resolveServer(
+        'gated.example',
+        client: MockClient((_) async => http.Response('', 401)),
+        probe: (url) async => ProbeResult.basicGatedResult(url),
+      );
+      expect(r.outcome, ResolveOutcome.basicGated);
+      expect(r.isFound, isFalse); // basic-gated NEVER reads as found
+    });
+
+    test('fallback priority: reached-unconfirmed beats not-reached', () async {
+      final r = await resolveServer(
+        'mystery.example',
+        client: MockClient((_) async => http.Response('', 200)),
+        probe: (url) async {
+          // only the http (last) candidate even answers, unconfirmed.
+          if (url == 'http://mystery.example') {
+            return ProbeResult.reachedUnconfirmed(url);
+          }
+          return ProbeResult.notReached(url);
+        },
+      );
+      expect(r.outcome, ResolveOutcome.reachedUnconfirmed);
+      expect(r.baseUrl, 'http://mystery.example');
+    });
+
+    test('all not-reached → notReached on the first candidate', () async {
+      final r = await resolveServer(
+        'dead.example',
+        client: MockClient((_) async => http.Response('', 200)),
+        probe: (url) async => ProbeResult.notReached(url),
+      );
+      expect(r.outcome, ResolveOutcome.notReached);
+      expect(r.baseUrl, 'http://dead.example:4567');
+    });
+
+    test('unparseable input falls back to a scheme-bearing URL', () async {
+      final r = await resolveServer(
+        'host:abc', // malformed → no candidates
+        client: MockClient((_) async => http.Response('', 200)),
+      );
+      expect(r.outcome, ResolveOutcome.notReached);
+      expect(r.baseUrl, startsWith('http://')); // never raw schemeless text
+    });
+  });
+
+  group('displayAddress — always shows the explicit host:port', () {
+    test('non-default port is kept', () {
+      expect(displayAddress('http://192.168.0.10:4567'),
+          'http://192.168.0.10:4567');
+    });
+    test('http default :80 is made explicit (not hidden)', () {
+      expect(displayAddress('http://192.168.0.10'), 'http://192.168.0.10:80');
+    });
+    test('https default :443 is made explicit', () {
+      expect(displayAddress('https://suwayomi.example.com'),
+          'https://suwayomi.example.com:443');
+    });
+    test('base path is preserved after the port', () {
+      expect(displayAddress('http://host.example/suwayomi'),
+          'http://host.example:80/suwayomi');
+    });
+    test('IPv6 host is bracketed', () {
+      expect(displayAddress('http://[::1]:4567'), 'http://[::1]:4567');
+    });
+  });
+
+  group('normalisedFallbackUrl — use-this-address-anyway always has a scheme',
+      () {
+    test('bare host gets http:// + default port', () {
+      expect(normalisedFallbackUrl('192.168.0.10'), startsWith('http://'));
+    });
+    test('explicit scheme is preserved', () {
+      expect(normalisedFallbackUrl('https://x.example'), 'https://x.example');
+    });
+    test('malformed input still gets a scheme', () {
+      expect(normalisedFallbackUrl('weird input'), startsWith('http://'));
+    });
+  });
+
+  group('probeServer — wire behaviour via MockClient', () {
+    test('confirms a Suwayomi server and reads auth mode', () async {
+      final mock = MockClient.streaming((request, bodyStream) async {
+        final body = await bodyStream.bytesToString();
+        final query = (jsonDecode(body) as Map)['query'] as String;
+        expect(request.url.path, '/api/graphql');
+        if (query.contains('aboutServer')) {
+          return http.StreamedResponse(
+              Stream.value(utf8.encode(_aboutOk)), 200);
+        }
+        // auth probe → unauthorized
+        return http.StreamedResponse(
+            Stream.value(utf8.encode(_authUnauthorized)), 200);
+      });
+      final r = await probeServer('http://h:4567', client: mock);
+      expect(r.confirmed, isTrue);
+      expect(r.authMode, ProbeAuthMode.authRequired);
+    });
+
+    test('401 + WWW-Authenticate: Basic → basicGated', () async {
+      final mock = MockClient.streaming((request, bodyStream) async {
+        return http.StreamedResponse(
+          Stream.value(utf8.encode('')),
+          401,
+          headers: {'www-authenticate': 'Basic realm="suwayomi"'},
+        );
+      });
+      final r = await probeServer('http://h:4567', client: mock);
+      expect(r.basicGated, isTrue);
+      expect(r.confirmed, isFalse);
+    });
+
+    test('https→http downgrade redirect is NOT followed → reachedUnconfirmed',
+        () async {
+      final mock = MockClient.streaming((request, bodyStream) async {
+        return http.StreamedResponse(
+          Stream.value(utf8.encode('')),
+          302,
+          headers: {'location': 'http://h:4567/login'},
+        );
+      });
+      final r = await probeServer('https://h:4567', client: mock);
+      expect(r.reached, isTrue);
+      expect(r.confirmed, isFalse);
+      expect(r.basicGated, isFalse);
+    });
+
+    test('single-hop redirect to a confirmable endpoint → found at destination',
+        () async {
+      final mock = MockClient.streaming((request, bodyStream) async {
+        if (request.url.host == 'proxy.example') {
+          // The proxy bounces /api/graphql to the real origin (same scheme).
+          return http.StreamedResponse(Stream.value(utf8.encode('')), 302,
+              headers: {'location': 'https://real.example/api/graphql'});
+        }
+        final body = await bodyStream.bytesToString();
+        final isAbout =
+            ((jsonDecode(body) as Map)['query'] as String).contains('aboutServer');
+        return http.StreamedResponse(
+            Stream.value(utf8.encode(isAbout ? _aboutOk : _authOpen)), 200);
+      });
+      final r = await probeServer('https://proxy.example', client: mock);
+      expect(r.confirmed, isTrue);
+      expect(r.url, 'https://real.example'); // persists the DESTINATION base
+    });
+
+    test('a second redirect is not chased → reachedUnconfirmed', () async {
+      final mock = MockClient.streaming((request, bodyStream) async {
+        // Every request redirects again (same scheme, no downgrade).
+        return http.StreamedResponse(Stream.value(utf8.encode('')), 302, headers: {
+          'location': 'https://${request.url.host}x/api/graphql',
+        });
+      });
+      final r = await probeServer('https://loop.example', client: mock);
+      expect(r.confirmed, isFalse);
+      expect(r.reached, isTrue);
+    });
+  });
+
+  group('shouldSuggestHttps — reverse-proxy hint only when https not tried', () {
+    test('explicit http:// → https was never tried → suggest https', () {
+      expect(shouldSuggestHttps('http://192.168.0.10:4567'), isTrue);
+    });
+    test('bare host → https IS a candidate → do NOT suggest', () {
+      expect(shouldSuggestHttps('192.168.0.10'), isFalse);
+    });
+    test('explicit https:// → already https → do NOT suggest', () {
+      expect(shouldSuggestHttps('https://suwayomi.example.com'), isFalse);
+    });
+  });
+
+  group('basicAuthConfirms — verifies Basic creds against aboutServer', () {
+    test('valid Basic creds → aboutServer confirms → true', () async {
+      final mock = MockClient.streaming((request, _) async {
+        final auth = request.headers['authorization'] ?? '';
+        if (auth.startsWith('Basic ')) {
+          return http.StreamedResponse(
+              Stream.value(utf8.encode(_aboutOk)), 200);
+        }
+        return http.StreamedResponse(Stream.value(utf8.encode('')), 401,
+            headers: {'www-authenticate': 'Basic'});
+      });
+      expect(
+          await basicAuthConfirms('http://h:4567',
+              client: mock, username: 'u', password: 'p'),
+          isTrue);
+    });
+
+    test('wrong Basic creds → 401 → false', () async {
+      final mock = MockClient.streaming((_, __) async => http.StreamedResponse(
+          Stream.value(utf8.encode('')), 401,
+          headers: {'www-authenticate': 'Basic'}));
+      expect(
+          await basicAuthConfirms('http://h:4567',
+              client: mock, username: 'u', password: 'x'),
+          isFalse);
+    });
+
+    test('reached but not Suwayomi (200 non-JSON) → false', () async {
+      final mock = MockClient.streaming((_, __) async =>
+          http.StreamedResponse(Stream.value(utf8.encode('<html>')), 200));
+      expect(
+          await basicAuthConfirms('http://h:4567',
+              client: mock, username: 'u', password: 'p'),
+          isFalse);
+    });
+  });
+
+  group('authProbeAuthorized — verifies a credential against @RequireAuth', () {
+    test('a credential the @RequireAuth gate rejects → not authorised',
+        () async {
+      // Server honours ONLY the bearer (models ui_login): a cookie gets
+      // Unauthorized, a bearer gets data.
+      final mock = MockClient.streaming((request, _) async {
+        final hasBearer =
+            request.headers['authorization']?.startsWith('Bearer ') ?? false;
+        return http.StreamedResponse(
+            Stream.value(utf8.encode(hasBearer ? _authOpen : _authUnauthorized)),
+            200);
+      });
+      expect(
+          await authProbeAuthorized('http://h:4567',
+              client: mock, cookie: 'JSESSIONID=abc'),
+          isFalse);
+      expect(
+          await authProbeAuthorized('http://h:4567',
+              client: mock, bearer: 'jwt.token'),
+          isTrue);
+    });
+
+    test('a 401 status reads as not authorised', () async {
+      final mock = MockClient.streaming((_, __) async =>
+          http.StreamedResponse(Stream.value(utf8.encode('')), 401));
+      expect(
+          await authProbeAuthorized('http://h:4567',
+              client: mock, cookie: 'x'),
+          isFalse);
+    });
+
+    test('basic credential the @RequireAuth gate authorises → true', () async {
+      // Models genuine basic_auth: the gate returns data ONLY when a Basic
+      // Authorization header is present.
+      final mock = MockClient.streaming((request, _) async {
+        final hasBasic =
+            request.headers['authorization']?.startsWith('Basic ') ?? false;
+        return http.StreamedResponse(
+            Stream.value(utf8.encode(hasBasic ? _authOpen : _authUnauthorized)),
+            200);
+      });
+      expect(
+          await authProbeAuthorized('http://h:4567',
+              client: mock, basic: 'u:p'),
+          isTrue);
+    });
+
+    test('basic credential on a server that ignores it → not authorised',
+        () async {
+      // Models picking "Basic" on a ui_login/simple_login server: the public
+      // surface answers, but the @RequireAuth probe stays Unauthorized because
+      // a Basic header is meaningless to that server. THIS is the bug guard —
+      // a wrong auth type must NOT read as authorised.
+      final mock = MockClient.streaming((_, __) async => http.StreamedResponse(
+          Stream.value(utf8.encode(_authUnauthorized)), 200));
+      expect(
+          await authProbeAuthorized('http://h:4567',
+              client: mock, basic: 'u:wrong'),
+          isFalse);
+    });
+  });
+
+  group('verifyAuthMode — the VERIFIED submit-time try-both', () {
+    test('ui_login server: cookie 303s at login but only the bearer authorises '
+        'the API → resolves to uiLogin (the round-4 trap, closed)', () async {
+      // The @RequireAuth gate honours ONLY the bearer. /login.html still
+      // "succeeds" (we hand back a cookie), but that cookie is INERT at the
+      // API — exactly the ui_login-cookie trap. Trusting the 303 would mislabel
+      // this simpleLogin; verifying via re-probe correctly yields uiLogin.
+      final mock = MockClient.streaming((request, _) async {
+        final hasBearer =
+            request.headers['authorization']?.startsWith('Bearer ') ?? false;
+        return http.StreamedResponse(
+            Stream.value(utf8.encode(hasBearer ? _authOpen : _authUnauthorized)),
+            200);
+      });
+      final mode = await verifyAuthMode(
+        baseUrl: 'http://h:4567',
+        client: mock,
+        obtainSimpleCookie: () async => 'JSESSIONID=abc', // login "succeeded"
+        obtainUiBearer: () async => 'jwt.token',
+      );
+      expect(mode, VerifiedAuthMode.uiLogin);
+    });
+
+    test('simple_login server: cookie authorises → simpleLogin, ui not tried',
+        () async {
+      var uiTried = false;
+      final mock = MockClient.streaming((request, _) async {
+        final hasCookie =
+            (request.headers['cookie']?.isNotEmpty) ?? false;
+        return http.StreamedResponse(
+            Stream.value(utf8.encode(hasCookie ? _authOpen : _authUnauthorized)),
+            200);
+      });
+      final mode = await verifyAuthMode(
+        baseUrl: 'http://h:4567',
+        client: mock,
+        obtainSimpleCookie: () async => 'JSESSIONID=abc',
+        obtainUiBearer: () async {
+          uiTried = true;
+          return 'jwt';
+        },
+      );
+      expect(mode, VerifiedAuthMode.simpleLogin);
+      expect(uiTried, isFalse,
+          reason: 'simple verified first → ui-login never attempted');
+    });
+
+    test('wrong credentials (neither authorises) → null', () async {
+      final mock = MockClient.streaming((_, __) async =>
+          http.StreamedResponse(
+              Stream.value(utf8.encode(_authUnauthorized)), 200));
+      final mode = await verifyAuthMode(
+        baseUrl: 'http://h:4567',
+        client: mock,
+        obtainSimpleCookie: () async => 'JSESSIONID=abc',
+        obtainUiBearer: () async => 'jwt',
+      );
+      expect(mode, isNull);
+    });
+
+    test('simple-login throwing (bad simple creds) falls through to ui',
+        () async {
+      final mock = MockClient.streaming((request, _) async {
+        final hasBearer =
+            request.headers['authorization']?.startsWith('Bearer ') ?? false;
+        return http.StreamedResponse(
+            Stream.value(utf8.encode(hasBearer ? _authOpen : _authUnauthorized)),
+            200);
+      });
+      final mode = await verifyAuthMode(
+        baseUrl: 'http://h:4567',
+        client: mock,
+        obtainSimpleCookie: () async => throw Exception('bad simple creds'),
+        obtainUiBearer: () async => 'jwt',
+      );
+      expect(mode, VerifiedAuthMode.uiLogin);
+    });
+  });
+}

--- a/test/onboarding/server_step_signin_test.dart
+++ b/test/onboarding/server_step_signin_test.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// Widget test for the gated-server flow: Test connection → "needs a login" →
+// auth sub-form.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/onboarding/presentation/onboarding_screen.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/utils/theme/brand.dart';
+
+const _aboutOk =
+    '{"data":{"aboutServer":{"name":"Suwayomi-Server","version":"2.0"}}}';
+const _authUnauthorized = '{"data":null,"errors":[{"message":"Unauthorized"}]}';
+
+/// A server that confirms via aboutServer but gates the @RequireAuth probe →
+/// Test connection should report "needs a login" and reveal the auth sub-form.
+http.Client _gatedServerClient() => MockClient.streaming((request, body) async {
+      final q = ((jsonDecode(await body.bytesToString()) as Map)['query']
+          as String);
+      final isAbout = q.contains('aboutServer');
+      return http.StreamedResponse(
+          Stream.value(utf8.encode(isAbout ? _aboutOk : _authUnauthorized)),
+          200);
+    });
+
+void main() {
+  testWidgets('Test connection on a gated server reveals the auth sub-form',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+
+    await tester.binding.setSurfaceSize(const Size(1080, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sp),
+          onboardingHttpClientProvider.overrideWithValue(_gatedServerClient),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const OnboardingScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Step 1 → Step 2.
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+    expect(find.text('Connect your server'), findsOneWidget);
+    // The two distinct actions exist.
+    expect(find.text('Search my network'), findsOneWidget);
+    expect(find.text('Test connection'), findsOneWidget);
+
+    // Type an address and test it.
+    await tester.enterText(find.byType(TextField).first, '192.168.0.10');
+    await tester.tap(find.text('Test connection'));
+    await tester.pumpAndSettle();
+
+    // Gated → "needs a login" + the auth dropdown (Basic default) + creds.
+    expect(find.text('This server needs a login'), findsOneWidget);
+    expect(find.text('Basic auth'), findsWidgets);
+    expect(find.widgetWithText(TextField, 'User Name'), findsOneWidget);
+    expect(find.widgetWithText(TextField, 'Password'), findsOneWidget);
+  });
+
+  testWidgets(
+      'wrong auth type / credentials must NOT report connected — they are '
+      'rejected and Next stays gated', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+
+    await tester.binding.setSurfaceSize(const Size(1080, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sp),
+          // Gated server: aboutServer answers, but the @RequireAuth probe is
+          // ALWAYS Unauthorized — no credential of any kind authorises it. This
+          // models picking the wrong auth type (e.g. Basic on a ui_login
+          // server, whose public aboutServer answers regardless of creds).
+          onboardingHttpClientProvider.overrideWithValue(_gatedServerClient),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const OnboardingScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Next'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, '192.168.0.10');
+    await tester.tap(find.text('Test connection'));
+    await tester.pumpAndSettle();
+    expect(find.text('This server needs a login'), findsOneWidget);
+
+    // Enter credentials with the default (Basic) auth type and Sign in.
+    await tester.enterText(
+        find.widgetWithText(TextField, 'User Name'), 'whoever');
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Password'), 'whatever');
+    await tester.tap(find.text('Sign in'));
+    await tester.pumpAndSettle();
+
+    // The credentials are rejected — NOT a false "Connected".
+    expect(find.text("Those credentials didn't work. Double-check your "
+        'username, password, and sign-in method.'), findsOneWidget);
+    expect(find.textContaining('Connected'), findsNothing);
+
+    // Next is still gated (onboarding can't be finished with a broken config).
+    final nextButton = tester.widget<BrandButton>(
+        find.widgetWithText(BrandButton, 'Next'));
+    expect(nextButton.onPressed, isNull,
+        reason: 'Next must stay disabled when sign-in was rejected');
+  });
+}


### PR DESCRIPTION
## What

A three-step first-run wizard shown to new users until setup is complete: **pick a theme → connect a server → done**, with a **Skip** escape for anyone who wants to configure later.

Previously a fresh install dropped users on an empty library with no guidance on pointing the app at a Suwayomi server.

## The connect step

It does the hard part for the user instead of making them understand schemes and ports:

- **🔍 Search my network** — scans the LAN for a Suwayomi server on the default port and fills the address in.
- **Test connection** — resolves a half-remembered address (bare host, `host:port`, http/https, IPv6) via an ordered candidate ladder under the hood, and reports a clear outcome:
  - ✅ Connected — Suwayomi v{version}
  - 🔒 This server needs a login → reveals an auth sub-form (Basic / Simple / UI login)
  - ❌ Couldn't reach that address
  - ⚠️ Reachable, but doesn't look like a Suwayomi server
- **Login validation is real.** Entered credentials are checked against a protected (`@RequireAuth`) API surface, so a **wrong auth type or wrong password is rejected** rather than falsely reporting success. (This closes a bug where picking "Basic" on a non-Basic server "succeeded" against the public server-info field.)

"Connected" / advancing is gated on a genuinely usable connection; the "No server yet" link lets users skip into the friendly empty-library state.

## Also

- Anchors the `http`→`ws` scheme rewrite to the start of the string so a base path containing `http` (e.g. `/proxy/http`) isn't mangled.

## Tests

68 onboarding tests covering the candidate ladder, auth-posture detection, credential validation (incl. the wrong-type rejection), LAN discovery, and the wizard flow/gating. Verified on a real device.