### PR TITLE
Manage on-device downloads from the On device tab

### DIFF
--- a/docs/architecture/offline.md
+++ b/docs/architecture/offline.md
@@ -31,6 +31,14 @@ Four layers, all driven through one entry point — **`downloadStarterProvider`*
 
 `offline_reconciler.dart` + `reconcile_logic.dart` (pure) compute a `ReconcilePlan` (`toDownload` / `toEvict`): `desiredChapterIds()` applies the rule; `applySafetyNets()` evicts unwanted, un-pinned chapters, then a **time net** (older than `keepDays`, default 30) and a **storage cap** (evict oldest until under `storageCapBytes`, default 2 GB). The cap also stops *adding* download candidates once projected bytes would exceed it. Settings live in `offline_settings_providers.dart`.
 
+## On device tab (downloads + management, one surface)
+
+`presentation/offline_files_view.dart` (the **Downloads → On device** tab) is the single place to see and manage on-device downloads. It lists every series with an offline footprint — files present OR an active keep-rule — via `offlineSeriesProvider` over `OfflineDatabase.watchOfflineSeries()`, one Drift join whose `having` keeps rows where `downloaded>0 OR inFlight>0 OR keepRule != off` (so a rule with **nothing downloaded yet** and **hand-saved files with no rule** both appear). Each row shows what's downloaded + its rule; a per-row sliders button (`Icons.tune_rounded`) opens the rule sheet, and long-press multi-selects for bulk actions. Actions live in `offline_download_providers.dart`:
+
+- `changeKeepRule` — set a new rule + reconcile (confirms when the new rule grows the footprint for any selected series).
+- `detachKeepRule` — **stop keeping but keep the files**: cancels in-flight chapters, then pins the downloaded set and clears the rule **in one transaction** (so the instant the rule is `off`, every catalog-downloaded chapter is already pinned and can't be evicted by this or a concurrent reconcile), then reconciles. Unfinished chapters are dropped.
+- `removeKeepRuleAndDelete` — clear the rule and delete the device copies (server untouched).
+
 ## Enable / web
 
 `offlineEnabledProvider` defaults **false**. At startup `initOfflineStorage()` opens the catalog on native, and the storage providers (`offlineDatabaseProvider`, `offlinePathsProvider`, `offlinePageStoreProvider`) plus `offlineEnabledProvider` are overridden to the live instances. On web it returns null, the override never happens, and the storage providers throw `UnimplementedError`. Every caller guards on `offlineEnabledProvider` first, so those throws are unreachable on web.

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -412,6 +412,48 @@ class OfflineDatabase extends _$OfflineDatabase {
             ])))
       .watch();
 
+  /// Live list of every series with an offline footprint on this device —
+  /// either chapters present (downloaded / in-flight) OR an active keep-rule
+  /// (`keepRule != off`) — with per-series aggregates and the manga row (which
+  /// carries `keepRule` / `keepUnreadCount`). The union is what makes the
+  /// Downloads → On device tab the single surface: a rule with nothing
+  /// downloaded yet still appears, and hand-saved chapters with no rule still
+  /// appear. Updates on either table changing.
+  Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
+      watchOfflineSeries() {
+    final downloaded = offlineChapters.id.count(
+        filter:
+            offlineChapters.deviceState.equalsValue(OfflineDeviceState.downloaded));
+    final inFlight = offlineChapters.id.count(
+        filter: offlineChapters.deviceState
+                .equalsValue(OfflineDeviceState.downloading) |
+            offlineChapters.deviceState.equalsValue(OfflineDeviceState.queued));
+    final byteSum = offlineChapters.bytes.sum(
+        filter:
+            offlineChapters.deviceState.equalsValue(OfflineDeviceState.downloaded));
+    final query = select(offlineMangas).join([
+      leftOuterJoin(offlineChapters,
+          offlineChapters.mangaId.equalsExp(offlineMangas.id)),
+    ])
+      ..addColumns([downloaded, inFlight, byteSum])
+      ..groupBy(
+        [offlineMangas.id],
+        // Keep series that have files OR a rule; drop the rest of the library.
+        having: downloaded.isBiggerThanValue(0) |
+            inFlight.isBiggerThanValue(0) |
+            offlineMangas.keepRule.equalsValue(OfflineKeepRule.off).not(),
+      );
+    return query.watch().map((rows) => [
+          for (final row in rows)
+            (
+              manga: row.readTable(offlineMangas),
+              downloaded: row.read(downloaded) ?? 0,
+              inFlight: row.read(inFlight) ?? 0,
+              bytes: row.read(byteSum) ?? 0,
+            ),
+        ]);
+  }
+
   /// How many pages of a chapter are already on disk. Cheap COUNT (no row
   /// materialisation) — called on the main isolate on every page completion.
   Future<int> downloadedPageCount(int chapterId) async {

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -630,50 +630,85 @@ Stream<({int downloaded, int inFlight})> mangaOfflineProgress(
   }).distinct(); // only rebuild the button when the counts actually change
 }
 
-/// Series with chapters on this device — downloaded AND actively downloading /
-/// queued — with per-series counts + byte size. Drives the Downloads → Offline
-/// files tab; live (re-emits as downloads progress or are removed).
+/// Every series with an offline footprint on this device — chapters present
+/// (downloaded / in-flight) OR an active keep-rule — with per-series counts,
+/// byte size, and the manga row (carrying the rule). The single source for the
+/// Downloads → On device tab, which both shows what's downloaded AND manages the
+/// keep-rules. Sorted active-first, then biggest, then strongest rule.
 @riverpod
-Stream<List<({OfflineManga manga, int count, int inFlight, int bytes})>>
-    offlineDownloadedSeries(Ref ref) async* {
-  if (!ref.watch(offlineEnabledProvider)) {
-    yield const [];
-    return;
-  }
-  final db = ref.watch(offlineDatabaseProvider);
-  final mangas = {for (final m in await db.libraryManga()) m.id: m};
-  await for (final chapters in db.watchOfflineChapters()) {
-    final done = <int, int>{};
-    final inFlight = <int, int>{};
-    final bytes = <int, int>{};
-    for (final c in chapters) {
-      if (c.deviceState == OfflineDeviceState.downloaded) {
-        done[c.mangaId] = (done[c.mangaId] ?? 0) + 1;
-        bytes[c.mangaId] = (bytes[c.mangaId] ?? 0) + c.bytes;
-      } else {
-        inFlight[c.mangaId] = (inFlight[c.mangaId] ?? 0) + 1;
-      }
-    }
-    final ids = {...done.keys, ...inFlight.keys};
-    final out = <({OfflineManga manga, int count, int inFlight, int bytes})>[];
-    for (final id in ids) {
-      final m = mangas[id];
-      if (m != null) {
-        out.add((
-          manga: m,
-          count: done[id] ?? 0,
-          inFlight: inFlight[id] ?? 0,
-          bytes: bytes[id] ?? 0,
-        ));
-      }
-    }
-    // Actively-downloading series first, then alphabetical.
-    out.sort((a, b) {
+Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
+    offlineSeries(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return Stream.value(const []);
+  return ref.watch(offlineDatabaseProvider).watchOfflineSeries().map((rows) {
+    final sorted = [...rows];
+    sorted.sort((a, b) {
       if ((a.inFlight > 0) != (b.inFlight > 0)) return a.inFlight > 0 ? -1 : 1;
-      return a.manga.title.toLowerCase().compareTo(b.manga.title.toLowerCase());
+      if (a.bytes != b.bytes) return b.bytes.compareTo(a.bytes);
+      return b.manga.keepRule.index.compareTo(a.manga.keepRule.index);
     });
-    yield out;
+    return sorted;
+  });
+}
+
+/// Stop auto-keeping [mangaId] offline but KEEP the chapters already fully
+/// downloaded on the device. Unfinished (queued / partially-downloaded)
+/// chapters are dropped — "keep what I already have", not "finish the rest".
+///
+/// Order is load-bearing (see the design's interleaving analysis):
+/// 1. Quiesce the series' pipeline (cancel its queued/downloading chapters) so
+///    the downloaded set can't grow underneath us.
+/// 2. Pin every still-downloaded chapter — pinned is immune to reconcile
+///    eviction. Done BEFORE clearing the rule, so any reconcile that interleaves
+///    while we pin still sees the rule active (and so evicts nothing).
+/// 3. Clear the rule (count is dormant while off; preserve it).
+/// 4. Reconcile — now eviction-safe: desired set = pinned = all downloaded.
+Future<void> detachKeepRule(WidgetRef ref, int mangaId) async {
+  if (!ref.read(offlineEnabledProvider)) return;
+  final db = ref.read(offlineDatabaseProvider);
+  for (final c in await db.chaptersForManga(mangaId)) {
+    if (c.deviceState == OfflineDeviceState.queued ||
+        c.deviceState == OfflineDeviceState.downloading) {
+      await deleteChapterFromDevice(ref, c.id);
+    }
   }
+  final cfg = await ref.read(offlineRepositoryProvider).keepConfigFor(mangaId);
+  // Pin the downloaded set and clear the rule ATOMICALLY: the cancel above is
+  // async on Android (the FGS worker may finish a chapter slightly later), so
+  // re-read the downloaded set HERE and pin it inside the same transaction that
+  // flips the rule off. That guarantees that the instant the rule is off, every
+  // chapter the catalog shows as downloaded is already pinned (immune to
+  // eviction) — so neither this call's reconcile nor a concurrent one can evict
+  // a downloaded chapter. A chapter still finishing after this was in-flight at
+  // detach time and is intentionally dropped.
+  await db.transaction(() async {
+    for (final c in await db.downloadedChaptersForManga(mangaId)) {
+      await db.setChapterPinned(c.id, true);
+    }
+    await db.setKeepRule(mangaId, OfflineKeepRule.off, cfg.count);
+  });
+  await reconcileMangaWidget(ref, mangaId);
+}
+
+/// Stop keeping [mangaId] offline AND delete every on-device chapter (the
+/// server copy is untouched). Mirrors the per-series "remove" action.
+Future<void> removeKeepRuleAndDelete(WidgetRef ref, int mangaId) async {
+  if (!ref.read(offlineEnabledProvider)) return;
+  final db = ref.read(offlineDatabaseProvider);
+  final cfg = await ref.read(offlineRepositoryProvider).keepConfigFor(mangaId);
+  await db.setKeepRule(mangaId, OfflineKeepRule.off, cfg.count);
+  for (final c in await db.chaptersForManga(mangaId)) {
+    if (c.deviceState != OfflineDeviceState.none) {
+      await deleteChapterFromDevice(ref, c.id);
+    }
+  }
+}
+
+/// Change the keep-rule for [mangaId] and reconcile (download/evict to match).
+Future<void> changeKeepRule(
+    WidgetRef ref, int mangaId, OfflineKeepRule rule, int count) async {
+  if (!ref.read(offlineEnabledProvider)) return;
+  await ref.read(offlineDatabaseProvider).setKeepRule(mangaId, rule, count);
+  await reconcileMangaWidget(ref, mangaId);
 }
 
 /// Total bytes of on-device offline content — for the storage settings UI.

--- a/lib/src/features/offline/presentation/offline_files_view.dart
+++ b/lib/src/features/offline/presentation/offline_files_view.dart
@@ -5,72 +5,363 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../routes/router_config.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../../widgets/emoticons.dart';
+import '../../../widgets/selection_action_bar.dart';
 import '../../../widgets/server_image.dart';
+import '../data/offline_database.dart';
 import '../data/offline_download_providers.dart';
 import '../data/offline_repository.dart';
 import 'offline_settings_format.dart';
 
-/// The "On device" segment of the Downloads tab: every series with chapters
-/// saved on this device, with per-series chapter count + size, plus total
-/// usage. Live — updates as background downloads complete or are removed.
-class OfflineFilesView extends ConsumerWidget {
+typedef _SeriesRow = ({OfflineManga manga, int downloaded, int inFlight, int bytes});
+
+/// The "On device" segment of the Downloads tab — the single surface for
+/// on-device downloads: every series with files saved here OR an active
+/// keep-rule, showing what's downloaded + its rule, with a per-series rule
+/// editor and bulk actions. (Replaces the old separate "Manage downloads" page.)
+class OfflineFilesView extends HookConsumerWidget {
   const OfflineFilesView({super.key});
+
+  /// The unread-buffer sizes offered for "Keep N unread" (matches the per-series
+  /// offline sheet).
+  static const _bufferSizes = [5, 10, 25];
+
+  String _ruleLabel(BuildContext context, OfflineManga m) => switch (m.keepRule) {
+        OfflineKeepRule.all => context.l10n.keepOfflineAll,
+        OfflineKeepRule.allUnread => context.l10n.keepOfflineAllUnread,
+        OfflineKeepRule.nUnread =>
+          context.l10n.keepOfflineNextUnread(m.keepUnreadCount),
+        OfflineKeepRule.off => context.l10n.offlineManualOnly,
+      };
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (!ref.watch(offlineEnabledProvider)) {
       return Center(child: Text(context.l10n.offlineNotAvailable));
     }
-    final series =
-        ref.watch(offlineDownloadedSeriesProvider).valueOrNull ?? const [];
+    final series = ref.watch(offlineSeriesProvider).valueOrNull ?? const [];
     final totalBytes = ref.watch(offlineUsageBytesProvider).valueOrNull ?? 0;
+    final selection = useState<Set<int>>(const {});
+    final selecting = selection.value.isNotEmpty;
+
+    void clear() => selection.value = const {};
+    void toggle(int id) {
+      final next = {...selection.value};
+      if (!next.add(id)) next.remove(id);
+      selection.value = next;
+    }
+
     if (series.isEmpty) {
       return Emoticons(title: context.l10n.offlineNoFiles);
     }
-    return ListView.builder(
-      itemCount: series.length + 1,
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return ListTile(
-            dense: true,
-            leading: const Icon(Icons.sd_storage_outlined),
-            title: Text(context.l10n.offlineStorageUsage),
-            trailing: Text(formatBytes(totalBytes)),
-          );
-        }
-        final s = series[index - 1];
-        final downloading = s.inFlight > 0;
-        return ListTile(
-          leading: SizedBox(
-            width: 40,
-            height: 56,
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(4),
-              child: ServerImage(
-                imageUrl: s.manga.thumbnailUrl ?? '',
-                fit: BoxFit.cover,
+
+    List<_SeriesRow> selectedRows() =>
+        series.where((s) => selection.value.contains(s.manga.id)).toList();
+
+    return Stack(
+      children: [
+        ListView.builder(
+          padding: const EdgeInsets.only(bottom: 88),
+          itemCount: series.length + 1,
+          itemBuilder: (context, index) {
+            if (index == 0) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ListTile(
+                    dense: true,
+                    leading: const Icon(Icons.sd_storage_outlined),
+                    title: Text(context.l10n.offlineStorageUsage),
+                    trailing: Text(formatBytes(totalBytes)),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                    child: Text(
+                      context.l10n.offlineManageHint,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: context.theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  const Divider(height: 1),
+                ],
+              );
+            }
+            final s = series[index - 1];
+            final selected = selection.value.contains(s.manga.id);
+            final filesLine = s.inFlight > 0
+                ? '${context.l10n.offlineDownloadingCount(s.inFlight)} · ${context.l10n.nChapters(s.downloaded)}'
+                : s.downloaded > 0
+                    ? '${context.l10n.nChapters(s.downloaded)} · ${formatBytes(s.bytes)}'
+                    : context.l10n.manageDownloadsNothingYet;
+            return ListTile(
+              selected: selected,
+              isThreeLine: true,
+              leading: SizedBox(
+                width: 40,
+                height: 56,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: ServerImage(
+                    imageUrl: s.manga.thumbnailUrl ?? '',
+                    fit: BoxFit.cover,
+                  ),
+                ),
               ),
+              title:
+                  Text(s.manga.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+              subtitle: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(filesLine,
+                      maxLines: 1, overflow: TextOverflow.ellipsis),
+                  Text(
+                    _ruleLabel(context, s.manga),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: context.theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+              trailing: IconButton(
+                tooltip: context.l10n.manageDownloadsChangeRule,
+                icon: const Icon(Icons.tune_rounded),
+                onPressed: () => _openSeriesSheet(context, ref, s.manga),
+              ),
+              onTap: selecting
+                  ? () => toggle(s.manga.id)
+                  : () => MangaRoute(mangaId: s.manga.id).push(context),
+              onLongPress: () => toggle(s.manga.id),
+            );
+          },
+        ),
+        if (selecting)
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: SelectionActionBar(
+              leading: [
+                IconButton(
+                  tooltip: context.l10n.cancel,
+                  icon: const Icon(Icons.close_rounded),
+                  onPressed: clear,
+                ),
+                Text('${selection.value.length}',
+                    style: context.textTheme.titleMedium),
+              ],
+              actions: [
+                IconButton(
+                  tooltip: context.l10n.manageDownloadsChangeRule,
+                  icon: const Icon(Icons.tune_rounded),
+                  onPressed: () =>
+                      _bulkChangeRule(context, ref, selectedRows(), clear),
+                ),
+                IconButton(
+                  tooltip: context.l10n.manageDownloadsStopKeep,
+                  icon: const Icon(Icons.bookmark_remove_outlined),
+                  onPressed: () => _bulkStopKeep(
+                      context, ref, selection.value.toList(), clear),
+                ),
+                IconButton(
+                  tooltip: context.l10n.manageDownloadsStopDelete,
+                  icon: const Icon(Icons.delete_outline_rounded),
+                  onPressed: () => _bulkStopDelete(
+                      context, ref, selection.value.toList(), clear),
+                ),
+              ],
             ),
           ),
-          title: Text(s.manga.title,
-              maxLines: 1, overflow: TextOverflow.ellipsis),
-          subtitle: Text(downloading
-              ? '${context.l10n.offlineDownloadingCount(s.inFlight)} · ${context.l10n.nChapters(s.count)}'
-              : '${context.l10n.nChapters(s.count)} · ${formatBytes(s.bytes)}'),
-          trailing: downloading
-              ? const SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2))
-              : null,
-          onTap: () => MangaRoute(mangaId: s.manga.id).push(context),
-        );
-      },
+      ],
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Single-series action sheet (the row's gear button)
+  // ---------------------------------------------------------------------------
+
+  void _openSeriesSheet(
+      BuildContext context, WidgetRef ref, OfflineManga manga) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final n in _bufferSizes)
+              ListTile(
+                leading: const Icon(Icons.bookmark_add_outlined),
+                title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+                trailing: (manga.keepRule == OfflineKeepRule.nUnread &&
+                        manga.keepUnreadCount == n)
+                    ? const Icon(Icons.check_rounded)
+                    : null,
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  changeKeepRule(ref, manga.id, OfflineKeepRule.nUnread, n);
+                },
+              ),
+            ListTile(
+              leading: const Icon(Icons.menu_book_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAllUnread),
+              trailing: manga.keepRule == OfflineKeepRule.allUnread
+                  ? const Icon(Icons.check_rounded)
+                  : null,
+              onTap: () {
+                Navigator.pop(sheetContext);
+                changeKeepRule(ref, manga.id, OfflineKeepRule.allUnread,
+                    manga.keepUnreadCount);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.library_books_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAll),
+              trailing: manga.keepRule == OfflineKeepRule.all
+                  ? const Icon(Icons.check_rounded)
+                  : null,
+              onTap: () {
+                Navigator.pop(sheetContext);
+                changeKeepRule(
+                    ref, manga.id, OfflineKeepRule.all, manga.keepUnreadCount);
+              },
+            ),
+            const Divider(height: 1),
+            ListTile(
+              leading: const Icon(Icons.bookmark_remove_outlined),
+              title: Text(sheetContext.l10n.manageDownloadsStopKeep),
+              onTap: () {
+                Navigator.pop(sheetContext);
+                detachKeepRule(ref, manga.id);
+              },
+            ),
+            ListTile(
+              leading: Icon(Icons.delete_outline_rounded,
+                  color: sheetContext.theme.colorScheme.error),
+              title: Text(sheetContext.l10n.manageDownloadsStopDelete,
+                  style:
+                      TextStyle(color: sheetContext.theme.colorScheme.error)),
+              onTap: () async {
+                final ok = await _confirm(sheetContext,
+                    sheetContext.l10n.manageDownloadsDeleteConfirm(1));
+                if (!sheetContext.mounted) return;
+                Navigator.pop(sheetContext);
+                if (ok) await removeKeepRuleAndDelete(ref, manga.id);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Bulk actions
+  // ---------------------------------------------------------------------------
+
+  Future<void> _bulkChangeRule(BuildContext context, WidgetRef ref,
+      List<_SeriesRow> rows, VoidCallback clear) async {
+    if (rows.isEmpty) return;
+    final picked = await _pickRule(context);
+    if (picked == null || !context.mounted) return;
+    final growing =
+        rows.where((r) => picked.rule.index > r.manga.keepRule.index).length;
+    if (growing > 0 &&
+        !await _confirm(
+            context, context.l10n.manageDownloadsGrowConfirm(growing))) {
+      return;
+    }
+    clear();
+    for (final r in rows) {
+      await changeKeepRule(ref, r.manga.id, picked.rule, picked.count);
+    }
+  }
+
+  Future<void> _bulkStopKeep(BuildContext context, WidgetRef ref,
+      List<int> ids, VoidCallback clear) async {
+    if (ids.isEmpty) return;
+    if (!await _confirm(
+        context, context.l10n.manageDownloadsKeepFilesConfirm(ids.length))) {
+      return;
+    }
+    clear();
+    for (final id in ids) {
+      await detachKeepRule(ref, id);
+    }
+  }
+
+  Future<void> _bulkStopDelete(BuildContext context, WidgetRef ref,
+      List<int> ids, VoidCallback clear) async {
+    if (ids.isEmpty) return;
+    if (!await _confirm(
+        context, context.l10n.manageDownloadsDeleteConfirm(ids.length))) {
+      return;
+    }
+    clear();
+    for (final id in ids) {
+      await removeKeepRuleAndDelete(ref, id);
+    }
+  }
+
+  Future<({OfflineKeepRule rule, int count})?> _pickRule(
+      BuildContext context) {
+    return showModalBottomSheet<({OfflineKeepRule rule, int count})>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final n in _bufferSizes)
+              ListTile(
+                leading: const Icon(Icons.bookmark_add_outlined),
+                title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+                onTap: () => Navigator.pop(
+                    sheetContext, (rule: OfflineKeepRule.nUnread, count: n)),
+              ),
+            ListTile(
+              leading: const Icon(Icons.menu_book_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAllUnread),
+              onTap: () => Navigator.pop(
+                  sheetContext, (rule: OfflineKeepRule.allUnread, count: 3)),
+            ),
+            ListTile(
+              leading: const Icon(Icons.library_books_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAll),
+              onTap: () => Navigator.pop(
+                  sheetContext, (rule: OfflineKeepRule.all, count: 3)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<bool> _confirm(BuildContext context, String message) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            content: Text(message),
+            actions: [
+              TextButton(
+                  onPressed: () => Navigator.pop(ctx, false),
+                  child: Text(ctx.l10n.cancel)),
+              FilledButton(
+                  onPressed: () => Navigator.pop(ctx, true),
+                  child: Text(ctx.l10n.yes)),
+            ],
+          ),
+        ) ??
+        false;
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1804,6 +1804,29 @@
     "@offlineDownloadingToast": {
         "description": "Snackbar shown after starting a series download"
     },
+    "manageDownloads": "Manage downloads",
+    "@manageDownloads": {
+        "description": "Title/entry for the page listing on-device keep-rule subscriptions"
+    },
+    "manageDownloadsEmpty": "No download subscriptions yet",
+    "manageDownloadsNothingYet": "Nothing downloaded yet",
+    "offlineManualOnly": "Manual only",
+    "offlineManageHint": "Series saved on this device. Tap the sliders icon on a series to auto-keep new chapters, or remove a series to free space. Long-press to select several.",
+    "manageDownloadsChangeRule": "Change rule",
+    "manageDownloadsStopKeep": "Stop keeping (keep files)",
+    "manageDownloadsStopDelete": "Stop keeping & delete files",
+    "manageDownloadsKeepFilesConfirm": "Stop auto-keeping {count} series but leave the chapters already downloaded on this device?",
+    "@manageDownloadsKeepFilesConfirm": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "manageDownloadsDeleteConfirm": "Stop keeping {count} series and delete their downloaded chapters from this device? The server copies are untouched.",
+    "@manageDownloadsDeleteConfirm": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "manageDownloadsGrowConfirm": "This will download more chapters for {count} series. Continue?",
+    "@manageDownloadsGrowConfirm": {
+        "placeholders": { "count": { "type": "int" } }
+    },
     "offlineDownloadingCount": "Downloading {count}",
     "@offlineDownloadingCount": {
         "description": "Series button label while N chapters are downloading",

--- a/test/src/features/offline/data/offline_subscriptions_test.dart
+++ b/test/src/features/offline/data/offline_subscriptions_test.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seedManga(int id, String title) =>
+      db.upsertMangaMetadata(id: id, title: title, updatedAt: DateTime(2026));
+
+  Future<void> seedChapter(int id, int mangaId) => db.upsertChapterMetadata(
+        id: id,
+        mangaId: mangaId,
+        name: 'c$id',
+        chapterIndex: id,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 1,
+        updatedAt: DateTime(2026),
+      );
+
+  test('lists series with files OR a rule (union); excludes neither', () async {
+    // m1: keep all + 2 downloaded (100B each) + 1 queued.
+    await seedManga(1, 'Alpha');
+    await db.setKeepRule(1, OfflineKeepRule.all, 3);
+    for (final c in [10, 11]) {
+      await seedChapter(c, 1);
+      await db.setChapterDeviceState(c, OfflineDeviceState.downloaded,
+          bytes: 100, downloadedAt: DateTime(2026));
+    }
+    await seedChapter(12, 1);
+    await db.setChapterDeviceState(12, OfflineDeviceState.queued);
+
+    // m2: a rule, NOTHING downloaded yet (must still appear).
+    await seedManga(2, 'Beta');
+    await db.setKeepRule(2, OfflineKeepRule.nUnread, 5);
+
+    // m3: files but NO rule (hand-saved) — must appear too.
+    await seedManga(3, 'Gamma');
+    await seedChapter(30, 3);
+    await db.setChapterDeviceState(30, OfflineDeviceState.downloaded,
+        bytes: 50, downloadedAt: DateTime(2026));
+
+    // m4: no rule, no files — must NOT appear.
+    await seedManga(4, 'Delta');
+
+    final rows = await db.watchOfflineSeries().first;
+    final byId = {for (final s in rows) s.manga.id: s};
+
+    expect(byId.keys.toSet(), {1, 2, 3}); // m4 excluded
+
+    expect(byId[1]!.manga.keepRule, OfflineKeepRule.all);
+    expect(byId[1]!.downloaded, 2);
+    expect(byId[1]!.inFlight, 1);
+    expect(byId[1]!.bytes, 200);
+
+    // Rule with nothing downloaded — surfaced with zeroed aggregates.
+    expect(byId[2]!.manga.keepRule, OfflineKeepRule.nUnread);
+    expect(byId[2]!.downloaded, 0);
+
+    // Files with no rule — surfaced as Manual (keepRule off).
+    expect(byId[3]!.manga.keepRule, OfflineKeepRule.off);
+    expect(byId[3]!.downloaded, 1);
+    expect(byId[3]!.bytes, 50);
+  });
+
+  test('detach basis: pinned downloaded survive a rule→off; series still listed',
+      () async {
+    // Mirrors detachKeepRule at the DB level: pin downloaded, clear the rule.
+    // The reconciler protects pinned chapters (tested in reconcile_eviction);
+    // here we assert the catalog state detach leaves behind.
+    await seedManga(1, 'Alpha');
+    await db.setKeepRule(1, OfflineKeepRule.all, 3);
+    await seedChapter(10, 1);
+    await db.setChapterDeviceState(10, OfflineDeviceState.downloaded,
+        bytes: 100, downloadedAt: DateTime(2026));
+    await seedChapter(11, 1);
+    await db.setChapterDeviceState(11, OfflineDeviceState.queued);
+
+    await db.setChapterPinned(10, true);
+    await db.setKeepRule(1, OfflineKeepRule.off, 3);
+
+    final downloaded = await db.downloadedChaptersForManga(1);
+    expect(downloaded.single.id, 10);
+    expect(downloaded.single.pinned, true); // protected from eviction
+
+    // Still listed (it has files), now as Manual (rule off).
+    final rows = await db.watchOfflineSeries().first;
+    final row = rows.firstWhere((s) => s.manga.id == 1);
+    expect(row.manga.keepRule, OfflineKeepRule.off);
+    expect(row.downloaded, 1);
+  });
+}


### PR DESCRIPTION
Makes Downloads -> On device the single place to see and manage downloads: every series with files saved or an active keep-rule, each row showing what's downloaded and its rule. A per-row sliders button opens a rule editor (change rule / stop keeping but keep files / stop keeping and delete), and long-press multi-selects for the same in bulk.