### PR TITLE
Restore idempotent offline DB migration

### DIFF
--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -128,23 +128,44 @@ class OfflineDatabase extends _$OfflineDatabase {
   MigrationStrategy get migration => MigrationStrategy(
         onCreate: (m) => m.createAll(),
         onUpgrade: (m, from, to) async {
+          // Idempotent adds: a device migrated by an intermediate/dev build can
+          // already have a column while still recording an older schema version,
+          // which would make a plain addColumn crash with "duplicate column".
           if (from < 2) {
-            await m.addColumn(offlineMangas, offlineMangas.keepRule);
-            await m.addColumn(offlineMangas, offlineMangas.keepUnreadCount);
-            await m.addColumn(offlineChapters, offlineChapters.pinned);
-            await m.addColumn(offlineChapters, offlineChapters.downloadedAt);
+            await _addColumnIfMissing(m, offlineMangas, offlineMangas.keepRule);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.keepUnreadCount);
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.pinned);
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.downloadedAt);
           }
           if (from < 3) {
-            await m.addColumn(offlineChapters, offlineChapters.progressDirty);
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.progressDirty);
           }
           if (from < 4) {
-            await m.addColumn(offlineChapters, offlineChapters.lastReadAt);
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.lastReadAt);
           }
           if (from < 5) {
-            await m.addColumn(offlineChapters, offlineChapters.bookmarkDirty);
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.bookmarkDirty);
           }
         },
       );
+
+  /// drift's [Migrator.addColumn] throws if the column already exists. A device
+  /// migrated by an intermediate/dev build can have a column present while still
+  /// recording an older schema version, so guard each add to stay idempotent.
+  Future<void> _addColumnIfMissing(
+      Migrator m, TableInfo table, GeneratedColumn column) async {
+    final info =
+        await customSelect("PRAGMA table_info('${table.actualTableName}')")
+            .get();
+    final exists = info.any((row) => row.read<String>('name') == column.name);
+    if (!exists) await m.addColumn(table, column);
+  }
 
   // --- metadata down-sync upserts -------------------------------------------
   // These set ONLY server-sourced columns, so device-managed columns

--- a/test/src/features/offline/data/offline_schema_migration_test.dart
+++ b/test/src/features/offline/data/offline_schema_migration_test.dart
@@ -71,6 +71,30 @@ void main() {
     }
   });
 
+  test('migration is idempotent: re-adding existing columns does not crash',
+      () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    // Create a fresh DB (all current columns present), then force the recorded
+    // schema version back to 1 — exactly the inconsistent state a device left
+    // by an intermediate/dev build can end up in (column present, old version).
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.customStatement('PRAGMA user_version = 1');
+      await db.close();
+    }
+
+    // Reopen: onUpgrade(from: 1) runs every `from < N` branch and would re-add
+    // already-present columns. The idempotent guard must skip them instead of
+    // throwing "duplicate column" — so the DB opens and is usable.
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      expect(await db.select(db.offlineChapters).get(), isEmpty);
+      await db.close();
+    }
+  });
+
   test('v4 lastReadAt persists across close/reopen', () async {
     final dbPath = p.join(tmp.path, 'test.db');
 


### PR DESCRIPTION
The offline database migration adds columns idempotently (skip a column that already exists) so an upgrade self-heals instead of failing to open the database with a "duplicate column" error.

That guard, plus its regression test, was inadvertently overwritten by a later merge whose branch predated it — bringing back the plain `addColumn` calls that crash on launch when a device already has the column. This reinstates the guard and the test.

- `offline_database.dart`: re-add `_addColumnIfMissing` and route every `onUpgrade` column-add through it.
- `offline_schema_migration_test.dart`: restore the "migration is idempotent" test (re-running the migration over existing columns must not throw).