### PR TITLE
Surface GraphQL mutation failures instead of swallowing them

### DIFF
--- a/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
+++ b/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
@@ -33,44 +33,50 @@ class ExtensionRepository {
     if (!(file!.name.endsWith('.apk'))) {
       throw context.l10n.errorFilePickUnknownExtension(".apk");
     }
-    await client.mutate$InstallExternalExtension(
-      Options$Mutation$InstallExternalExtension(
-        variables: Variables$Mutation$InstallExternalExtension(
-          extensionFile:
-              await http.MultipartFile.fromPath("extensionFile", file.path!),
-        ),
-      ),
-    );
+    await client
+        .mutate$InstallExternalExtension(
+          Options$Mutation$InstallExternalExtension(
+            variables: Variables$Mutation$InstallExternalExtension(
+              extensionFile: await http.MultipartFile.fromPath(
+                  "extensionFile", file.path!),
+            ),
+          ),
+        )
+        .getData((data) => null);
   }
 
-  Future<void> installExtension(String pkgName) =>
-      client.mutate$UpdateExtension(
+  Future<void> installExtension(String pkgName) => client
+      .mutate$UpdateExtension(
         Options$Mutation$UpdateExtension(
           variables: Variables$Mutation$UpdateExtension(
             id: pkgName,
             install: true,
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
-  Future<void> uninstallExtension(String pkgName) =>
-      client.mutate$UpdateExtension(
+  Future<void> uninstallExtension(String pkgName) => client
+      .mutate$UpdateExtension(
         Options$Mutation$UpdateExtension(
           variables: Variables$Mutation$UpdateExtension(
             id: pkgName,
             uninstall: true,
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
-  Future<void> updateExtension(String pkgName) => client.mutate$UpdateExtension(
+  Future<void> updateExtension(String pkgName) => client
+      .mutate$UpdateExtension(
         Options$Mutation$UpdateExtension(
           variables: Variables$Mutation$UpdateExtension(
             id: pkgName,
             update: true,
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
   Future<List<Extension>?> getExtensionListStream() => client
       .mutate$FetchExtensionList()

--- a/lib/src/features/library/data/category_repository.dart
+++ b/lib/src/features/library/data/category_repository.dart
@@ -28,87 +28,98 @@ class CategoryRepository {
       .query$AllCategories()
       .getData((data) => data.categories.nodes);
 
-  Future<void> createCategory({required CategoryCreate category}) =>
-      ferryClient.mutate$CreateCategory(
+  Future<void> createCategory({required CategoryCreate category}) => ferryClient
+      .mutate$CreateCategory(
         Options$Mutation$CreateCategory(
           variables: Variables$Mutation$CreateCategory(input: category),
         ),
-      );
+      )
+      .getData((data) => null);
 
   Future<void> editCategory({
     required int categoryId,
     required CategoryUpdate category,
   }) =>
-      ferryClient.mutate$UpdateCategory(
-        Options$Mutation$UpdateCategory(
-          variables: Variables$Mutation$UpdateCategory(
-            input: Input$UpdateCategoryInput(
-              id: categoryId,
-              patch: category,
+      ferryClient
+          .mutate$UpdateCategory(
+            Options$Mutation$UpdateCategory(
+              variables: Variables$Mutation$UpdateCategory(
+                input: Input$UpdateCategoryInput(
+                  id: categoryId,
+                  patch: category,
+                ),
+              ),
             ),
-          ),
-        ),
-      );
+          )
+          .getData((data) => null);
 
   Future<void> deleteCategory({
     required int categoryId,
   }) =>
-      ferryClient.mutate$DeleteCategory(
-        Options$Mutation$DeleteCategory(
-          variables: Variables$Mutation$DeleteCategory(
-            input: Input$DeleteCategoryInput(categoryId: categoryId),
-          ),
-        ),
-      );
+      ferryClient
+          .mutate$DeleteCategory(
+            Options$Mutation$DeleteCategory(
+              variables: Variables$Mutation$DeleteCategory(
+                input: Input$DeleteCategoryInput(categoryId: categoryId),
+              ),
+            ),
+          )
+          .getData((data) => null);
 
   Future<void> reorderCategory({
     required int categoryId,
     required int position,
   }) =>
-      ferryClient.mutate$UpdateCategoryOrder(
-        Options$Mutation$UpdateCategoryOrder(
-          variables: Variables$Mutation$UpdateCategoryOrder(
-            input: Input$UpdateCategoryOrderInput(
-              id: categoryId,
-              position: position,
+      ferryClient
+          .mutate$UpdateCategoryOrder(
+            Options$Mutation$UpdateCategoryOrder(
+              variables: Variables$Mutation$UpdateCategoryOrder(
+                input: Input$UpdateCategoryOrderInput(
+                  id: categoryId,
+                  position: position,
+                ),
+              ),
             ),
-          ),
-        ),
-      );
+          )
+          .getData((data) => null);
 
   Future<void> setCategoryMeta({
     required int categoryId,
     required String key,
     required String value,
   }) =>
-      ferryClient.mutate$SetCategoryMeta(
-        Options$Mutation$SetCategoryMeta(
-          variables: Variables$Mutation$SetCategoryMeta(
-            input: Input$SetCategoryMetaInput(
-              meta: Input$CategoryMetaTypeInput(
-                categoryId: categoryId,
-                key: key,
-                value: value,
+      ferryClient
+          .mutate$SetCategoryMeta(
+            Options$Mutation$SetCategoryMeta(
+              variables: Variables$Mutation$SetCategoryMeta(
+                input: Input$SetCategoryMetaInput(
+                  meta: Input$CategoryMetaTypeInput(
+                    categoryId: categoryId,
+                    key: key,
+                    value: value,
+                  ),
+                ),
               ),
             ),
-          ),
-        ),
-      );
+          )
+          .getData((data) => null);
 
   Future<void> deleteCategoryMeta({
     required int categoryId,
     required String key,
   }) =>
-      ferryClient.mutate$DeleteCategoryMeta(
-        Options$Mutation$DeleteCategoryMeta(
-          variables: Variables$Mutation$DeleteCategoryMeta(
-            input: Input$DeleteCategoryMetaInput(
-              categoryId: categoryId,
-              key: key,
+      ferryClient
+          .mutate$DeleteCategoryMeta(
+            Options$Mutation$DeleteCategoryMeta(
+              variables: Variables$Mutation$DeleteCategoryMeta(
+                input: Input$DeleteCategoryMetaInput(
+                  categoryId: categoryId,
+                  key: key,
+                ),
+              ),
             ),
-          ),
-        ),
-      );
+          )
+          .getData((data) => null);
 
   //  Manga
   Future<List<MangaDto>?> getMangasFromCategory({

--- a/lib/src/features/manga_book/data/downloads/downloads_repository.dart
+++ b/lib/src/features/manga_book/data/downloads/downloads_repository.dart
@@ -23,46 +23,54 @@ class DownloadsRepository {
   final GraphQLClient client;
   final GraphQLClient subscriptionClient;
   // Downloads
-  Future<void> startDownloads() => client.mutate$StartDownloader(
+  Future<void> startDownloads() => client
+      .mutate$StartDownloader(
         Options$Mutation$StartDownloader(
           variables: Variables$Mutation$StartDownloader(
             input: Input$StartDownloaderInput(),
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
-  Future<void> stopDownloads() => client.mutate$StopDownloader(
+  Future<void> stopDownloads() => client
+      .mutate$StopDownloader(
         Options$Mutation$StopDownloader(
           variables: Variables$Mutation$StopDownloader(
             input: Input$StopDownloaderInput(),
           ),
         ),
-      );
-  Future<void> clearDownloads() => client.mutate$ClearDownloader(
+      )
+      .getData((data) => null);
+  Future<void> clearDownloads() => client
+      .mutate$ClearDownloader(
         Options$Mutation$ClearDownloader(
           variables: Variables$Mutation$ClearDownloader(
             input: Input$ClearDownloaderInput(),
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
-  Future<void> addChaptersBatchToDownloadQueue(List<int> chapterIds) =>
-      client.mutate$EnqueueChapterDownloads(
+  Future<void> addChaptersBatchToDownloadQueue(List<int> chapterIds) => client
+      .mutate$EnqueueChapterDownloads(
         Options$Mutation$EnqueueChapterDownloads(
           variables: Variables$Mutation$EnqueueChapterDownloads(
             input: Input$EnqueueChapterDownloadsInput(ids: chapterIds),
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
-  Future<void> removeChapterFromDownloadQueue(int chapterId) =>
-      client.mutate$DequeueChapterDownloads(
+  Future<void> removeChapterFromDownloadQueue(int chapterId) => client
+      .mutate$DequeueChapterDownloads(
         Options$Mutation$DequeueChapterDownloads(
           variables: Variables$Mutation$DequeueChapterDownloads(
             input: Input$DequeueChapterDownloadInput(id: chapterId),
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
   Future<DownloadStatusDto?> reorderDownload(int chapterId, int to) => client
       .mutate$ReorderChapterDownload(

--- a/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
+++ b/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
@@ -50,25 +50,25 @@ class MangaBookRepository {
       )
       .getData((data) => data.updateManga?.manga);
 
-  Future<void> modifyBulkChapters(ChapterBatch batch) =>
-      client.mutate$UpdateChapters(
+  Future<void> modifyBulkChapters(ChapterBatch batch) => client
+      .mutate$UpdateChapters(
         Options$Mutation$UpdateChapters(
           variables: Variables$Mutation$UpdateChapters(input: batch),
         ),
-      );
+      )
+      .getData((data) => null);
 
-  Future<void> deleteChapters(List<int> chapterIds) =>
-      client
-          .mutate$DeleteDownloadedChapters(
-            Options$Mutation$DeleteDownloadedChapters(
-              variables: Variables$Mutation$DeleteDownloadedChapters(
-                input: Input$DeleteDownloadedChaptersInput(ids: chapterIds),
-              ),
-            ),
-          )
-          // Surface failure as a throw so callers don't cascade a device delete
-          // when the server delete didn't actually happen.
-          .getData((data) => null);
+  Future<void> deleteChapters(List<int> chapterIds) => client
+      .mutate$DeleteDownloadedChapters(
+        Options$Mutation$DeleteDownloadedChapters(
+          variables: Variables$Mutation$DeleteDownloadedChapters(
+            input: Input$DeleteDownloadedChaptersInput(ids: chapterIds),
+          ),
+        ),
+      )
+      // Surface failure as a throw so callers don't cascade a device delete
+      // when the server delete didn't actually happen.
+      .getData((data) => null);
 
   // Mangas
   Future<MangaDto?> getManga({
@@ -91,8 +91,8 @@ class MangaBookRepository {
           )
           .getData((data) => data.manga.categories.nodes);
 
-  Future<void> addMangaToCategory(int mangaId, int categoryId) =>
-      client.mutate$UpdateMangaCategories(
+  Future<void> addMangaToCategory(int mangaId, int categoryId) => client
+      .mutate$UpdateMangaCategories(
         Options$Mutation$UpdateMangaCategories(
           variables: Variables$Mutation$UpdateMangaCategories(
             updateCategoryInput: Input$UpdateMangaCategoriesInput(
@@ -103,10 +103,11 @@ class MangaBookRepository {
             ),
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
-  Future<void> removeMangaFromCategory(int mangaId, int categoryId) =>
-      client.mutate$UpdateMangaCategories(
+  Future<void> removeMangaFromCategory(int mangaId, int categoryId) => client
+      .mutate$UpdateMangaCategories(
         Options$Mutation$UpdateMangaCategories(
           variables: Variables$Mutation$UpdateMangaCategories(
             updateCategoryInput: Input$UpdateMangaCategoriesInput(
@@ -117,7 +118,8 @@ class MangaBookRepository {
             ),
           ),
         ),
-      );
+      )
+      .getData((data) => null);
 
   // Chapters
 
@@ -171,19 +173,21 @@ class MangaBookRepository {
     required String key,
     required dynamic value,
   }) async =>
-      client.mutate$SetMangaMeta(
-        Options$Mutation$SetMangaMeta(
-          variables: Variables$Mutation$SetMangaMeta(
-            input: Input$SetMangaMetaInput(
-              meta: Input$MangaMetaTypeInput(
-                key: key,
-                mangaId: mangaId,
-                value: value,
+      client
+          .mutate$SetMangaMeta(
+            Options$Mutation$SetMangaMeta(
+              variables: Variables$Mutation$SetMangaMeta(
+                input: Input$SetMangaMetaInput(
+                  meta: Input$MangaMetaTypeInput(
+                    key: key,
+                    mangaId: mangaId,
+                    value: value,
+                  ),
+                ),
               ),
             ),
-          ),
-        ),
-      );
+          )
+          .getData((data) => null);
 
   /// Fetches the chapter list FROM THE SOURCE (the server re-scrapes the source
   /// site). Returns nothing if the source is down/gone — callers that need to


### PR DESCRIPTION
Several Future<void> repository mutations returned the raw mutate$… future
without .getData, so a server-side failure never threw and callers assumed
success — silent data loss on mark-read, category changes, extension
install/uninstall, and download-queue actions. Append .getData((data) => null)
(the same pattern deleteChapters/putChapter already use) so failures propagate
and the UI can react.

Covers modifyBulkChapters, add/removeMangaFromCategory, patchMangaMeta,
install/uninstall/updateExtension(+File), the six category CRUD mutations, and
the download-queue start/stop/clear/enqueue/dequeue mutations.
