### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.6.1+33
+version: 0.7.0+34
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Release bump for v0.7.0 — manga tracking, offline downloads (delete-on-read, keep-buffer presets), library continue-reading button, and stored-chapter fallback when a source is down.