### PR TITLE
Track offline bookmark dirtiness separately so progress sync can't clobber bookmarks

### DIFF
--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -64,6 +64,13 @@ class OfflineChapters extends Table {
   BoolColumn get progressDirty =>
       boolean().withDefault(const Constant(false))();
 
+  /// True when this chapter's bookmark was toggled locally but not yet pushed
+  /// to the server. Tracked separately from [progressDirty] so a read-progress
+  /// sync can't clobber a server bookmark that hasn't down-synced yet, and a
+  /// bookmark sync can't clobber un-synced read progress (#13/#33).
+  BoolColumn get bookmarkDirty =>
+      boolean().withDefault(const Constant(false))();
+
   /// The server's last-read timestamp (epoch millis as a string, matching the
   /// server's LongString) — synced down so the offline library can sort by
   /// "Last Read". Server is the source of truth; this is never the device clock.
@@ -115,7 +122,7 @@ class OfflineDatabase extends _$OfflineDatabase {
   OfflineDatabase(super.e);
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -132,6 +139,9 @@ class OfflineDatabase extends _$OfflineDatabase {
           }
           if (from < 4) {
             await m.addColumn(offlineChapters, offlineChapters.lastReadAt);
+          }
+          if (from < 5) {
+            await m.addColumn(offlineChapters, offlineChapters.bookmarkDirty);
           }
         },
       );
@@ -257,18 +267,46 @@ class OfflineDatabase extends _$OfflineDatabase {
         ),
       );
 
-  /// Clear the dirty flag after the progress was pushed to the server.
+  /// Clear the progress dirty flag after the progress was pushed to the server.
   Future<void> clearProgressDirty(int chapterId) =>
       (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
           .write(const OfflineChaptersCompanion(progressDirty: Value(false)));
 
-  /// Record a local bookmark change. Reuses `progressDirty` so the bookmark is
-  /// pushed to the server on the next online sync, alongside read progress (#33).
+  /// Clear the bookmark dirty flag after the bookmark was pushed to the server.
+  Future<void> clearBookmarkDirty(int chapterId) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
+          .write(const OfflineChaptersCompanion(bookmarkDirty: Value(false)));
+
+  /// Clear progressDirty only if the row still holds the exact values that were
+  /// pushed — so a newer local write that landed during the push isn't marked
+  /// clean and lost (the snapshot-then-clear race). A non-matching row keeps its
+  /// flag and re-syncs on the next pass.
+  Future<void> clearProgressDirtyIfUnchanged(int chapterId,
+          {required int lastPageRead, required bool isRead}) =>
+      (update(offlineChapters)
+            ..where((t) =>
+                t.id.equals(chapterId) &
+                t.lastPageRead.equals(lastPageRead) &
+                t.isRead.equals(isRead)))
+          .write(const OfflineChaptersCompanion(progressDirty: Value(false)));
+
+  /// Clear bookmarkDirty only if the bookmark still matches what was pushed —
+  /// same race guard as [clearProgressDirtyIfUnchanged].
+  Future<void> clearBookmarkDirtyIfUnchanged(int chapterId,
+          {required bool isBookmarked}) =>
+      (update(offlineChapters)
+            ..where((t) =>
+                t.id.equals(chapterId) & t.isBookmarked.equals(isBookmarked)))
+          .write(const OfflineChaptersCompanion(bookmarkDirty: Value(false)));
+
+  /// Record a local bookmark change. Marks `bookmarkDirty` (separate from
+  /// `progressDirty`) so the bookmark is pushed on the next online sync without
+  /// dragging stale read progress with it, and vice versa (#13/#33).
   Future<void> setChapterBookmark(int chapterId, bool isBookmarked) =>
       (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
         OfflineChaptersCompanion(
           isBookmarked: Value(isBookmarked),
-          progressDirty: const Value(true),
+          bookmarkDirty: const Value(true),
         ),
       );
 
@@ -276,6 +314,13 @@ class OfflineDatabase extends _$OfflineDatabase {
   Future<List<OfflineChapter>> dirtyProgressChapters() =>
       (select(offlineChapters)..where((t) => t.progressDirty.equals(true)))
           .get();
+
+  /// Chapters with any unpushed local change — read progress OR bookmark — for
+  /// the up-sync to flush and the down-sync to preserve.
+  Future<List<OfflineChapter>> dirtyChapters() => (select(offlineChapters)
+        ..where((t) =>
+            t.progressDirty.equals(true) | t.bookmarkDirty.equals(true)))
+      .get();
 
   // --- offline queries -------------------------------------------------------
 

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -159,7 +159,8 @@ Future<void> recordReadingProgress(
         ),
   );
   if (offline && !result.hasError) {
-    await ref.read(offlineDatabaseProvider).clearProgressDirty(chapterId);
+    await ref.read(offlineDatabaseProvider).clearProgressDirtyIfUnchanged(
+        chapterId, lastPageRead: lastPageRead, isRead: isRead);
   }
 }
 
@@ -178,27 +179,18 @@ Future<void> recordBookmark(
         .read(offlineDatabaseProvider)
         .setChapterBookmark(chapterId, isBookmarked);
   }
-  // Bookmarks share the one `progressDirty` flag with read progress, so the
-  // row may also carry an offline read that hasn't reached the server. Push the
-  // full state (not just the bookmark) — otherwise clearing the flag below
-  // would silently drop that pending read progress.
-  final row = offline
-      ? await ref.read(offlineRepositoryProvider).chapterById(chapterId)
-      : null;
+  // Bookmark dirtiness is tracked separately from read progress, so push only
+  // the bookmark and clear only its flag — any pending offline read stays dirty
+  // and is flushed independently by pushPendingProgress.
   final result = await AsyncValue.guard(
     () => ref.read(mangaBookRepositoryProvider).putChapter(
           chapterId: chapterId,
-          patch: row == null
-              ? ChapterChange(isBookmarked: isBookmarked)
-              : ChapterChange(
-                  isBookmarked: isBookmarked,
-                  isRead: row.isRead,
-                  lastPageRead: row.lastPageRead,
-                ),
+          patch: ChapterChange(isBookmarked: isBookmarked),
         ),
   );
   if (offline && !result.hasError) {
-    await ref.read(offlineDatabaseProvider).clearProgressDirty(chapterId);
+    await ref.read(offlineDatabaseProvider).clearBookmarkDirtyIfUnchanged(
+        chapterId, isBookmarked: isBookmarked);
   }
 }
 
@@ -366,20 +358,34 @@ Future<void> pushPendingProgress(ProviderContainer container) async {
   // is marked read — deduplicated so we call trackProgress once per manga.
   final syncedReadMangaIds = <int>{};
 
-  for (final c in await db.dirtyProgressChapters()) {
+  for (final c in await db.dirtyChapters()) {
     final result = await AsyncValue.guard(
       () => repo.putChapter(
         chapterId: c.id,
         patch: ChapterChange(
-          lastPageRead: c.lastPageRead,
-          isRead: c.isRead,
-          isBookmarked: c.isBookmarked,
+          // Send only the locally-changed fields (null = omitted from the
+          // patch), so a progress sync never overwrites a server bookmark that
+          // hasn't down-synced, and a bookmark sync never overwrites pending
+          // read progress (#13).
+          lastPageRead: c.progressDirty ? c.lastPageRead : null,
+          isRead: c.progressDirty ? c.isRead : null,
+          isBookmarked: c.bookmarkDirty ? c.isBookmarked : null,
         ),
       ),
     );
     if (!result.hasError) {
-      await db.clearProgressDirty(c.id);
-      if (c.isRead) syncedReadMangaIds.add(c.mangaId);
+      // Clear each flag only if the row still holds what we just pushed — a
+      // newer local write that arrived during the push keeps its flag and
+      // re-syncs on the next pass (no silent data loss).
+      if (c.progressDirty) {
+        await db.clearProgressDirtyIfUnchanged(c.id,
+            lastPageRead: c.lastPageRead, isRead: c.isRead);
+      }
+      if (c.bookmarkDirty) {
+        await db.clearBookmarkDirtyIfUnchanged(c.id,
+            isBookmarked: c.isBookmarked);
+      }
+      if (c.progressDirty && c.isRead) syncedReadMangaIds.add(c.mangaId);
     }
   }
 

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -32,21 +32,26 @@ class OfflineSync {
     // server — otherwise a down-sync would overwrite it with the stale server
     // value (the up-sync pushes it; this just stops it being lost in the gap).
     final dirty = {
-      for (final c in await _db.dirtyProgressChapters()) c.id: c,
+      for (final c in await _db.dirtyChapters()) c.id: c,
     };
     for (final c in chapters) {
       final local = dirty[c.id];
+      // Keep a locally-changed value only while its own flag is still dirty;
+      // otherwise take the server's. Tracking read-progress and bookmark
+      // dirtiness separately means a server bookmark set elsewhere still
+      // propagates to the device even while a read is pending up-sync, and
+      // vice versa — instead of the old code pinning ALL of progress+bookmark
+      // to the stale local value whenever either was dirty (#13).
+      final keepProgress = local?.progressDirty ?? false;
+      final keepBookmark = local?.bookmarkDirty ?? false;
       await _db.upsertChapterMetadata(
         id: c.id,
         mangaId: c.mangaId,
         name: c.name,
         chapterIndex: c.sourceOrder,
-        isRead: local?.isRead ?? c.isRead,
-        lastPageRead: local?.lastPageRead ?? c.lastPageRead,
-        // Bookmarks are dirty-tracked too (#33) — preserve a local bookmark that
-        // hasn't been pushed yet, or a down-sync would revert it to the stale
-        // server value before the up-sync gets a chance to send it.
-        isBookmarked: local?.isBookmarked ?? c.isBookmarked,
+        isRead: keepProgress ? local!.isRead : c.isRead,
+        lastPageRead: keepProgress ? local!.lastPageRead : c.lastPageRead,
+        isBookmarked: keepBookmark ? local!.isBookmarked : c.isBookmarked,
         serverIsDownloaded: c.isDownloaded,
         pageCount: c.pageCount,
         updatedAt: now,

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -16,8 +16,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 4', () {
-    expect(db.schemaVersion, 4);
+  test('opens at schema version 5', () {
+    expect(db.schemaVersion, 5);
   });
 
   test('inserts and reads a manga', () async {

--- a/test/src/features/offline/data/offline_download_manager_force_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_force_test.dart
@@ -42,6 +42,7 @@ void main() {
         pinned: false,
         downloadedAt: null,
         progressDirty: false,
+        bookmarkDirty: false,
         updatedAt: DateTime(2026),
       );
 

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 4', () {
-    expect(db.schemaVersion, 4);
+  test('opens at schema version 5', () {
+    expect(db.schemaVersion, 5);
   });
 
   test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',

--- a/test/src/features/offline/data/offline_progress_test.dart
+++ b/test/src/features/offline/data/offline_progress_test.dart
@@ -13,10 +13,13 @@ import 'package:tsumiru/src/features/offline/data/offline_sync.dart';
 import '../../../../helpers/offline_test_db.dart';
 
 ChapterDto serverChapter(int id,
-        {required int lastPageRead, required bool isRead}) =>
+        {required int lastPageRead,
+        required bool isRead,
+        bool isBookmarked = false}) =>
     Fragment$ChapterDto(
       id: id, mangaId: 1, name: 'c$id', chapterNumber: id.toDouble(),
-      sourceOrder: id, isRead: isRead, isBookmarked: false, isDownloaded: true,
+      sourceOrder: id, isRead: isRead, isBookmarked: isBookmarked,
+      isDownloaded: true,
       lastPageRead: lastPageRead, pageCount: 30, fetchedAt: '0', uploadDate: '0',
       lastReadAt: '0', url: '', meta: const <Fragment$ChapterDto$meta>[],
     );
@@ -64,7 +67,7 @@ void main() {
         .syncChapters([serverChapter(7, lastPageRead: 0, isRead: false)]);
     final c = await db.chapterById(7);
     expect(c!.isBookmarked, true); // local kept, not clobbered
-    expect(c.progressDirty, true); // still pending up-sync
+    expect(c.bookmarkDirty, true); // still pending up-sync
   });
 
   test('down-sync applies server progress for non-dirty chapters', () async {
@@ -74,5 +77,49 @@ void main() {
     final c = await db.chapterById(6);
     expect(c!.lastPageRead, 12);
     expect(c.isRead, true);
+  });
+
+  test('down-sync applies a server bookmark even while a read is pending (#13)',
+      () async {
+    // Local has a pending offline READ (progressDirty) but a stale bookmark;
+    // the server has since bookmarked the chapter (from another client). The
+    // old code pinned ALL of progress+bookmark to the local row whenever it was
+    // dirty, so the server bookmark was lost and the next up-sync clobbered it.
+    await seed(8, lastPageRead: 0);
+    await db.setChapterProgress(8, lastPageRead: 20, isRead: false);
+    await OfflineSync(db).syncChapters(
+        [serverChapter(8, lastPageRead: 0, isRead: false, isBookmarked: true)]);
+    final c = await db.chapterById(8);
+    expect(c!.isBookmarked, true); // server bookmark propagated, not clobbered
+    expect(c.lastPageRead, 20); // pending local read preserved
+    expect(c.progressDirty, true); // read still pending up-sync
+    expect(c.bookmarkDirty, false); // bookmark was not a local change
+  });
+
+  test('setChapterBookmark marks bookmarkDirty, not progressDirty', () async {
+    await seed(9);
+    await db.setChapterBookmark(9, true);
+    final c = await db.chapterById(9);
+    expect(c!.bookmarkDirty, true);
+    expect(c.progressDirty, false); // independent of read-progress dirtiness
+    expect((await db.dirtyChapters()).map((e) => e.id), [9]);
+    await db.clearBookmarkDirty(9);
+    expect(await db.dirtyChapters(), isEmpty);
+  });
+
+  test('clearProgressDirtyIfUnchanged keeps the flag when a newer write landed',
+      () async {
+    await seed(10);
+    await db.setChapterProgress(10, lastPageRead: 5, isRead: false);
+    // A newer local write arrives (e.g. during the up-sync push).
+    await db.setChapterProgress(10, lastPageRead: 9, isRead: false);
+    // Clearing with the OLD pushed values must NOT mark the newer row clean.
+    await db.clearProgressDirtyIfUnchanged(10, lastPageRead: 5, isRead: false);
+    final c = await db.chapterById(10);
+    expect(c!.progressDirty, true); // newer write still pending up-sync
+    expect(c.lastPageRead, 9);
+    // Clearing with the CURRENT values clears it.
+    await db.clearProgressDirtyIfUnchanged(10, lastPageRead: 9, isRead: false);
+    expect((await db.chapterById(10))!.progressDirty, false);
   });
 }

--- a/test/src/features/offline/data/reconcile_desired_set_test.dart
+++ b/test/src/features/offline/data/reconcile_desired_set_test.dart
@@ -8,7 +8,7 @@ OfflineChapter ch(int id, int idx, {bool read = false, bool pinned = false}) =>
       lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
       deviceState: OfflineDeviceState.none, pageCount: 1, bytes: 0,
       pinned: pinned, downloadedAt: null, progressDirty: false,
-      updatedAt: DateTime(2026),
+      bookmarkDirty: false, updatedAt: DateTime(2026),
     );
 
 void main() {

--- a/test/src/features/offline/data/reconcile_eviction_test.dart
+++ b/test/src/features/offline/data/reconcile_eviction_test.dart
@@ -15,7 +15,7 @@ OfflineChapter dl(int id, {int bytes = 100, DateTime? at, bool pinned = false}) 
       lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
       deviceState: OfflineDeviceState.downloaded, pageCount: 1, bytes: bytes,
       pinned: pinned, downloadedAt: at ?? DateTime(2026, 1, id),
-      progressDirty: false, updatedAt: DateTime(2026),
+      progressDirty: false, bookmarkDirty: false, updatedAt: DateTime(2026),
     );
 
 void main() {


### PR DESCRIPTION
The offline catalog had a single progressDirty flag shared by read progress and
bookmarks, so pushPendingProgress sent isBookmarked alongside every progress
sync and the down-sync pinned BOTH fields to the local row whenever either was
dirty. Result: read a chapter offline while the server bookmarked it elsewhere
(not yet down-synced) -> the read sync pushed the stale local isBookmarked=false
and clobbered the server bookmark (#13).

Add a bookmarkDirty column (schema v4->v5) distinct from progressDirty:
- setChapterBookmark marks bookmarkDirty; setChapterProgress marks progressDirty.
- pushPendingProgress (over dirtyChapters) sends only the locally-changed fields
  and clears each flag independently.
- the down-sync keeps a local value only while its OWN flag is dirty, so a
  server bookmark propagates even with a read pending, and vice versa.
- recordBookmark pushes just the bookmark and clears just bookmarkDirty.

Keeping the device's bookmark in sync with the server also addresses the
delete-on-read bookmark gate (#14). Adds regression tests.
