### PR TITLE
Add a library continue-reading button

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -38,6 +38,9 @@ enum DBKeys {
   downloadedBadge(false),
   unreadBadge(true),
   languageBadge(false),
+  // Library display: overlay a play button on covers that jumps straight into
+  // the next unread chapter. Off by default, matching Mihon/Komikku/WebUI.
+  showContinueReadingButton(false),
   l10n(Locale('en')),
   mangaFilterDownloaded(null),
   mangaFilterOffline(null),

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -16,6 +16,7 @@ import '../../../../widgets/emoticons.dart';
 import '../../../../widgets/manga_cover/grid/manga_cover_grid_tile.dart';
 import '../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart';
 import '../../../../widgets/manga_cover/list/manga_cover_list_tile.dart';
+import '../../../../widgets/manga_cover/providers/manga_cover_providers.dart';
 import '../../../../widgets/selection_action_bar.dart';
 import '../../../manga_book/data/downloads/downloads_repository.dart';
 import '../../../manga_book/data/manga_book/manga_book_repository.dart';
@@ -60,6 +61,20 @@ class CategoryMangaList extends HookConsumerWidget {
       } else {
         MangaRoute(mangaId: manga.id, categoryId: categoryId).push(context);
       }
+    }
+
+    // Continue-reading button: opt-in display toggle. Shown only when the server
+    // (or offline catalog) reports a next-unread chapter, and never while
+    // multi-selecting (taps belong to selection then). Opens that chapter
+    // straight in the reader, bypassing the details page.
+    final showContinueReading =
+        ref.watch(showContinueReadingButtonProvider).ifNull(false);
+    VoidCallback? continueReadingFor(MangaDto manga) {
+      if (!showContinueReading || selecting) return null;
+      final chapter = manga.firstUnreadChapter;
+      if (chapter == null) return null;
+      return () =>
+          ReaderRoute(mangaId: manga.id, chapterId: chapter.id).push(context);
     }
 
     // Mark every chapter of the selected series read / unread, via the bulk
@@ -108,6 +123,7 @@ class CategoryMangaList extends HookConsumerWidget {
                 selected: selection.value.contains(items[index].id),
                 onPressed: () => open(items[index]),
                 onLongPress: () => toggle(items[index].id),
+                onContinueReading: continueReadingFor(items[index]),
                 showCountBadges: true,
               ),
             ),
@@ -119,6 +135,7 @@ class CategoryMangaList extends HookConsumerWidget {
                 selected: selection.value.contains(items[index].id),
                 onLongPress: () => toggle(items[index].id),
                 onPressed: () => open(items[index]),
+                onContinueReading: continueReadingFor(items[index]),
                 showCountBadges: true,
                 showDarkOverlay: false,
               ),
@@ -131,6 +148,7 @@ class CategoryMangaList extends HookConsumerWidget {
                 selected: selection.value.contains(items[index].id),
                 onPressed: () => open(items[index]),
                 onLongPress: () => toggle(items[index].id),
+                onContinueReading: continueReadingFor(items[index]),
                 showBadges: true,
               ),
             ),

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -98,11 +98,18 @@ class LibraryScreen extends HookConsumerWidget {
                               } else {
                                 showModalBottomSheet(
                                   context: context,
+                                  isScrollControlled: true,
                                   shape: RoundedRectangleBorder(
                                     borderRadius: KBorderRadius.rT16.radius,
                                   ),
                                   clipBehavior: Clip.hardEdge,
-                                  builder: (_) => const LibraryMangaOrganizer(),
+                                  // Taller than the default (~0.56) so the
+                                  // Display tab's options all fit without a
+                                  // cramped scroll.
+                                  builder: (_) => const FractionallySizedBox(
+                                    heightFactor: 0.72,
+                                    child: LibraryMangaOrganizer(),
+                                  ),
                                 );
                               }
                             },

--- a/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
@@ -56,6 +56,13 @@ class LibraryMangaDisplay extends ConsumerWidget {
           onChanged: ref.read(unreadBadgeProvider.notifier).update,
           tristate: false,
         ),
+        CustomCheckboxListTile(
+          title: context.l10n.continueReadingButton,
+          provider: showContinueReadingButtonProvider,
+          onChanged:
+              ref.read(showContinueReadingButtonProvider.notifier).update,
+          tristate: false,
+        ),
       ],
     );
   }

--- a/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
+++ b/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
@@ -10,6 +10,9 @@ fragment MangaDto on MangaType {
   chaptersLastFetchedAt
   description
   downloadCount
+  firstUnreadChapter {
+    ...ChapterDto
+  }
   genre
   id
   inLibrary

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -312,6 +312,30 @@ class OfflineDatabase extends _$OfflineDatabase {
     return result;
   }
 
+  /// The next unread chapter that is downloaded on this device, per manga — the
+  /// lowest `chapterIndex` row with `isRead = false` and
+  /// `deviceState = downloaded`. Drives the offline "continue reading" button:
+  /// offline you can only open a chapter that's actually on the device, so a
+  /// manga with no downloaded unread chapter is simply absent from the map.
+  Future<Map<int, OfflineChapter>> firstUnreadDownloadedChapterByManga() async {
+    final rows = await (select(offlineChapters)
+          ..where((t) =>
+              t.isRead.equals(false) &
+              t.deviceState.equalsValue(OfflineDeviceState.downloaded))
+          ..orderBy([
+            (t) => OrderingTerm(expression: t.mangaId),
+            (t) => OrderingTerm(expression: t.chapterIndex),
+          ]))
+        .get();
+    final result = <int, OfflineChapter>{};
+    for (final c in rows) {
+      // Rows are ordered by chapterIndex, so the first seen per manga is the
+      // earliest unread downloaded chapter.
+      result.putIfAbsent(c.mangaId, () => c);
+    }
+    return result;
+  }
+
   Future<List<OfflineChapter>> chaptersForManga(int mangaId) =>
       (select(offlineChapters)
             ..where((t) => t.mangaId.equals(mangaId))

--- a/lib/src/features/offline/data/offline_dto_mappers.dart
+++ b/lib/src/features/offline/data/offline_dto_mappers.dart
@@ -21,6 +21,7 @@ MangaDto offlineMangaToDto(
   OfflineManga m, {
   int chapterCount = 0,
   String? lastReadAt,
+  OfflineChapter? firstUnread,
 }) =>
     Fragment$MangaDto(
       id: m.id,
@@ -29,6 +30,11 @@ MangaDto offlineMangaToDto(
       bookmarkCount: 0,
       chapters: Fragment$MangaDto$chapters(totalCount: chapterCount),
       downloadCount: 0,
+      // The next unread chapter that's downloaded on this device, if any. Drives
+      // the offline "continue reading" button — left null (button hidden) when
+      // the next unread chapter isn't on the device, so it's never a dead end.
+      firstUnreadChapter:
+          firstUnread == null ? null : offlineChapterToDto(firstUnread),
       genre: const [],
       inLibrary: true,
       inLibraryAt: '0',

--- a/lib/src/features/offline/data/offline_read_fallback.dart
+++ b/lib/src/features/offline/data/offline_read_fallback.dart
@@ -25,9 +25,14 @@ Future<List<MangaDto>?> libraryWithOfflineFallback({
     final rows = await db.libraryManga();
     if (rows.isEmpty) rethrow;
     final lastReadByManga = await db.lastReadAtByManga();
+    final firstUnreadByManga = await db.firstUnreadDownloadedChapterByManga();
     return [
       for (final m in rows)
-        offlineMangaToDto(m, lastReadAt: lastReadByManga[m.id]),
+        offlineMangaToDto(
+          m,
+          lastReadAt: lastReadByManga[m.id],
+          firstUnread: firstUnreadByManga[m.id],
+        ),
     ];
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -144,6 +144,9 @@
     "@bookmarked": {
         "description": "Checkbox text to filter bookmarked manga chapters in Manga Details screen"
     },
+    "@continueReadingButton": {
+        "description": "Library display checkbox to overlay a continue-reading (next unread chapter) button on manga covers"
+    },
     "@browse": {
         "description": "Screen title, Navigation Bar text and Button text of both Browse screen and Browse Settings Screen"
     },
@@ -1122,6 +1125,7 @@
     "backupTime": "Backup Time",
     "badges": "Badges",
     "bookmarked": "Bookmarked",
+    "continueReadingButton": "Continue reading button",
     "browse": "Browse",
     "buildTime": "Build time",
     "cacheCleared": "Cache Cleared",

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -12,6 +12,7 @@ import '../../../features/manga_book/domain/manga/manga_model.dart';
 import '../../../features/manga_book/presentation/manga_thumbnail_viewer/manga_thumbnail_viewer.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../server_image.dart';
+import '../widgets/continue_reading_button.dart';
 import '../widgets/manga_badges.dart';
 
 class MangaCoverGridTile extends StatelessWidget {
@@ -20,6 +21,7 @@ class MangaCoverGridTile extends StatelessWidget {
     required this.manga,
     this.onPressed,
     this.onLongPress,
+    this.onContinueReading,
     this.showTitle = true,
     this.showBadges = true,
     this.showCountBadges = false,
@@ -29,6 +31,11 @@ class MangaCoverGridTile extends StatelessWidget {
   final MangaDto manga;
   final VoidCallback? onPressed;
   final VoidCallback? onLongPress;
+
+  /// When non-null, a play button is overlaid on the cover that opens the next
+  /// unread chapter. The library list supplies this only when the toggle is on
+  /// and a target chapter exists.
+  final VoidCallback? onContinueReading;
   final bool showCountBadges;
   final bool showTitle;
   final bool showBadges;
@@ -90,6 +97,12 @@ class MangaCoverGridTile extends StatelessWidget {
                   color: context.theme.colorScheme.primary,
                   shadows: const [Shadow(blurRadius: 4)],
                 ),
+              ),
+            if (onContinueReading != null && !selected)
+              Positioned(
+                right: 6,
+                bottom: 6,
+                child: ContinueReadingButton(onPressed: onContinueReading!),
               ),
           ],
         ),

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -98,7 +98,10 @@ class MangaCoverGridTile extends StatelessWidget {
                   shadows: const [Shadow(blurRadius: 4)],
                 ),
               ),
-            if (onContinueReading != null && !selected)
+            // No title to flow beside (cover-only / descriptive-list cover):
+            // overlay the button on the cover corner. With a title, the button
+            // lives in the footer row instead so it can't cover the text.
+            if (onContinueReading != null && !selected && !showTitle)
               Positioned(
                 right: 6,
                 bottom: 6,
@@ -124,6 +127,15 @@ class MangaCoverGridTile extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                     maxLines: 2,
                   ),
+                  // The button shares the footer row: the title takes the
+                  // remaining width, so it can never sit under the button.
+                  trailing: onContinueReading != null
+                      ? ContinueReadingButton(
+                          onPressed: onContinueReading!,
+                          size: 28,
+                          iconSize: 16,
+                        )
+                      : null,
                 )
               : null,
           child: manga.thumbnailUrl.isNotBlank

--- a/lib/src/widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart
+++ b/lib/src/widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart
@@ -23,6 +23,7 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
     required this.manga,
     this.onPressed,
     this.onLongPress,
+    this.onContinueReading,
     this.onTitleClicked,
     this.showBadges = true,
     this.showCountBadges = true,
@@ -34,6 +35,10 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
   final bool showCountBadges;
   final VoidCallback? onPressed;
   final VoidCallback? onLongPress;
+
+  /// When non-null, a play button is overlaid on the cover that opens the next
+  /// unread chapter.
+  final VoidCallback? onContinueReading;
   final ValueChanged<String?>? onTitleClicked;
   final bool selected;
   /// Optional widget rendered below the status/source line (details screen only).
@@ -62,6 +67,7 @@ class MangaCoverDescriptiveListTile extends StatelessWidget {
                 showBadges: false,
                 showTitle: false,
                 showDarkOverlay: false,
+                onContinueReading: onContinueReading,
               ),
             ),
             Expanded(

--- a/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
+++ b/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import '../../../constants/app_sizes.dart';
 import '../../../features/manga_book/domain/manga/manga_model.dart';
 import '../../server_image.dart';
+import '../widgets/continue_reading_button.dart';
 import '../widgets/manga_badges.dart';
 
 class MangaCoverListTile extends StatelessWidget {
@@ -17,6 +18,7 @@ class MangaCoverListTile extends StatelessWidget {
     required this.manga,
     this.onPressed,
     this.onLongPress,
+    this.onContinueReading,
     this.showBadges = true,
     this.showCountBadges = false,
     this.selected = false,
@@ -25,6 +27,9 @@ class MangaCoverListTile extends StatelessWidget {
   final MangaDto manga;
   final VoidCallback? onPressed;
   final VoidCallback? onLongPress;
+
+  /// When non-null, a play button at the row end opens the next unread chapter.
+  final VoidCallback? onContinueReading;
   final bool showCountBadges;
   final bool showBadges;
   final bool selected;
@@ -61,6 +66,14 @@ class MangaCoverListTile extends StatelessWidget {
           ),
             if (showBadges)
               MangaBadgesRow(manga: manga, showCountBadges: showCountBadges),
+            if (onContinueReading != null)
+              Padding(
+                padding: KEdgeInsets.h8.size,
+                child: ContinueReadingButton(
+                  onPressed: onContinueReading!,
+                  size: 28,
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/src/widgets/manga_cover/providers/manga_cover_providers.dart
+++ b/lib/src/widgets/manga_cover/providers/manga_cover_providers.dart
@@ -24,6 +24,13 @@ class UnreadBadge extends _$UnreadBadge with SharedPreferenceClientMixin<bool> {
   bool? build() => initialize(DBKeys.unreadBadge);
 }
 
+@riverpod
+class ShowContinueReadingButton extends _$ShowContinueReadingButton
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.showContinueReadingButton);
+}
+
 // @riverpod
 // class LanguageBadge extends _$LanguageBadge
 //     with SharedPreferenceClient<bool> {

--- a/lib/src/widgets/manga_cover/widgets/continue_reading_button.dart
+++ b/lib/src/widgets/manga_cover/widgets/continue_reading_button.dart
@@ -8,26 +8,29 @@ import 'package:flutter/material.dart';
 
 import '../../../utils/extensions/custom_extensions.dart';
 
-/// A small circular play button overlaid on a library cover that jumps straight
-/// into the next unread chapter. Shown only when a "continue reading" target
-/// exists (see the library list). Its own [InkWell] wins the tap over the
-/// cover's gesture, so opening the reader never also opens the details page.
+/// A small rounded-square play button overlaid on / beside a library cover that
+/// jumps straight into the next unread chapter. Matches Komikku: a filled icon
+/// button with the `small` shape, a `primaryContainer` fill, and a play glyph.
+/// Its own [InkWell] wins the tap over the cover's gesture, so opening the
+/// reader never also opens the details page.
 class ContinueReadingButton extends StatelessWidget {
   const ContinueReadingButton({
     super.key,
     required this.onPressed,
     this.size = 32,
+    this.iconSize = 20,
   });
 
   final VoidCallback onPressed;
   final double size;
+  final double iconSize;
 
   @override
   Widget build(BuildContext context) {
     final scheme = context.theme.colorScheme;
     return Material(
-      color: scheme.primary.withValues(alpha: 0.9),
-      shape: const CircleBorder(),
+      color: scheme.primaryContainer.withValues(alpha: 0.9),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       clipBehavior: Clip.antiAlias,
       elevation: 2,
       child: InkWell(
@@ -36,8 +39,8 @@ class ContinueReadingButton extends StatelessWidget {
           dimension: size,
           child: Icon(
             Icons.play_arrow_rounded,
-            size: size * 0.62,
-            color: scheme.onPrimary,
+            size: iconSize,
+            color: scheme.onPrimaryContainer,
           ),
         ),
       ),

--- a/lib/src/widgets/manga_cover/widgets/continue_reading_button.dart
+++ b/lib/src/widgets/manga_cover/widgets/continue_reading_button.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../../utils/extensions/custom_extensions.dart';
+
+/// A small circular play button overlaid on a library cover that jumps straight
+/// into the next unread chapter. Shown only when a "continue reading" target
+/// exists (see the library list). Its own [InkWell] wins the tap over the
+/// cover's gesture, so opening the reader never also opens the details page.
+class ContinueReadingButton extends StatelessWidget {
+  const ContinueReadingButton({
+    super.key,
+    required this.onPressed,
+    this.size = 32,
+  });
+
+  final VoidCallback onPressed;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = context.theme.colorScheme;
+    return Material(
+      color: scheme.primary.withValues(alpha: 0.9),
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      elevation: 2,
+      child: InkWell(
+        onTap: onPressed,
+        child: SizedBox.square(
+          dimension: size,
+          child: Icon(
+            Icons.play_arrow_rounded,
+            size: size * 0.62,
+            color: scheme.onPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/src/features/offline/data/offline_dto_mappers_test.dart
+++ b/test/src/features/offline/data/offline_dto_mappers_test.dart
@@ -38,6 +38,22 @@ void main() {
     expect(neverRead.lastReadChapter, isNull);
   });
 
+  test('offlineMangaToDto carries firstUnreadChapter when supplied', () async {
+    await db.upsertMangaMetadata(id: 7, title: 'Solo', updatedAt: DateTime(2026));
+    final m = (await db.mangaById(7))!;
+    await db.upsertChapterMetadata(id: 42, mangaId: 7, name: 'Ch 5',
+        chapterIndex: 5, isRead: false, lastPageRead: 0, isBookmarked: false,
+        serverIsDownloaded: true, pageCount: 18, updatedAt: DateTime(2026));
+    final chapter = (await db.chaptersForManga(7)).single;
+
+    final withTarget = offlineMangaToDto(m, firstUnread: chapter);
+    expect(withTarget.firstUnreadChapter?.id, 42);
+    expect(withTarget.firstUnreadChapter?.sourceOrder, 5);
+
+    final noTarget = offlineMangaToDto(m);
+    expect(noTarget.firstUnreadChapter, isNull);
+  });
+
   test('offlineChapterToDto maps fields from a catalog row', () async {
     await db.upsertChapterMetadata(id: 3, mangaId: 7, name: 'Ch 3',
         chapterIndex: 3, isRead: true, lastPageRead: 4, isBookmarked: false,

--- a/test/src/features/offline/data/offline_read_fallback_test.dart
+++ b/test/src/features/offline/data/offline_read_fallback_test.dart
@@ -25,6 +25,35 @@ void main() {
     expect(r!.map((m) => m.id).toSet(), {1, 2});
   });
 
+  test('library: offline continue-reading target is the earliest unread '
+      'downloaded chapter', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    // ch1 read+downloaded, ch2 unread+downloaded, ch3 unread+downloaded.
+    // The button should point at ch2 (earliest unread that's on the device).
+    for (final (id, idx, read) in [(11, 1, true), (12, 2, false), (13, 3, false)]) {
+      await db.upsertChapterMetadata(id: id, mangaId: 1, name: 'c$id',
+          chapterIndex: idx, isRead: read, lastPageRead: 0, isBookmarked: false,
+          serverIsDownloaded: true, pageCount: 1, updatedAt: DateTime(2026));
+      await db.setChapterDeviceState(id, OfflineDeviceState.downloaded);
+    }
+    final r = await libraryWithOfflineFallback(
+        fetch: boom, db: db, offlineEnabled: true);
+    expect(r!.single.firstUnreadChapter?.id, 12);
+  });
+
+  test('library: no offline button when the next unread chapter is not '
+      'downloaded', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    // Unread chapter exists but only as metadata (deviceState defaults to none),
+    // so it can't be opened offline -> firstUnreadChapter stays null (hidden).
+    await db.upsertChapterMetadata(id: 21, mangaId: 1, name: 'c21',
+        chapterIndex: 1, isRead: false, lastPageRead: 0, isBookmarked: false,
+        serverIsDownloaded: false, pageCount: 1, updatedAt: DateTime(2026));
+    final r = await libraryWithOfflineFallback(
+        fetch: boom, db: db, offlineEnabled: true);
+    expect(r!.single.firstUnreadChapter, isNull);
+  });
+
   test('library: rethrows when offline disabled', () async {
     await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
     expect(libraryWithOfflineFallback(fetch: boom, db: db, offlineEnabled: false),


### PR DESCRIPTION
Closes #24.

Adds an opt-in **continue reading** button to the library: a small play button on a manga's cover that opens its next unread chapter directly, skipping the details page. Parity with Suwayomi-WebUI, Mihon, and Komikku — the toggle is **off by default**, matching all three.

## How it works
- The next-unread chapter comes straight from the server's `MangaType.firstUnreadChapter` field (added to the library's `MangaDto` fragment), so there's no per-manga chapter fetch.
- A `showContinueReadingButton` display preference (default off) with a checkbox in Library → Display, alongside the badge toggles.
- Works in all three display modes (grid, list, descriptive list).

## Offline
When the library is browsed offline, the button only appears when the next unread chapter is actually **downloaded on the device** — resolved from the on-device catalog (`firstUnreadDownloadedChapterByManga`), never via the network. So it's never a dead end; if the next unread chapter isn't on the device, the button is simply hidden.

## Look & feel
Matches Komikku's control: a rounded-square `primaryContainer` filled button with a play glyph. In grid mode the button shares the title's footer row (the title takes the remaining width) so it can never overlap the title; covers without a title overlay it on the corner. The library options sheet is also a bit taller so the Display tab's options fit comfortably.

## Tests
Full suite green (381 tests). New coverage: the offline mapper carries the target chapter; the offline fallback picks the earliest unread *downloaded* chapter; and no button is offered when the next unread chapter isn't downloaded.