### PR TITLE
Bug fixes: library ghosts, filter dialog, reader toasts, light-theme visibility

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -56,6 +56,9 @@ enum DBKeys {
   sourceDisplayMode(DisplayMode.grid),
   gridMangaCoverWidth(192.0),
   readerOverlay(true),
+  // Show the continuous-reader feedback snackbars ("loading next chapter",
+  // "no more chapters", etc.). Off = a quiet reading experience.
+  readerFeedbackToasts(true),
   volumeTap(false),
   volumeTapInvert(false),
   hideEmptyCategory(false),

--- a/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_list_view.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_list_view.dart
@@ -51,7 +51,7 @@ class SourceMangaListView extends ConsumerWidget {
               padding: KEdgeInsets.h8.size,
               child: Shimmer.fromColors(
                 baseColor: context.colorScheme.surface,
-                highlightColor: context.theme.indicatorColor,
+                highlightColor: context.theme.colorScheme.primary,
                 child: Container(
                   width: context.width * .3,
                   decoration: BoxDecoration(

--- a/lib/src/features/library/data/category_repository.dart
+++ b/lib/src/features/library/data/category_repository.dart
@@ -117,10 +117,23 @@ class CategoryRepository {
       ferryClient
           .query$GetCategoryMangas(
             Options$Query$GetCategoryMangas(
-              variables: Variables$Query$GetCategoryMangas(id: categoryId),
+              variables: Variables$Query$GetCategoryMangas(
+                // Fetch the library entries for this category via the top-level
+                // mangas filter (not the category->manga relation, which also
+                // returns entries removed from the library — they linger in the
+                // DB with inLibrary=false). The virtual "Default" category
+                // (id 0) is "in library and uncategorized", so match a null
+                // categoryId for it; real categories match by id.
+                filter: Input$MangaFilterInput(
+                  inLibrary: Input$BooleanFilterInput(equalTo: true),
+                  categoryId: categoryId == 0
+                      ? Input$IntFilterInput(isNull: true)
+                      : Input$IntFilterInput(equalTo: categoryId),
+                ),
+              ),
             ),
           )
-          .getData((data) => data.category.mangas.nodes);
+          .getData((data) => data.mangas.nodes);
 }
 
 @riverpod

--- a/lib/src/features/library/data/graphql/query.graphql
+++ b/lib/src/features/library/data/graphql/query.graphql
@@ -58,21 +58,17 @@ mutation DeleteCategoryMeta($input: DeleteCategoryMetaInput!) {
   }
 }
 
-query GetCategoryMangas($id: Int!) {
-  category(id: $id) {
-    id
-    mangas {
-      nodes {
-        ...MangaDto
-        __typename
-      }
-      pageInfo {
-        ...PageInfoDto
-        __typename
-      }
-      totalCount
+query GetCategoryMangas($filter: MangaFilterInput) {
+  mangas(filter: $filter) {
+    nodes {
+      ...MangaDto
       __typename
     }
+    pageInfo {
+      ...PageInfoDto
+      __typename
+    }
+    totalCount
     __typename
   }
 }

--- a/lib/src/features/library/presentation/library/widgets/library_manga_organizer.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_organizer.dart
@@ -24,6 +24,11 @@ class LibraryMangaOrganizer extends StatelessWidget {
       length: 3,
       child: Scaffold(
         appBar: TabBar(
+          // Non-scrollable tabs: fill alignment keeps the selection underline
+          // aligned under every tab. The global theme defaults to
+          // TabAlignment.center (for the scrollable category tabs), which
+          // misaligns the indicator under the last tab here.
+          tabAlignment: TabAlignment.fill,
           tabs: [
             Tab(text: context.l10n.filter),
             Tab(text: context.l10n.sort),

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -32,6 +32,9 @@ class DownloadsScreen extends ConsumerWidget {
         appBar: AppBar(
           title: Text(context.l10n.downloads),
           bottom: TabBar(
+            // Fill alignment so the underline aligns under each tab (the global
+            // theme's center alignment is for the scrollable category tabs).
+            tabAlignment: TabAlignment.fill,
             tabs: [
               Tab(text: context.l10n.downloadsServerTab),
               Tab(text: context.l10n.downloadsOnDeviceTab),

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_organizer.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_organizer.dart
@@ -19,6 +19,9 @@ class MangaChapterOrganizer extends StatelessWidget {
       length: 2,
       child: Scaffold(
         appBar: TabBar(
+          // Fill alignment so the underline aligns under each tab (the global
+          // theme's center alignment is for the scrollable category tabs).
+          tabAlignment: TabAlignment.fill,
           tabs: [
             Tab(text: context.l10n.filter),
             Tab(text: context.l10n.sort),

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -18,6 +18,7 @@ import '../../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../../utils/misc/app_utils.dart';
 import '../../../../../../../widgets/server_image.dart';
 import '../../../../../../../widgets/zoom/scroll_offset_to_scroll_controller.dart';
+import '../../../../../../settings/presentation/reader/widgets/reader_feedback_toasts_tile/reader_feedback_toasts_tile.dart';
 import '../../../../../../settings/presentation/reader/widgets/reader_pinch_to_zoom/reader_pinch_to_zoom.dart';
 import '../../../../../../settings/presentation/reader/widgets/reader_scroll_animation_tile/reader_scroll_animation_tile.dart';
 import '../../../../../data/manga_book/manga_book_repository.dart';
@@ -79,6 +80,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Whether the reader feedback snackbars are enabled (user setting). Read
+    // live so toggling the setting applies without reopening the reader.
+    bool readerToastsEnabled() =>
+        ref.read(readerFeedbackToastsProvider).ifNull(true);
     final ItemScrollController itemScrollController =
         useMemoized(() => ItemScrollController());
     final ItemPositionsListener positionsListener =
@@ -269,7 +274,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       if (loadedRef.value.any((e) => e.chapterId == next.id)) return;
       loadingNext.value = true;
       try {
-        if (context.mounted) {
+        if (context.mounted && readerToastsEnabled()) {
           InfinityContinuousFeedback.showLoadingNextChapterFeedback(
               context, next.name);
         }
@@ -286,7 +291,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         ];
         // Decode the appended chapter's pages ahead of the user reaching them.
         prefetchPagesFrom(currentGlobalIndex());
-        if (context.mounted) {
+        if (context.mounted && readerToastsEnabled()) {
           InfinityContinuousFeedback.showNextChapterLoadedFeedback(
               context, next.name);
         }
@@ -302,7 +307,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       if (loadedRef.value.any((e) => e.chapterId == prev.id)) return;
       loadingPrevious.value = true;
       try {
-        if (context.mounted) {
+        if (context.mounted && readerToastsEnabled()) {
           InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
               context, prev.name);
         }
@@ -353,7 +358,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           });
         }
 
-        if (context.mounted) {
+        if (context.mounted && readerToastsEnabled()) {
           InfinityContinuousFeedback.showPreviousChapterLoadedFeedback(
               context, prev.name);
         }
@@ -465,15 +470,26 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           if (next != null) {
             loadNextChapter(next);
           } else if (!hasReachedEnd.value) {
-            InfinityContinuousFeedback.showEndOfMangaFeedback(
-                context, lastEndFeedbackTime);
+            // Only surface the end-of-manga toast once the bottom of the very
+            // last page is actually on screen. On long webtoon pages the last
+            // page item becomes "visible" (counts toward maxIdx) long before
+            // the reader reaches its end, which previously spammed the toast on
+            // every scroll. itemTrailingEdge <= 1.0 means the page bottom has
+            // reached (or passed) the viewport bottom.
+            final lastPage = positions.where((p) => p.index == total - 1);
+            final atBottom =
+                lastPage.isNotEmpty && lastPage.first.itemTrailingEdge <= 1.0;
+            if (atBottom && readerToastsEnabled()) {
+              InfinityContinuousFeedback.showEndOfMangaFeedback(
+                  context, lastEndFeedbackTime);
+            }
           }
         }
         if (scrollingUp && minIdx <= 0) {
           final prev = nextPrevChapterPair.value?.second;
           if (prev != null) {
             loadPreviousChapter(prev);
-          } else if (!hasReachedStart.value) {
+          } else if (!hasReachedStart.value && readerToastsEnabled()) {
             InfinityContinuousFeedback.showStartOfMangaFeedback(
                 context, lastStartFeedbackTime);
           }

--- a/lib/src/features/manga_book/widgets/update_status_summary_sheet.dart
+++ b/lib/src/features/manga_book/widgets/update_status_summary_sheet.dart
@@ -83,8 +83,8 @@ class UpdateStatusExpansionTile extends StatelessWidget {
     return ExpansionTile(
       title: Text("$title (${mangas.length.padLeft()})"),
       initiallyExpanded: initiallyExpanded,
-      textColor: context.theme.indicatorColor,
-      iconColor: context.theme.indicatorColor,
+      textColor: context.theme.colorScheme.primary,
+      iconColor: context.theme.colorScheme.primary,
       shape: const RoundedRectangleBorder(),
       children: mangas
           .map((e) => MangaCoverListTile(

--- a/lib/src/features/settings/presentation/library/widgets/skip_updating_entries_popup.dart
+++ b/lib/src/features/settings/presentation/library/widgets/skip_updating_entries_popup.dart
@@ -26,7 +26,7 @@ class SkipUpdatingEntriesPopup extends ConsumerWidget {
           children: [
             CheckboxListTile(
               controlAffinity: ListTileControlAffinity.leading,
-              activeColor: context.theme.indicatorColor,
+              activeColor: context.theme.colorScheme.primary,
               title: Text(context.l10n.withCompletedStatus),
               value: librarySettingsDto?.excludeCompleted.ifNull(),
               onChanged: (value) async {
@@ -41,7 +41,7 @@ class SkipUpdatingEntriesPopup extends ConsumerWidget {
             ),
             CheckboxListTile(
               controlAffinity: ListTileControlAffinity.leading,
-              activeColor: context.theme.indicatorColor,
+              activeColor: context.theme.colorScheme.primary,
               title: Text(context.l10n.thatHaventBeenStarted),
               value: librarySettingsDto?.excludeNotStarted.ifNull(),
               onChanged: (value) async {
@@ -56,7 +56,7 @@ class SkipUpdatingEntriesPopup extends ConsumerWidget {
             ),
             CheckboxListTile(
               controlAffinity: ListTileControlAffinity.leading,
-              activeColor: context.theme.indicatorColor,
+              activeColor: context.theme.colorScheme.primary,
               title: Text(context.l10n.withUnreadChapter),
               value: librarySettingsDto?.excludeUnreadChapters.ifNull(),
               onChanged: (value) async {

--- a/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
+++ b/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
+import 'widgets/reader_feedback_toasts_tile/reader_feedback_toasts_tile.dart';
 import 'widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
 import 'widgets/reader_infinity_scrolling_mode_tile/reader_infinity_scrolling_mode_tile.dart';
 import 'widgets/reader_initial_overlay_tile/reader_initial_overlay_tile.dart';
@@ -45,6 +46,7 @@ class ReaderSettingsScreen extends ConsumerWidget {
           const ReaderLastPageSwipeTile(),
           const ReaderInfinityScrollingModeTile(),
           const ReaderScrollAnimationTile(),
+          const ReaderFeedbackToastsTile(),
           const ReaderPaddingSlider(),
           const ReaderMagnifierSizeSlider(),
           if (!kIsWeb) ...[

--- a/lib/src/features/settings/presentation/reader/widgets/reader_feedback_toasts_tile/reader_feedback_toasts_tile.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_feedback_toasts_tile/reader_feedback_toasts_tile.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'reader_feedback_toasts_tile.g.dart';
+
+@riverpod
+class ReaderFeedbackToasts extends _$ReaderFeedbackToasts
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.readerFeedbackToasts);
+}
+
+class ReaderFeedbackToastsTile extends HookConsumerWidget {
+  const ReaderFeedbackToastsTile({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.notifications_active_outlined),
+      title: Text(context.l10n.readerFeedbackToasts),
+      subtitle: Text(context.l10n.readerFeedbackToastsSubtitle),
+      onChanged: ref.read(readerFeedbackToastsProvider.notifier).update,
+      value: ref.watch(readerFeedbackToastsProvider).ifNull(true),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -811,6 +811,12 @@
     "@readerScrollAnimation": {
         "description": "Switch title to Disable scroll animation in reader screen"
     },
+    "@readerFeedbackToasts": {
+        "description": "Switch title for the toggle that shows reader feedback toasts"
+    },
+    "@readerFeedbackToastsSubtitle": {
+        "description": "Switch subtitle explaining the reader feedback toasts toggle"
+    },
     "@readerSwipeChapterToggle": {
         "description": "Switch title to toggle `swipe to change chapter` in reader screen"
     },
@@ -1440,6 +1446,8 @@
     "readerOverlaySubtitle": "Shows title and quick settings when opening a chapter",
     "readerPadding": "Reader Padding",
     "readerScrollAnimation": "Scroll animation",
+    "readerFeedbackToasts": "Reading feedback toasts",
+    "readerFeedbackToastsSubtitle": "Show messages like \"loading next chapter\" and \"no more chapters\"",
     "readerSwipeChapterToggle": "Swipe toggle",
     "readerSwipeChapterToggleDescription": "Swipe to change chapter in reader",
     "readerLastPageSwipeToggle": "Last page swipe",

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -260,6 +260,10 @@ class QuickSearchRoute extends ShellRouteData {
               .colorScheme
               .surface
               .withValues(alpha: 0.60),
+          systemNavigationBarIconBrightness:
+              Theme.of(context).brightness == Brightness.dark
+                  ? Brightness.light
+                  : Brightness.dark,
           systemNavigationBarDividerColor: Colors.transparent,
         ),
         child: SearchStackScreen(child: navigator),

--- a/lib/src/utils/theme/app_theme_builder.dart
+++ b/lib/src/utils/theme/app_theme_builder.dart
@@ -1,5 +1,6 @@
 // lib/src/utils/theme/app_theme_builder.dart
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../constants/app_theme.dart';
 import 'app_color_scheme.dart';
@@ -47,6 +48,20 @@ ThemeData buildAppTheme({
       surfaceTintColor: Colors.transparent,
       elevation: 0,
       scrolledUnderElevation: 0,
+      // Make the status-bar and bottom system-navigation-bar icons track the
+      // theme brightness. Without this the system nav-bar icons stayed light
+      // and went invisible on the light surface in light themes.
+      systemOverlayStyle: SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        statusBarIconBrightness:
+            brightness == Brightness.dark ? Brightness.light : Brightness.dark,
+        statusBarBrightness:
+            brightness == Brightness.dark ? Brightness.dark : Brightness.light,
+        systemNavigationBarColor: scheme.surface,
+        systemNavigationBarIconBrightness:
+            brightness == Brightness.dark ? Brightness.light : Brightness.dark,
+        systemNavigationBarDividerColor: Colors.transparent,
+      ),
     ),
     tabBarTheme: const TabBarThemeData(tabAlignment: TabAlignment.center),
     // Bottom navigation: brand-tinted selected indicator + accent selection.

--- a/lib/src/widgets/custom_checkbox_list_tile.dart
+++ b/lib/src/widgets/custom_checkbox_list_tile.dart
@@ -42,7 +42,7 @@ class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
   }
 
   Widget _tristateLeading(BuildContext context, bool? value) {
-    final activeColor = context.theme.indicatorColor;
+    final activeColor = context.theme.colorScheme.primary;
     final excludeColor = context.theme.colorScheme.error;
     if (value == null) {
       return Icon(
@@ -62,7 +62,7 @@ class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
     if (!tristate) {
       return CheckboxListTile(
         controlAffinity: ListTileControlAffinity.leading,
-        activeColor: context.theme.indicatorColor,
+        activeColor: context.theme.colorScheme.primary,
         value: val.ifNull(true),
         title: Text(title),
         tristate: false,

--- a/lib/src/widgets/custom_circular_progress_indicator.dart
+++ b/lib/src/widgets/custom_circular_progress_indicator.dart
@@ -32,7 +32,7 @@ class SorayomiShimmerIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return Shimmer.fromColors(
       baseColor: context.colorScheme.surface,
-      highlightColor: context.theme.indicatorColor,
+      highlightColor: context.theme.colorScheme.primary,
       child: ImageIcon(AssetImage(Assets.icons.darkIcon.path)),
     );
   }

--- a/lib/src/widgets/popup_widgets/multi_select_popup.dart
+++ b/lib/src/widgets/popup_widgets/multi_select_popup.dart
@@ -99,7 +99,7 @@ class _CheckboxSelectListState<T> extends State<CheckboxSelectList<T>> {
   ) {
     return CheckboxListTile(
       key: Key(value.key.hashCode.toString()),
-      activeColor: context.theme.indicatorColor,
+      activeColor: context.theme.colorScheme.primary,
       title: Text(
         widget.getTitle?.call(value.key) ?? value.toString(),
       ),

--- a/lib/src/widgets/popup_widgets/radio_list_popup.dart
+++ b/lib/src/widgets/popup_widgets/radio_list_popup.dart
@@ -63,7 +63,7 @@ class RadioList<T> extends StatelessWidget {
 
   Widget getRadioListTile(BuildContext context, T option) {
     return RadioListTile<T>(
-      activeColor: context.theme.indicatorColor,
+      activeColor: context.theme.colorScheme.primary,
       title: Text(
         getTitle?.call(option) ?? option.toString(),
       ),

--- a/lib/src/widgets/sort_list_tile.dart
+++ b/lib/src/widgets/sort_list_tile.dart
@@ -31,7 +31,7 @@ class SortListTile extends StatelessWidget {
 
     return ListTile(
       leading: selected
-          ? Icon(icon, color: context.theme.indicatorColor)
+          ? Icon(icon, color: context.theme.colorScheme.primary)
           : SizedBox(width: context.theme.iconTheme.size),
       title: title,
       subtitle: subtitle,


### PR DESCRIPTION
Four bug fixes, verified on-device. No release intended yet — merging this does not cut a release.

## Library shows entries removed long ago (#27)
The library fetched each category through the category→manga relation, which still returns entries that were removed from the library (the server keeps the rows with `inLibrary=false`). Switched to the top-level `mangas` filter with `inLibrary=true`; the virtual Default category (id 0) is matched by a null `categoryId`. Verified live against a server (Default 77, categories 6/9 — zero removed entries returned).

## Filter dialog: invisible checkboxes + misaligned tab underline (#23)
- The checkboxes coloured their checked state with `theme.indicatorColor`, which resolves to pure white in light themes → white-on-white. Now use `colorScheme.primary`.
- The selection underline used the global `TabAlignment.center` (intended for the scrollable category tabs), which misaligns the indicator on non-scrollable tab bars. Set `TabAlignment.fill` on the non-scrollable bars (filter dialog, chapter filter, downloads).

## Reader: end-of-chapter toast spam + a toggle to silence toasts (#26)
- The "no more chapters" toast fired as soon as the last page became visible, so a long webtoon page re-triggered it on every scroll. It now only fires once the bottom of the last page is actually on screen (the page-load prefetch still triggers early, unchanged).
- Added a "Reading feedback toasts" switch in reader settings (on by default) that suppresses all the continuous-reader feedback snackbars.

## Light-theme visibility (found while testing the above)
- Several widgets used `theme.indicatorColor` (white in light themes) as their active/selected/highlight colour — the display-mode radio, the sort indicator, multi-select, the skip-update checkboxes, and two progress spinners — all invisible in light themes. Switched to `colorScheme.primary`.
- The Android system navigation-bar icons stayed light and disappeared on the light surface. Status-bar and system-nav-bar icon brightness are now driven by the theme.

Closes #23
Closes #26
Closes #27
