### PR TITLE
Pause/resume on-device downloads

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -92,6 +92,10 @@ enum DBKeys {
   offlineDownloadConcurrency(2),
   // Restrict background downloads to Wi-Fi connections only.
   downloadOnlyOverWifi(false),
+  // User-initiated pause of all ON-DEVICE downloads. Persisted (an explicit
+  // pause shouldn't silently resume on restart); read synchronously by the
+  // download starters to gate every restart path.
+  offlineDownloadsPaused(false),
   // ON-DEVICE delete-on-read settings (frees device space; the server copy is
   // untouched). Independent of the server's "Delete chapters" settings.
   // whileReading: 0 = off, 1 = the just-read chapter, 2..5 = the Nth behind it.

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -5,12 +5,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/emoticons.dart';
+import '../../../offline/data/offline_download_providers.dart';
+import '../../../offline/data/offline_settings_providers.dart';
 import '../../../offline/presentation/offline_files_view.dart';
 import '../../data/downloads/downloads_repository.dart';
 import '../../domain/downloads/downloads_model.dart';
@@ -18,7 +21,7 @@ import 'controller/downloads_controller.dart';
 import 'widgets/download_progress_list_tile.dart';
 import 'widgets/downloads_fab.dart';
 
-class DownloadsScreen extends ConsumerWidget {
+class DownloadsScreen extends HookConsumerWidget {
   const DownloadsScreen({super.key});
 
   @override
@@ -26,45 +29,72 @@ class DownloadsScreen extends ConsumerWidget {
     final downloadsChapterIds = ref.watch(downloadsChapterIdsProvider);
     final downloadsGlobalStatus = ref.watch(downloaderStateProvider);
     final showDownloadsFAB = ref.watch(showDownloadsFABProvider);
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(context.l10n.downloads),
-          bottom: TabBar(
-            // Fill alignment so the underline aligns under each tab (the global
-            // theme's center alignment is for the scrollable category tabs).
-            tabAlignment: TabAlignment.fill,
-            tabs: [
-              Tab(text: context.l10n.downloadsServerTab),
-              Tab(text: context.l10n.downloadsOnDeviceTab),
-            ],
-          ),
-          actions: [
-            if ((downloadsChapterIds).isNotBlank)
-              IconButton(
-                onPressed: () => AsyncValue.guard(
-                  ref.read(downloadsRepositoryProvider).clearDownloads,
-                ),
-                icon: const Icon(Icons.delete_sweep_rounded),
+    // Own the tab controller so the FAB can be tab-contextual: the server queue
+    // pause on the Server tab, the on-device pause on the On-device tab.
+    final tabController = useTabController(initialLength: 2);
+    useListenable(tabController);
+    final onDeviceTab = tabController.index == 1;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n.downloads),
+        bottom: TabBar(
+          controller: tabController,
+          // Fill alignment so the underline aligns under each tab (the global
+          // theme's center alignment is for the scrollable category tabs).
+          tabAlignment: TabAlignment.fill,
+          tabs: [
+            Tab(text: context.l10n.downloadsServerTab),
+            Tab(text: context.l10n.downloadsOnDeviceTab),
+          ],
+        ),
+        actions: [
+          if (!onDeviceTab && (downloadsChapterIds).isNotBlank)
+            IconButton(
+              onPressed: () => AsyncValue.guard(
+                ref.read(downloadsRepositoryProvider).clearDownloads,
               ),
-          ],
-        ),
-        floatingActionButton: showDownloadsFAB
-            ? DownloadsFab(
-                status: downloadsGlobalStatus.valueOrNull ??
-                    DownloaderState.STARTED)
-            : null,
-        body: TabBarView(
-          children: [
-            _ServerDownloads(
-              downloadsChapterIds: downloadsChapterIds,
-              downloadsGlobalStatus: downloadsGlobalStatus,
+              icon: const Icon(Icons.delete_sweep_rounded),
             ),
-            const OfflineFilesView(),
-          ],
-        ),
+        ],
       ),
+      floatingActionButton: onDeviceTab
+          ? const OfflineDownloadsFab()
+          : (showDownloadsFAB
+              ? DownloadsFab(
+                  status: downloadsGlobalStatus.valueOrNull ??
+                      DownloaderState.STARTED)
+              : null),
+      body: TabBarView(
+        controller: tabController,
+        children: [
+          _ServerDownloads(
+            downloadsChapterIds: downloadsChapterIds,
+            downloadsGlobalStatus: downloadsGlobalStatus,
+          ),
+          const OfflineFilesView(),
+        ],
+      ),
+    );
+  }
+}
+
+/// Pause/Resume control for ON-DEVICE downloads, shown on the Downloads →
+/// On device tab (mirrors the server [DownloadsFab]). Hidden when there's
+/// nothing queued/downloading; flips between Pause and Resume otherwise.
+class OfflineDownloadsFab extends ConsumerWidget {
+  const OfflineDownloadsFab({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final hasPending = ref.watch(offlineHasPendingProvider).valueOrNull ?? false;
+    final paused = ref.watch(offlineDownloadsPausedProvider) ?? false;
+    // Hide when idle (no pending work) — paused-but-idle included; the next
+    // enqueue flips it back to Resume.
+    if (!hasPending) return const SizedBox.shrink();
+    return FloatingActionButton.extended(
+      icon: Icon(paused ? Icons.play_arrow_rounded : Icons.pause_rounded),
+      label: Text(paused ? context.l10n.resume : context.l10n.pause),
+      onPressed: () => setOfflineDownloadsPaused(ref, !paused),
     );
   }
 }

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -13,6 +13,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../constants/db_keys.dart';
 import '../../../../constants/enum.dart';
 import '../../../../global_providers/global_providers.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
@@ -99,6 +100,10 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// active connection is metered, the service is not started.
   Future<void> ensureServiceRunning() async {
     if (!Platform.isAndroid) return;
+    // PAUSE GATE — first line so EVERY restart path inherits it: the public
+    // start, onEnqueued, replayOnResume, replayAtLaunchAndMaybeStart, _onDrained,
+    // _onServiceStopped, and the connectivity-resume branch all funnel here.
+    if (_isPaused()) return;
     if (_ensuring) return;
     _ensuring = true;
     try {
@@ -124,6 +129,12 @@ class BackgroundDownloadController with WidgetsBindingObserver {
 
       await _ensureNotificationPermission();
       await _writeWorkOrder(pending);
+      // Re-check the pause gate: a pause could have landed while we awaited the
+      // steps above (this call passed the gate at the top before the user
+      // paused). Without this, we'd start the service into a paused state, and
+      // pause() — which only messages a *running* service — would have skipped
+      // it because the service wasn't up yet.
+      if (_isPaused()) return;
       final res = await FlutterForegroundTask.startService(
         serviceTypes: [ForegroundServiceTypes.dataSync],
         notificationTitle: 'Downloading chapters',
@@ -153,6 +164,30 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// Called after the caller has written drift `queued` for [chapterIds]. Just
   /// ensures the service owns the queue (it reads drift, not the argument).
   Future<void> onEnqueued(List<int> chapterIds) => ensureServiceRunning();
+
+  /// True when the user has paused all on-device downloads (persisted flag).
+  /// Read synchronously so the start gate can't be bypassed by an unhydrated
+  /// provider read.
+  bool _isPaused() =>
+      _ref.read(sharedPreferencesProvider).getBool(
+          DBKeys.offlineDownloadsPaused.name) ??
+      false;
+
+  /// Pause all on-device downloads: tell the worker to park the in-flight
+  /// chapter and self-stop. The caller persists the flag first; the start gate
+  /// in [ensureServiceRunning] then prevents any restart until [resume].
+  Future<void> pause() async {
+    if (!Platform.isAndroid) return;
+    if (await FlutterForegroundTask.isRunningService) {
+      // Graceful: the worker cancels the active chapter (left resumable) and
+      // self-stops. Never main-side stopService here — that would race the
+      // worker and could corrupt a half-written page.
+      FlutterForegroundTask.sendDataToTask({'op': 'pause'});
+    }
+  }
+
+  /// Resume on-device downloads (caller has cleared the persisted flag first).
+  Future<void> resume() => ensureServiceRunning();
 
   /// Tell the worker to drop a chapter (delete/cancel). The caller still does
   /// the actual drift/file delete; this only stops the in-flight download.

--- a/lib/src/features/offline/data/background/background_download_controller_stub.dart
+++ b/lib/src/features/offline/data/background/background_download_controller_stub.dart
@@ -24,6 +24,8 @@ class BackgroundDownloadController {
   Future<void> onEnqueued(List<int> chapterIds) async {}
   Future<void> onRemoved(int chapterId) async {}
   Future<void> onWifiOnlyChanged(bool value) async {}
+  Future<void> pause() async {}
+  Future<void> resume() async {}
   Future<void> replayAtLaunchAndMaybeStart() async {}
 }
 

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -81,6 +81,11 @@ class DownloadTaskHandler extends TaskHandler {
   /// the in-flight chapter observe it and unwind.
   var _stopping = false;
 
+  /// True once the main isolate sends `{op:'pause'}` (user paused downloads).
+  /// The in-flight chapter is cancelled (left resumable) and the worker
+  /// self-stops; drift retains queued/downloading so resume re-enqueues them.
+  var _paused = false;
+
   BackgroundWorkOrder? _order;
   late BackgroundCompletionLog _log;
   late OfflinePaths _paths;
@@ -142,6 +147,12 @@ class DownloadTaskHandler extends TaskHandler {
         _queue.remove(id);
       case 'setWifiOnly':
         _wifiOnly = data['value'] as bool;
+      case 'pause':
+        // User paused all device downloads. The in-flight chapter's isCancelled
+        // picks this up and unwinds (left resumable); the drain loop then exits
+        // and the worker self-stops. The main side won't restart while the
+        // persisted pause flag is set.
+        _paused = true;
     }
   }
 
@@ -160,7 +171,7 @@ class DownloadTaskHandler extends TaskHandler {
   // ---------------------------------------------------------------------------
 
   Future<void> _drain() async {
-    while (!_stopping) {
+    while (!_stopping && !_paused) {
       final next = _queue.where((c) => !_cancelled.contains(c)).firstOrNull;
       if (next == null) {
         if (_sawNewWork) {
@@ -177,6 +188,14 @@ class DownloadTaskHandler extends TaskHandler {
       }
       _queue.remove(next);
       await _downloadChapter(next, _mangaOf[next]!);
+    }
+    // Exited because the user paused (not a stop/timeout): self-stop cleanly so
+    // the FGS notification clears. drift still has the queued/downloading rows
+    // (the in-flight chapter was cancelled, left resumable), so resume just
+    // re-enqueues from drift. Do NOT append a drained marker — the queue isn't
+    // drained, it's parked.
+    if (_paused && !_stopping) {
+      await FlutterForegroundTask.stopService();
     }
   }
 
@@ -211,7 +230,7 @@ class DownloadTaskHandler extends TaskHandler {
       mangaId: mangaId,
       chapterId: chapterId,
       pages: pages,
-      isCancelled: () => _cancelled.contains(chapterId) || _stopping,
+      isCancelled: () => _cancelled.contains(chapterId) || _stopping || _paused,
       onPageStored: (i, rel, bytes) {
         // Live per-page progress for the foreground UI (drift row applied by the
         // main isolate). The durable record is still the completion log.

--- a/lib/src/features/offline/data/offline_background_downloads.dart
+++ b/lib/src/features/offline/data/offline_background_downloads.dart
@@ -86,6 +86,10 @@ OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
         (await repo.getChapterPages(chapterId: chapterId))?.pages ??
         const <String>[],
     measureChapterBytes: store.chapterBytes,
+    persistedPaused: () =>
+        ref.read(sharedPreferencesProvider).getBool(
+            DBKeys.offlineDownloadsPaused.name) ??
+        false,
   );
 }
 

--- a/lib/src/features/offline/data/offline_download_coordinator.dart
+++ b/lib/src/features/offline/data/offline_download_coordinator.dart
@@ -30,12 +30,26 @@ class OfflineDownloadCoordinator {
     required this.resolvePages,
     required this.engine,
     required this.measureChapterBytes,
+    this.persistedPaused,
   });
 
   final OfflineDatabase db;
   final PageUrlsResolver resolvePages;
   final ChapterDownloadEngine engine;
   final ChapterBytesMeasurer measureChapterBytes;
+
+  /// Reads the persisted "downloads paused" flag (injected so the pump survives
+  /// a restart with the pause intact, without the coordinator depending on
+  /// SharedPreferences directly). Null in tests = never persistently paused.
+  final bool Function()? persistedPaused;
+
+  /// In-session pause, set by [pause]/[resume] for an immediate brake. The gate
+  /// is the OR of this and the persisted flag, so a restart honours a saved
+  /// pause even though this resets to false.
+  bool _paused = false;
+
+  /// True when on-device downloads are paused (in-session or persisted).
+  bool get isPaused => _paused || (persistedPaused?.call() ?? false);
 
   /// Chapter currently being downloaded by the engine (in-memory). One at a
   /// time, so at most one entry.
@@ -61,6 +75,21 @@ class OfflineDownloadCoordinator {
     if (_active.contains(chapterId)) _cancelled.add(chapterId);
   }
 
+  /// Pause all on-device downloading: stop starting new chapters and cancel the
+  /// in-flight one (left `downloading` = resumable). The persisted flag is set
+  /// by the caller; this is the immediate in-session brake.
+  void pause() {
+    _paused = true;
+    _cancelled.addAll(_active);
+  }
+
+  /// Resume on-device downloading and drain the backlog. Returns the drain
+  /// future so callers can await it (the UI fires it and forgets).
+  Future<void> resume() {
+    _paused = false;
+    return pumpDownloads();
+  }
+
   /// Add a chapter to the persistent download queue (state `queued`). The pump
   /// starts it when it reaches the front. Skips chapters already downloaded or
   /// in flight.
@@ -81,6 +110,11 @@ class OfflineDownloadCoordinator {
   /// `downloading` by a previous run (e.g. an app kill) simply resumes.
   Future<void> enqueueChapter(OfflineChapter chapter) async {
     if (chapter.deviceState == OfflineDeviceState.downloaded) return;
+    // Paused: don't start (or re-start a stranded) chapter. Guarded here too —
+    // not just in pumpDownloads — because enqueueChapter's `finally` clears the
+    // chapter from `_cancelled`, so a stray pump could otherwise re-select a
+    // stranded `downloading` chapter and restart it while paused.
+    if (isPaused) return;
     if (_active.contains(chapter.id)) return;
     _active.add(chapter.id);
     try {
@@ -178,10 +212,12 @@ class OfflineDownloadCoordinator {
     // (two isolates writing the same files/catalog corrupts it). Downloads on
     // Android are driven by BackgroundDownloadController instead.
     if (isAndroidNative) return;
+    if (isPaused) return;
     if (_pumping) return;
     _pumping = true;
     try {
       while (true) {
+        if (isPaused) break;
         final next = await _nextChapter();
         if (next == null) break;
         await enqueueChapter(next);

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -64,6 +64,43 @@ final downloadStarterProvider = Provider<Future<void> Function()>((ref) {
   };
 });
 
+/// Pause or resume ALL on-device downloads. Persists the flag (so it survives a
+/// restart) and acts immediately on the active pipeline: the FGS worker on
+/// Android, the main-isolate pump elsewhere. The persisted flag is what the
+/// download starters gate on, so no enqueue/connectivity/launch path can restart
+/// downloads while paused.
+Future<void> setOfflineDownloadsPaused(WidgetRef ref, bool paused) async {
+  ref.read(offlineDownloadsPausedProvider.notifier).update(paused);
+  if (isAndroidNative) {
+    final controller = ref.read(backgroundDownloadControllerProvider);
+    if (paused) {
+      await controller.pause();
+    } else {
+      await controller.resume();
+    }
+  } else {
+    final coordinator = ref.read(offlineDownloadCoordinatorProvider);
+    if (paused) {
+      coordinator?.pause();
+    } else {
+      coordinator?.resume();
+    }
+  }
+}
+
+/// True while any chapter is queued or downloading on this device — drives the
+/// On-device Pause/Resume control and the global paused badge. False when
+/// offline is unavailable.
+@riverpod
+Stream<bool> offlineHasPending(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return Stream.value(false);
+  return ref.watch(offlineDatabaseProvider).watchOfflineChapters().map(
+        (chapters) => chapters.any((c) =>
+            c.deviceState == OfflineDeviceState.queued ||
+            c.deviceState == OfflineDeviceState.downloading),
+      );
+}
+
 /// Live on-device download state for a chapter (none / queued / downloading /
 /// downloaded / error). Always `none` when offline is unavailable.
 @riverpod

--- a/lib/src/features/offline/data/offline_nav_status.dart
+++ b/lib/src/features/offline/data/offline_nav_status.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'offline_download_providers.dart';
+import 'offline_settings_providers.dart';
+
+part 'offline_nav_status.g.dart';
+
+/// True when on-device downloads are paused AND there's still work waiting —
+/// the condition under which the Downloads nav entry shows a paused badge, so a
+/// persisted pause can't silently freeze downloads with no visible signal.
+@riverpod
+bool downloadsPausedBadge(Ref ref) {
+  final paused = ref.watch(offlineDownloadsPausedProvider) ?? false;
+  if (!paused) return false;
+  return ref.watch(offlineHasPendingProvider).valueOrNull ?? false;
+}

--- a/lib/src/features/offline/data/offline_settings_providers.dart
+++ b/lib/src/features/offline/data/offline_settings_providers.dart
@@ -55,3 +55,13 @@ class OfflineWifiOnly extends _$OfflineWifiOnly
   @override
   bool? build() => initialize(DBKeys.downloadOnlyOverWifi);
 }
+
+/// User-initiated pause of all on-device downloads (persisted). The UI watches
+/// this for the Pause/Resume control + the global paused badge; the download
+/// starters gate on the persisted value directly (see [DBKeys.offlineDownloadsPaused]).
+@riverpod
+class OfflineDownloadsPaused extends _$OfflineDownloadsPaused
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.offlineDownloadsPaused);
+}

--- a/lib/src/widgets/shell/big_screen_navigation_bar.dart
+++ b/lib/src/widgets/shell/big_screen_navigation_bar.dart
@@ -5,13 +5,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../constants/gen/assets.gen.dart';
 import '../../constants/navigation_bar_data.dart';
+import '../../features/offline/data/offline_nav_status.dart';
 import '../../routes/router_config.dart';
 import '../../utils/extensions/custom_extensions.dart';
 
-class BigScreenNavigationBar extends StatelessWidget {
+class BigScreenNavigationBar extends ConsumerWidget {
   const BigScreenNavigationBar(
       {super.key,
       required this.selectedIndex,
@@ -26,16 +28,19 @@ class BigScreenNavigationBar extends StatelessWidget {
   static const double _extendedWidth = 256;
 
   NavigationRailDestination getNavigationRailDestination(
-      BuildContext context, NavigationBarData data) {
+      BuildContext context, NavigationBarData data, bool downloadsPaused) {
+    final badged = downloadsPaused && data.icon == Icons.download_outlined;
     return NavigationRailDestination(
-      icon: Icon(data.icon),
+      icon: badged ? Badge(child: Icon(data.icon)) : Icon(data.icon),
       label: Text(data.label(context)),
-      selectedIcon: Icon(data.activeIcon),
+      selectedIcon:
+          badged ? Badge(child: Icon(data.activeIcon)) : Icon(data.activeIcon),
     );
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final downloadsPaused = ref.watch(downloadsPausedBadgeProvider);
     // The rail shows on any wide screen (width >= 600), which includes a phone
     // in landscape (short side < 600). There the height is tight, so drop the
     // app-icon header to make room for all destinations ("More" was falling off
@@ -95,7 +100,7 @@ class BigScreenNavigationBar extends StatelessWidget {
       leading: isPhone ? null : leadingIcon,
       destinations: NavigationBarData.getNavList(context)
           .map<NavigationRailDestination>(
-              (e) => getNavigationRailDestination(context, e))
+              (e) => getNavigationRailDestination(context, e, downloadsPaused))
           .toList(),
       selectedIndex: selectedIndex,
       onDestinationSelected: onDestinationSelected,

--- a/lib/src/widgets/shell/small_screen_navigation_bar.dart
+++ b/lib/src/widgets/shell/small_screen_navigation_bar.dart
@@ -5,10 +5,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../constants/navigation_bar_data.dart';
+import '../../features/offline/data/offline_nav_status.dart';
 
-class SmallScreenNavigationBar extends StatelessWidget {
+class SmallScreenNavigationBar extends ConsumerWidget {
   const SmallScreenNavigationBar({
     super.key,
     required this.selectedIndex,
@@ -19,17 +21,20 @@ class SmallScreenNavigationBar extends StatelessWidget {
   final void Function(int) onDestinationSelected;
 
   NavigationDestination getNavigationDestination(
-      BuildContext context, NavigationBarData data) {
+      BuildContext context, NavigationBarData data, bool downloadsPaused) {
+    final badged = downloadsPaused && data.icon == Icons.download_outlined;
     return NavigationDestination(
-      icon: Icon(data.icon),
+      icon: badged ? Badge(child: Icon(data.icon)) : Icon(data.icon),
       label: data.label(context),
-      selectedIcon: Icon(data.activeIcon),
+      selectedIcon:
+          badged ? Badge(child: Icon(data.activeIcon)) : Icon(data.activeIcon),
       tooltip: data.label(context),
     );
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final downloadsPaused = ref.watch(downloadsPausedBadgeProvider);
     return NavigationBarTheme(
       data: NavigationBarThemeData(
         labelTextStyle: WidgetStateProperty.all(
@@ -41,7 +46,7 @@ class SmallScreenNavigationBar extends StatelessWidget {
         onDestinationSelected: onDestinationSelected,
         destinations: NavigationBarData.getNavList(context)
             .map<NavigationDestination>(
-              (e) => getNavigationDestination(context, e),
+              (e) => getNavigationDestination(context, e, downloadsPaused),
             )
             .toList(),
       ),

--- a/test/src/features/offline/data/offline_download_coordinator_test.dart
+++ b/test/src/features/offline/data/offline_download_coordinator_test.dart
@@ -56,6 +56,7 @@ void main() {
     bool fail = false,
     bool auth401 = false,
     bool refreshOk = false,
+    bool Function()? persistedPaused,
   }) {
     final engine = ChapterDownloadEngine(
       writePage: store,
@@ -73,6 +74,7 @@ void main() {
       engine: engine,
       resolvePages: (_) async => pages,
       measureChapterBytes: store.chapterBytes,
+      persistedPaused: persistedPaused,
     );
   }
 
@@ -136,5 +138,54 @@ void main() {
     await db.setChapterDeviceState(1, OfflineDeviceState.downloading);
     await coord(pages: const ['/p/0', '/p/1']).pumpDownloads();
     expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+  });
+
+  test('paused pump does not download queued chapters', () async {
+    await seedChapter(1, 7, 2);
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    await c.queueChapter(1);
+    c.pause();
+    await c.pumpDownloads();
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.queued);
+    expect(store.pages, isEmpty);
+  });
+
+  test('paused enqueueChapter is a no-op (no re-start of a stranded chapter)',
+      () async {
+    await seedChapter(1, 7, 2);
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloading);
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    c.pause();
+    await c.enqueueChapter((await db.chapterById(1))!);
+    // Left as-is (resumable), nothing written.
+    expect((await db.chapterById(1))!.deviceState,
+        OfflineDeviceState.downloading);
+    expect(store.pages, isEmpty);
+  });
+
+  test('resume after pause drains the queue', () async {
+    await seedChapter(1, 7, 2);
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    await c.queueChapter(1);
+    c.pause();
+    await c.pumpDownloads(); // gated — no-op
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.queued);
+    await c.resume();
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+  });
+
+  test('persisted pause flag gates the pump even on a fresh coordinator',
+      () async {
+    await seedChapter(1, 7, 2);
+    var paused = true; // simulates the saved flag after a restart
+    final c = coord(pages: const ['/p/0', '/p/1'], persistedPaused: () => paused);
+    await c.queueChapter(1);
+    await c.pumpDownloads();
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.queued);
+    paused = false; // user resumes
+    await c.pumpDownloads();
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
   });
 }


### PR DESCRIPTION
The Downloads tab's pause only stopped the server downloader. Adds a Pause/Resume on the On device tab that halts on-device downloading (the Android foreground-service worker and the desktop/iOS pump), parking the in-flight chapter resumably. The pause persists across app restarts, and a badge on the Downloads nav entry shows while paused with work still queued.