### PR TITLE
Guard bulk downloads: clearer device icon + confirmation

### DIFF
--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -12,6 +12,7 @@ import '../../../../constants/app_sizes.dart';
 import '../../../../constants/enum.dart';
 import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../widgets/confirm_bulk_download_dialog.dart';
 import '../../../../widgets/emoticons.dart';
 import '../../../../widgets/manga_cover/grid/manga_cover_grid_tile.dart';
 import '../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart';
@@ -183,6 +184,11 @@ class CategoryMangaList extends HookConsumerWidget {
                     onMarkUnread: () => markSelection(false),
                     onKeepOffline: () async {
                       final ids = selection.value.toList();
+                      if (ids.length > 1 &&
+                          !await confirmBulkDownload(context,
+                              summary: '${ids.length} series', toDevice: true)) {
+                        return;
+                      }
                       selection.value = const {};
                       final db = ref.read(offlineDatabaseProvider);
                       for (final id in ids) {
@@ -197,6 +203,12 @@ class CategoryMangaList extends HookConsumerWidget {
                     },
                     onDownloadToServer: () async {
                       final ids = selection.value.toList();
+                      if (ids.length > 1 &&
+                          !await confirmBulkDownload(context,
+                              summary: '${ids.length} series',
+                              toDevice: false)) {
+                        return;
+                      }
                       selection.value = const {};
                       final repo = ref.read(mangaBookRepositoryProvider);
                       final dl = ref.read(downloadsRepositoryProvider);
@@ -304,8 +316,8 @@ class _SelectionBar extends StatelessWidget {
           onPressed: onMarkUnread,
         ),
         IconButton(
-          tooltip: 'Keep offline (sync)',
-          icon: const Icon(Icons.download_for_offline_outlined),
+          tooltip: 'Keep on device (sync)',
+          icon: const Icon(Icons.save_alt_rounded),
           onPressed: onKeepOffline,
         ),
         IconButton(

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -12,6 +12,7 @@ import '../../../../features/offline/data/offline_download_providers.dart';
 import '../../../../features/offline/data/offline_repository.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
+import '../../../../widgets/confirm_bulk_download_dialog.dart';
 import '../../../../widgets/selection_action_bar.dart';
 import '../../data/downloads/downloads_repository.dart';
 import '../../data/manga_book/manga_book_repository.dart';
@@ -84,12 +85,17 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
         ),
         IconButton(
           tooltip: context.l10n.keepOffline,
-          icon: const Icon(Icons.download_for_offline_outlined),
+          icon: const Icon(Icons.save_alt_rounded),
           onPressed: () async {
             // Download FIRST, clear selection AFTER: clearing selection disposes
             // this bar, which would invalidate `ref` mid-loop and silently drop
             // the remaining downloads.
             final ids = selectedChapterList;
+            if (ids.length > kBulkDownloadConfirmThreshold &&
+                !await confirmBulkDownload(context,
+                    summary: '${ids.length} chapters', toDevice: true)) {
+              return;
+            }
             for (final id in ids) {
               await saveChapterToDevice(ref, id);
             }
@@ -100,10 +106,16 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
           tooltip: context.l10n.downloads,
           icon: const Icon(Icons.cloud_download_outlined),
           onPressed: () async {
+            final ids = selectedChapterList;
+            if (ids.length > kBulkDownloadConfirmThreshold &&
+                !await confirmBulkDownload(context,
+                    summary: '${ids.length} chapters', toDevice: false)) {
+              return;
+            }
             final result = await AsyncValue.guard(
               () => ref
                   .read(downloadsRepositoryProvider)
-                  .addChaptersBatchToDownloadQueue(selectedChapterList),
+                  .addChaptersBatchToDownloadQueue(ids),
             );
             if (context.mounted) {
               result.showToastOnError(ref.read(toastProvider));

--- a/lib/src/widgets/confirm_bulk_download_dialog.dart
+++ b/lib/src/widgets/confirm_bulk_download_dialog.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../utils/extensions/custom_extensions.dart';
+
+/// Above this many chapters, a bulk download asks for confirmation first.
+const int kBulkDownloadConfirmThreshold = 20;
+
+/// Confirms a large bulk download before it starts, so a stray tap can't
+/// silently queue hundreds of chapters (the keep-offline accident). Returns
+/// true only if the user confirms.
+///
+/// [summary] describes the target in user terms — e.g. "12 series" or
+/// "45 chapters". [toDevice] picks device-vs-server wording and icon (and is
+/// why the device case warns about storage — that's the one that bites).
+Future<bool> confirmBulkDownload(
+  BuildContext context, {
+  required String summary,
+  required bool toDevice,
+}) async {
+  final cs = Theme.of(context).colorScheme;
+  return await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          icon: Icon(
+            toDevice ? Icons.save_alt_rounded : Icons.cloud_download_outlined,
+            color: cs.primary,
+          ),
+          title: Text(
+            toDevice
+                ? 'Keep $summary on this device?'
+                : 'Download $summary to the server?',
+          ),
+          content: Text(
+            toDevice
+                ? 'Every chapter of $summary will download to this device and '
+                    'stay in sync as you read. This can use a lot of storage.'
+                : 'Every chapter of $summary will be queued for download on '
+                    'the server.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(ctx.l10n.cancel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Download'),
+            ),
+          ],
+        ),
+      ) ??
+      false;
+}


### PR DESCRIPTION
Prevents the easy mistake of bulk-downloading the wrong thing:

- The library multi-select bar used a download icon for **keep-on-device** that was a near-twin of the cloud **download-to-server** button next to it. Swap it for the distinct save-to-device glyph already used on per-chapter saves.
- Add a confirmation before any bulk download that covers **more than one series** (library) or **more than 20 chapters** (chapter list), naming the count and whether it's going to the device or the server. A single small download is unaffected.