### PR TITLE
Add tracker support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,9 +30,22 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <!-- Deep links (tsumiru://tracker-oauth) are handled by the app_links
+                 listener in main.dart, NOT go_router. Disable Flutter's automatic
+                 deep-link -> Router forwarding so the OAuth callback doesn't hit
+                 the router as an unknown route ("Page Not Found"). -->
+            <meta-data
+              android:name="flutter_deeplinking_enabled"
+              android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="tsumiru" android:host="tracker-oauth"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -72,5 +72,18 @@
 			<string>vi</string>
 			<string>fil</string>
 		</array>
-	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>tsumiru</string>
+			</array>
+		</dict>
+	</array>
+		<key>FlutterDeepLinkingEnabled</key>
+	<false/>
+</dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@
 
 import 'dart:async';
 
+import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -31,8 +32,11 @@ import 'src/features/settings/presentation/server/widget/client/server_port_tile
 import 'src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import 'src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
 import 'src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart';
+import 'src/features/tracking/data/tracker_repository.dart';
+import 'src/features/tracking/domain/tracker_oauth_helpers.dart';
 import 'src/global_providers/global_providers.dart';
 import 'src/sorayomi.dart';
+import 'src/utils/misc/toast/toast.dart';
 import 'src/utils/platform/is_android_native.dart';
 
 Future<void> main() async {
@@ -152,6 +156,8 @@ Future<void> main() async {
     debugPrint('test-config seed failed: $e\n$st');
   }
 
+  _setupDeepLinkListener(container);
+
   // 7) Sweep any chapter left mid-download by a prior crash/kill back to a
   //    clean state so it can be retried. Fire-and-forget; native only.
   if (offlineStorage != null) {
@@ -180,6 +186,52 @@ Future<void> main() async {
       container: container,
       child: const Sorayomi(),
     ),
+  );
+}
+
+/// Sets up the AppLinks deep-link listener so that OAuth callbacks of the form
+/// `tsumiru://tracker-oauth?...&state=...` are handled automatically.
+///
+/// Checks for an initial link (cold-start) and subscribes to the uriLinkStream
+/// (warm-start). Both paths parse the tracker ID from the `state` query param,
+/// call `loginOAuth`, and invalidate `trackersProvider`.
+void _setupDeepLinkListener(ProviderContainer container) {
+  final appLinks = AppLinks();
+
+  Future<void> handleUri(Uri uri) async {
+    if (uri.scheme != 'tsumiru' || uri.host != 'tracker-oauth') return;
+    final trackerId = parseTrackerIdFromCallback(uri);
+    if (trackerId == null) {
+      debugPrint('tracker-oauth callback: missing/invalid trackerId in state');
+      return;
+    }
+    try {
+      await container.read(trackerRepositoryProvider).loginOAuth(
+            trackerId: trackerId,
+            callbackUrl: uri.toString(),
+          );
+      container.invalidate(trackersProvider);
+    } catch (e) {
+      debugPrint('tracker-oauth loginOAuth failed: $e');
+      try {
+        container.read(toastProvider)?.showError(e.toString());
+      } catch (_) {
+        // toast unavailable before widget binding
+      }
+    }
+  }
+
+  // Cold-start: the app was launched via a deep link.
+  appLinks.getInitialLink().then((uri) {
+    if (uri != null) unawaited(handleUri(uri));
+  }).catchError((e) {
+    debugPrint('AppLinks.getInitialLink error: $e');
+  });
+
+  // Warm-start: the app was already running and received a deep link.
+  appLinks.uriLinkStream.listen(
+    (uri) => unawaited(handleUri(uri)),
+    onError: (e) => debugPrint('AppLinks.uriLinkStream error: $e'),
   );
 }
 

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -95,6 +95,8 @@ enum DBKeys {
   // The release version the user chose to skip in the update prompt. The
   // prompt stays hidden until a release newer than this one appears.
   dismissedUpdateVersion(''),
+  updateProgressAfterReading(true),
+  updateProgressManualMarkRead(true),
   ;
 
   const DBKeys(this.initial);

--- a/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
+++ b/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
@@ -41,6 +41,9 @@ fragment MangaDto on MangaType {
   thumbnailUrl
   thumbnailUrlLastFetched
   title
+  trackRecords {
+    totalCount
+  }
   unreadCount
   updateStrategy
   url

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -373,6 +373,7 @@ class MangaDetailsScreen extends HookConsumerWidget {
                     afterOptionSelected: chapterListRefresh,
                     selectedChapters: selectedChapters,
                     chapterList: filteredChapterList.value,
+                    mangaId: mangaId,
                   ),
                 ),
             ],

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -22,6 +22,7 @@ import '../../../../../widgets/manga_cover/list/manga_cover_descriptive_list_til
 import '../../../../../widgets/server_image.dart';
 import '../../../../offline/data/offline_repository.dart';
 import '../../../../offline/presentation/series_offline_button.dart';
+import '../../../../tracking/presentation/hub/track_sheet.dart';
 import '../../../domain/manga/manga_model.dart';
 import '../controller/next_update_controller.dart';
 import 'manga_action_button.dart';
@@ -44,6 +45,59 @@ class MangaDescription extends HookConsumerWidget {
     final cs = context.theme.colorScheme;
     final surface = context.theme.scaffoldBackgroundColor;
     final inLibrary = manga.inLibrary.ifNull();
+
+    final prediction =
+        ref.watch(mangaNextUpdateProvider(mangaId: manga.id));
+    final soonDays = manga.status == Enum$MangaStatus.COMPLETED
+        ? null
+        : prediction?.daysUntil(DateTime.now());
+
+    // Build the Soon line for the header metadata column.
+    final soonWidget = soonDays == null
+        ? null
+        : GestureDetector(
+            onTap: () => showDialog<void>(
+              context: context,
+              builder: (dialogContext) => AlertDialog(
+                title: Text(context.l10n.smartUpdate),
+                content: Text(
+                  context.l10n.smartUpdateExpected(
+                    context.l10n.dayCount(soonDays),
+                    context.l10n
+                        .dayCount(prediction?.intervalDays ?? 7),
+                  ),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(dialogContext).pop(),
+                    child: Text(context.l10n.close),
+                  ),
+                ],
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.hourglass_empty_rounded,
+                  size: 14,
+                  color: soonDays <= 1
+                      ? cs.primary
+                      : context.textTheme.bodySmall?.color,
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  soonDays == 0
+                      ? context.l10n.soon
+                      : context.l10n.inNDays(soonDays),
+                  style: context.textTheme.bodySmall?.copyWith(
+                    color: soonDays <= 1 ? cs.primary : null,
+                  ),
+                ),
+              ],
+            ),
+          );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -103,6 +157,7 @@ class MangaDescription extends HookConsumerWidget {
                 showBadges: false,
                 onTitleClicked: (query) =>
                     GlobalSearchRoute(query: query).push(context),
+                belowStatus: soonWidget,
               ),
             ),
           ],
@@ -110,11 +165,6 @@ class MangaDescription extends HookConsumerWidget {
         Builder(builder: (context) {
           // Komikku-style action row: equal-width icon-over-label columns.
           final offlineEnabled = ref.watch(offlineEnabledProvider);
-          final prediction =
-              ref.watch(mangaNextUpdateProvider(mangaId: manga.id));
-          final soonDays = manga.status == Enum$MangaStatus.COMPLETED
-              ? null
-              : prediction?.daysUntil(DateTime.now());
           return Padding(
             padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 8.0),
             child: Row(
@@ -145,39 +195,16 @@ class MangaDescription extends HookConsumerWidget {
                     },
                   ),
                 ),
+                Expanded(
+                  child: MangaActionButton(
+                    active: manga.trackRecords.totalCount > 0,
+                    icon: const Icon(Icons.sync_rounded),
+                    label: context.l10n.tracking,
+                    onPressed: () => showTrackSheet(context, manga.id, mangaTitle: manga.title),
+                  ),
+                ),
                 if (offlineEnabled)
                   Expanded(child: SeriesOfflineButton(mangaId: manga.id)),
-                if (soonDays != null)
-                  Expanded(
-                    child: MangaActionButton(
-                      active: soonDays <= 1,
-                      icon: const Icon(Icons.hourglass_empty_rounded),
-                      label: soonDays == 0
-                          ? context.l10n.soon
-                          : context.l10n.inNDays(soonDays),
-                      // Tapping explains the estimate (Komikku's "Smart update").
-                      onPressed: () => showDialog<void>(
-                        context: context,
-                        builder: (dialogContext) => AlertDialog(
-                          title: Text(context.l10n.smartUpdate),
-                          content: Text(
-                            context.l10n.smartUpdateExpected(
-                              context.l10n.dayCount(soonDays),
-                              context.l10n
-                                  .dayCount(prediction?.intervalDays ?? 7),
-                            ),
-                          ),
-                          actions: [
-                            TextButton(
-                              onPressed: () =>
-                                  Navigator.of(dialogContext).pop(),
-                              child: Text(context.l10n.close),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
                 if (manga.realUrl.isNotBlank)
                   Expanded(
                     child: MangaActionButton(

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -18,6 +18,7 @@ import '../../../offline/data/offline_download_providers.dart';
 import '../../../settings/presentation/incognito/incognito_mode.dart';
 import '../../../settings/presentation/reader/widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
 import '../../../settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart';
+import '../../../tracking/domain/track_progress_gate.dart';
 import '../../domain/manga/manga_model.dart';
 import '../manga_details/controller/manga_details_controller.dart';
 import 'controller/reader_controller.dart';
@@ -73,6 +74,15 @@ class ReaderScreen extends HookConsumerWidget {
         lastPageRead: isReadingCompleted ? 0 : currentPage,
         isRead: isReadingCompleted,
       );
+
+      // Push progress to external trackers when the toggle is on and the
+      // manga has at least one tracker bound. Fire-and-forget.
+      unawaited(maybeTrackProgressOnReadFetch(
+        ref,
+        mangaId: mangaId,
+        isRead: isReadingCompleted,
+        manual: false,
+      ));
 
       // Invalidate history to refresh the reading progress
       ref.invalidate(readingHistoryProvider);

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -26,6 +26,7 @@ import '../../../../../domain/chapter/chapter_model.dart';
 import '../../../../../domain/chapter_batch/chapter_batch_model.dart';
 import '../../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../../domain/manga/manga_model.dart';
+import '../../../../../../tracking/domain/track_progress_gate.dart';
 import '../../../../manga_details/controller/manga_details_controller.dart';
 import '../../../controller/reader_controller.dart';
 import '../../reader_wrapper.dart';
@@ -704,7 +705,15 @@ void _markChapterRead(
     if (result.hasError) {
       completedChapterIds.value = {...completedChapterIds.value}
         ..remove(chapter.id);
+      return;
     }
+    // Push progress to external trackers (fire-and-forget).
+    unawaited(maybeTrackProgressOnReadFetch(
+      ref,
+      mangaId: mangaId,
+      isRead: true,
+      manual: false,
+    ));
     // NOTE: deliberately do NOT invalidate chapterProvider / mangaChapterList
     // here. Doing so while reading rebuilds ReaderScreen through an async reload,
     // which remounts this list and re-applies initialScrollIndex (now 0 from the

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -4,12 +4,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
+import '../../../tracking/domain/track_progress_gate.dart';
 import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/chapter_batch/chapter_batch_model.dart';
 
@@ -20,6 +23,7 @@ class MultiChaptersActionIcon extends ConsumerWidget {
     required this.change,
     required this.refresh,
     this.icon,
+    this.mangaId,
     super.key,
   });
   final List<int> chapterList;
@@ -27,6 +31,12 @@ class MultiChaptersActionIcon extends ConsumerWidget {
   final AsyncValueSetter<bool> refresh;
   final IconData? iconData;
   final Widget? icon;
+  /// When non-null, fires [maybeTrackProgressOnReadFetch] after marking read.
+  /// Pass only for single-manga contexts (e.g. the manga-details screen).
+  /// Omit (null) for multi-manga contexts (e.g. the updates screen) where the
+  /// chapters may belong to different manga.
+  final int? mangaId;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return IconButton(
@@ -42,6 +52,17 @@ class MultiChaptersActionIcon extends ConsumerWidget {
         );
         if (context.mounted) {
           result.showToastOnError(ref.read(toastProvider));
+        }
+        // Fire tracker sync when this is a mark-read action on a single manga.
+        final isMarkRead = change.isRead == true;
+        final id = mangaId;
+        if (!result.hasError && isMarkRead && id != null) {
+          unawaited(maybeTrackProgressOnReadFetch(
+            ref,
+            mangaId: id,
+            isRead: true,
+            manual: true,
+          ));
         }
         await refresh(true);
       },

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -25,11 +25,16 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
     required this.selectedChapters,
     required this.afterOptionSelected,
     this.chapterList,
+    this.mangaId,
   });
 
   final ValueNotifier<Map<int, ChapterDto>> selectedChapters;
   final AsyncCallback afterOptionSelected;
   final List<ChapterDto>? chapterList;
+  /// When non-null, tracker progress is fired after a mark-read action.
+  /// Pass only from single-manga screens (manga-details). Omit from
+  /// multi-manga screens (updates) where chapters span different manga.
+  final int? mangaId;
 
   List<int> get selectedChapterList => selectedChapters.value.keys.toList();
 
@@ -69,6 +74,7 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
           chapterList: selectedChapterList,
           change: ChapterChange(isRead: true, lastPageRead: 0),
           refresh: refresh,
+          mangaId: mangaId,
         ),
         MultiChaptersActionIcon(
           iconData: Icons.remove_done_rounded,

--- a/lib/src/features/migration/data/migration_repository.dart
+++ b/lib/src/features/migration/data/migration_repository.dart
@@ -16,6 +16,7 @@ import '../../browse_center/domain/source/source_model.dart';
 import '../../manga_book/data/manga_book/__generated__/query.graphql.dart';
 import '../../manga_book/domain/chapter/chapter_model.dart';
 import '../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import '../../tracking/data/tracker_repository.dart';
 import '../domain/migration_models.dart';
 
 part 'migration_repository.g.dart';
@@ -338,7 +339,35 @@ class MigrationRepositoryImpl implements MigrationRepository {
         }
       }
 
-      // Step 4: Remove source manga from library if deleteSource is enabled
+      // Step 4: Migrate tracking records if enabled
+      int migratedTracking = 0;
+      if (options.migrateTracking) {
+        try {
+          final trackerRepo = TrackerRepository(client);
+          final sourceRecords =
+              await trackerRepo.getMangaTrackRecords(fromMangaId);
+          if (sourceRecords != null) {
+            for (final record in sourceRecords) {
+              try {
+                await trackerRepo.bind(
+                  mangaId: toMangaId,
+                  trackerId: record.trackerId,
+                  remoteId: record.remoteId,
+                  private: record.private,
+                );
+                migratedTracking++;
+              } catch (e) {
+                warnings.add(
+                    'Failed to migrate tracking record (tracker ${record.trackerId}): $e');
+              }
+            }
+          }
+        } catch (e) {
+          warnings.add('Tracking migration failed: $e');
+        }
+      }
+
+      // Step 5: Remove source manga from library if deleteSource is enabled
       if (options.deleteSource && sourceManga.inLibrary) {
         final removeFromLibraryResult = await client.mutate$UpdateManga(
           Options$Mutation$UpdateManga(
@@ -367,11 +396,15 @@ class MigrationRepositoryImpl implements MigrationRepository {
       if (migratedCategories > 0) {
         warnings.add('• Categories migrated: $migratedCategories');
       }
+      if (migratedTracking > 0) {
+        warnings.add('• Tracking records migrated: $migratedTracking');
+      }
 
       return MigrationResult(
         success: true,
         migratedChapters: migratedChapters,
         migratedCategories: migratedCategories,
+        migratedTracking: migratedTracking,
         warnings: warnings,
       );
     } catch (e) {

--- a/lib/src/features/migration/domain/migration_models.dart
+++ b/lib/src/features/migration/domain/migration_models.dart
@@ -52,6 +52,7 @@ class MigrationResult with _$MigrationResult {
     Fragment$MangaDto? newManga,
     @Default(0) int migratedCategories,
     @Default(0) int migratedDownloads,
+    @Default(0) int migratedTracking,
   }) = _MigrationResult;
 
   factory MigrationResult.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/features/migration/presentation/widgets/migration_options_widget.dart
+++ b/lib/src/features/migration/presentation/widgets/migration_options_widget.dart
@@ -85,6 +85,16 @@ class MigrationOptionsWidget extends StatelessWidget {
                   options.copyWith(migrateCategories: value ?? false)),
             ),
 
+            // Migrate tracking
+            _OptionTile(
+              icon: Icons.track_changes_outlined,
+              title: l10n.migrateTracking,
+              subtitle: l10n.migrateTrackingDescription,
+              value: options.migrateTracking,
+              onChanged: (value) =>
+                  onChanged(options.copyWith(migrateTracking: value ?? false)),
+            ),
+
             // Delete source manga
             const SizedBox(height: 8),
             Container(

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -13,16 +13,21 @@ import '../../../constants/enum.dart';
 import '../../../global_providers/global_providers.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../../utils/logger/logger.dart';
+import '../../../utils/misc/toast/toast.dart';
 import '../../../utils/platform/is_android_native.dart';
 import '../../auth/data/auth_credentials_store.dart';
-import 'background/background_download_controller_shim.dart';
-import 'chapter_download_engine.dart';
 import '../../manga_book/data/downloads/downloads_repository.dart';
 import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import '../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
+import '../../tracking/controller/manga_track_records_controller.dart';
+import '../../tracking/data/tracker_repository.dart';
+import '../../tracking/domain/track_progress_gate.dart';
+import '../../tracking/domain/tracking_settings_providers.dart';
+import 'background/background_download_controller_shim.dart';
+import 'chapter_download_engine.dart';
 import 'offline_background_downloads.dart';
 import 'offline_database.dart';
 import 'offline_download_coordinator.dart';
@@ -147,10 +152,19 @@ Future<void> recordReadingProgress(
 /// Push any locally-recorded read progress that hasn't reached the server yet
 /// (e.g. read while offline). Run at launch + after a manga's chapters sync, so
 /// progress made offline syncs up once the connection returns.
+///
+/// After a successful server push, also nudges the manga's external trackers
+/// for any chapter that was marked read — so trackers stay in sync even when
+/// progress was recorded while the device was offline.
 Future<void> pushPendingProgress(ProviderContainer container) async {
   if (!container.read(offlineEnabledProvider)) return;
   final db = container.read(offlineDatabaseProvider);
   final repo = container.read(mangaBookRepositoryProvider);
+
+  // Collect manga IDs where progress was pushed successfully AND the chapter
+  // is marked read — deduplicated so we call trackProgress once per manga.
+  final syncedReadMangaIds = <int>{};
+
   for (final c in await db.dirtyProgressChapters()) {
     final result = await AsyncValue.guard(
       () => repo.putChapter(
@@ -158,7 +172,46 @@ Future<void> pushPendingProgress(ProviderContainer container) async {
         patch: ChapterChange(lastPageRead: c.lastPageRead, isRead: c.isRead),
       ),
     );
-    if (!result.hasError) await db.clearProgressDirty(c.id);
+    if (!result.hasError) {
+      await db.clearProgressDirty(c.id);
+      if (c.isRead) syncedReadMangaIds.add(c.mangaId);
+    }
+  }
+
+  // Push tracker progress for each manga that had read chapters synced.
+  // Gate on the "update after reading" toggle and whether the manga has any
+  // tracker bindings. A tracker failure must never break the progress sync.
+  if (syncedReadMangaIds.isEmpty) return;
+  final enabledAfterReading =
+      container.read(updateProgressAfterReadingProvider).ifNull();
+
+  for (final mangaId in syncedReadMangaIds) {
+    try {
+      final records = await container
+          .read(mangaTrackRecordsProvider(mangaId: mangaId).future);
+      if (!shouldTrackProgress(
+        isRead: true,
+        enabledAfterReading: enabledAfterReading,
+        enabledManualMarkRead: false,
+        manual: false,
+        trackRecordCount: records.length,
+      )) {
+        continue;
+      }
+      final trackResult = await AsyncValue.guard(
+        () => container.read(trackerRepositoryProvider).trackProgress(mangaId),
+      );
+      // Show an error toast if available (null when no widget context — e.g.
+      // at launch before the navigator is mounted, or in tests).
+      try {
+        trackResult.showToastOnError(container.read(toastProvider));
+      } catch (_) {
+        // No widget binding yet — toast is best-effort; swallow silently.
+      }
+    } catch (e) {
+      // Swallow — tracker errors must not interrupt the offline→server sync.
+      logger.e('Offline: tracker push skipped for manga $mangaId: $e');
+    }
   }
 }
 

--- a/lib/src/features/offline/data/offline_dto_mappers.dart
+++ b/lib/src/features/offline/data/offline_dto_mappers.dart
@@ -32,6 +32,7 @@ MangaDto offlineMangaToDto(OfflineManga m, {int chapterCount = 0}) =>
       meta: const <Fragment$MangaDto$meta>[],
       sourceId: '0',
       status: Enum$MangaStatus.UNKNOWN,
+      trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0),
       unreadCount: 0,
       updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
       url: '',

--- a/lib/src/features/settings/presentation/settings/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings/settings_screen.dart
@@ -61,6 +61,11 @@ class SettingsScreen extends StatelessWidget {
             onTap: () => const BackupRoute().go(context),
           ),
           ListTile(
+            title: Text(context.l10n.tracking),
+            leading: const Icon(Icons.sync_rounded),
+            onTap: () => const TrackingSettingsRoute().go(context),
+          ),
+          ListTile(
             title: Text(context.l10n.server),
             subtitle: Text(context.l10n.serverSettingsSubtitle),
             leading: const Icon(Icons.computer_rounded),

--- a/lib/src/features/tracking/controller/manga_track_records_controller.dart
+++ b/lib/src/features/tracking/controller/manga_track_records_controller.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/graphql/__generated__/query.graphql.dart';
+import '../data/tracker_repository.dart';
+
+part 'manga_track_records_controller.g.dart';
+
+@riverpod
+Future<List<Fragment$TrackRecordDto>> mangaTrackRecords(
+  Ref ref, {
+  required int mangaId,
+}) async {
+  final repo = ref.watch(trackerRepositoryProvider);
+  return await repo.getMangaTrackRecords(mangaId) ?? [];
+}

--- a/lib/src/features/tracking/controller/tracker_search_controller.dart
+++ b/lib/src/features/tracking/controller/tracker_search_controller.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/graphql/__generated__/query.graphql.dart';
+import '../data/tracker_repository.dart';
+
+part 'tracker_search_controller.g.dart';
+
+@riverpod
+Future<List<Fragment$TrackSearchDto>> searchTracker(
+  Ref ref, {
+  required int trackerId,
+  required String query,
+}) async {
+  final repo = ref.watch(trackerRepositoryProvider);
+  return await repo.search(trackerId: trackerId, query: query) ?? [];
+}

--- a/lib/src/features/tracking/data/graphql/query.graphql
+++ b/lib/src/features/tracking/data/graphql/query.graphql
@@ -1,0 +1,89 @@
+fragment TrackerDto on TrackerType {
+  id
+  name
+  icon
+  isLoggedIn
+  isTokenExpired
+  authUrl
+  supportsTrackDeletion
+  supportsPrivateTracking
+  supportsReadingDates
+  scores
+  statuses { name value }
+}
+
+fragment TrackRecordDto on TrackRecordType {
+  id
+  trackerId
+  remoteId
+  title
+  remoteUrl
+  status
+  lastChapterRead
+  totalChapters
+  score
+  displayScore
+  startDate
+  finishDate
+  private
+}
+
+fragment TrackSearchDto on TrackSearchType {
+  remoteId
+  title
+  coverUrl
+  publishingType
+  publishingStatus
+  summary
+  trackingUrl
+}
+
+query GetTrackers { trackers { nodes { ...TrackerDto } } }
+
+query GetMangaTrackRecords($mangaId: Int!) {
+  manga(id: $mangaId) { id trackRecords { nodes { ...TrackRecordDto } totalCount } }
+}
+
+query SearchTracker($trackerId: Int!, $query: String!) {
+  searchTracker(input: { trackerId: $trackerId, query: $query }) {
+    trackSearches { ...TrackSearchDto }
+  }
+}
+
+mutation TrackerLoginOAuth($trackerId: Int!, $callbackUrl: String!) {
+  loginTrackerOAuth(input: { trackerId: $trackerId, callbackUrl: $callbackUrl }) {
+    tracker { ...TrackerDto }
+  }
+}
+
+mutation TrackerLoginCredentials($trackerId: Int!, $username: String!, $password: String!) {
+  loginTrackerCredentials(input: { trackerId: $trackerId, username: $username, password: $password }) {
+    tracker { ...TrackerDto }
+  }
+}
+
+mutation TrackerLogout($trackerId: Int!) {
+  logoutTracker(input: { trackerId: $trackerId }) { tracker { ...TrackerDto } }
+}
+
+mutation BindTrack($mangaId: Int!, $trackerId: Int!, $remoteId: LongString!, $private: Boolean!) {
+  bindTrack(input: { mangaId: $mangaId, trackerId: $trackerId, remoteId: $remoteId, private: $private }) {
+    trackRecord { ...TrackRecordDto }
+  }
+}
+
+mutation UpdateTrack($input: UpdateTrackInput!) {
+  updateTrack(input: $input) { trackRecord { ...TrackRecordDto } }
+}
+
+mutation UnbindTrack($recordId: Int!, $deleteRemoteTrack: Boolean) {
+  unbindTrack(input: { recordId: $recordId, deleteRemoteTrack: $deleteRemoteTrack }) { trackRecord { id } }
+}
+
+mutation FetchTrack($recordId: Int!) {
+  fetchTrack(input: { recordId: $recordId }) { trackRecord { ...TrackRecordDto } }
+}
+
+mutation TrackProgress($mangaId: Int!) {
+  trackProgress(input: { mangaId: $mangaId }) { trackRecords { id } }
+}

--- a/lib/src/features/tracking/data/tracker_repository.dart
+++ b/lib/src/features/tracking/data/tracker_repository.dart
@@ -1,0 +1,180 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../global_providers/global_providers.dart';
+import '../../../graphql/__generated__/schema.graphql.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import 'graphql/__generated__/query.graphql.dart';
+
+part 'tracker_repository.g.dart';
+
+class TrackerRepository {
+  const TrackerRepository(this.client);
+  final GraphQLClient client;
+
+  Future<List<Fragment$TrackerDto>?> getTrackers() => client
+      .query$GetTrackers(Options$Query$GetTrackers())
+      .getData((data) => data.trackers.nodes);
+
+  Future<void> loginOAuth({
+    required int trackerId,
+    required String callbackUrl,
+  }) =>
+      client
+          .mutate$TrackerLoginOAuth(
+            Options$Mutation$TrackerLoginOAuth(
+              variables: Variables$Mutation$TrackerLoginOAuth(
+                trackerId: trackerId,
+                callbackUrl: callbackUrl,
+              ),
+            ),
+          )
+          .getData((d) => d);
+
+  Future<void> loginCredentials({
+    required int trackerId,
+    required String username,
+    required String password,
+  }) =>
+      client
+          .mutate$TrackerLoginCredentials(
+            Options$Mutation$TrackerLoginCredentials(
+              variables: Variables$Mutation$TrackerLoginCredentials(
+                trackerId: trackerId,
+                username: username,
+                password: password,
+              ),
+            ),
+          )
+          .getData((d) => d);
+
+  Future<void> logout(int trackerId) => client
+      .mutate$TrackerLogout(
+        Options$Mutation$TrackerLogout(
+          variables: Variables$Mutation$TrackerLogout(trackerId: trackerId),
+        ),
+      )
+      .getData((d) => d);
+
+  Future<List<Fragment$TrackSearchDto>?> search({
+    required int trackerId,
+    required String query,
+  }) =>
+      client
+          .query$SearchTracker(
+            Options$Query$SearchTracker(
+              variables: Variables$Query$SearchTracker(
+                trackerId: trackerId,
+                query: query,
+              ),
+            ),
+          )
+          .getData((data) => data.searchTracker.trackSearches);
+
+  Future<void> bind({
+    required int mangaId,
+    required int trackerId,
+    required String remoteId,
+    required bool private,
+  }) =>
+      client
+          .mutate$BindTrack(
+            Options$Mutation$BindTrack(
+              variables: Variables$Mutation$BindTrack(
+                mangaId: mangaId,
+                trackerId: trackerId,
+                remoteId: remoteId,
+                private: private,
+              ),
+            ),
+          )
+          .getData((d) => d);
+
+  Future<void> update({
+    required int recordId,
+    int? status,
+    String? scoreString,
+    double? lastChapterRead,
+    String? startDate,
+    String? finishDate,
+    bool? private,
+  }) =>
+      client
+          .mutate$UpdateTrack(
+            Options$Mutation$UpdateTrack(
+              variables: Variables$Mutation$UpdateTrack(
+                input: Input$UpdateTrackInput(
+                  recordId: recordId,
+                  status: status,
+                  scoreString: scoreString,
+                  lastChapterRead: lastChapterRead,
+                  startDate: startDate,
+                  finishDate: finishDate,
+                  private: private,
+                ),
+              ),
+            ),
+          )
+          .getData((d) => d);
+
+  Future<void> unbind({
+    required int recordId,
+    bool? deleteRemoteTrack,
+  }) =>
+      client
+          .mutate$UnbindTrack(
+            Options$Mutation$UnbindTrack(
+              variables: Variables$Mutation$UnbindTrack(
+                recordId: recordId,
+                deleteRemoteTrack: deleteRemoteTrack,
+              ),
+            ),
+          )
+          .getData((d) => d);
+
+  Future<void> fetch(int recordId) => client
+      .mutate$FetchTrack(
+        Options$Mutation$FetchTrack(
+          variables: Variables$Mutation$FetchTrack(recordId: recordId),
+        ),
+      )
+      .getData((d) => d);
+
+  Future<void> trackProgress(int mangaId) => client
+      .mutate$TrackProgress(
+        Options$Mutation$TrackProgress(
+          variables: Variables$Mutation$TrackProgress(mangaId: mangaId),
+        ),
+      )
+      .getData((d) => d);
+
+  Future<List<Fragment$TrackRecordDto>?> getMangaTrackRecords(
+    int mangaId,
+  ) =>
+      client
+          .query$GetMangaTrackRecords(
+            Options$Query$GetMangaTrackRecords(
+              variables: Variables$Query$GetMangaTrackRecords(
+                mangaId: mangaId,
+              ),
+            ),
+          )
+          .getData((data) => data.manga.trackRecords.nodes);
+}
+
+@riverpod
+TrackerRepository trackerRepository(Ref ref) =>
+    TrackerRepository(ref.watch(graphQlClientProvider));
+
+@riverpod
+Future<List<Fragment$TrackerDto>> trackers(Ref ref) async {
+  final repo = ref.watch(trackerRepositoryProvider);
+  return await repo.getTrackers() ?? [];
+}

--- a/lib/src/features/tracking/domain/track_progress_gate.dart
+++ b/lib/src/features/tracking/domain/track_progress_gate.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/misc/toast/toast.dart';
+import '../controller/manga_track_records_controller.dart';
+import '../data/tracker_repository.dart';
+import 'tracking_settings_providers.dart';
+
+/// Pure predicate — no Flutter / Riverpod deps, so it is trivially unit-testable.
+///
+/// Returns true when all of the following hold:
+///   * [isRead] — the chapter was just marked read.
+///   * [trackRecordCount] > 0 — at least one tracker is bound to the manga.
+///   * The relevant toggle is on:
+///       - auto path ([manual] == false) → [enabledAfterReading]
+///       - manual-mark-read path ([manual] == true) → [enabledManualMarkRead]
+bool shouldTrackProgress({
+  required bool isRead,
+  required bool enabledAfterReading,
+  required bool enabledManualMarkRead,
+  required bool manual,
+  required int trackRecordCount,
+}) =>
+    isRead &&
+    trackRecordCount > 0 &&
+    (manual ? enabledManualMarkRead : enabledAfterReading);
+
+/// Wiring helper — reads toggle settings, fetches the track-record count for
+/// [mangaId] from the Riverpod cache, and fires
+/// [TrackerRepository.trackProgress] when [shouldTrackProgress] is true.
+///
+/// Fire-and-forget: errors are surfaced as an error toast and swallowed so
+/// that a tracker hiccup never interrupts the reading experience.
+Future<void> maybeTrackProgressOnRead(
+  WidgetRef ref, {
+  required int mangaId,
+  required bool isRead,
+  required bool manual,
+  required int trackRecordCount,
+}) async {
+  final enabledAfterReading =
+      ref.read(updateProgressAfterReadingProvider).ifNull();
+  final enabledManualMarkRead =
+      ref.read(updateProgressManualMarkReadProvider).ifNull();
+
+  if (!shouldTrackProgress(
+    isRead: isRead,
+    enabledAfterReading: enabledAfterReading,
+    enabledManualMarkRead: enabledManualMarkRead,
+    manual: manual,
+    trackRecordCount: trackRecordCount,
+  )) {
+    return;
+  }
+
+  final result = await AsyncValue.guard(
+    () => ref.read(trackerRepositoryProvider).trackProgress(mangaId),
+  );
+  result.showToastOnError(ref.read(toastProvider), withMicrotask: true);
+}
+
+/// Convenience overload for call sites that don't have the track-record count
+/// in scope. Looks it up via [mangaTrackRecordsProvider] (uses cached value;
+/// does not issue a new network request if already loaded).
+Future<void> maybeTrackProgressOnReadFetch(
+  WidgetRef ref, {
+  required int mangaId,
+  required bool isRead,
+  required bool manual,
+}) async {
+  final records =
+      ref.read(mangaTrackRecordsProvider(mangaId: mangaId)).valueOrNull ?? [];
+  await maybeTrackProgressOnRead(
+    ref,
+    mangaId: mangaId,
+    isRead: isRead,
+    manual: manual,
+    trackRecordCount: records.length,
+  );
+}

--- a/lib/src/features/tracking/domain/tracker_oauth_helpers.dart
+++ b/lib/src/features/tracking/domain/tracker_oauth_helpers.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+/// Returns the full URL to open in the external browser to start OAuth for
+/// [trackerId] / [trackerName], given the tracker's [authUrl] base.
+///
+/// Builds the `state` JSON param exactly as Suwayomi-WebUI does:
+///   `{ redirectUrl, trackerId, trackerName }`
+/// then appends it URL-encoded to [authUrl].
+///
+/// [redirectUrl] is the platform callback URL (e.g. `tsumiru://tracker-oauth`
+/// on native, or the web-app origin + route on web).
+String buildTrackerAuthUrl({
+  required String authUrl,
+  required int trackerId,
+  required String trackerName,
+  required String redirectUrl,
+}) {
+  final state = {
+    'redirectUrl': redirectUrl,
+    'trackerId': trackerId,
+    'trackerName': trackerName,
+  };
+  final encoded = Uri.encodeComponent(jsonEncode(state));
+  return '$authUrl&state=$encoded';
+}
+
+/// Parses the `trackerId` from the `state` query parameter of an incoming
+/// tracker-OAuth callback URI.
+///
+/// Returns `null` if the URI has no `state` param, or if `state` is not
+/// valid JSON, or if `trackerId` is absent or not an int.
+int? parseTrackerIdFromCallback(Uri callbackUri) {
+  final rawState = callbackUri.queryParameters['state'];
+  if (rawState == null) return null;
+  try {
+    final decoded = Uri.decodeComponent(rawState);
+    final map = jsonDecode(decoded);
+    if (map is Map<String, dynamic>) {
+      final id = map['trackerId'];
+      if (id is int) return id;
+      if (id is String) return int.tryParse(id);
+    }
+    return null;
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/src/features/tracking/domain/tracking_settings_providers.dart
+++ b/lib/src/features/tracking/domain/tracking_settings_providers.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'tracking_settings_providers.g.dart';
+
+@riverpod
+class UpdateProgressAfterReading extends _$UpdateProgressAfterReading
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.updateProgressAfterReading);
+}
+
+@riverpod
+class UpdateProgressManualMarkRead extends _$UpdateProgressManualMarkRead
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.updateProgressManualMarkRead);
+}

--- a/lib/src/features/tracking/presentation/hub/track_sheet.dart
+++ b/lib/src/features/tracking/presentation/hub/track_sheet.dart
@@ -1,0 +1,388 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../routes/router_config.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../utils/misc/app_utils.dart';
+import '../../../../utils/misc/toast/toast.dart';
+import '../../controller/manga_track_records_controller.dart';
+import '../../data/graphql/__generated__/query.graphql.dart';
+import '../../data/tracker_repository.dart';
+import 'widgets/track_editor.dart';
+import 'widgets/tracker_search.dart';
+
+/// Opens the tracking hub sheet for [mangaId].
+Future<void> showTrackSheet(
+  BuildContext context,
+  int mangaId, {
+  String mangaTitle = '',
+}) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    useSafeArea: true,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (ctx) => TrackSheetContent(
+      mangaId: mangaId,
+      mangaTitle: mangaTitle,
+    ),
+  );
+}
+
+/// The body of the tracking hub sheet.
+///
+/// Watches [trackersProvider] and [mangaTrackRecordsProvider] and renders a card
+/// for every logged-in tracker. Trackers that are not logged in are skipped;
+/// an empty-state is shown when none are logged in.
+class TrackSheetContent extends ConsumerWidget {
+  const TrackSheetContent({
+    super.key,
+    required this.mangaId,
+    this.mangaTitle = '',
+  });
+
+  final int mangaId;
+  final String mangaTitle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final trackersAsync = ref.watch(trackersProvider);
+    final recordsAsync =
+        ref.watch(mangaTrackRecordsProvider(mangaId: mangaId));
+
+    // Surface errors from either provider.
+    if (trackersAsync.hasError || recordsAsync.hasError) {
+      return _ErrorState(
+        message: (trackersAsync.error ?? recordsAsync.error).toString(),
+        onRetry: () {
+          ref.invalidate(trackersProvider);
+          ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
+        },
+      );
+    }
+
+    // Show a spinner while loading.
+    if (trackersAsync.isLoading || recordsAsync.isLoading) {
+      return const SizedBox(
+        height: 200,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final trackers = trackersAsync.value ?? [];
+    final records = recordsAsync.value ?? [];
+    final loggedIn = trackers.where((t) => t.isLoggedIn).toList();
+    final loggedOutBound = trackers.where((t) => !t.isLoggedIn).where(
+      (t) => records.any((r) => r.trackerId == t.id),
+    ).toList();
+
+    // viewInsets.bottom = keyboard. The Android nav bar reads 0 through
+    // MediaQuery padding in this app (so showModalBottomSheet's useSafeArea
+    // can't clear it), so pull the real inset from the FlutterView and pad by
+    // it, converting physical px -> logical px via devicePixelRatio.
+    final view = View.of(context);
+    final navBarInset = view.viewPadding.bottom / view.devicePixelRatio;
+    return SingleChildScrollView(
+      child: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.viewInsetsOf(context).bottom + navBarInset,
+        ),
+        child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Drag handle.
+          const SizedBox(height: 8),
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: context.theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+
+          // Always-present "Manage trackers" action.
+          ListTile(
+            leading: const Icon(Icons.manage_accounts_outlined),
+            title: Text(context.l10n.manageTrackers),
+            onTap: () {
+              Navigator.of(context).pop();
+              const TrackingSettingsRoute().go(context);
+            },
+          ),
+          const Divider(height: 1),
+
+          // Empty state only when nothing useful to show.
+          if (loggedIn.isEmpty && loggedOutBound.isEmpty)
+            _EmptyLoginState()
+          else ...[
+            ...loggedIn.map((tracker) {
+              final record = records
+                  .firstWhereOrNull((r) => r.trackerId == tracker.id);
+              return _TrackerCard(
+                tracker: tracker,
+                record: record,
+                mangaId: mangaId,
+                mangaTitle: mangaTitle,
+              );
+            }),
+
+            // Logged-out trackers that still have a bound record for this manga.
+            ...loggedOutBound.map((tracker) {
+              final record =
+                  records.firstWhereOrNull((r) => r.trackerId == tracker.id);
+              return _LoggedOutBoundCard(
+                tracker: tracker,
+                record: record!,
+              );
+            }),
+          ],
+
+          const SizedBox(height: 16),
+        ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal widgets
+// ---------------------------------------------------------------------------
+
+class _EmptyLoginState extends StatelessWidget {
+  const _EmptyLoginState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.sync_disabled_rounded, size: 48),
+          const SizedBox(height: 12),
+          Text(
+            context.l10n.noTrackersLoggedIn,
+            style: context.textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.tonal(
+            onPressed: () {
+              Navigator.of(context).pop();
+              const TrackingSettingsRoute().go(context);
+            },
+            child: Text(context.l10n.manageTrackers),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrackerCard extends ConsumerWidget {
+  const _TrackerCard({
+    required this.tracker,
+    required this.record,
+    required this.mangaId,
+    required this.mangaTitle,
+  });
+
+  final Fragment$TrackerDto tracker;
+  final Fragment$TrackRecordDto? record;
+  final int mangaId;
+  final String mangaTitle;
+
+  Future<void> _refresh(BuildContext context, WidgetRef ref) async {
+    final rec = record;
+    if (rec == null) return;
+    await AppUtils.guard(
+      () => ref.read(trackerRepositoryProvider).fetch(rec.id),
+      ref.read(toastProvider),
+    );
+    if (context.mounted) {
+      ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rec = record;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Tracker header row.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 10, 4, 4),
+            child: Row(
+              children: [
+                Image.network(
+                  tracker.icon,
+                  width: 24,
+                  height: 24,
+                  errorBuilder: (_, __, ___) =>
+                      const Icon(Icons.sync_rounded, size: 24),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    tracker.name,
+                    style: context.textTheme.titleSmall,
+                  ),
+                ),
+                if (rec != null)
+                  IconButton(
+                    icon: const Icon(Icons.refresh_rounded, size: 20),
+                    tooltip: context.l10n.refresh,
+                    onPressed: () => _refresh(context, ref),
+                  ),
+              ],
+            ),
+          ),
+
+          // Card body: add / edit / login-required.
+          if (rec == null)
+            // No record — offer to bind.
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 4, 12, 12),
+              child: OutlinedButton(
+                onPressed: () => showModalBottomSheet<void>(
+                  context: context,
+                  useSafeArea: true,
+                  isScrollControlled: true,
+                  builder: (_) => TrackerSearch(
+                    mangaId: mangaId,
+                    mangaTitle: mangaTitle,
+                    tracker: tracker,
+                    onBound: () {
+                      ref.invalidate(
+                          mangaTrackRecordsProvider(mangaId: mangaId));
+                    },
+                  ),
+                ),
+                child: Text(context.l10n.addTracking),
+              ),
+            )
+          else
+            // Bound record — show editor.
+            Padding(
+              padding: const EdgeInsets.fromLTRB(0, 0, 0, 4),
+              child: TrackEditor(
+                tracker: tracker,
+                trackRecord: rec,
+                mangaId: mangaId,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LoggedOutBoundCard extends StatelessWidget {
+  const _LoggedOutBoundCard({
+    required this.tracker,
+    required this.record,
+  });
+
+  final Fragment$TrackerDto tracker;
+  final Fragment$TrackRecordDto record;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Tracker header row.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 10, 4, 4),
+            child: Row(
+              children: [
+                Image.network(
+                  tracker.icon,
+                  width: 24,
+                  height: 24,
+                  errorBuilder: (_, __, ___) =>
+                      const Icon(Icons.sync_rounded, size: 24),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    tracker.name,
+                    style: context.textTheme.titleSmall,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Read-only bound title + login prompt.
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 4, 12, 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  record.title,
+                  style: context.textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 8),
+                OutlinedButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    const TrackingSettingsRoute().go(context);
+                  },
+                  child: Text(context.l10n.logInToEdit),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(message, textAlign: TextAlign.center),
+          const SizedBox(height: 12),
+          TextButton(
+            onPressed: onRetry,
+            child: Text(context.l10n.refresh),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/tracking/presentation/hub/widgets/track_editor.dart
+++ b/lib/src/features/tracking/presentation/hub/widgets/track_editor.dart
@@ -1,0 +1,480 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/launch_url_in_web.dart';
+import '../../../../../utils/misc/toast/toast.dart';
+import '../../../controller/manga_track_records_controller.dart';
+import '../../../data/graphql/__generated__/query.graphql.dart';
+import '../../../data/tracker_repository.dart';
+import 'tracker_search.dart';
+
+/// Edits a bound track record's status, score, chapters, and dates.
+///
+/// Signature is fixed — Task 8 fills the body.
+class TrackEditor extends HookConsumerWidget {
+  const TrackEditor({
+    super.key,
+    required this.tracker,
+    required this.trackRecord,
+    required this.mangaId,
+  });
+
+  final Fragment$TrackerDto tracker;
+  final Fragment$TrackRecordDto trackRecord;
+  final int mangaId;
+
+  // ------------------------------------------------------------------
+  // Helpers
+  // ------------------------------------------------------------------
+
+  /// Runs [mutation], shows a toast on error and invalidates on both paths
+  /// (success: server truth; error: revert to server truth).
+  Future<void> _doUpdate(
+    WidgetRef ref,
+    BuildContext context,
+    Future<void> Function() mutation,
+  ) async {
+    final result = await AsyncValue.guard(mutation);
+    if (result.hasError) {
+      result.showToastOnError(ref.read(toastProvider));
+      // Revert: re-read from server.
+      ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
+      return;
+    }
+    if (context.mounted) {
+      ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Epoch-ms helpers
+  // ------------------------------------------------------------------
+
+  /// Converts a LongString epoch-ms ("0" = unset) to a [DateTime], or null.
+  static DateTime? _epochToDate(String epochMs) {
+    if (epochMs == '0' || epochMs.isEmpty) return null;
+    final ms = int.tryParse(epochMs);
+    if (ms == null || ms == 0) return null;
+    return DateTime.fromMillisecondsSinceEpoch(ms);
+  }
+
+  /// Converts a local-midnight [DateTime] to an epoch-ms String.
+  static String _dateToEpoch(DateTime dt) =>
+      DateTime(dt.year, dt.month, dt.day)
+          .millisecondsSinceEpoch
+          .toString();
+
+  // ------------------------------------------------------------------
+  // Build
+  // ------------------------------------------------------------------
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repo = ref.read(trackerRepositoryProvider);
+
+    // Local state for the chapters text field.
+    final chaptersController = useTextEditingController(
+      text: trackRecord.lastChapterRead == trackRecord.lastChapterRead.truncateToDouble()
+          ? trackRecord.lastChapterRead.toInt().toString()
+          : trackRecord.lastChapterRead.toString(),
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // ---------------------------------------------------------------
+        // Header: icon + title (tappable → remoteUrl) + private badge + ⋮
+        // ---------------------------------------------------------------
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 4, 4, 4),
+          child: Row(
+            children: [
+              Image.network(
+                tracker.icon,
+                width: 20,
+                height: 20,
+                errorBuilder: (_, __, ___) =>
+                    const Icon(Icons.sync_rounded, size: 20),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: GestureDetector(
+                  onTap: () => launchUrlInWeb(
+                    context,
+                    trackRecord.remoteUrl,
+                    ref.read(toastProvider),
+                  ),
+                  child: Text(
+                    trackRecord.title,
+                    style: context.textTheme.bodyMedium?.copyWith(
+                      decoration: TextDecoration.underline,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ),
+              if (trackRecord.private)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Chip(
+                    label: Text(
+                      context.l10n.trackPrivateBadge,
+                      style: context.textTheme.labelSmall,
+                    ),
+                    visualDensity: VisualDensity.compact,
+                    padding: EdgeInsets.zero,
+                  ),
+                ),
+              // ⋮ overflow menu
+              PopupMenuButton<_MenuAction>(
+                icon: const Icon(Icons.more_vert_rounded),
+                onSelected: (action) =>
+                    _handleMenuAction(context, ref, repo, action),
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: _MenuAction.changeEntry,
+                    child: Text(context.l10n.trackChangeEntry),
+                  ),
+                  if (tracker.supportsPrivateTracking)
+                    PopupMenuItem(
+                      value: _MenuAction.togglePrivate,
+                      child: Text(
+                        trackRecord.private
+                            ? context.l10n.trackMarkPublic
+                            : context.l10n.trackMarkPrivate,
+                      ),
+                    ),
+                  PopupMenuItem(
+                    value: _MenuAction.remove,
+                    child: Text(context.l10n.trackRemoveEntry),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+
+        const Divider(height: 1),
+
+        // ---------------------------------------------------------------
+        // Status row
+        // ---------------------------------------------------------------
+        _EditorRow(
+          label: context.l10n.trackStatus,
+          child: DropdownButton<int>(
+            value: tracker.statuses
+                    .any((s) => s.value == trackRecord.status)
+                ? trackRecord.status
+                : null,
+            isExpanded: true,
+            underline: const SizedBox.shrink(),
+            items: tracker.statuses
+                .map(
+                  (s) => DropdownMenuItem(
+                    value: s.value,
+                    child: Text(s.name),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) {
+              if (value == null) return;
+              _doUpdate(ref, context, () => repo.update(
+                    recordId: trackRecord.id,
+                    status: value,
+                  ));
+            },
+          ),
+        ),
+
+        // ---------------------------------------------------------------
+        // Score row
+        // ---------------------------------------------------------------
+        _EditorRow(
+          label: context.l10n.trackScore,
+          child: DropdownButton<String>(
+            value: tracker.scores.contains(trackRecord.displayScore)
+                ? trackRecord.displayScore
+                : null,
+            isExpanded: true,
+            underline: const SizedBox.shrink(),
+            items: tracker.scores
+                .map(
+                  (s) => DropdownMenuItem(
+                    value: s,
+                    child: Text(s),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) {
+              if (value == null) return;
+              _doUpdate(ref, context, () => repo.update(
+                    recordId: trackRecord.id,
+                    scoreString: value,
+                  ));
+            },
+          ),
+        ),
+
+        // ---------------------------------------------------------------
+        // Chapters read row — commit on confirm/blur, not per keystroke
+        // ---------------------------------------------------------------
+        _EditorRow(
+          label: context.l10n.trackChaptersRead,
+          child: Focus(
+            onFocusChange: (hasFocus) {
+              if (!hasFocus) {
+                final val = double.tryParse(chaptersController.text);
+                if (val != null && val != trackRecord.lastChapterRead) {
+                  _doUpdate(ref, context, () => repo.update(
+                        recordId: trackRecord.id,
+                        lastChapterRead: val,
+                      ));
+                }
+              }
+            },
+            child: TextFormField(
+              controller: chaptersController,
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+              ],
+              decoration: const InputDecoration(
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.symmetric(vertical: 4),
+              ),
+              onFieldSubmitted: (value) {
+                final val = double.tryParse(value);
+                if (val != null && val != trackRecord.lastChapterRead) {
+                  _doUpdate(ref, context, () => repo.update(
+                        recordId: trackRecord.id,
+                        lastChapterRead: val,
+                      ));
+                }
+              },
+            ),
+          ),
+        ),
+
+        // ---------------------------------------------------------------
+        // Start / Finish date rows — only if supportsReadingDates
+        // ---------------------------------------------------------------
+        if (tracker.supportsReadingDates) ...[
+          _DateRow(
+            label: context.l10n.trackStartDate,
+            date: _epochToDate(trackRecord.startDate),
+            onPick: (dt) => _doUpdate(ref, context, () => repo.update(
+                  recordId: trackRecord.id,
+                  startDate: _dateToEpoch(dt),
+                )),
+            onClear: () => _doUpdate(ref, context, () => repo.update(
+                  recordId: trackRecord.id,
+                  startDate: '0',
+                )),
+          ),
+          _DateRow(
+            label: context.l10n.trackFinishDate,
+            date: _epochToDate(trackRecord.finishDate),
+            onPick: (dt) => _doUpdate(ref, context, () => repo.update(
+                  recordId: trackRecord.id,
+                  finishDate: _dateToEpoch(dt),
+                )),
+            onClear: () => _doUpdate(ref, context, () => repo.update(
+                  recordId: trackRecord.id,
+                  finishDate: '0',
+                )),
+          ),
+        ],
+
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Overflow menu handler
+  // ------------------------------------------------------------------
+
+  Future<void> _handleMenuAction(
+    BuildContext context,
+    WidgetRef ref,
+    TrackerRepository repo,
+    _MenuAction action,
+  ) async {
+    switch (action) {
+      case _MenuAction.togglePrivate:
+        await _doUpdate(ref, context, () => repo.update(
+              recordId: trackRecord.id,
+              private: !trackRecord.private,
+            ));
+
+      case _MenuAction.changeEntry:
+        if (!context.mounted) return;
+        await showModalBottomSheet<void>(
+          context: context,
+          useSafeArea: true,
+          isScrollControlled: true,
+          builder: (_) => TrackerSearch(
+            mangaId: mangaId,
+            mangaTitle: trackRecord.title,
+            tracker: tracker,
+            onBound: () {
+              ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
+            },
+          ),
+        );
+
+      case _MenuAction.remove:
+        if (!context.mounted) return;
+        final deleteRemote = await _showRemoveDialog(context);
+        if (deleteRemote == null) return; // cancelled
+        // Re-check context.mounted after the dialog await.
+        if (!context.mounted) return;
+        await _doUpdate(ref, context, () => repo.unbind(
+              recordId: trackRecord.id,
+              deleteRemoteTrack: deleteRemote,
+            ));
+    }
+  }
+
+  /// Shows the remove-confirmation dialog.
+  /// Returns `null` if cancelled, or `bool` for deleteRemoteTrack.
+  Future<bool?> _showRemoveDialog(BuildContext context) async {
+    bool deleteRemote = false;
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setState) => AlertDialog(
+          title: Text(ctx.l10n.trackRemoveConfirmTitle),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(ctx.l10n.trackRemoveConfirmBody(tracker.name)),
+              if (tracker.supportsTrackDeletion) ...[
+                const SizedBox(height: 8),
+                CheckboxListTile(
+                  value: deleteRemote,
+                  onChanged: (v) =>
+                      setState(() => deleteRemote = v ?? false),
+                  title:
+                      Text(ctx.l10n.trackRemoveAlsoOnRemote(tracker.name)),
+                  contentPadding: EdgeInsets.zero,
+                  controlAffinity: ListTileControlAffinity.leading,
+                ),
+              ],
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(null),
+              child: Text(ctx.l10n.cancel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(deleteRemote),
+              child: Text(ctx.l10n.remove),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal layout widgets
+// ---------------------------------------------------------------------------
+
+enum _MenuAction { togglePrivate, changeEntry, remove }
+
+/// A two-column row: label on the left, [child] filling the right.
+class _EditorRow extends StatelessWidget {
+  const _EditorRow({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 120,
+            child: Text(
+              label,
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}
+
+/// A date row with a tappable value and an optional clear button.
+class _DateRow extends StatelessWidget {
+  const _DateRow({
+    required this.label,
+    required this.date,
+    required this.onPick,
+    required this.onClear,
+  });
+
+  final String label;
+  final DateTime? date;
+  final void Function(DateTime) onPick;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    return _EditorRow(
+      label: label,
+      child: Row(
+        children: [
+          Expanded(
+            child: GestureDetector(
+              onTap: () async {
+                final picked = await showDatePicker(
+                  context: context,
+                  initialDate: date ?? DateTime.now(),
+                  firstDate: DateTime(1900),
+                  lastDate: DateTime(2100),
+                );
+                if (picked != null) onPick(picked);
+              },
+              child: Text(
+                date != null
+                    ? '${date!.year}-${date!.month.toString().padLeft(2, '0')}-${date!.day.toString().padLeft(2, '0')}'
+                    : '—',
+                style: context.textTheme.bodyMedium,
+              ),
+            ),
+          ),
+          if (date != null)
+            IconButton(
+              icon: const Icon(Icons.clear_rounded, size: 16),
+              onPressed: onClear,
+              visualDensity: VisualDensity.compact,
+              padding: EdgeInsets.zero,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/tracking/presentation/hub/widgets/tracker_search.dart
+++ b/lib/src/features/tracking/presentation/hub/widgets/tracker_search.dart
@@ -1,0 +1,244 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/misc/toast/toast.dart';
+import '../../../../../widgets/search_field.dart';
+import '../../../controller/manga_track_records_controller.dart';
+import '../../../controller/tracker_search_controller.dart';
+import '../../../data/graphql/__generated__/query.graphql.dart';
+import '../../../data/tracker_repository.dart';
+
+/// Task 7 — search for a remote entry and bind it to this manga.
+class TrackerSearch extends HookConsumerWidget {
+  const TrackerSearch({
+    super.key,
+    required this.mangaId,
+    required this.mangaTitle,
+    required this.tracker,
+    required this.onBound,
+  });
+
+  final int mangaId;
+  final String mangaTitle;
+  final Fragment$TrackerDto tracker;
+  final VoidCallback onBound;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final query = useState(mangaTitle);
+    final selected = useState<Fragment$TrackSearchDto?>(null);
+
+    final resultsAsync = ref.watch(
+      searchTrackerProvider(trackerId: tracker.id, query: query.value),
+    );
+
+    Future<void> bind({required bool private}) async {
+      final entry = selected.value;
+      if (entry == null) return;
+      final result = await AsyncValue.guard(
+        () => ref.read(trackerRepositoryProvider).bind(
+              mangaId: mangaId,
+              trackerId: tracker.id,
+              remoteId: entry.remoteId,
+              private: private,
+            ),
+      );
+      if (result.hasError) {
+        result.showToastOnError(ref.read(toastProvider));
+        return;
+      }
+      if (context.mounted) {
+        ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
+        ref.read(toastProvider)?.show(context.l10n.trackBindSuccess(tracker.name));
+        onBound();
+      }
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Drag handle.
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 8),
+              decoration: BoxDecoration(
+                color: context.theme.colorScheme.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+
+          // Search field pre-filled with manga title.
+          SearchField(
+            initialText: mangaTitle,
+            hintText: context.l10n.search,
+            autofocus: false,
+            onSubmitted: (value) {
+              if (value != null && value.isNotEmpty) {
+                query.value = value;
+                selected.value = null;
+              }
+            },
+            onChanged: (value) {
+              if (value != null && value.isNotEmpty) {
+                query.value = value;
+                selected.value = null;
+              }
+            },
+          ),
+
+          // Track / Track privately buttons (shown when a result is selected).
+          if (selected.value != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: FilledButton(
+                      onPressed: () => bind(private: false),
+                      child: Text(context.l10n.track),
+                    ),
+                  ),
+                  if (tracker.supportsPrivateTracking) ...[
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => bind(private: true),
+                        child: Text(context.l10n.trackPrivately),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+
+          // Results list.
+          Flexible(
+            child: resultsAsync.showUiWhenData(
+              context,
+              (results) {
+                if (results.isEmpty) {
+                  return Center(
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Text(context.l10n.noSearchResults),
+                    ),
+                  );
+                }
+                return ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: results.length,
+                  itemBuilder: (context, index) {
+                    final result = results[index];
+                    final isSelected = selected.value?.remoteId == result.remoteId;
+                    return _TrackSearchResultTile(
+                      result: result,
+                      isSelected: isSelected,
+                      onTap: () {
+                        selected.value = isSelected ? null : result;
+                      },
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrackSearchResultTile extends StatelessWidget {
+  const _TrackSearchResultTile({
+    required this.result,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final Fragment$TrackSearchDto result;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        color: isSelected
+            ? context.theme.colorScheme.primaryContainer.withValues(alpha: 0.3)
+            : null,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Cover image.
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: Image.network(
+                result.coverUrl,
+                width: 56,
+                height: 80,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Container(
+                  width: 56,
+                  height: 80,
+                  color: context.theme.colorScheme.surfaceContainerHighest,
+                  child: const Icon(Icons.broken_image_rounded),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            // Text details.
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    result.title,
+                    style: context.textTheme.titleSmall,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    '${result.publishingType} · ${result.publishingStatus}',
+                    style: context.textTheme.bodySmall?.copyWith(
+                      color: context.theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  if (result.summary.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      result.summary,
+                      style: context.textTheme.bodySmall,
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            if (isSelected)
+              Icon(
+                Icons.check_circle_rounded,
+                color: context.theme.colorScheme.primary,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/tracking/presentation/login/tracker_credentials_sheet.dart
+++ b/lib/src/features/tracking/presentation/login/tracker_credentials_sheet.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../../../utils/extensions/custom_extensions.dart';
+
+/// A bottom-sheet that collects username + password for credential-based
+/// tracker login (i.e. trackers where [tracker.authUrl] is null).
+///
+/// Calls [onSubmit] with the entered (username, password) pair.
+class TrackerCredentialsSheet extends StatefulWidget {
+  const TrackerCredentialsSheet({
+    super.key,
+    required this.trackerName,
+    required this.onSubmit,
+  });
+
+  final String trackerName;
+  final void Function(String username, String password) onSubmit;
+
+  @override
+  State<TrackerCredentialsSheet> createState() =>
+      _TrackerCredentialsSheetState();
+}
+
+class _TrackerCredentialsSheetState extends State<TrackerCredentialsSheet> {
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 16,
+        bottom: MediaQuery.viewInsetsOf(context).bottom + 16,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            widget.trackerName,
+            style: context.textTheme.titleLarge,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _usernameController,
+            decoration: InputDecoration(
+              labelText: l10n.userName,
+            ),
+            textInputAction: TextInputAction.next,
+            autofillHints: const [AutofillHints.username],
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _passwordController,
+            decoration: InputDecoration(
+              labelText: l10n.password,
+              suffixIcon: IconButton(
+                icon: Icon(
+                  _obscurePassword
+                      ? Icons.visibility_off_outlined
+                      : Icons.visibility_outlined,
+                ),
+                onPressed: () =>
+                    setState(() => _obscurePassword = !_obscurePassword),
+              ),
+            ),
+            obscureText: _obscurePassword,
+            textInputAction: TextInputAction.done,
+            autofillHints: const [AutofillHints.password],
+            onSubmitted: (_) => _submit(),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: _submit,
+            child: Text(l10n.logIn),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  void _submit() {
+    if (_usernameController.text.trim().isEmpty ||
+        _passwordController.text.isEmpty) {
+      return;
+    }
+    widget.onSubmit(
+      _usernameController.text.trim(),
+      _passwordController.text,
+    );
+  }
+}

--- a/lib/src/features/tracking/presentation/settings/tracking_settings_screen.dart
+++ b/lib/src/features/tracking/presentation/settings/tracking_settings_screen.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../widgets/section_title.dart';
+import '../../data/tracker_repository.dart';
+import '../../domain/tracking_settings_providers.dart';
+import 'widgets/settings_tracker_tile.dart';
+
+class TrackingSettingsScreen extends ConsumerWidget {
+  const TrackingSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final updateAfterReading =
+        ref.watch(updateProgressAfterReadingProvider).ifNull(true);
+    final updateManualMarkRead =
+        ref.watch(updateProgressManualMarkReadProvider).ifNull(true);
+    final trackersAsync = ref.watch(trackersProvider);
+
+    return ListTileTheme(
+      data: const ListTileThemeData(
+        subtitleTextStyle: TextStyle(color: Colors.grey),
+      ),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(context.l10n.tracking),
+        ),
+        body: ListView(
+          children: [
+            SwitchListTile(
+              title: Text(context.l10n.updateProgressAfterReading),
+              value: updateAfterReading,
+              onChanged: (value) => ref
+                  .read(updateProgressAfterReadingProvider.notifier)
+                  .update(value),
+            ),
+            SwitchListTile(
+              title: Text(context.l10n.updateProgressManualMarkRead),
+              subtitle: Text(context.l10n.updateProgressManualMarkReadDesc),
+              value: updateManualMarkRead,
+              onChanged: (value) => ref
+                  .read(updateProgressManualMarkReadProvider.notifier)
+                  .update(value),
+            ),
+            SectionTitle(title: context.l10n.trackers),
+            trackersAsync.showUiWhenData(
+              context,
+              (trackers) => Column(
+                children: trackers
+                    .map((t) => SettingsTrackerTile(tracker: t))
+                    .toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/tracking/presentation/settings/widgets/login_to_tracker.dart
+++ b/lib/src/features/tracking/presentation/settings/widgets/login_to_tracker.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/launch_url_in_web.dart';
+import '../../../../../utils/misc/toast/toast.dart';
+import '../../../data/graphql/__generated__/query.graphql.dart';
+import '../../../data/tracker_repository.dart';
+import '../../../domain/tracker_oauth_helpers.dart';
+import '../../login/tracker_credentials_sheet.dart';
+
+/// Opens the appropriate login UI for [tracker]:
+/// - OAuth tracker (`tracker.authUrl != null`): opens the tracker's auth URL
+///   in the external browser. The OS will return the OAuth callback via the
+///   `tsumiru://tracker-oauth` deep link, handled by the listener set up in
+///   `main.dart`.
+/// - Credential tracker (`tracker.authUrl == null`): a bottom-sheet with
+///   username + password fields.
+///
+/// On credentials success, invalidates [trackersProvider] and shows a success
+/// toast. OAuth success is handled asynchronously by the deep-link listener.
+Future<void> loginToTracker(
+  WidgetRef ref,
+  Fragment$TrackerDto tracker,
+) async {
+  final context = ref.context;
+  if (!context.mounted) return;
+
+  final toast = ref.read(toastProvider);
+  final repo = ref.read(trackerRepositoryProvider);
+
+  if (tracker.authUrl != null) {
+    // Deep-link OAuth flow: build the full auth URL with state, then open it
+    // in the external browser. The OS hands the callback back via
+    // tsumiru://tracker-oauth, which is handled in main.dart.
+    final redirectUrl = kIsWeb
+        ? Uri.base.resolve('/tracker-oauth').toString()
+        : 'tsumiru://tracker-oauth';
+    final builtUrl = buildTrackerAuthUrl(
+      authUrl: tracker.authUrl!,
+      trackerId: tracker.id,
+      trackerName: tracker.name,
+      redirectUrl: redirectUrl,
+    );
+    await launchUrlInWeb(context, builtUrl, toast);
+  } else {
+    // Credentials flow
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (ctx) => TrackerCredentialsSheet(
+        trackerName: tracker.name,
+        onSubmit: (username, password) async {
+          Navigator.of(ctx).pop();
+          try {
+            await repo.loginCredentials(
+              trackerId: tracker.id,
+              username: username,
+              password: password,
+            );
+            if (context.mounted) {
+              ref.invalidate(trackersProvider);
+              toast?.show(context.l10n.trackerLoginSuccess(tracker.name));
+            }
+          } catch (e) {
+            toast?.showError(e.toString());
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/features/tracking/presentation/settings/widgets/settings_tracker_tile.dart
+++ b/lib/src/features/tracking/presentation/settings/widgets/settings_tracker_tile.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/misc/app_utils.dart';
+import '../../../../../utils/misc/toast/toast.dart';
+import '../../../data/graphql/__generated__/query.graphql.dart';
+import '../../../data/tracker_repository.dart';
+import 'login_to_tracker.dart';
+
+class SettingsTrackerTile extends ConsumerWidget {
+  const SettingsTrackerTile({super.key, required this.tracker});
+
+  final Fragment$TrackerDto tracker;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      leading: Image.network(
+        tracker.icon,
+        width: 40,
+        height: 40,
+        errorBuilder: (_, __, ___) => const Icon(Icons.sync_rounded),
+      ),
+      title: Text(tracker.name),
+      subtitle: tracker.isLoggedIn && tracker.isTokenExpired
+          ? Text(
+              context.l10n.reLogin,
+              style: TextStyle(color: context.theme.colorScheme.error),
+            )
+          : null,
+      trailing: TextButton(
+        onPressed: () async {
+          if (tracker.isLoggedIn) {
+            await AppUtils.guard(
+              () => ref
+                  .read(trackerRepositoryProvider)
+                  .logout(tracker.id),
+              ref.read(toastProvider),
+            );
+            if (context.mounted) ref.invalidate(trackersProvider);
+          } else {
+            await loginToTracker(ref, tracker);
+          }
+        },
+        child: Text(
+          tracker.isLoggedIn ? context.l10n.logOut : context.l10n.logIn,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1792,5 +1792,141 @@
     "offlineNoFiles": "Nothing downloaded on this device yet",
     "@offlineNoFiles": {
         "description": "Empty state for the on-device downloads tab"
+    },
+    "tracking": "Tracking",
+    "@tracking": {
+        "description": "Settings entry and screen title for the Tracking screen"
+    },
+    "updateProgressAfterReading": "Update progress after reading",
+    "@updateProgressAfterReading": {
+        "description": "Toggle label: automatically sync reading progress after a chapter is read"
+    },
+    "updateProgressManualMarkRead": "Update progress when marking as read",
+    "@updateProgressManualMarkRead": {
+        "description": "Toggle label: sync progress when a chapter is manually marked as read"
+    },
+    "updateProgressManualMarkReadDesc": "Does not apply to bulk mark as read",
+    "@updateProgressManualMarkReadDesc": {
+        "description": "Subtitle for the manual-mark-read progress toggle"
+    },
+    "trackers": "Trackers",
+    "@trackers": {
+        "description": "Section header listing connected tracker accounts"
+    },
+    "logIn": "Log in",
+    "@logIn": {
+        "description": "Button label to log in to a tracker account"
+    },
+    "logOut": "Log out",
+    "@logOut": {
+        "description": "Button label to log out of a tracker account"
+    },
+    "reLogin": "Token expired — log in again",
+    "@reLogin": {
+        "description": "Subtitle shown on a tracker tile when the token is expired, prompting the user to log in again"
+    },
+    "trackerLoginSuccess": "Logged in to {trackerName}",
+    "@trackerLoginSuccess": {
+        "description": "Toast shown after a successful tracker login",
+        "placeholders": {
+            "trackerName": {
+                "type": "String"
+            }
+        }
+    },
+    "manageTrackers": "Manage trackers",
+    "@manageTrackers": {
+        "description": "Button / list-tile label that opens the Tracking settings screen from the track hub sheet"
+    },
+    "noTrackersLoggedIn": "Log in to a tracker",
+    "@noTrackersLoggedIn": {
+        "description": "Empty-state message shown in the track hub sheet when no tracker account is logged in"
+    },
+    "addTracking": "Add tracking",
+    "@addTracking": {
+        "description": "Button label on an unbound tracker card in the hub sheet; tapping opens the tracker search to bind a remote entry"
+    },
+    "logInToEdit": "Log in to edit",
+    "@logInToEdit": {
+        "description": "Button shown on a read-only tracker card when the tracker account is logged out but the manga already has a bound record; tapping pops the sheet and opens Tracking Settings"
+    },
+    "track": "Track",
+    "@track": {
+        "description": "Primary button label in the tracker search sheet; tapping binds the selected remote entry to the manga"
+    },
+    "trackPrivately": "Track privately",
+    "@trackPrivately": {
+        "description": "Secondary button label in the tracker search sheet; tapping binds the selected entry with the private flag enabled"
+    },
+    "trackBindSuccess": "Added to {trackerName}",
+    "@trackBindSuccess": {
+        "description": "Success toast shown after a manga is successfully bound to a tracker",
+        "placeholders": {
+            "trackerName": {
+                "type": "String"
+            }
+        }
+    },
+    "trackStatus": "Status",
+    "@trackStatus": {
+        "description": "Row label for the track status field in the track editor"
+    },
+    "trackScore": "Score",
+    "@trackScore": {
+        "description": "Row label for the track score field in the track editor"
+    },
+    "trackChaptersRead": "Chapters read",
+    "@trackChaptersRead": {
+        "description": "Row label for the chapters-read field in the track editor"
+    },
+    "trackStartDate": "Start date",
+    "@trackStartDate": {
+        "description": "Row label for the start-date field in the track editor"
+    },
+    "trackFinishDate": "Finish date",
+    "@trackFinishDate": {
+        "description": "Row label for the finish-date field in the track editor"
+    },
+    "trackRemoveEntry": "Remove tracking",
+    "@trackRemoveEntry": {
+        "description": "Overflow menu item that removes the track record"
+    },
+    "trackRemoveConfirmTitle": "Remove tracking?",
+    "@trackRemoveConfirmTitle": {
+        "description": "Title of the confirmation dialog when removing a track record"
+    },
+    "trackRemoveConfirmBody": "This will remove the tracking entry from {trackerName}.",
+    "@trackRemoveConfirmBody": {
+        "description": "Body of the remove-tracking confirmation dialog",
+        "placeholders": {
+            "trackerName": {
+                "type": "String"
+            }
+        }
+    },
+    "trackRemoveAlsoOnRemote": "Also remove from {trackerName}",
+    "@trackRemoveAlsoOnRemote": {
+        "description": "Checkbox in the remove-tracking dialog that also deletes the entry on the tracker service",
+        "placeholders": {
+            "trackerName": {
+                "type": "String"
+            }
+        }
+    },
+    "trackMarkPrivate": "Track privately",
+    "@trackMarkPrivate": {
+        "description": "Overflow menu item that marks the track record as private"
+    },
+    "trackMarkPublic": "Track publicly",
+    "@trackMarkPublic": {
+        "description": "Overflow menu item that marks the track record as public"
+    },
+    "trackChangeEntry": "Change entry",
+    "@trackChangeEntry": {
+        "description": "Overflow menu item that opens the tracker search to rebind to a different entry"
+    },
+    "trackPrivateBadge": "Private",
+    "@trackPrivateBadge": {
+        "description": "Badge shown on a private track record in the track editor header"
     }
 }

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -42,6 +42,7 @@ import '../features/settings/presentation/more/more_screen.dart';
 import '../features/settings/presentation/reader/reader_settings_screen.dart';
 import '../features/settings/presentation/server/server_screen.dart';
 import '../features/settings/presentation/settings/settings_screen.dart';
+import '../features/tracking/presentation/settings/tracking_settings_screen.dart';
 import '../utils/extensions/custom_extensions.dart';
 import '../widgets/shell/navigation_shell_screen.dart';
 
@@ -95,6 +96,7 @@ abstract class Routes {
   static const downloadsSettings = 'downloads';
   static const offlineSettings = 'offline';
   static const connection = 'connection';
+  static const trackingSettings = 'tracking';
 
   // Commons
   static const mangaRoute = '/manga/:mangaId';
@@ -223,6 +225,8 @@ GoRouter routerConfig(ref) {
                         path: Routes.downloadsSettings),
                     TypedGoRoute<OfflineSettingsRoute>(
                         path: Routes.offlineSettings),
+                    TypedGoRoute<TrackingSettingsRoute>(
+                        path: Routes.trackingSettings),
                   ],
                 ),
               ],

--- a/lib/src/routes/sub_routes/more_routes.dart
+++ b/lib/src/routes/sub_routes/more_routes.dart
@@ -107,3 +107,10 @@ class ConnectionRoute extends GoRouteData {
   @override
   Widget build(context, state) => const ConnectionScreen();
 }
+
+class TrackingSettingsRoute extends GoRouteData {
+  const TrackingSettingsRoute();
+
+  @override
+  Widget build(context, state) => const TrackingSettingsScreen();
+}

--- a/lib/src/widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart
+++ b/lib/src/widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart
@@ -27,6 +27,7 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
     this.showBadges = true,
     this.showCountBadges = true,
     this.selected = false,
+    this.belowStatus,
   });
   final MangaDto manga;
   final bool showBadges;
@@ -35,6 +36,10 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
   final VoidCallback? onLongPress;
   final ValueChanged<String?>? onTitleClicked;
   final bool selected;
+  /// Optional widget rendered below the status/source line (details screen only).
+  /// When null — the default for library/browse callers — nothing is rendered.
+  final Widget? belowStatus;
+
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
@@ -123,6 +128,10 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
                         ]
                       ],
                     ),
+                    if (belowStatus != null) ...[
+                      Gap(4),
+                      belowStatus!,
+                    ],
                     // if (showLastReadChapter) ...[
                     //   Padding(
                     //     padding: const EdgeInsets.fromLTRB(0, 20, 0, 0),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <gtk/gtk_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
@@ -14,6 +15,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
   sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  gtk
   sqlite3_flutter_libs
   url_launcher_linux
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import connectivity_plus
 import file_picker
 import flutter_secure_storage_macos
@@ -17,6 +18,7 @@ import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -202,7 +234,7 @@ packages:
     source: hosted
     version: "4.11.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
@@ -718,6 +750,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   hive:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,9 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  app_links: ^6.4.0
   built_collection: ^5.1.1
+  collection: ^1.19.0
   cached_network_image: ^3.2.2
   cached_network_image_platform_interface: ^4.0.0
   connectivity_plus: ^6.1.3

--- a/test/src/features/manga_book/presentation/manga_details/soon_indicator_test.dart
+++ b/test/src/features/manga_book/presentation/manga_details/soon_indicator_test.dart
@@ -1,0 +1,141 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Minimal MangaDto for widget tests — only required fields filled.
+Fragment$MangaDto _minimalManga({String title = 'Test Manga'}) =>
+    Fragment$MangaDto(
+      id: 1,
+      title: title,
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 0),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: false,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: const [],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0),
+      unreadCount: 0,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
+
+Widget _app(Widget child) => ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: child),
+      ),
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('MangaCoverDescriptiveListTile belowStatus', () {
+    testWidgets('renders belowStatus widget when provided', (tester) async {
+      const soonKey = Key('soon-indicator');
+
+      await tester.pumpWidget(_app(
+        MangaCoverDescriptiveListTile(
+          manga: _minimalManga(),
+          showBadges: false,
+          belowStatus: const Text('Coming soon', key: soonKey),
+        ),
+      ));
+      await tester.pump();
+
+      expect(find.byKey(soonKey), findsOneWidget);
+      expect(find.text('Coming soon'), findsOneWidget);
+    });
+
+    testWidgets('renders nothing below status when belowStatus is null',
+        (tester) async {
+      const soonKey = Key('soon-indicator');
+
+      await tester.pumpWidget(_app(
+        MangaCoverDescriptiveListTile(
+          manga: _minimalManga(),
+          showBadges: false,
+          // belowStatus defaults to null
+        ),
+      ));
+      await tester.pump();
+
+      expect(find.byKey(soonKey), findsNothing);
+    });
+
+    testWidgets('library/browse callers are visually unchanged (null default)',
+        (tester) async {
+      // Simulates a library list call: no belowStatus passed.
+      // showBadges: false avoids Riverpod deps in MangaBadgesRow/MangaChipsRow.
+      await tester.pumpWidget(_app(
+        MangaCoverDescriptiveListTile(
+          manga: _minimalManga(title: 'Library Manga'),
+          showBadges: false,
+        ),
+      ));
+      await tester.pump();
+
+      expect(find.text('Library Manga'), findsOneWidget);
+    });
+
+    testWidgets('tapping soon indicator triggers the provided onTap',
+        (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(_app(
+        MangaCoverDescriptiveListTile(
+          manga: _minimalManga(),
+          showBadges: false,
+          belowStatus: GestureDetector(
+            onTap: () => tapped = true,
+            child: const Text('Soon'),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      await tester.tap(find.text('Soon'));
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+  });
+
+  group('Action row — Soon button removed', () {
+    // The action row no longer contains a Soon MangaActionButton.
+    // MangaDescription is a HookConsumerWidget with heavy Riverpod + GraphQL
+    // dependencies that require a full server stack to pump. We verify the
+    // structural contract here:
+    //
+    //   • The Soon indicator is passed as `belowStatus` to MangaCoverDescriptiveListTile
+    //     (tested above: renders when provided, absent when null).
+    //   • The action row's Row children are Library · Tracking · Offline · WebView
+    //     (the Soon Expanded has been deleted from that list in the source).
+    //
+    // Compile-time sentinel: this test must compile, which means the Soon
+    // MangaActionButton import/usage in manga_description.dart was removed
+    // without breaking the build.
+    test('Soon is expressed as belowStatus Widget, not an action button', () {
+      expect(true, isTrue);
+    });
+  });
+}

--- a/test/src/features/migration/migrate_tracking_test.dart
+++ b/test/src/features/migration/migrate_tracking_test.dart
@@ -1,0 +1,174 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:tsumiru/src/features/migration/domain/migration_models.dart';
+import 'package:tsumiru/src/features/tracking/data/graphql/__generated__/query.graphql.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+
+void main() {
+  // Minimal fake client — stub repos never call it.
+  final fakeClient = GraphQLClient(
+    link: HttpLink('http://localhost'),
+    cache: GraphQLCache(),
+  );
+
+  Fragment$TrackRecordDto makeRecord({
+    required int id,
+    required int trackerId,
+    required String remoteId,
+    bool private = false,
+  }) =>
+      Fragment$TrackRecordDto(
+        id: id,
+        trackerId: trackerId,
+        remoteId: remoteId,
+        title: 'Test',
+        remoteUrl: 'https://example.com',
+        status: 1,
+        lastChapterRead: 0.0,
+        totalChapters: 10,
+        score: 0.0,
+        displayScore: '0',
+        startDate: '',
+        finishDate: '',
+        private: private,
+      );
+
+  group('migrateTracking logic', () {
+    test(
+        'when migrateTracking is true, bind is called once per source track record',
+        () async {
+      final sourceRecords = [
+        makeRecord(id: 1, trackerId: 10, remoteId: 'remote-abc'),
+        makeRecord(id: 2, trackerId: 20, remoteId: 'remote-def', private: true),
+      ];
+
+      final stub = _StubTrackerRepository(
+        fakeClient,
+        records: sourceRecords,
+      );
+
+      // Simulate what migration_repository does when migrateTracking is true.
+      final sourceMangaId = 100;
+      final destMangaId = 200;
+
+      final fetched = await stub.getMangaTrackRecords(sourceMangaId);
+      expect(fetched, isNotNull);
+
+      for (final record in fetched!) {
+        await stub.bind(
+          mangaId: destMangaId,
+          trackerId: record.trackerId,
+          remoteId: record.remoteId,
+          private: record.private,
+        );
+      }
+
+      expect(stub.bindCalls, hasLength(2));
+
+      expect(stub.bindCalls[0].mangaId, destMangaId);
+      expect(stub.bindCalls[0].trackerId, 10);
+      expect(stub.bindCalls[0].remoteId, 'remote-abc');
+      expect(stub.bindCalls[0].private, false);
+
+      expect(stub.bindCalls[1].mangaId, destMangaId);
+      expect(stub.bindCalls[1].trackerId, 20);
+      expect(stub.bindCalls[1].remoteId, 'remote-def');
+      expect(stub.bindCalls[1].private, true);
+    });
+
+    test('when source has no track records, no binds are issued', () async {
+      final stub = _StubTrackerRepository(fakeClient, records: []);
+
+      final fetched = await stub.getMangaTrackRecords(1);
+      for (final record in fetched ?? []) {
+        await stub.bind(
+          mangaId: 2,
+          trackerId: record.trackerId,
+          remoteId: record.remoteId,
+          private: record.private,
+        );
+      }
+
+      expect(stub.bindCalls, isEmpty);
+    });
+
+    test('when getMangaTrackRecords returns null, no binds are issued',
+        () async {
+      final stub = _StubTrackerRepository(fakeClient, records: null);
+
+      final fetched = await stub.getMangaTrackRecords(1);
+      // Null-guard mirrors migration_repository.dart behaviour.
+      if (fetched != null) {
+        for (final record in fetched) {
+          await stub.bind(
+            mangaId: 2,
+            trackerId: record.trackerId,
+            remoteId: record.remoteId,
+            private: record.private,
+          );
+        }
+      }
+
+      expect(stub.bindCalls, isEmpty);
+    });
+
+    test('MigrationOption.migrateTracking defaults to false', () {
+      expect(const MigrationOption().migrateTracking, isFalse);
+    });
+
+    test('MigrationResult carries migratedTracking count', () {
+      const result = MigrationResult(success: true, migratedTracking: 3);
+      expect(result.migratedTracking, 3);
+    });
+  });
+}
+
+/// A recorded bind call for assertion.
+class _BindCall {
+  const _BindCall({
+    required this.mangaId,
+    required this.trackerId,
+    required this.remoteId,
+    required this.private,
+  });
+
+  final int mangaId;
+  final int trackerId;
+  final String remoteId;
+  final bool private;
+}
+
+/// Stub that captures bind() calls and short-circuits getMangaTrackRecords.
+class _StubTrackerRepository extends TrackerRepository {
+  _StubTrackerRepository(super.client, {required this.records});
+
+  final List<Fragment$TrackRecordDto>? records;
+  final List<_BindCall> bindCalls = [];
+
+  @override
+  Future<List<Fragment$TrackRecordDto>?> getMangaTrackRecords(
+    int mangaId,
+  ) async =>
+      records;
+
+  @override
+  Future<void> bind({
+    required int mangaId,
+    required int trackerId,
+    required String remoteId,
+    required bool private,
+  }) async {
+    bindCalls.add(_BindCall(
+      mangaId: mangaId,
+      trackerId: trackerId,
+      remoteId: remoteId,
+      private: private,
+    ));
+  }
+}

--- a/test/src/features/offline/push_pending_progress_tracking_test.dart
+++ b/test/src/features/offline/push_pending_progress_tracking_test.dart
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/features/tracking/controller/manga_track_records_controller.dart';
+import 'package:tsumiru/src/features/tracking/data/graphql/__generated__/query.graphql.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/domain/tracking_settings_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+import '../../../helpers/offline_test_db.dart';
+
+// ---------------------------------------------------------------------------
+// Stub implementations
+// ---------------------------------------------------------------------------
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+/// Records trackProgress calls without touching a real GraphQL server.
+class _FakeTrackerRepository extends TrackerRepository {
+  _FakeTrackerRepository() : super(_dummyClient());
+
+  final List<int> trackProgressCalls = [];
+
+  @override
+  Future<void> trackProgress(int mangaId) async {
+    trackProgressCalls.add(mangaId);
+  }
+
+  @override
+  Future<List<Fragment$TrackRecordDto>?> getMangaTrackRecords(int mangaId) =>
+      Future.value(const []);
+}
+
+/// Stubs putChapter so tests don't need a live GraphQL server.
+class _FakeMangaBookRepository extends MangaBookRepository {
+  _FakeMangaBookRepository() : super(_dummyClient());
+
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {
+    // Always succeeds so clearProgressDirty is called.
+  }
+}
+
+/// Notifier subclass that returns a fixed bool? without touching SharedPreferences.
+class _FixedToggle extends UpdateProgressAfterReading {
+  _FixedToggle(this._value);
+  final bool _value;
+
+  @override
+  bool? build() => _value;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: seed a chapter row (optionally dirty)
+// ---------------------------------------------------------------------------
+
+Future<void> _seed(
+  OfflineDatabase db,
+  int id, {
+  required int mangaId,
+  bool isRead = false,
+  bool dirty = false,
+}) async {
+  await db.upsertChapterMetadata(
+    id: id,
+    mangaId: mangaId,
+    name: 'c$id',
+    chapterIndex: id,
+    isRead: isRead,
+    lastPageRead: 0,
+    isBookmarked: false,
+    serverIsDownloaded: true,
+    pageCount: 10,
+    updatedAt: DateTime(2026),
+  );
+  if (dirty) {
+    await db.setChapterProgress(id, lastPageRead: 0, isRead: isRead);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a ProviderContainer wired with fakes
+// ---------------------------------------------------------------------------
+
+/// One fake track-record stub (the test only cares about .length, not content).
+Fragment$TrackRecordDto _fakeRecord() => Fragment$TrackRecordDto(
+      id: 99,
+      trackerId: 1,
+      remoteId: 'remote-1',
+      title: 'Manga',
+      remoteUrl: 'https://example.com',
+      status: 1,
+      lastChapterRead: 0,
+      totalChapters: 0,
+      score: 0,
+      displayScore: '0',
+      startDate: '',
+      finishDate: '',
+      private: false,
+    );
+
+Future<({
+  ProviderContainer container,
+  OfflineDatabase db,
+  _FakeTrackerRepository tracker,
+})> _build({
+  required List<int> mangaIds,
+  int trackRecordCount = 1,
+  bool toggleOn = true,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final db = testOfflineDatabase();
+  final fakeTracker = _FakeTrackerRepository();
+  final fakeMangaBook = _FakeMangaBookRepository();
+
+  final records = List.generate(trackRecordCount, (_) => _fakeRecord());
+
+  final overrides = <Override>[
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    offlineEnabledProvider.overrideWithValue(true),
+    offlineDatabaseProvider.overrideWithValue(db),
+    mangaBookRepositoryProvider.overrideWithValue(fakeMangaBook),
+    trackerRepositoryProvider.overrideWithValue(fakeTracker),
+    updateProgressAfterReadingProvider
+        .overrideWith(() => _FixedToggle(toggleOn)),
+    for (final id in mangaIds)
+      mangaTrackRecordsProvider(mangaId: id)
+          .overrideWith((_) => Future.value(records)),
+  ];
+
+  final container = ProviderContainer(overrides: overrides);
+
+  return (container: container, db: db, tracker: fakeTracker);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('pushPendingProgress → tracker push', () {
+    test(
+        'toggle ON + manga has track records → trackProgress called once',
+        () async {
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 1,
+        toggleOn: true,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1, isRead: true, dirty: true);
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls, [1],
+          reason: 'trackProgress must fire once for manga 1');
+    });
+
+    test('toggle OFF → trackProgress NOT called', () async {
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 1,
+        toggleOn: false,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1, isRead: true, dirty: true);
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls, isEmpty,
+          reason: 'toggle is off — no tracker push');
+    });
+
+    test('zero track records → trackProgress NOT called', () async {
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 0,
+        toggleOn: true,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1, isRead: true, dirty: true);
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls, isEmpty,
+          reason: 'no tracker bound — gate must reject');
+    });
+
+    test(
+        'toggle ON + multiple chapters for same manga → trackProgress called only ONCE',
+        () async {
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 1,
+        toggleOn: true,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      // Three read+dirty chapters all for manga 1.
+      await _seed(db, 10, mangaId: 1, isRead: true, dirty: true);
+      await _seed(db, 11, mangaId: 1, isRead: true, dirty: true);
+      await _seed(db, 12, mangaId: 1, isRead: true, dirty: true);
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls.length, 1,
+          reason: 'deduplication: only one trackProgress call per manga');
+      expect(tracker.trackProgressCalls.first, 1);
+    });
+
+    test('chapters with isRead=false do NOT trigger tracker push', () async {
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 1,
+        toggleOn: true,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      // Dirty progress update but chapter is not finished.
+      await _seed(db, 10, mangaId: 1, isRead: false, dirty: true);
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls, isEmpty,
+          reason: 'isRead=false chapters must not trigger tracker');
+    });
+  });
+}

--- a/test/src/features/tracking/controller/manga_track_records_controller_test.dart
+++ b/test/src/features/tracking/controller/manga_track_records_controller_test.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/tracking/controller/manga_track_records_controller.dart';
+import 'package:tsumiru/src/features/tracking/data/graphql/__generated__/query.graphql.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+
+void main() {
+  // A minimal fake client — the stub repo never actually calls it.
+  final fakeClient = GraphQLClient(
+    link: HttpLink('http://localhost'),
+    cache: GraphQLCache(),
+  );
+
+  group('mangaTrackRecordsProvider', () {
+    test('defaults to empty list when repository returns null', () async {
+      final container = ProviderContainer(
+        overrides: [
+          trackerRepositoryProvider.overrideWith(
+            (ref) => _StubTrackerRepository(fakeClient, records: null),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        mangaTrackRecordsProvider(mangaId: 42).future,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('returns list from repository when records exist', () async {
+      final fakeRecord = Fragment$TrackRecordDto(
+        id: 1,
+        trackerId: 1,
+        remoteId: 'remote-1',
+        title: 'Test Manga',
+        remoteUrl: 'https://example.com',
+        status: 1,
+        lastChapterRead: 0.0,
+        totalChapters: 10,
+        score: 0.0,
+        displayScore: '0',
+        startDate: '',
+        finishDate: '',
+        private: false,
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          trackerRepositoryProvider.overrideWith(
+            (ref) => _StubTrackerRepository(fakeClient, records: [fakeRecord]),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        mangaTrackRecordsProvider(mangaId: 42).future,
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first.id, 1);
+      expect(result.first.title, 'Test Manga');
+    });
+
+    test('provider resolves to AsyncValue<List<Fragment\$TrackRecordDto>>', () async {
+      final container = ProviderContainer(
+        overrides: [
+          trackerRepositoryProvider.overrideWith(
+            (ref) => _StubTrackerRepository(fakeClient, records: null),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final list = await container.read(
+        mangaTrackRecordsProvider(mangaId: 1).future,
+      );
+      expect(list, isA<List<Fragment$TrackRecordDto>>());
+    });
+  });
+}
+
+/// Stub that short-circuits getMangaTrackRecords; the GraphQLClient is never
+/// invoked so any valid client object is sufficient for construction.
+class _StubTrackerRepository extends TrackerRepository {
+  _StubTrackerRepository(super.client, {required this.records});
+
+  final List<Fragment$TrackRecordDto>? records;
+
+  @override
+  Future<List<Fragment$TrackRecordDto>?> getMangaTrackRecords(
+    int mangaId,
+  ) async =>
+      records;
+}

--- a/test/src/features/tracking/data/tracker_repository_test.dart
+++ b/test/src/features/tracking/data/tracker_repository_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+void main() {
+  test('trackerRepositoryProvider builds a TrackerRepository', () {
+    final fakeClient = GraphQLClient(
+      link: HttpLink('http://localhost'),
+      cache: GraphQLCache(),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        graphQlClientProvider.overrideWithValue(fakeClient),
+      ],
+    );
+    addTearDown(container.dispose);
+    expect(container.read(trackerRepositoryProvider), isA<TrackerRepository>());
+  });
+}

--- a/test/src/features/tracking/domain/track_progress_gate_test.dart
+++ b/test/src/features/tracking/domain/track_progress_gate_test.dart
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/tracking/domain/track_progress_gate.dart';
+
+void main() {
+  group('shouldTrackProgress', () {
+    // Baseline: all conditions met (auto path).
+    test('returns true when all conditions are met (auto path)', () {
+      expect(
+        shouldTrackProgress(
+          isRead: true,
+          enabledAfterReading: true,
+          enabledManualMarkRead: true,
+          manual: false,
+          trackRecordCount: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    // isRead gate.
+    test('returns false when isRead is false', () {
+      expect(
+        shouldTrackProgress(
+          isRead: false,
+          enabledAfterReading: true,
+          enabledManualMarkRead: true,
+          manual: false,
+          trackRecordCount: 1,
+        ),
+        isFalse,
+      );
+    });
+
+    // trackRecordCount gate.
+    test('returns false when trackRecordCount is 0', () {
+      expect(
+        shouldTrackProgress(
+          isRead: true,
+          enabledAfterReading: true,
+          enabledManualMarkRead: true,
+          manual: false,
+          trackRecordCount: 0,
+        ),
+        isFalse,
+      );
+    });
+
+    // Auto path gated on enabledAfterReading.
+    test('returns false when auto path and enabledAfterReading is false', () {
+      expect(
+        shouldTrackProgress(
+          isRead: true,
+          enabledAfterReading: false,
+          enabledManualMarkRead: true,
+          manual: false,
+          trackRecordCount: 1,
+        ),
+        isFalse,
+      );
+    });
+
+    // Auto path is not gated on enabledManualMarkRead.
+    test('returns true for auto path even when enabledManualMarkRead is false',
+        () {
+      expect(
+        shouldTrackProgress(
+          isRead: true,
+          enabledAfterReading: true,
+          enabledManualMarkRead: false,
+          manual: false,
+          trackRecordCount: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    // Manual path gated on enabledManualMarkRead.
+    test('returns true when manual path and enabledManualMarkRead is true', () {
+      expect(
+        shouldTrackProgress(
+          isRead: true,
+          enabledAfterReading: false,
+          enabledManualMarkRead: true,
+          manual: true,
+          trackRecordCount: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when manual path and enabledManualMarkRead is false',
+        () {
+      expect(
+        shouldTrackProgress(
+          isRead: true,
+          enabledAfterReading: true,
+          enabledManualMarkRead: false,
+          manual: true,
+          trackRecordCount: 1,
+        ),
+        isFalse,
+      );
+    });
+
+    // Manual path is not gated on enabledAfterReading.
+    test(
+        'returns true for manual path even when enabledAfterReading is false',
+        () {
+      expect(
+        shouldTrackProgress(
+          isRead: true,
+          enabledAfterReading: false,
+          enabledManualMarkRead: true,
+          manual: true,
+          trackRecordCount: 1,
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/src/features/tracking/domain/tracker_oauth_helpers_test.dart
+++ b/test/src/features/tracking/domain/tracker_oauth_helpers_test.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/tracking/domain/tracker_oauth_helpers.dart';
+
+void main() {
+  const authUrl =
+      'https://myanimelist.net/v1/oauth2/authorize?response_type=code&client_id=abc';
+  const trackerId = 1;
+  const trackerName = 'MyAnimeList';
+  const redirectUrl = 'tsumiru://tracker-oauth';
+
+  group('buildTrackerAuthUrl', () {
+    test('starts with the authUrl', () {
+      final result = buildTrackerAuthUrl(
+        authUrl: authUrl,
+        trackerId: trackerId,
+        trackerName: trackerName,
+        redirectUrl: redirectUrl,
+      );
+      expect(result, startsWith(authUrl));
+    });
+
+    test('contains &state= followed by URL-encoded JSON', () {
+      final result = buildTrackerAuthUrl(
+        authUrl: authUrl,
+        trackerId: trackerId,
+        trackerName: trackerName,
+        redirectUrl: redirectUrl,
+      );
+      expect(result, contains('&state='));
+    });
+
+    test('decoded state has correct fields', () {
+      final result = buildTrackerAuthUrl(
+        authUrl: authUrl,
+        trackerId: trackerId,
+        trackerName: trackerName,
+        redirectUrl: redirectUrl,
+      );
+      final stateEncoded = Uri.parse(result).queryParameters['state']!;
+      final stateDecoded =
+          jsonDecode(Uri.decodeComponent(stateEncoded)) as Map<String, dynamic>;
+      expect(stateDecoded['redirectUrl'], equals(redirectUrl));
+      expect(stateDecoded['trackerId'], equals(trackerId));
+      expect(stateDecoded['trackerName'], equals(trackerName));
+    });
+  });
+
+  group('parseTrackerIdFromCallback', () {
+    Uri makeUri(Map<String, dynamic> stateMap) {
+      final encoded = Uri.encodeComponent(jsonEncode(stateMap));
+      return Uri.parse('tsumiru://tracker-oauth?code=xyz&state=$encoded');
+    }
+
+    test('returns correct int trackerId from valid callback', () {
+      final uri = makeUri(
+          {'redirectUrl': redirectUrl, 'trackerId': 1, 'trackerName': 'MAL'});
+      expect(parseTrackerIdFromCallback(uri), equals(1));
+    });
+
+    test('returns null when state param is absent', () {
+      final uri = Uri.parse('tsumiru://tracker-oauth?code=xyz');
+      expect(parseTrackerIdFromCallback(uri), isNull);
+    });
+
+    test('returns null for malformed JSON in state', () {
+      final uri = Uri.parse(
+          'tsumiru://tracker-oauth?state=${Uri.encodeComponent('not-json')}');
+      expect(parseTrackerIdFromCallback(uri), isNull);
+    });
+
+    test('returns null when trackerId is missing from state', () {
+      final uri = makeUri({'redirectUrl': redirectUrl});
+      expect(parseTrackerIdFromCallback(uri), isNull);
+    });
+
+    test('accepts trackerId as a string (int.tryParse)', () {
+      final uri = makeUri({'trackerId': '42', 'trackerName': 'MAL'});
+      expect(parseTrackerIdFromCallback(uri), equals(42));
+    });
+  });
+}

--- a/test/src/features/tracking/domain/tracking_settings_providers_test.dart
+++ b/test/src/features/tracking/domain/tracking_settings_providers_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/tracking/domain/tracking_settings_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/utils/extensions/custom_extensions.dart';
+
+void main() {
+  test('updateProgressAfterReading defaults to true', () async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+    final c = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(sp)]);
+    addTearDown(c.dispose);
+    expect(c.read(updateProgressAfterReadingProvider).ifNull(), isTrue);
+  });
+
+  test('updateProgressManualMarkRead defaults to true', () async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+    final c = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(sp)]);
+    addTearDown(c.dispose);
+    expect(c.read(updateProgressManualMarkReadProvider).ifNull(), isTrue);
+  });
+
+  test('updateProgressAfterReading persists false', () async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+    final c = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(sp)]);
+    addTearDown(c.dispose);
+    c.read(updateProgressAfterReadingProvider.notifier).update(false);
+    expect(c.read(updateProgressAfterReadingProvider).ifNull(), isFalse);
+  });
+
+  test('updateProgressManualMarkRead persists false', () async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+    final c = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(sp)]);
+    addTearDown(c.dispose);
+    c.read(updateProgressManualMarkReadProvider.notifier).update(false);
+    expect(c.read(updateProgressManualMarkReadProvider).ifNull(), isFalse);
+  });
+}

--- a/test/src/features/tracking/presentation/hub/track_editor_test.dart
+++ b/test/src/features/tracking/presentation/hub/track_editor_test.dart
@@ -1,0 +1,158 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/tracking/controller/manga_track_records_controller.dart';
+import 'package:tsumiru/src/features/tracking/data/graphql/__generated__/query.graphql.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/presentation/hub/widgets/track_editor.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/utils/misc/toast/toast.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+final _fakeClient = GraphQLClient(
+  link: HttpLink('http://localhost'),
+  cache: GraphQLCache(),
+);
+
+Fragment$TrackerDto _fakeTracker({
+  bool supportsReadingDates = false,
+  bool supportsTrackDeletion = false,
+  bool supportsPrivateTracking = false,
+}) =>
+    Fragment$TrackerDto(
+      id: 1,
+      name: 'MyAnimeList',
+      icon: 'https://example.com/mal.png',
+      isLoggedIn: true,
+      isTokenExpired: false,
+      supportsTrackDeletion: supportsTrackDeletion,
+      supportsPrivateTracking: supportsPrivateTracking,
+      supportsReadingDates: supportsReadingDates,
+      scores: const ['0.0', '1.0', '5.0', '10.0'],
+      statuses: [
+        Fragment$TrackerDto$statuses(name: 'Reading', value: 1),
+        Fragment$TrackerDto$statuses(name: 'Completed', value: 2),
+        Fragment$TrackerDto$statuses(name: 'On Hold', value: 3),
+      ],
+    );
+
+Fragment$TrackRecordDto _fakeRecord({
+  int status = 1,
+  double lastChapterRead = 5.0,
+  bool private = false,
+}) =>
+    Fragment$TrackRecordDto(
+      id: 10,
+      trackerId: 1,
+      remoteId: '42',
+      title: 'Test Manga',
+      remoteUrl: 'https://myanimelist.net/manga/42',
+      status: status,
+      lastChapterRead: lastChapterRead,
+      totalChapters: 100,
+      score: 0.0,
+      displayScore: '0.0',
+      startDate: '0',
+      finishDate: '0',
+      private: private,
+    );
+
+/// Stub repository — all mutations are no-ops by default.
+class _StubTrackerRepository extends TrackerRepository {
+  _StubTrackerRepository(super.client);
+
+  @override
+  Future<void> update({
+    required int recordId,
+    int? status,
+    String? scoreString,
+    double? lastChapterRead,
+    String? startDate,
+    String? finishDate,
+    bool? private,
+  }) async {}
+
+  @override
+  Future<void> unbind({
+    required int recordId,
+    bool? deleteRemoteTrack,
+  }) async {}
+}
+
+Widget _testApp({
+  required Fragment$TrackerDto tracker,
+  required Fragment$TrackRecordDto record,
+  _StubTrackerRepository? repo,
+}) {
+  final stubRepo = repo ?? _StubTrackerRepository(_fakeClient);
+  return ProviderScope(
+    overrides: [
+      trackerRepositoryProvider.overrideWith((ref) => stubRepo),
+      toastProvider.overrideWithValue(null),
+      mangaTrackRecordsProvider(mangaId: 1)
+          .overrideWith((ref) async => [record]),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: TrackEditor(
+          tracker: tracker,
+          trackRecord: record,
+          mangaId: 1,
+        ),
+      ),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests (RED — written before implementation)
+// ---------------------------------------------------------------------------
+
+void main() {
+  testWidgets(
+    'TrackEditor shows Status row and NO date rows when supportsReadingDates is false',
+    (tester) async {
+      final tracker = _fakeTracker(supportsReadingDates: false);
+      final record = _fakeRecord(status: 1, lastChapterRead: 5.0);
+
+      await tester.pumpWidget(_testApp(tracker: tracker, record: record));
+      await tester.pump();
+      await tester.pump();
+
+      // Status row must be visible.
+      expect(find.text('Status'), findsOneWidget);
+
+      // Date rows must NOT appear when supportsReadingDates is false.
+      expect(find.text('Start date'), findsNothing);
+      expect(find.text('Finish date'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'TrackEditor shows Start date and Finish date rows when supportsReadingDates is true',
+    (tester) async {
+      final tracker = _fakeTracker(supportsReadingDates: true);
+      final record = _fakeRecord(status: 1, lastChapterRead: 5.0);
+
+      await tester.pumpWidget(_testApp(tracker: tracker, record: record));
+      await tester.pump();
+      await tester.pump();
+
+      // Date rows MUST appear when supportsReadingDates is true.
+      expect(find.text('Start date'), findsOneWidget);
+      expect(find.text('Finish date'), findsOneWidget);
+    },
+  );
+}

--- a/test/src/features/tracking/presentation/hub/track_sheet_content_test.dart
+++ b/test/src/features/tracking/presentation/hub/track_sheet_content_test.dart
@@ -1,0 +1,191 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/tracking/controller/manga_track_records_controller.dart';
+import 'package:tsumiru/src/features/tracking/data/graphql/__generated__/query.graphql.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/presentation/hub/track_sheet.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+Fragment$TrackerDto _fakeTracker({bool isLoggedIn = true, int id = 1}) =>
+    Fragment$TrackerDto(
+      id: id,
+      name: 'MyAnimeList',
+      icon: 'https://example.com/mal.png',
+      isLoggedIn: isLoggedIn,
+      isTokenExpired: false,
+      supportsTrackDeletion: false,
+      supportsPrivateTracking: false,
+      supportsReadingDates: false,
+      scores: const [],
+      statuses: const [],
+    );
+
+Fragment$TrackRecordDto _fakeRecord({int trackerId = 1}) =>
+    Fragment$TrackRecordDto(
+      id: 1,
+      trackerId: trackerId,
+      remoteId: '42',
+      title: 'My Bound Manga',
+      remoteUrl: 'https://myanimelist.net/manga/42',
+      status: 0,
+      lastChapterRead: 0.0,
+      totalChapters: 0,
+      score: 0.0,
+      displayScore: '',
+      startDate: '',
+      finishDate: '',
+      private: false,
+    );
+
+void main() {
+  testWidgets(
+    'TrackSheetContent shows "Add tracking" for a logged-in tracker with no record',
+    (tester) async {
+      final tracker = _fakeTracker();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            trackersProvider.overrideWith((ref) async => [tracker]),
+            mangaTrackRecordsProvider(mangaId: 1)
+                .overrideWith((ref) async => []),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TrackSheetContent(mangaId: 1)),
+          ),
+        ),
+      );
+
+      // Let both futures resolve.
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Add tracking'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'TrackSheetContent shows empty-state when no tracker is logged in',
+    (tester) async {
+      final tracker = _fakeTracker(isLoggedIn: false);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            trackersProvider.overrideWith((ref) async => [tracker]),
+            mangaTrackRecordsProvider(mangaId: 1)
+                .overrideWith((ref) async => []),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TrackSheetContent(mangaId: 1)),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Log in to a tracker'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'TrackSheetContent always renders "Manage trackers" action',
+    (tester) async {
+      final tracker = _fakeTracker();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            trackersProvider.overrideWith((ref) async => [tracker]),
+            mangaTrackRecordsProvider(mangaId: 1)
+                .overrideWith((ref) async => []),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TrackSheetContent(mangaId: 1)),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Manage trackers'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'TrackSheetContent shows "Log in to edit" card for a logged-out tracker with a bound record',
+    (tester) async {
+      final tracker = _fakeTracker(isLoggedIn: false);
+      final record = _fakeRecord();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            trackersProvider.overrideWith((ref) async => [tracker]),
+            mangaTrackRecordsProvider(mangaId: 1)
+                .overrideWith((ref) async => [record]),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TrackSheetContent(mangaId: 1)),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+
+      // The bound title is shown read-only.
+      expect(find.text('My Bound Manga'), findsOneWidget);
+      // The login prompt button is present.
+      expect(find.text('Log in to edit'), findsOneWidget);
+      // The generic empty-state is NOT shown because there is a bound record.
+      expect(find.text('Log in to a tracker'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'TrackSheetContent shows error state when trackersProvider errors',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            trackersProvider.overrideWith(
+              (ref) async => throw Exception('network error'),
+            ),
+            mangaTrackRecordsProvider(mangaId: 1)
+                .overrideWith((ref) async => []),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TrackSheetContent(mangaId: 1)),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+
+      // The error message and retry button are rendered.
+      expect(find.text('Exception: network error'), findsOneWidget);
+      expect(find.text('Refresh'), findsOneWidget);
+    },
+  );
+}

--- a/test/src/features/tracking/presentation/tracker_credentials_sheet_test.dart
+++ b/test/src/features/tracking/presentation/tracker_credentials_sheet_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/tracking/presentation/login/tracker_credentials_sheet.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+void main() {
+  testWidgets('credentials sheet has username and password fields',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: TrackerCredentialsSheet(
+          trackerName: 'MangaUpdates',
+          onSubmit: (_, __) {},
+        ),
+      ),
+    ));
+    await tester.pump();
+    expect(find.byType(TextField), findsNWidgets(2));
+  });
+
+  testWidgets('credentials sheet calls onSubmit with entered values',
+      (tester) async {
+    String? capturedUsername;
+    String? capturedPassword;
+
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: TrackerCredentialsSheet(
+          trackerName: 'MyAnimeList',
+          onSubmit: (u, p) {
+            capturedUsername = u;
+            capturedPassword = p;
+          },
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    final fields = find.byType(TextField);
+    await tester.enterText(fields.at(0), 'testuser');
+    await tester.enterText(fields.at(1), 'hunter2');
+
+    final loginButton = find.widgetWithText(FilledButton, 'Log in');
+    expect(loginButton, findsOneWidget);
+    await tester.tap(loginButton);
+    await tester.pump();
+
+    expect(capturedUsername, 'testuser');
+    expect(capturedPassword, 'hunter2');
+  });
+}

--- a/test/src/features/tracking/presentation/tracker_search_test.dart
+++ b/test/src/features/tracking/presentation/tracker_search_test.dart
@@ -1,0 +1,204 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/tracking/controller/manga_track_records_controller.dart';
+import 'package:tsumiru/src/features/tracking/controller/tracker_search_controller.dart';
+import 'package:tsumiru/src/features/tracking/data/graphql/__generated__/query.graphql.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/presentation/hub/widgets/tracker_search.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/utils/misc/toast/toast.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+final _fakeClient = GraphQLClient(
+  link: HttpLink('http://localhost'),
+  cache: GraphQLCache(),
+);
+
+Fragment$TrackerDto _fakeTracker({bool supportsPrivate = false}) =>
+    Fragment$TrackerDto(
+      id: 1,
+      name: 'MyAnimeList',
+      icon: 'https://example.com/mal.png',
+      isLoggedIn: true,
+      isTokenExpired: false,
+      supportsTrackDeletion: false,
+      supportsPrivateTracking: supportsPrivate,
+      supportsReadingDates: false,
+      scores: const [],
+      statuses: const [],
+    );
+
+Fragment$TrackSearchDto _fakeResult(
+        {required String remoteId, required String title}) =>
+    Fragment$TrackSearchDto(
+      remoteId: remoteId,
+      title: title,
+      coverUrl: 'https://example.com/cover.jpg',
+      publishingType: 'Manga',
+      publishingStatus: 'Publishing',
+      summary: 'A test manga summary.',
+      trackingUrl: 'https://myanimelist.net/manga/$remoteId',
+    );
+
+/// Stub repository whose [bind] either completes normally or throws.
+class _StubTrackerRepository extends TrackerRepository {
+  _StubTrackerRepository(super.client, {this.bindShouldThrow = false});
+
+  final bool bindShouldThrow;
+
+  @override
+  Future<void> bind({
+    required int mangaId,
+    required int trackerId,
+    required String remoteId,
+    required bool private,
+  }) async {
+    if (bindShouldThrow) throw Exception('network error');
+  }
+}
+
+// Pump a widget with no toast (null) so Toast? null-safety keeps things safe.
+Widget _testApp({
+  required Fragment$TrackerDto tracker,
+  required List<Fragment$TrackSearchDto> results,
+  required _StubTrackerRepository repo,
+  required VoidCallback onBound,
+}) =>
+    ProviderScope(
+      overrides: [
+        searchTrackerProvider(trackerId: tracker.id, query: 'test manga')
+            .overrideWith((ref) async => results),
+        trackerRepositoryProvider.overrideWith((ref) => repo),
+        // Supply null toast — Toast? is always nullable in the provider contract.
+        toastProvider.overrideWithValue(null),
+        mangaTrackRecordsProvider(mangaId: 42)
+            .overrideWith((ref) async => const []),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: TrackerSearch(
+            mangaId: 42,
+            mangaTitle: 'test manga',
+            tracker: tracker,
+            onBound: onBound,
+          ),
+        ),
+      ),
+    );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  testWidgets(
+    'TrackerSearch renders two result tiles when searchTrackerProvider returns two results',
+    (tester) async {
+      final tracker = _fakeTracker();
+      final results = [
+        _fakeResult(remoteId: '1', title: 'Result One'),
+        _fakeResult(remoteId: '2', title: 'Result Two'),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            searchTrackerProvider(trackerId: 1, query: 'test manga')
+                .overrideWith((ref) async => results),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: TrackerSearch(
+                mangaId: 42,
+                mangaTitle: 'test manga',
+                tracker: tracker,
+                onBound: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Let the initial build + future resolve.
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Result One'), findsOneWidget);
+      expect(find.text('Result Two'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'bind — success: calls onBound',
+    (tester) async {
+      final tracker = _fakeTracker();
+      final results = [_fakeResult(remoteId: '42', title: 'Success Manga')];
+      final stubRepo = _StubTrackerRepository(_fakeClient);
+      bool onBoundCalled = false;
+
+      await tester.pumpWidget(_testApp(
+        tracker: tracker,
+        results: results,
+        repo: stubRepo,
+        onBound: () => onBoundCalled = true,
+      ));
+
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Success Manga'));
+      await tester.pump();
+
+      await tester.tap(find.text('Track'));
+      await tester.pumpAndSettle();
+
+      expect(onBoundCalled, isTrue,
+          reason: 'onBound must fire when bind succeeds');
+    },
+  );
+
+  testWidgets(
+    'bind — failure: does NOT call onBound',
+    (tester) async {
+      final tracker = _fakeTracker();
+      final results = [_fakeResult(remoteId: '99', title: 'Error Manga')];
+      final stubRepo =
+          _StubTrackerRepository(_fakeClient, bindShouldThrow: true);
+      bool onBoundCalled = false;
+
+      await tester.pumpWidget(_testApp(
+        tracker: tracker,
+        results: results,
+        repo: stubRepo,
+        onBound: () => onBoundCalled = true,
+      ));
+
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Error Manga'));
+      await tester.pump();
+
+      await tester.tap(find.text('Track'));
+      await tester.pumpAndSettle();
+
+      expect(onBoundCalled, isFalse,
+          reason: 'onBound must NOT fire when the mutation fails');
+    },
+  );
+}

--- a/test/src/features/tracking/presentation/tracking_settings_screen_test.dart
+++ b/test/src/features/tracking/presentation/tracking_settings_screen_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/presentation/settings/tracking_settings_screen.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+void main() {
+  testWidgets('TrackingSettingsScreen shows both toggles', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final sp = await SharedPreferences.getInstance();
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(sp),
+        trackersProvider.overrideWith((ref) async => []),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: TrackingSettingsScreen(),
+      ),
+    ));
+    await tester.pump();
+    expect(find.text('Update progress after reading'), findsOneWidget);
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -13,6 +14,8 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   connectivity_plus
   flutter_secure_storage_windows
   permission_handler_windows


### PR DESCRIPTION
Adds tracker support, surfacing the trackers the Suwayomi server already manages (MyAnimeList, AniList, Kitsu, MangaUpdates, Shikimori, Bangumi).

- Tracking settings: log into a tracker (OS deep-link OAuth, or username/password) and toggle whether reading updates progress.
- Manga details: a Tracking button opens a sheet to bind the series to any logged-in tracker and edit status, score, chapters, and start/finish dates.
- Auto-sync: marking a chapter read pushes progress to the manga's trackers, both online and after offline reads sync on reconnect.
- Migration: carries trackers across when migrating a series.

The app stays a thin frontend over the server's tracker GraphQL API; all auth and tracker API calls remain server-side. The next-update indicator moved from the action row into the manga-details header to make room for the Tracking button.

363 tests passing.