### PR TITLE
Build an unsigned iOS IPA on release + document sideloading

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,29 @@
+A fast, multiplatform reader for your [Suwayomi](https://suwayomi.org/) server.
+
+## What's new in vX.Y.Z
+
+<!-- Summarise the headline changes here, grouped by area. -->
+
+## Install
+
+You'll need a running Suwayomi server. See [Getting started](https://tsumiru-app.github.io/docs/guides/getting-started).
+
+**Linux - Flatpak (recommended, auto-updates):**
+```sh
+flatpak remote-add --if-not-exists tsumiru https://tsumiru-app.github.io/tsumiru/index.flatpakrepo
+flatpak install tsumiru io.github.aaronbamblett.tsumiru
+```
+
+**Linux - AppImage (portable):** download the `…-linux-x86_64.AppImage` below, `chmod +x`, run.
+
+**Android:** grab the universal APK (or a per-ABI build). **Windows / macOS / Web:** attached below.
+
+**iOS (sideload only — advanced):** the `…-ios.ipa` below is **unsigned**, so you can't just download and open it. Apple requires every app to be signed to your own account first, using one of these tools:
+
+- **[SideStore](https://sidestore.io/)** — signs and refreshes the app *on-device*, no computer needed after setup. Best choice for most people.
+- **[AltStore](https://altstore.io/)** — also signs the app, but it expires every 7 days and only auto-refreshes while a computer running AltServer is powered on and on the same Wi-Fi as your phone.
+- **[TrollStore](https://ios.cfw.guide/installing-trollstore/)** — permanent install with no expiry, but only works on older iPhones/iOS versions with the required vulnerability.
+
+With SideStore or AltStore the app must be re-signed periodically (the tools automate this); only TrollStore avoids that. There is no App Store build.
+
+Full docs at [tsumiru-app.github.io](https://tsumiru-app.github.io/).

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -183,6 +183,17 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath "dist\${env:pkg_name}-${{ github.ref_name }}-windows-x64.zip"
 
+      # TEMPORARY: lets a manual (non-tag) run expose the built artifacts for
+      # download so the unsigned iOS IPA can be inspected before a real release.
+      # Skipped on tagged release runs. Remove once iOS is verified.
+      - name: Upload artifacts (manual test runs only)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: ignore
+
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -1,6 +1,6 @@
 # Multi-platform release builder for Aaron's fork.
 #
-# Triggered by pushing a v*.*.* tag (or manually). Builds Android, Linux,
+# Triggered by pushing a v*.*.* tag (or manually). Builds Android, iOS, Linux,
 # Windows, macOS and Web from the tagged commit and attaches the artifacts to
 # the GitHub release. Distinct from the inherited upstream `publish.yml`
 # (which targets winget/homebrew/Play Store and uses unpinned Flutter).
@@ -8,6 +8,10 @@
 # Android is signed with the repo's debug keystore (stored as secrets) so CI
 # builds keep the same signature as locally-built debug APKs — installs upgrade
 # cleanly instead of being rejected for a signature mismatch.
+#
+# iOS is built UNSIGNED (no Apple Developer account needed). The resulting
+# .ipa is not installable directly — users re-sign it themselves via AltStore /
+# SideStore / TrollStore. See the release notes / docs install section.
 name: Release (fork)
 
 on:
@@ -39,6 +43,8 @@ jobs:
             target: web
           - os: macos-latest
             target: macos
+          - os: macos-latest
+            target: ios
           # Pinned to 2022: windows-latest (Server 2025) ships VS 2022 in a
           # layout Flutter 3.32.4 fails to detect, so CMake falls back to the
           # "Visual Studio 16 2019" generator and can't find an instance.
@@ -104,8 +110,15 @@ jobs:
 
       - name: Build ${{ matrix.target }}
         # Linux is built by fastforge in the AppImage step below (and by the Flatpak workflow).
-        if: matrix.target != 'android' && matrix.target != 'linux'
+        # iOS needs --no-codesign, handled in its own step below.
+        if: matrix.target != 'android' && matrix.target != 'linux' && matrix.target != 'ios'
         run: flutter build ${{ matrix.target }} --release
+
+      - name: Build iOS (unsigned)
+        if: matrix.target == 'ios'
+        # No Apple Developer account / signing certs in CI — build an unsigned
+        # binary. Flutter runs `pod install` automatically as part of this.
+        run: flutter build ios --release --no-codesign
 
       # ---- package into dist/ ----
       - name: Package Android
@@ -152,6 +165,16 @@ jobs:
           mkdir -p dist
           APP=$(find build/macos/Build/Products/Release -maxdepth 1 -name "*.app" | head -1)
           ditto -c -k --sequesterRsrc --keepParent "$APP" "dist/${pkg_name}-${{ github.ref_name }}-macos-x64.zip"
+
+      - name: Package iOS (unsigned IPA)
+        if: matrix.target == 'ios'
+        # An .ipa is just a zip with the .app inside a top-level Payload/ dir.
+        run: |
+          mkdir -p dist Payload
+          APP=$(find build/ios/iphoneos -maxdepth 1 -name "*.app" | head -1)
+          cp -R "$APP" Payload/
+          zip -r -y "dist/${pkg_name}-${{ github.ref_name }}-ios.ipa" Payload
+          rm -rf Payload
 
       - name: Package Windows
         if: matrix.target == 'windows'

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -183,17 +183,6 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath "dist\${env:pkg_name}-${{ github.ref_name }}-windows-x64.zip"
 
-      # TEMPORARY: lets a manual (non-tag) run expose the built artifacts for
-      # download so the unsigned iOS IPA can be inspected before a real release.
-      # Skipped on tagged release runs. Remove once iOS is verified.
-      - name: Upload artifacts (manual test runs only)
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-${{ matrix.target }}
-          path: dist/*
-          if-no-files-found: ignore
-
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## What this does

Adds iOS to the release pipeline so every `v*` tag also produces an **unsigned `…-ios.ipa`**, attached to the release alongside the existing platforms. No Apple Developer account or signing certs required.

- New `ios` matrix target on a macOS runner; builds with `flutter build ios --release --no-codesign` and packages the `.app` into a `Payload/` zip → `.ipa`.
- Isolated from the other jobs (`fail-fast: false`), so an iOS hiccup never blocks an Android/desktop release.

## Why unsigned

Apple won't install an arbitrary downloaded app — it must be re-signed to the user's own account. So the IPA serves sideloaders who use **SideStore** (on-device, recommended), **AltStore** (needs a computer on the same Wi-Fi), or **TrollStore** (older iOS, permanent). There is no App Store build.

## Docs

Adds `.github/RELEASE_NOTES_TEMPLATE.md` carrying the full install section, including an iOS sideload how-to, so the instructions are owned by the repo and copied into each release body instead of hand-retyped.

## Verification

Ran the workflow manually on this branch (non-tag, so nothing was published). All six platform jobs went green, and the downloaded iOS artifact was a well-formed `Payload/Runner.app` bundle (executable + Info.plist present). The temporary artifact-upload step used for that check has been removed.