### PR TITLE
Show stored chapters when the source is down; add source-refresh toggle

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -59,6 +59,10 @@ enum DBKeys {
   volumeTap(false),
   volumeTapInvert(false),
   hideEmptyCategory(false),
+  // When false (default, Mihon-style), opening an entry shows the chapters the
+  // server already has, without re-scraping the source. When true, also refresh
+  // from the source on open.
+  refreshChaptersFromSource(false),
   pinchToZoom(true),
   // Default to edge-to-edge like Komikku (fullscreen=true + drawUnderCutout):
   // the webtoon strip fills the whole screen, including the status-bar / camera

--- a/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
+++ b/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
@@ -176,6 +176,9 @@ class MangaBookRepository {
         ),
       );
 
+  /// Fetches the chapter list FROM THE SOURCE (the server re-scrapes the source
+  /// site). Returns nothing if the source is down/gone — callers that need to
+  /// survive a dead source should fall back to [getStoredChapterList].
   Future<List<ChapterDto>?> getChapterList(int mangaId) async => client
       .mutate$GetChaptersByMangaId(
         Options$Mutation$GetChaptersByMangaId(
@@ -187,6 +190,25 @@ class MangaBookRepository {
         ),
       )
       .getData((data) => data.fetchChapters?.chapters);
+
+  /// Reads the chapters the server already has STORED for this entry, without
+  /// touching the source. Works whenever the server is reachable, even if the
+  /// source is down — this is what the WebUI shows.
+  Future<List<ChapterDto>?> getStoredChapterList(int mangaId) async => client
+      .query$GetChapterPage(
+        Options$Query$GetChapterPage(
+          variables: Variables$Query$GetChapterPage(
+            condition: Input$ChapterConditionInput(mangaId: mangaId),
+            order: [
+              Input$ChapterOrderInput(
+                by: Enum$ChapterOrderBy.SOURCE_ORDER,
+                byType: Enum$SortOrder.ASC,
+              ),
+            ],
+          ),
+        ),
+      )
+      .getData((data) => data.chapters.nodes);
 }
 
 @riverpod

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -14,6 +14,7 @@ import '../../../../../constants/enum.dart';
 import '../../../../../features/offline/data/offline_download_providers.dart';
 import '../../../../../features/offline/data/offline_read_fallback.dart';
 import '../../../../../features/offline/data/offline_repository.dart';
+import '../../../../../features/settings/presentation/library/widgets/refresh_chapters_from_source_tile/refresh_chapters_from_source_tile.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../library/domain/category/category_model.dart';
@@ -50,9 +51,27 @@ class MangaWithId extends _$MangaWithId {
 class MangaChapterList extends _$MangaChapterList {
   @override
   Future<List<ChapterDto>?> build({required int mangaId}) async {
+    final repo = ref.watch(mangaBookRepositoryProvider);
+    final refreshFromSource =
+        ref.watch(refreshChaptersFromSourceProvider).ifNull();
     final result = await chaptersWithOfflineFallback(
-      fetch: () =>
-          ref.watch(mangaBookRepositoryProvider).getChapterList(mangaId),
+      fetch: () async {
+        // Read the chapters the server already has stored (like the WebUI).
+        final stored = await repo.getStoredChapterList(mangaId);
+        // Show them as-is unless the source has never been fetched (no chapters
+        // yet) or the user opted into refreshing from the source on open.
+        if (!refreshFromSource && stored != null && stored.isNotEmpty) {
+          return stored;
+        }
+        try {
+          final fetched = await repo.getChapterList(mangaId);
+          if (fetched != null && fetched.isNotEmpty) return fetched;
+        } catch (_) {
+          // Source down / gone — fall back to the server's stored chapters
+          // instead of showing an empty list (issue #28).
+        }
+        return stored;
+      },
       db: ref.watch(offlineDatabaseProvider),
       offlineEnabled: ref.watch(offlineEnabledProvider),
       mangaId: mangaId,
@@ -68,8 +87,19 @@ class MangaChapterList extends _$MangaChapterList {
   }
 
   Future<void> refresh([bool onlineFetch = false]) async {
-    final result = await AsyncValue.guard(
-        () => ref.read(mangaBookRepositoryProvider).getChapterList(mangaId));
+    final repo = ref.read(mangaBookRepositoryProvider);
+    // An explicit refresh always tries the source, but falls back to the
+    // server's stored chapters if the source is unavailable (rather than
+    // erroring or clearing the list).
+    final result = await AsyncValue.guard(() async {
+      try {
+        final fetched = await repo.getChapterList(mangaId);
+        if (fetched != null && fetched.isNotEmpty) return fetched;
+      } catch (_) {
+        // fall through to stored
+      }
+      return repo.getStoredChapterList(mangaId);
+    });
     ref.keepAlive();
     if (result.hasError) {
       state = result.copyWithPrevious(state);

--- a/lib/src/features/settings/presentation/library/library_settings_screen.dart
+++ b/lib/src/features/settings/presentation/library/library_settings_screen.dart
@@ -18,6 +18,7 @@ import '../../../../widgets/section_title.dart';
 import '../../controller/server_controller.dart';
 import '../../domain/settings/settings.dart';
 import 'data/library_settings_repository.dart';
+import 'widgets/refresh_chapters_from_source_tile/refresh_chapters_from_source_tile.dart';
 import 'widgets/skip_updating_entries_popup.dart';
 
 class LibrarySettingsScreen extends ConsumerWidget {
@@ -74,6 +75,7 @@ class LibrarySettingsScreen extends ConsumerWidget {
                     onTap: () => const EditCategoriesRoute().go(context),
                   ),
                   // HideEmptyCategoryTile(),
+                  const RefreshChaptersFromSourceTile(),
                   SectionTitle(title: context.l10n.globalUpdate),
                   SettingsPropTile(
                     leading: const Icon(Icons.autorenew_rounded),

--- a/lib/src/features/settings/presentation/library/widgets/refresh_chapters_from_source_tile/refresh_chapters_from_source_tile.dart
+++ b/lib/src/features/settings/presentation/library/widgets/refresh_chapters_from_source_tile/refresh_chapters_from_source_tile.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'refresh_chapters_from_source_tile.g.dart';
+
+@riverpod
+class RefreshChaptersFromSource extends _$RefreshChaptersFromSource
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.refreshChaptersFromSource);
+}
+
+class RefreshChaptersFromSourceTile extends HookConsumerWidget {
+  const RefreshChaptersFromSourceTile({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.sync_rounded),
+      title: Text(context.l10n.refreshChaptersFromSource),
+      subtitle: Text(context.l10n.refreshChaptersFromSourceSubtitle),
+      onChanged: ref.read(refreshChaptersFromSourceProvider.notifier).update,
+      value: ref.watch(refreshChaptersFromSourceProvider).ifNull(),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -105,6 +105,12 @@
     "@automaticUpdate": {
         "description": "Popup title and Settings text to update Automatic Global Update interval"
     },
+    "@refreshChaptersFromSource": {
+        "description": "Switch title for refreshing chapters from the source when opening an entry"
+    },
+    "@refreshChaptersFromSourceSubtitle": {
+        "description": "Switch subtitle explaining the refresh-chapters-from-source toggle"
+    },
     "@automaticallyRefreshMetadata": {
         "description": "Settings text to update Automatically refresh metadata"
     },
@@ -1096,6 +1102,8 @@
     "autoDownloadNewChapters": "Download new chapters",
     "automaticBackup": "Automatic Backup",
     "automaticUpdate": "Automatic Update",
+    "refreshChaptersFromSource": "Refresh chapters from source",
+    "refreshChaptersFromSourceSubtitle": "When off, opening an entry shows the chapters already on the server. When on, also check the source for new chapters.",
     "automaticallyRefreshMetadata": "Automatically refresh metadata",
     "automaticallyRefreshMetadataSubtitle": "Check for new cover and details when updating library",
     "backup": "Backup & Restore",


### PR DESCRIPTION
Opening an entry loaded its chapter list with the `fetchChapters` mutation, which makes the server re-scrape the source on every open. When the source was down or gone the scrape returned nothing, so the chapter list showed empty even though the server still had the chapters stored (the WebUI shows them). It also made every open slower.

**Changes**
- On open, read the server's **stored** chapters (the `chapters` query) instead of scraping the source.
- The source is only scraped when there are no stored chapters yet (a new entry) or the user opts in. If a scrape fails, fall back to the stored list rather than clearing it.
- Pull-to-refresh still tries the source first, with the same stored fallback.
- New **"Refresh chapters from source"** toggle in Library settings (off by default, Mihon-style): off shows server data only, on also checks the source on open.
- Offline reading (server unreachable) is unchanged — the stored read still throws through to the existing offline-DB fallback.

Verified live against a server: the stored-chapters query returned all 126 chapters for a test entry with no source scrape. All tests pass.

Closes #28
