### PR TITLE
Evict on-device copies of chapters deleted on the server

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -105,6 +105,17 @@ class MangaChapterList extends _$MangaChapterList {
       state = result.copyWithPrevious(state);
     } else {
       state = result;
+      final chapters = result.valueOrNull;
+      if (chapters != null) {
+        // Mirror build(): down-sync the fresh list (which orphans chapters the
+        // server no longer lists) then reconcile to evict them — so a
+        // server-side delete discovered via pull-to-refresh is cleaned up too,
+        // not only on a cold provider rebuild.
+        unawaited(
+            (ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
+                    Future.value())
+                .then((_) => reconcileManga(ref, mangaId)));
+      }
     }
   }
 

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -342,6 +342,15 @@ class OfflineDatabase extends _$OfflineDatabase {
             ..orderBy([(t) => OrderingTerm(expression: t.chapterIndex)]))
           .get();
 
+  /// Mark chapters as orphaned (server-gone) so the next reconcile pass evicts
+  /// their on-device copies — keeping the device set a subset of the server.
+  Future<void> markChaptersOrphaned(List<int> chapterIds) =>
+      (update(offlineChapters)..where((t) => t.id.isIn(chapterIds))).write(
+        const OfflineChaptersCompanion(
+          deviceState: Value(OfflineDeviceState.orphaned),
+        ),
+      );
+
   /// Live stream of a manga's chapter rows — drives the series download
   /// progress UI (emits as device states change during a background download).
   Stream<List<OfflineChapter>> watchChaptersForManga(int mangaId) =>

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -55,5 +55,32 @@ class OfflineSync {
         lastReadAt: c.lastReadAt,
       );
     }
+
+    // Device ⊆ server: a chapter the server no longer lists (deleted there) must
+    // lose its on-device copy too. Mark any FULLY-DOWNLOADED local chapter
+    // that's absent from this (full, per-manga) sync as orphaned — the reconcile
+    // pass that runs right after a sync evicts orphaned chapters. Only the
+    // `downloaded` state is orphaned: an in-flight queued/downloading chapter is
+    // owned by the background worker (evicting it mid-flight would race the
+    // worker, which would just re-create the row), and it will resolve on its
+    // own (a deleted chapter's pages fail to fetch). Scoped to the manga(s) in
+    // this sync, and a no-op for an empty list (a failed/empty fetch must never
+    // orphan everything). A chapter the server lists but hasn't downloaded
+    // server-side yet is still present here, so a device-on-demand download is
+    // NOT orphaned (#32).
+    final serverIdsByManga = <int, Set<int>>{};
+    for (final c in chapters) {
+      (serverIdsByManga[c.mangaId] ??= <int>{}).add(c.id);
+    }
+    for (final entry in serverIdsByManga.entries) {
+      final serverIds = entry.value;
+      final goneIds = [
+        for (final lc in await _db.chaptersForManga(entry.key))
+          if (!serverIds.contains(lc.id) &&
+              lc.deviceState == OfflineDeviceState.downloaded)
+            lc.id,
+      ];
+      if (goneIds.isNotEmpty) await _db.markChaptersOrphaned(goneIds);
+    }
   }
 }

--- a/test/src/features/offline/data/offline_orphan_eviction_test.dart
+++ b/test/src/features/offline/data/offline_orphan_eviction_test.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:drift/drift.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_sync.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+ChapterDto serverChapter(int id) => Fragment$ChapterDto(
+      id: id, mangaId: 1, name: 'c$id', chapterNumber: id.toDouble(),
+      sourceOrder: id, isRead: false, isBookmarked: false, isDownloaded: true,
+      lastPageRead: 0, pageCount: 30, fetchedAt: '0', uploadDate: '0',
+      lastReadAt: '0', url: '', meta: const <Fragment$ChapterDto$meta>[],
+    );
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> downloaded(int id) =>
+      db.into(db.offlineChapters).insert(OfflineChaptersCompanion.insert(
+            id: Value(id), mangaId: 1, name: 'c$id', chapterIndex: id,
+            updatedAt: DateTime(2026),
+            deviceState: const Value(OfflineDeviceState.downloaded),
+          ));
+
+  test('syncChapters orphans a downloaded chapter the server no longer lists',
+      () async {
+    await downloaded(1);
+    await downloaded(2);
+    // The server now lists only chapter 1 — chapter 2 was deleted server-side.
+    await OfflineSync(db).syncChapters([serverChapter(1)]);
+    // Still on the server → kept.
+    expect((await db.chapterById(1))!.deviceState,
+        OfflineDeviceState.downloaded);
+    // Gone from the server → orphaned so the next reconcile evicts it.
+    expect(
+        (await db.chapterById(2))!.deviceState, OfflineDeviceState.orphaned);
+  });
+
+  test('syncChapters does not orphan device chapters on an empty list',
+      () async {
+    await downloaded(1);
+    await OfflineSync(db).syncChapters(const []); // failed/empty fetch
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+  });
+
+  test('syncChapters does not orphan an in-flight (downloading) chapter',
+      () async {
+    await db.into(db.offlineChapters).insert(OfflineChaptersCompanion.insert(
+          id: const Value(5), mangaId: 1, name: 'c5', chapterIndex: 5,
+          updatedAt: DateTime(2026),
+          deviceState: const Value(OfflineDeviceState.downloading),
+        ));
+    // Chapter 5 is gone from the server but mid-download — the background worker
+    // owns it; orphaning/evicting it now would race the worker, which recreates
+    // the row. Leave it to resolve on its own.
+    await OfflineSync(db).syncChapters([serverChapter(1)]);
+    expect((await db.chapterById(5))!.deviceState,
+        OfflineDeviceState.downloading);
+  });
+
+  test('syncChapters keeps a device chapter the server lists but has not '
+      'downloaded (device-on-demand, #32)', () async {
+    await downloaded(1);
+    // Server lists the chapter but reports it not downloaded server-side; the
+    // device copy (served on demand) must NOT be orphaned.
+    await OfflineSync(db).syncChapters([
+      Fragment$ChapterDto(
+        id: 1, mangaId: 1, name: 'c1', chapterNumber: 1, sourceOrder: 1,
+        isRead: false, isBookmarked: false, isDownloaded: false,
+        lastPageRead: 0, pageCount: 30, fetchedAt: '0', uploadDate: '0',
+        lastReadAt: '0', url: '', meta: const <Fragment$ChapterDto$meta>[],
+      ),
+    ]);
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+  });
+}


### PR DESCRIPTION
The reconciler evicts chapters in OfflineDeviceState.orphaned, but nothing ever
transitioned a chapter INTO that state, so a chapter deleted on the server kept
its on-device copy forever — violating the device-subset-of-server invariant.

In the down-sync, after upserting the server's chapters, mark any local chapter
with a device footprint that is absent from the (full, per-manga) server list
as orphaned; the reconcile that runs right after a sync then evicts it. Scoped
to the manga(s) in the sync and a no-op on an empty list, so a failed/empty
fetch can't orphan everything, and a chapter the server lists but hasn't
downloaded server-side yet (device-on-demand, #32) is preserved. Adds tests.
