### PR TITLE
Fix onboarding network discovery: detection, scan timeout, and scanning indicator

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
         applicationId "io.github.aaronbamblett.tsumiru"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 23 // raised for flutter_foreground_task (Android 6.0+)
+        minSdkVersion flutter.minSdkVersion // raised for flutter_foreground_task (Android 6.0+)
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/src/features/onboarding/data/server_discovery.dart
+++ b/lib/src/features/onboarding/data/server_discovery.dart
@@ -35,7 +35,7 @@ Future<String?> discoverServerOnLan({
   Future<bool> Function(String host, int port)? ping,
   int batchSize = 48,
 }) async {
-  final ip = await (wifiIp ?? () => NetworkInfo().getWifiIP())();
+  final ip = await (wifiIp ?? localLanIp)();
   if (ip == null || ip.isEmpty) return null;
 
   final doPing = ping ?? _ping;
@@ -56,10 +56,49 @@ Future<String?> discoverServerOnLan({
 Future<bool> _ping(String host, int port) async {
   try {
     final socket = await Socket.connect(host, port,
-        timeout: const Duration(milliseconds: 120));
+        timeout: const Duration(milliseconds: 1000));
     socket.destroy();
     return true;
   } catch (_) {
     return false;
   }
+}
+
+/// The device's private LAN IPv4, found WITHOUT any runtime permission via
+/// [NetworkInterface.list]. The old default — `network_info_plus.getWifiIP()` —
+/// can return null on a fresh install that hasn't been granted location access,
+/// so the subnet scan never ran and "Search my network" found nothing. Falls
+/// back to the Wi-Fi plugin if no private IPv4 interface is found.
+Future<String?> localLanIp() async {
+  try {
+    final ifaces = await NetworkInterface.list(
+      type: InternetAddressType.IPv4,
+      includeLoopback: false,
+      includeLinkLocal: false,
+    );
+    for (final iface in ifaces) {
+      for (final addr in iface.addresses) {
+        if (_isPrivateV4(addr.address)) return addr.address;
+      }
+    }
+  } catch (_) {
+    // Fall through to the plugin.
+  }
+  try {
+    return await NetworkInfo().getWifiIP();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// RFC 1918 private IPv4: 10/8, 172.16/12, 192.168/16.
+bool _isPrivateV4(String ip) {
+  final parts = ip.split('.');
+  if (parts.length != 4) return false;
+  final a = int.tryParse(parts[0]);
+  final b = int.tryParse(parts[1]);
+  if (a == null || b == null) return false;
+  return a == 10 ||
+      (a == 172 && b >= 16 && b <= 31) ||
+      (a == 192 && b == 168);
 }

--- a/lib/src/features/onboarding/presentation/onboarding_screen.dart
+++ b/lib/src/features/onboarding/presentation/onboarding_screen.dart
@@ -562,8 +562,15 @@ class _ServerStep extends HookConsumerWidget {
             alignment: Alignment.centerLeft,
             child: TextButton.icon(
               onPressed: busy ? null : searchNetwork,
-              icon: const Icon(Icons.search_rounded, size: 18),
-              label: Text(context.l10n.onboardingSearchNetwork),
+              icon: state.value == _TestState.searching
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2))
+                  : const Icon(Icons.search_rounded, size: 18),
+              label: Text(state.value == _TestState.searching
+                  ? context.l10n.onboardingSearching
+                  : context.l10n.onboardingSearchNetwork),
             ),
           ),
         Text(context.l10n.onboardingServerPortHint,
@@ -572,15 +579,13 @@ class _ServerStep extends HookConsumerWidget {
         // Validate: test the connection.
         FilledButton.tonalIcon(
           onPressed: busy ? null : testConnection,
-          icon: busy
+          icon: state.value == _TestState.testing
               ? const SizedBox(
                   width: 16,
                   height: 16,
                   child: CircularProgressIndicator(strokeWidth: 2))
               : const Icon(Icons.wifi_tethering_rounded),
-          label: Text(state.value == _TestState.searching
-              ? context.l10n.onboardingSearching
-              : context.l10n.onboardingTestConnection),
+          label: Text(context.l10n.onboardingTestConnection),
           style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(46)),
         ),
         const SizedBox(height: 12),


### PR DESCRIPTION
Three issues in 'Search my network', all surfaced by a fresh install:

1. Detection: it got the subnet from network_info_plus getWifiIP(), which
   returns null without location access — and the app declares no location
   permission — so on a fresh install the scan never ran. Detect the LAN IPv4
   via NetworkInterface.list (built into dart:io, no runtime permission),
   falling back to getWifiIP; pick a private (RFC 1918) address, skipping
   cellular/VPN interfaces.
2. Scan timeout: the per-host TCP probe timed out at 120ms. A real server on
   the LAN answers in ~110ms idle, which tips over 120ms under the concurrent
   batch load, so it was missed. Raise the probe timeout to 1s (most hosts
   still fail/refuse fast, so the sweep stays quick).
3. UX: the scan showed no indicator on the button you tapped — the spinner
   landed on the Test-connection button instead. Show a spinner + 'Searching…'
   on the Search button itself; the Test button only spins while testing.

The :4567 default and the sweep structure are unchanged.
