### PR TITLE
Stop re-scraping the source every time a series is opened

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -88,18 +88,35 @@ class MangaChapterList extends _$MangaChapterList {
 
   Future<void> refresh([bool onlineFetch = false]) async {
     final repo = ref.read(mangaBookRepositoryProvider);
-    // An explicit refresh always tries the source, but falls back to the
-    // server's stored chapters if the source is unavailable (rather than
-    // erroring or clearing the list).
-    final result = await AsyncValue.guard(() async {
-      try {
-        final fetched = await repo.getChapterList(mangaId);
-        if (fetched != null && fetched.isNotEmpty) return fetched;
-      } catch (_) {
-        // fall through to stored
-      }
-      return repo.getStoredChapterList(mangaId);
-    });
+    // Only scrape the source when the user explicitly asked (pull-to-refresh /
+    // update button -> onlineFetch) or has the "refresh from source" setting on.
+    // Otherwise read the server's STORED chapters — mirrors build()'s gate
+    // (#28), so merely opening a series (the on-mount refresh) no longer fires a
+    // full, slow source re-scrape on every visit; an explicit refresh still
+    // tries the source and falls back to stored if it's unavailable.
+    final refreshFromSource =
+        onlineFetch || ref.read(refreshChaptersFromSourceProvider).ifNull();
+    // Wrap in chaptersWithOfflineFallback like build() does, so an explicit
+    // refresh while the device is offline serves the on-device catalog instead
+    // of erroring/clearing the list.
+    final result = await AsyncValue.guard(() => chaptersWithOfflineFallback(
+          fetch: () async {
+            final stored = await repo.getStoredChapterList(mangaId);
+            if (!refreshFromSource && stored != null && stored.isNotEmpty) {
+              return stored;
+            }
+            try {
+              final fetched = await repo.getChapterList(mangaId);
+              if (fetched != null && fetched.isNotEmpty) return fetched;
+            } catch (_) {
+              // Source down / gone — fall back to stored instead of clearing.
+            }
+            return stored;
+          },
+          db: ref.read(offlineDatabaseProvider),
+          offlineEnabled: ref.read(offlineEnabledProvider),
+          mangaId: mangaId,
+        ));
     ref.keepAlive();
     if (result.hasError) {
       state = result.copyWithPrevious(state);

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
@@ -58,7 +58,9 @@ class ChapterDownloadPresetsButton extends ConsumerWidget {
     if (context.mounted) {
       result.showToastOnError(ref.read(toastProvider));
     }
-    await refresh(true);
+    // Enqueuing a download doesn't change the source's chapter list — refresh
+    // from the server's stored chapters (updated download state), no re-scrape.
+    await refresh(false);
   }
 
   @override

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -108,7 +108,9 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
             if (context.mounted) {
               result.showToastOnError(ref.read(toastProvider));
             }
-            await refresh(true);
+            // Downloading doesn't change the source chapter list — refresh from
+            // the server's stored chapters, no source re-scrape.
+            await refresh(false);
           },
         ),
         IconButton(


### PR DESCRIPTION
The manga-details screen's on-mount refresh() called the chapter-list controller
refresh(), which ALWAYS ran getChapterList (a source scrape) regardless of the
onlineFetch flag or the user's 'refresh from source' setting. So opening any
series triggered a full source re-scrape on top of the stored chapters build()
had already loaded — slow, and it hammers the source.

Gate refresh() on onlineFetch / refreshChaptersFromSource (mirroring build()'s
#28 logic): read the server's stored chapters unless the user explicitly asked
to refresh from the source. Pull-to-refresh / the update button still scrape and
fall back to stored when the source is down.
