### PR TITLE
Fix quick-win bugs: stale unread badge, quick-search category, extension uninstall

### DIFF
--- a/lib/src/features/browse_center/presentation/extension/widgets/extension_list_tile.dart
+++ b/lib/src/features/browse_center/presentation/extension/widgets/extension_list_tile.dart
@@ -109,7 +109,7 @@ class ExtensionListTileTailing extends StatelessWidget {
       );
     } else {
       if (extension.isInstalled.ifNull()) {
-        return TextButton(
+        final actionButton = TextButton(
           onPressed: (!isLoading.value)
               ? () async {
                   try {
@@ -145,6 +145,38 @@ class ExtensionListTileTailing extends StatelessWidget {
                     ? context.l10n.uninstalling
                     : context.l10n.uninstall,
           ),
+        );
+        // When an update is pending the single button reads "Update", which used
+        // to leave no way to uninstall the extension. Keep Update but add a
+        // separate uninstall affordance so a pending update can't trap it (#290).
+        if (!extension.hasUpdate.ifNull()) return actionButton;
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            actionButton,
+            IconButton(
+              tooltip: context.l10n.uninstall,
+              icon: const Icon(Icons.delete_outline),
+              onPressed: isLoading.value
+                  ? null
+                  : () async {
+                      try {
+                        isLoading.value = (true);
+                        await AppUtils.guard(
+                          () async {
+                            await repository
+                                .uninstallExtension(extension.pkgName);
+                            await refresh();
+                          },
+                          ref.read(toastProvider),
+                        );
+                        isLoading.value = (false);
+                      } catch (e) {
+                        //
+                      }
+                    },
+            ),
+          ],
         );
       } else {
         return TextButton(

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -49,8 +49,11 @@ class LibraryScreen extends HookConsumerWidget {
         } else {
           return DefaultTabController(
             length: data!.length,
-            initialIndex:
-                min(categoryId.getValueOnNullOrNegative(), data.length - 1),
+            // The route param is a category ID (e.g. from quick-search), not a
+            // positional tab index — the visible list filters out empty/hidden
+            // categories, so id != index. Select the tab whose category matches
+            // the id, falling back to the first tab if it isn't visible (#284).
+            initialIndex: max(0, data.indexWhere((c) => c.id == categoryId)),
             child: Scaffold(
               appBar: AppBar(
                 title: !showSearch.value

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -14,6 +14,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../constants/enum.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../history/presentation/history_controller.dart';
+import '../../../library/presentation/library/controller/library_controller.dart';
 import '../../../offline/data/offline_download_providers.dart';
 import '../../../settings/presentation/incognito/incognito_mode.dart';
 import '../../../settings/presentation/reader/widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
@@ -153,13 +154,20 @@ class ReaderScreen extends HookConsumerWidget {
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop) {
           // Flush the latest page reached so progress isn't lost to a pending
-          // debounce when you back out (catalog write is synchronous here).
+          // debounce when you back out. AWAIT it so the read write lands before
+          // we invalidate the lists below — otherwise they re-fetch the stale
+          // (pre-read) state and the unread badge/count comes back wrong.
           debounce.value?.cancel();
           if (latestPage.value >= 0) {
-            updateLastRead(latestPage.value);
+            await updateLastRead(latestPage.value);
           }
           ref.invalidate(chapterProviderWithIndex);
           ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
+          // Refresh the library's per-category lists so the unread badge updates
+          // even when the reader was opened directly (e.g. the continue-reading
+          // button), bypassing the manga-details screen that would otherwise do
+          // this on its own pop (#282).
+          ref.invalidate(categoryMangaListProvider);
         }
       },
       child: ScrollConfiguration(

--- a/lib/src/features/quick_open/presentation/quick_search/widgets/category_query_list_tile.dart
+++ b/lib/src/features/quick_open/presentation/quick_search/widgets/category_query_list_tile.dart
@@ -51,7 +51,7 @@ class CategoryQueryListTile extends StatelessWidget {
           MangaRoute(mangaId: manga!.id, categoryId: category?.id)
               .push(context);
         } else {
-          LibraryRoute(categoryId: category?.order ?? 0).push(context);
+          LibraryRoute(categoryId: category?.id ?? 0).push(context);
         }
         afterClick?.call();
       },


### PR DESCRIPTION
- #282: the reader's PopScope refreshed the chapter list but not the library's
  per-category lists, so the unread badge went stale after reading via the
  continue-reading button (which opens the reader directly, bypassing the
  manga-details screen that would otherwise refresh them). Invalidate the
  categoryMangaList family on reader close.
- #284: quick-search passed a category's order and the library screen used it as
  a positional tab index, but the visible tab list filters out empty/hidden
  categories so order != index, landing on the wrong tab. Pass the category id
  and select the tab by matching id.
- #290: an extension with a pending update showed only an Update button with no
  way to uninstall it. Keep Update but add a separate uninstall action.
