### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.6.0+32
+version: 0.6.1+33
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Version bump for the 0.6.1 release: 0.6.0+32 → 0.6.1+33.

First release to include the connection/server settings redesign, the skippable update prompt, and an (unsigned) iOS IPA with sideload instructions.