### PR TITLE
Bundle the MSVC runtime in the Windows release zip

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -181,6 +181,12 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
+          # Bundle the MSVC runtime DLLs (msvcp140 / vcruntime140 / *_1) next to
+          # the exe, so the app runs on machines WITHOUT the Visual C++
+          # Redistributable installed. Without these the window opens but never
+          # paints — a blank white screen — on otherwise-fine PCs.
+          $redist = vswhere -latest -find 'VC\Redist\MSVC\*\x64\*\*.dll'
+          Copy-Item $redist build\windows\x64\runner\Release\ -Force
           Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath "dist\${env:pkg_name}-${{ github.ref_name }}-windows-x64.zip"
 
       - name: Attach to release


### PR DESCRIPTION
The release builder zipped `build/windows/x64/runner/Release` without the Visual C++ runtime DLLs (`msvcp140.dll`, `vcruntime140.dll`, `vcruntime140_1.dll`). Flutter Windows apps depend on those, so on any PC **without** the Visual C++ Redistributable installed the window opens but never paints — a blank white screen — and it reproduces on every version. (It works on dev machines, which always have the runtime.)

Copy the redist DLLs next to the exe before zipping — the same step the older `publish.yml` had and the fork builder dropped — so the Windows download is self-contained. Takes effect on the next tagged release; existing users can work around it by installing the Microsoft VC++ x64 Redistributable.