### PR TITLE
Show an error screen + write a crash log instead of a white void

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,11 +36,25 @@ import 'src/features/tracking/data/tracker_repository.dart';
 import 'src/features/tracking/domain/tracker_oauth_helpers.dart';
 import 'src/global_providers/global_providers.dart';
 import 'src/sorayomi.dart';
+import 'src/utils/crash/crash_log.dart';
 import 'src/utils/misc/toast/toast.dart';
 import 'src/utils/platform/is_android_native.dart';
+import 'src/widgets/app_error_app.dart';
 
-Future<void> main() async {
+/// Absolute path of the crash-log file (native only; null on web / if setup
+/// fails). The error handlers append to it synchronously.
+String? _crashLogPath;
+
+void main() {
+  // Run everything inside a guarded zone so a fatal error — sync, async, or
+  // framework — is caught, written to a log file, and shown as a readable
+  // screen instead of a blank white window (release desktop has no console).
+  runZonedGuarded<Future<void>>(_startApp, _onFatalError);
+}
+
+Future<void> _startApp() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await _setUpCrashReporting();
   // Initialise the foreground-task plugin (Android-only; no-op elsewhere) before
   // any download service is started. Must run after the binding is ready.
   initForegroundTaskService();
@@ -187,6 +201,40 @@ Future<void> main() async {
       child: const Sorayomi(),
     ),
   );
+}
+
+/// Install the framework + async error handlers and resolve the crash-log file.
+/// Each handler is best-effort and never throws, so crash reporting can't itself
+/// crash startup.
+Future<void> _setUpCrashReporting() async {
+  _crashLogPath = await initCrashLog();
+  FlutterError.onError = (details) {
+    FlutterError.presentError(details);
+    _logCrash(details.exception, details.stack);
+  };
+  WidgetsBinding.instance.platformDispatcher.onError = (error, stack) {
+    _logCrash(error, stack);
+    return true;
+  };
+  ErrorWidget.builder = (details) =>
+      AppErrorApp(message: details.exceptionAsString(), logPath: _crashLogPath);
+}
+
+void _logCrash(Object error, StackTrace? stack) {
+  debugPrint('Tsumiru fatal: $error\n$stack');
+  writeCrashLog(
+    _crashLogPath,
+    '[${DateTime.now().toIso8601String()}] $error\n$stack\n\n',
+  );
+}
+
+void _onFatalError(Object error, StackTrace stack) {
+  _logCrash(error, stack);
+  // A failure before/around runApp would otherwise leave a blank white window;
+  // best-effort show the error screen so there's something to act on.
+  try {
+    runApp(AppErrorApp(message: error.toString(), logPath: _crashLogPath));
+  } catch (_) {}
 }
 
 /// Sets up the AppLinks deep-link listener so that OAuth callbacks of the form

--- a/lib/src/utils/crash/crash_log.dart
+++ b/lib/src/utils/crash/crash_log.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Web-safe entry point for the crash-log file writer. The real implementation
+// needs `dart:io` (native only); on web this swaps in a no-op stub so main.dart
+// — which compiles for web too — still builds.
+export 'crash_log_stub.dart' if (dart.library.io) 'crash_log_io.dart';

--- a/lib/src/utils/crash/crash_log_io.dart
+++ b/lib/src/utils/crash/crash_log_io.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+/// Resolve (and create) the crash-log file path under the app support dir, so
+/// the error handlers can append to it synchronously. Returns null if it can't
+/// be set up (logging is best-effort and never blocks startup).
+Future<String?> initCrashLog() async {
+  try {
+    final dir = await getApplicationSupportDirectory();
+    final logDir = Directory('${dir.path}/logs');
+    logDir.createSync(recursive: true);
+    return '${logDir.path}/crash.log';
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Append [content] to the crash log. No-op if the path is null or the write
+/// fails — crash reporting must never throw.
+void writeCrashLog(String? path, String content) {
+  if (path == null) return;
+  try {
+    File(path).writeAsStringSync(content, mode: FileMode.append, flush: true);
+  } catch (_) {}
+}

--- a/lib/src/utils/crash/crash_log_stub.dart
+++ b/lib/src/utils/crash/crash_log_stub.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Web no-op: there's no filesystem to write a crash log to.
+Future<String?> initCrashLog() async => null;
+
+void writeCrashLog(String? path, String content) {}

--- a/lib/src/widgets/app_error_app.dart
+++ b/lib/src/widgets/app_error_app.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+/// A self-contained fallback screen shown when the app hits a fatal error —
+/// instead of a blank white window with no clue. Kept dependency-light (its own
+/// [MaterialApp]) so it renders even if the failure happened before/around the
+/// real app's first frame. The full error + stack are written to a log file
+/// ([logPath]) the user can send us.
+class AppErrorApp extends StatelessWidget {
+  const AppErrorApp({super.key, required this.message, this.logPath});
+
+  final String message;
+  final String? logPath;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        body: SafeArea(
+          child: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error_outline_rounded, size: 48),
+                  const SizedBox(height: 16),
+                  const Text(
+                    "Tsumiru couldn't start",
+                    style:
+                        TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  SelectableText(
+                    message,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontSize: 13, height: 1.3),
+                  ),
+                  if (logPath != null) ...[
+                    const SizedBox(height: 16),
+                    SelectableText(
+                      'A detailed log was saved to:\n$logPath',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontSize: 12),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Startup had no global error handling, so a fatal exception — or any failure before runApp — left a blank white window with nothing logged. Release builds have no console, which made a desktop white screen impossible to diagnose.

This wraps startup in a guarded zone and installs `FlutterError.onError`, `platformDispatcher.onError`, and `ErrorWidget.builder`. Fatal errors now:
- append to a crash log at `<app-support>/logs/crash.log` (native only, behind a web-safe shim), and
- render a self-contained error screen with the message + log path, instead of a white void.

Also serves as a diagnostic: a white-screen build that now shows the error screen was a Dart-level failure (captured in the log); one that stays white points below Dart (engine/GPU renderer).