### PR TITLE
Show manga metadata on first open without a manual refresh

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -54,6 +54,10 @@ class MangaChapterList extends _$MangaChapterList {
     final repo = ref.watch(mangaBookRepositoryProvider);
     final refreshFromSource =
         ref.watch(refreshChaptersFromSourceProvider).ifNull();
+    // Tracks whether we actually scraped the source on this open. A source
+    // scrape (getChapterList) also populates the manga's description/metadata
+    // server-side, so afterwards we refresh MangaWithId to pick it up (#363).
+    var didSourceFetch = false;
     final result = await chaptersWithOfflineFallback(
       fetch: () async {
         // Read the chapters the server already has stored (like the WebUI).
@@ -65,7 +69,10 @@ class MangaChapterList extends _$MangaChapterList {
         }
         try {
           final fetched = await repo.getChapterList(mangaId);
-          if (fetched != null && fetched.isNotEmpty) return fetched;
+          if (fetched != null && fetched.isNotEmpty) {
+            didSourceFetch = true;
+            return fetched;
+          }
         } catch (_) {
           // Source down / gone — fall back to the server's stored chapters
           // instead of showing an empty list (issue #28).
@@ -82,6 +89,16 @@ class MangaChapterList extends _$MangaChapterList {
           (ref.read(offlineSyncProvider)?.syncChapters(result) ??
                   Future.value())
               .then((_) => reconcileManga(ref, mangaId)));
+    }
+    if (didSourceFetch) {
+      // The source scrape above also populated this manga's description and
+      // metadata server-side, but MangaWithId loaded BEFORE that with an empty
+      // description (the client never calls fetchManga). Refresh it so the
+      // details screen shows the metadata on first open instead of only after a
+      // manual refresh (#363). Deferred past this build so we don't invalidate a
+      // provider mid-build.
+      Future.microtask(
+          () => ref.invalidate(mangaWithIdProvider(mangaId: mangaId)));
     }
     return result;
   }


### PR DESCRIPTION
Opening a never-fetched series loaded MangaWithId (getManga) with an empty
description, while MangaChapterList separately scraped the source via
getChapterList — which populates the description/metadata server-side (verified
live: 0 -> 926 chars after the chapter-fetch). But MangaWithId never re-read it
(the client doesn't call fetchManga), so the description stayed blank until a
manual refresh. Inherited from Sorayomi #363.

When the chapter list does an actual source fetch on open, refresh MangaWithId
afterwards so the freshly-populated metadata shows immediately.
