### PR TITLE
Fix stale Flatpak repo URL after the move to Suwayomi-Tsumiru

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -10,9 +10,10 @@ You'll need a running Suwayomi server. See [Getting started](https://tsumiru-app
 
 **Linux - Flatpak (recommended, auto-updates):**
 ```sh
-flatpak remote-add --if-not-exists tsumiru https://tsumiru-app.github.io/tsumiru/index.flatpakrepo
+flatpak remote-add --if-not-exists tsumiru https://suwayomi.github.io/Suwayomi-Tsumiru/index.flatpakrepo
 flatpak install tsumiru io.github.aaronbamblett.tsumiru
 ```
+> Added the `tsumiru` remote before? It may still point at the old `tsumiru-app.github.io` URL. Run `flatpak remote-delete tsumiru` first, then the commands above.
 
 **Linux - AppImage (portable):** download the `…-linux-x86_64.AppImage` below, `chmod +x`, run.
 

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,7 +5,7 @@
 #   2. flatpak       — in the freedesktop container, package the prebuilt bundle
 #                      with flatpak-builder (via flatter), sign, and upload the
 #                      OSTree repo as a Pages artifact
-#   3. deploy        — publish the Pages artifact (-> tsumiru-app.github.io/tsumiru)
+#   3. deploy        — publish the Pages artifact (-> suwayomi.github.io/Suwayomi-Tsumiru)
 name: Flatpak
 
 on:

--- a/docs/architecture/repo-build-release.md
+++ b/docs/architecture/repo-build-release.md
@@ -39,7 +39,7 @@ Pushing a `v*.*.*` tag fires two workflows in parallel:
 - Linux build deps: `clang cmake ninja-build pkg-config libgtk-3-dev libx11-dev libblkid-dev liblzma-dev libsecret-1-dev libjsoncpp-dev` (last two needed for `flutter_secure_storage_linux`).
 - Artifacts attach to the release only on a tag push (guarded by `startsWith(github.ref, 'refs/tags/')`); `workflow_dispatch` builds but does not attach.
 
-**`flatpak.yml`** (self-hosted Flatpak repo → GitHub Pages) — three sequential jobs: build the Linux bundle, package + GPG-sign in the `freedesktop:24.08` flatter container, deploy to Pages at `tsumiru-app.github.io/tsumiru`. Needs secrets `FLATPAK_GPG_PRIVATE_KEY` + `FLATPAK_GPG_KEY_ID`. Manifest id is still `io.github.aaronbamblett.tsumiru`.
+**`flatpak.yml`** (self-hosted Flatpak repo → GitHub Pages) — three sequential jobs: build the Linux bundle, package + GPG-sign in the `freedesktop:24.08` flatter container, deploy to Pages at `suwayomi.github.io/Suwayomi-Tsumiru` (the app repo's own Pages — it moved with the repo; the docs site stayed at `tsumiru-app.github.io`). Needs secrets `FLATPAK_GPG_PRIVATE_KEY` + `FLATPAK_GPG_KEY_ID`. Manifest id is still `io.github.aaronbamblett.tsumiru`.
 
 **Manual-only / vestigial:**
 - `publish.yml` — inherited upstream (winget/homebrew/Play/iOS). Stale: still names `tachidesk-sorayomi`, needs secrets this fork lacks. `workflow_dispatch` only; do not run.


### PR DESCRIPTION
The Flatpak repo is published from this repo's own GitHub Pages, which moved with the repo to `Suwayomi/Suwayomi-Tsumiru` — but the install instructions, the `flatpak.yml` comment, and the build doc still pointed at the old `tsumiru-app.github.io/tsumiru` URL (now 404).

Points all three at `suwayomi.github.io/Suwayomi-Tsumiru`, and notes in the release-notes template that anyone who already added the old `tsumiru` remote must `flatpak remote-delete tsumiru` first (`remote-add --if-not-exists` won't repoint an existing remote). The docs site stayed at `tsumiru-app.github.io`, so those links are unchanged.

The prior releases' notes have already been corrected to the new URL.