### PR TITLE
Offline menu: preset keep-buffer sizes (5/10/25 unread)

### DIFF
--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -541,6 +541,17 @@ Future<OfflineKeepRule> mangaKeepRule(Ref ref, int mangaId) async {
   return ref.watch(offlineRepositoryProvider).keepRuleFor(mangaId);
 }
 
+/// The keep-offline rule AND its unread-buffer size — so the sheet can tick the
+/// exact "Keep next N unread" preset that's active.
+@riverpod
+Future<({OfflineKeepRule rule, int count})> mangaKeepConfig(
+    Ref ref, int mangaId) async {
+  if (!ref.watch(offlineEnabledProvider)) {
+    return (rule: OfflineKeepRule.off, count: 5);
+  }
+  return ref.watch(offlineRepositoryProvider).keepConfigFor(mangaId);
+}
+
 /// How many of a manga's chapters are downloaded on this device — drives the
 /// series Download/On-device button label.
 @riverpod

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -105,6 +105,14 @@ class OfflineRepository {
     return m?.keepRule ?? OfflineKeepRule.off;
   }
 
+  /// The per-series keep-offline rule AND its unread-buffer size — so the UI can
+  /// tick the exact "Keep next N unread" preset that's active.
+  Future<({OfflineKeepRule rule, int count})> keepConfigFor(int mangaId) async {
+    final m = await (db.select(db.offlineMangas)..where((t) => t.id.equals(mangaId)))
+        .getSingleOrNull();
+    return (rule: m?.keepRule ?? OfflineKeepRule.off, count: m?.keepUnreadCount ?? 5);
+  }
+
   /// Manga ids with at least one chapter downloaded to this device — for the
   /// "On device" library filter.
   Future<Set<int>> deviceDownloadedMangaIds() => db.mangaIdsWithDeviceDownloads();

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -148,17 +148,25 @@ class SeriesOfflineButton extends ConsumerWidget {
     ref.invalidate(mangaKeepConfigProvider(mangaId));
     messenger.showSnackBar(SnackBar(content: Text(toast)));
     // The reconcile may pull many chapters; run it in the background and refresh
-    // the on-device count as it completes.
+    // the on-device count when it settles — even on failure, so the badge can't
+    // get stuck, and swallow the error (best-effort background work).
     unawaited(reconcileMangaWidget(ref, mangaId)
-        .then((_) => ref.invalidate(mangaDownloadedCountProvider(mangaId))));
+        .whenComplete(
+            () => ref.invalidate(mangaDownloadedCountProvider(mangaId)))
+        .catchError((_) {/* best-effort */}));
   }
 
   Future<void> _removeAll(BuildContext sheetContext, WidgetRef ref) async {
     Navigator.of(sheetContext).pop();
     final db = ref.read(offlineDatabaseProvider);
-    await db.setKeepRule(mangaId, OfflineKeepRule.off, 3);
-    for (final c in await db.downloadedChaptersForManga(mangaId)) {
-      await deleteChapterFromDevice(ref, c.id);
+    await db.setKeepRule(mangaId, OfflineKeepRule.off, 5);
+    // Purge every chapter with any on-device footprint — not just the fully
+    // downloaded ones — so an in-flight/queued download is cancelled too and
+    // can't finish after the user asked to remove everything.
+    for (final c in await db.chaptersForManga(mangaId)) {
+      if (c.deviceState != OfflineDeviceState.none) {
+        await deleteChapterFromDevice(ref, c.id);
+      }
     }
     ref.invalidate(mangaKeepRuleProvider(mangaId));
     ref.invalidate(mangaKeepConfigProvider(mangaId));

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -53,8 +53,9 @@ class SeriesOfflineButton extends ConsumerWidget {
   }
 
   void _openSheet(BuildContext context, WidgetRef ref, bool onDevice) {
-    final rule = ref.read(mangaKeepRuleProvider(mangaId)).valueOrNull ??
-        OfflineKeepRule.off;
+    final config = ref.read(mangaKeepConfigProvider(mangaId)).valueOrNull ??
+        (rule: OfflineKeepRule.off, count: 5);
+    final rule = config.rule;
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
@@ -88,35 +89,46 @@ class SeriesOfflineButton extends ConsumerWidget {
               ),
             ),
             const Divider(height: 1),
-            ListTile(
-              leading: const Icon(Icons.download_rounded),
-              title: Text(sheetContext.l10n.offlineDownloadAll),
-              trailing: rule == OfflineKeepRule.all
-                  ? const Icon(Icons.check_rounded)
-                  : null,
-              onTap: () => _apply(sheetContext, ref, OfflineKeepRule.all),
-            ),
-            ListTile(
-              leading: const Icon(Icons.bookmark_added_outlined),
-              title: Text(sheetContext.l10n.keepOfflineNUnread),
-              trailing: rule == OfflineKeepRule.nUnread
-                  ? const Icon(Icons.check_rounded)
-                  : null,
-              onTap: () => _apply(sheetContext, ref, OfflineKeepRule.nUnread),
-            ),
+            // Rolling forward buffer: keep the next N unread downloaded, topped
+            // up as you read. Distinct buffer sizes.
+            for (final n in const [5, 10, 25])
+              ListTile(
+                leading: const Icon(Icons.bookmark_add_outlined),
+                title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+                trailing: (rule == OfflineKeepRule.nUnread && config.count == n)
+                    ? const Icon(Icons.check_rounded)
+                    : null,
+                onTap: () =>
+                    _apply(sheetContext, ref, OfflineKeepRule.nUnread, n),
+              ),
             ListTile(
               leading: const Icon(Icons.menu_book_outlined),
               title: Text(sheetContext.l10n.keepOfflineAllUnread),
               trailing: rule == OfflineKeepRule.allUnread
                   ? const Icon(Icons.check_rounded)
                   : null,
-              onTap: () => _apply(sheetContext, ref, OfflineKeepRule.allUnread),
+              onTap: () => _apply(
+                  sheetContext, ref, OfflineKeepRule.allUnread, config.count),
             ),
-            if (onDevice) ...[
+            ListTile(
+              leading: const Icon(Icons.library_books_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAll),
+              trailing: rule == OfflineKeepRule.all
+                  ? const Icon(Icons.check_rounded)
+                  : null,
+              onTap: () =>
+                  _apply(sheetContext, ref, OfflineKeepRule.all, config.count),
+            ),
+            if (onDevice || rule != OfflineKeepRule.off) ...[
               const Divider(height: 1),
               ListTile(
-                leading: const Icon(Icons.delete_outline_rounded),
-                title: Text(sheetContext.l10n.offlineRemoveSeries),
+                leading: Icon(Icons.delete_outline_rounded,
+                    color: sheetContext.theme.colorScheme.error),
+                title: Text(
+                  sheetContext.l10n.offlineRemoveSeries,
+                  style: TextStyle(
+                      color: sheetContext.theme.colorScheme.error),
+                ),
                 onTap: () => _removeAll(sheetContext, ref),
               ),
             ],
@@ -126,13 +138,14 @@ class SeriesOfflineButton extends ConsumerWidget {
     );
   }
 
-  Future<void> _apply(
-      BuildContext sheetContext, WidgetRef ref, OfflineKeepRule rule) async {
+  Future<void> _apply(BuildContext sheetContext, WidgetRef ref,
+      OfflineKeepRule rule, int count) async {
     final messenger = ScaffoldMessenger.of(sheetContext);
     final toast = sheetContext.l10n.offlineDownloadingToast;
     Navigator.of(sheetContext).pop();
-    await ref.read(offlineDatabaseProvider).setKeepRule(mangaId, rule, 3);
+    await ref.read(offlineDatabaseProvider).setKeepRule(mangaId, rule, count);
     ref.invalidate(mangaKeepRuleProvider(mangaId));
+    ref.invalidate(mangaKeepConfigProvider(mangaId));
     messenger.showSnackBar(SnackBar(content: Text(toast)));
     // The reconcile may pull many chapters; run it in the background and refresh
     // the on-device count as it completes.
@@ -148,6 +161,7 @@ class SeriesOfflineButton extends ConsumerWidget {
       await deleteChapterFromDevice(ref, c.id);
     }
     ref.invalidate(mangaKeepRuleProvider(mangaId));
+    ref.invalidate(mangaKeepConfigProvider(mangaId));
     ref.invalidate(mangaDownloadedCountProvider(mangaId));
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1781,7 +1781,7 @@
     "@offlineDownloadAll": {
         "description": "Series offline action: download every chapter to this device"
     },
-    "offlineRemoveSeries": "Remove all downloads",
+    "offlineRemoveSeries": "Remove all (this series)",
     "@offlineRemoveSeries": {
         "description": "Series offline action: remove this series' downloads from the device"
     },

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1754,15 +1754,16 @@
     "@keepOfflineOff": {
         "description": "Keep-offline rule: disabled"
     },
-    "keepOfflineNUnread": "Keep 3 unread",
-    "@keepOfflineNUnread": {
-        "description": "Keep-offline rule: keep the N most recent unread chapters on device"
+    "keepOfflineNextUnread": "Keep next {count} unread",
+    "@keepOfflineNextUnread": {
+        "description": "Keep-offline rule: keep the next N unread chapters downloaded (rolling buffer)",
+        "placeholders": { "count": { "type": "int" } }
     },
     "keepOfflineAllUnread": "Keep all unread",
     "@keepOfflineAllUnread": {
         "description": "Keep-offline rule: keep all unread chapters on device"
     },
-    "keepOfflineAll": "Keep all",
+    "keepOfflineAll": "Keep all chapters",
     "@keepOfflineAll": {
         "description": "Keep-offline rule: keep every chapter on device"
     },
@@ -1775,12 +1776,12 @@
         "description": "Series offline button label when the series has downloads on this device"
     },
     "offlineSheetTitle": "Offline reading",
-    "offlineSheetSubtitle": "Keep chapters on this device so you can read them without a connection to your server. This is separate from server downloads (the cloud icon up top).",
+    "offlineSheetSubtitle": "Keep chapters downloaded on this device, topped up automatically as you read. Separate from server downloads (the cloud icon up top).",
     "offlineDownloadAll": "Download all chapters",
     "@offlineDownloadAll": {
         "description": "Series offline action: download every chapter to this device"
     },
-    "offlineRemoveSeries": "Remove downloads",
+    "offlineRemoveSeries": "Remove all downloads",
     "@offlineRemoveSeries": {
         "description": "Series offline action: remove this series' downloads from the device"
     },


### PR DESCRIPTION
Reworks the per-series **Offline** sheet from a single hardcoded "Keep 3 unread" into explicit rolling-buffer presets.

### Options
- **Keep next 5 / 10 / 25 unread** — rolling forward buffer (kept downloaded and topped up automatically as you read)
- **Keep all unread**
- **Keep all chapters**
- **Remove all (this series)** — red; scoped to the current series only

### Notes
- Same auto-managed keep-rule under the hood (`OfflineKeepRule` + `keepUnreadCount`) — only the choices and labels change.
- The active preset is ticked: the sheet now reads both the rule **and** its buffer size.
- Subtitle says the buffer is topped up automatically, so the auto behaviour is clear.
- "Remove all (this series)" is labelled to avoid confusion with the global "remove all downloads" in Settings → Offline.

Based on `delete-on-read` (#37) since it builds on that offline work; will retarget to `main` once #37 merges.
