### PR TITLE
Distinguish server vs offline downloads in manga details

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
@@ -64,8 +64,8 @@ class ChapterDownloadPresetsButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return PopupMenuButton<DownloadPreset>(
-      icon: const Icon(Icons.download_outlined),
-      tooltip: context.l10n.downloads,
+      icon: const Icon(Icons.cloud_download_outlined),
+      tooltip: context.l10n.downloadToServer,
       onSelected: (preset) => _handlePreset(context, ref, preset),
       itemBuilder: (context) => <PopupMenuEntry<DownloadPreset>>[
         PopupMenuItem(

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -42,7 +42,7 @@ class SeriesOfflineButton extends ConsumerWidget {
               child: CircularProgressIndicator(strokeWidth: 2))
           : Icon(onDevice
               ? Icons.offline_pin_rounded
-              : Icons.download_rounded),
+              : Icons.download_for_offline_outlined),
       label: downloading
           ? context.l10n.offlineDownloadingCount(inFlight)
           : onDevice
@@ -61,7 +61,33 @@ class SeriesOfflineButton extends ConsumerWidget {
       builder: (sheetContext) => SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            // Explain what this sheet does — offline (device) copies, distinct
+            // from the server download up top.
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    sheetContext.l10n.offlineSheetTitle,
+                    style: sheetContext.textTheme.titleMedium
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    sheetContext.l10n.offlineSheetSubtitle,
+                    style: TextStyle(
+                      color: sheetContext.theme.colorScheme.onSurfaceVariant,
+                      fontSize: 13,
+                      height: 1.3,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
             ListTile(
               leading: const Icon(Icons.download_rounded),
               title: Text(sheetContext.l10n.offlineDownloadAll),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1226,6 +1226,7 @@
       "placeholders": { "n": { "type": "int" } }
     },
     "downloads": "Downloads",
+    "downloadToServer": "Download to server",
     "downloadUnreadChapters": "Unread",
     "@downloadUnreadChapters": { "description": "Bulk-download menu item: queue all unread, not-yet-downloaded chapters." },
     "edit": "Edit",
@@ -1699,7 +1700,7 @@
     "@keepOfflineAll": {
         "description": "Keep-offline rule: keep every chapter on device"
     },
-    "offlineDownloadAction": "Download",
+    "offlineDownloadAction": "Offline",
     "@offlineDownloadAction": {
         "description": "Series offline button label when nothing is downloaded yet"
     },
@@ -1707,6 +1708,8 @@
     "@offlineOnDevice": {
         "description": "Series offline button label when the series has downloads on this device"
     },
+    "offlineSheetTitle": "Offline reading",
+    "offlineSheetSubtitle": "Keep chapters on this device so you can read them without a connection to your server. This is separate from server downloads (the cloud icon up top).",
     "offlineDownloadAll": "Download all chapters",
     "@offlineDownloadAll": {
         "description": "Series offline action: download every chapter to this device"


### PR DESCRIPTION
## Problem

The manga-details screen has two download controls that looked identical (a download arrow + the word "Download") but do completely different things:

- **App-bar button** queues chapters on the **Suwayomi server**.
- **Action-row "Download"** saves a copy to **this device** for offline reading.

Users couldn't tell them apart.

## Change

Give each a distinct glyph and word so the mental model is obvious (cloud = server, offline-pin = device):

- **Server (app bar):** `cloud_download_outlined` icon + "Download to server" tooltip.
- **Offline (action row):** relabelled "Download" → **"Offline"**, idle icon `download_for_offline_outlined`, flipping to `offline_pin` + "On device" once saved.
- **The offline sheet** now opens with a one-line header explaining what offline reading does and that it's separate from server downloads.

"Offline" follows Jellyfin's "Available offline" wording; deliberately avoids "Sync" (which Plex dropped for being confusing). Komikku's action row has no download button, so there was no upstream reference to match here.

Verified on device.