### PR TITLE
Sort the extensions list alphabetically

### DIFF
--- a/lib/src/features/browse_center/presentation/extension/controller/extension_controller.dart
+++ b/lib/src/features/browse_center/presentation/extension/controller/extension_controller.dart
@@ -55,6 +55,13 @@ AsyncValue<Map<String, List<Extension>>> extensionMap(Ref ref) {
       );
     }
   }
+  // Sort every bucket alphabetically by name. The server returns no meaningful
+  // order (install order is unhelpful); this matches Suwayomi-WebUI + Komikku,
+  // which sort each group by name.
+  for (final list in extensionMap.values) {
+    list.sort(
+        (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+  }
   return extensionListData.copyWithData((p0) => extensionMap);
 }
 


### PR DESCRIPTION
Installed/updatable extensions and the per-language available lists were rendered in server order (effectively install order), so there was no way to scan for one by name. Sort every bucket by name (case-insensitive) in `extensionMap`.

Matches the reference behaviour: Suwayomi-WebUI sorts every extension group by `name.localeCompare`, and Komikku does the same — neither offers pinning or install-order for extensions, so alphabetical is the expected default. (Source *pinning* stays a sources-only feature, also matching both.)