### PR TITLE
Next-update estimate: show real day counts, add Smart update dialog

### DIFF
--- a/lib/src/features/manga_book/domain/next_update/next_update_predictor.dart
+++ b/lib/src/features/manga_book/domain/next_update/next_update_predictor.dart
@@ -36,10 +36,10 @@ class NextUpdatePrediction {
 /// median gap between recent distinct release days (upload dates, falling back
 /// to fetch dates, else a 7-day default), clamped to 1..28 days.
 ///
-/// The next date is simply `latestRelease + interval`. (Komikku projects
-/// forward whole cycles, but that only ever reads "Soon" because it *stores*
-/// the value and counts down to a stale one; computed live, latest+interval
-/// gives the intended "In N days" while pending and "Soon" once due/overdue.)
+/// The next date projects forward WHOLE cycles from the latest release to the
+/// next future occurrence (`FetchInterval.calculateNextUpdate`), so a series
+/// whose last chapter is weeks old still reports a real "in N days" rather than
+/// flooring to "Soon".
 NextUpdatePrediction predictNextUpdate(
   List<ChapterRelease> chapters, {
   DateTime? now,
@@ -52,10 +52,28 @@ NextUpdatePrediction predictNextUpdate(
     return NextUpdatePrediction(intervalDays: interval, nextUpdate: null);
   }
 
+  // Project forward whole cycles to the next FUTURE date, exactly like
+  // Komikku's FetchInterval.calculateNextUpdate: a series whose last chapter is
+  // long past still gets a real upcoming date instead of flooring to "Soon".
+  final nowTime = now ?? DateTime.now();
+  final timeSinceLatest = math.max(0, nowTime.difference(latestDate).inDays);
+  final cycle =
+      timeSinceLatest ~/ _increaseInterval(interval, timeSinceLatest, 10);
   return NextUpdatePrediction(
     intervalDays: interval,
-    nextUpdate: latestDate.add(Duration(days: interval)),
+    nextUpdate: latestDate.add(Duration(days: (cycle + 1) * interval)),
   );
+}
+
+/// Komikku's `FetchInterval.increaseInterval`: when a series has missed many
+/// expected cycles, widen the effective interval (doubling) so we don't keep
+/// predicting an imminent release for something long-dormant. Capped at 28.
+int _increaseInterval(int delta, int timeSinceLatest, int increaseWhenOver) {
+  if (delta >= kMaxFetchIntervalDays) return kMaxFetchIntervalDays;
+  final cycle = (timeSinceLatest ~/ delta) + 1;
+  return cycle > increaseWhenOver
+      ? _increaseInterval(delta * 2, timeSinceLatest, increaseWhenOver)
+      : delta;
 }
 
 int _calculateInterval(List<ChapterRelease> chapters) {

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -155,6 +155,27 @@ class MangaDescription extends HookConsumerWidget {
                       label: soonDays == 0
                           ? context.l10n.soon
                           : context.l10n.inNDays(soonDays),
+                      // Tapping explains the estimate (Komikku's "Smart update").
+                      onPressed: () => showDialog<void>(
+                        context: context,
+                        builder: (dialogContext) => AlertDialog(
+                          title: Text(context.l10n.smartUpdate),
+                          content: Text(
+                            context.l10n.smartUpdateExpected(
+                              context.l10n.dayCount(soonDays),
+                              context.l10n
+                                  .dayCount(prediction?.intervalDays ?? 7),
+                            ),
+                          ),
+                          actions: [
+                            TextButton(
+                              onPressed: () =>
+                                  Navigator.of(dialogContext).pop(),
+                              child: Text(context.l10n.close),
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
                   ),
                 if (manga.realUrl.isNotBlank)

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1338,6 +1338,20 @@
             "days": { "type": "int" }
         }
     },
+    "smartUpdate": "Smart update",
+    "smartUpdateExpected": "New chapters predicted to be released in around {predicted}, checking around every {interval}.",
+    "@smartUpdateExpected": {
+        "placeholders": {
+            "predicted": { "type": "String" },
+            "interval": { "type": "String" }
+        }
+    },
+    "dayCount": "{count, plural, =1{1 day} other{{count} days}}",
+    "@dayCount": {
+        "placeholders": {
+            "count": { "type": "int" }
+        }
+    },
     "nHours": "{n, plural, =1{1 hour} other{{n} hours}}",
     "nMinutes": "{n, plural, =1{1 Minute} other{{n} Minutes}}",
     "nRepo": "{n, plural, =1{1 Repo} other{{n} Repos}}",

--- a/test/manga_book/next_update_predictor_test.dart
+++ b/test/manga_book/next_update_predictor_test.dart
@@ -62,10 +62,23 @@ void main() {
       expect(p.daysUntil(now), 4);
     });
 
-    test('overdue → Soon (0)', () {
-      // weekly, latest 10 days ago → 3 days overdue → 0.
+    test('overdue rolls forward to the next future cycle (Komikku)', () {
+      // weekly, latest 10 days ago. Komikku projects whole cycles forward:
+      // cycle = 10 // 7 = 1, nextUpdate = latest + 2*7 = 4 days out.
       final p = predictNextUpdate([up(10), up(17), up(24), up(31)], now: now);
-      expect(p.daysUntil(now), 0);
+      expect(p.daysUntil(now), 4);
+    });
+
+    test('long-dormant series still projects a future date, not Soon', () {
+      // ~58 days since last release, weekly cadence (the "Surviving the Game"
+      // case). cycle = 58 // 7 = 8, nextUpdate = latest + 9*7 = 63 days from
+      // latest = 5 days out. Must NOT floor to 0/"Soon".
+      final p = predictNextUpdate(
+        [up(58), up(65), up(72), up(79)],
+        now: now,
+      );
+      expect(p.intervalDays, 7);
+      expect(p.daysUntil(now), 5);
     });
 
     test('no chapters → null prediction', () {


### PR DESCRIPTION
## Problem

On the manga details action row, the next-update estimate showed **"Soon"** for nearly every series, and tapping it did nothing. Komikku, on the same source, shows a real **"6 days"** and opens an explanation when tapped.

## Cause

Our predictor set `nextUpdate = latestRelease + interval` once. As soon as that date passed (true for anything you've caught up on), `daysUntil` floored to 0 → "Soon".

## Fix

Project forward whole cycles to the next *future* date, ported from Komikku's `FetchInterval.calculateNextUpdate` (`FetchInterval.kt:87–121`):
- `cycle = daysSinceLatest ⌊÷⌋ effectiveInterval`
- `nextUpdate = latest + (cycle + 1) × interval`
- `increaseInterval` widens the interval (doubling, capped at 28) for long-dormant series so we don't predict an imminent release for something that hasn't updated in months.

A series whose last chapter is weeks old now reports a real "in N days."

## Smart update dialog

The estimate button is now tappable and opens a **"Smart update"** dialog explaining the prediction — *"New chapters predicted to be released in around N days, checking around every M days."* — matching Komikku's release-build behaviour (its custom-interval override is debug-only, so explain-only is the user-facing feature).

## Tests

Updated the predictor tests to assert the forward projection (the old "overdue → Soon (0)" expectation is replaced), plus a long-dormant-series case. All 10 pass.