### PR TITLE
Onboarding & Connection: share one sign-in routine; fix the auth-mode dropdown

### DIFF
--- a/lib/src/features/auth/presentation/sign_in_action.dart
+++ b/lib/src/features/auth/presentation/sign_in_action.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../constants/enum.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
+import '../../settings/presentation/server/widget/credential_popup/login_credentials_popup.dart';
+import '../data/auth_coordinator.dart';
+import '../data/auth_credentials_store.dart';
+import '../data/auth_state.dart';
+
+/// The single sign-in routine shared by first-run onboarding and the
+/// Connection settings screen. Neither surface reimplements login — they both
+/// call this so the wizard and the settings page behave identically.
+///
+/// Records the username, clears the other auth modes' stored credentials (so a
+/// mode switch can't leave a stale token behind), then commits via the matching
+/// canonical path:
+///   * basic       — store the `Basic` header (no round-trip; validated by the
+///                   next real request, exactly as the settings screen does),
+///   * simpleLogin — [AuthCoordinator.loginSimple] (verifies + persists cookie),
+///   * uiLogin     — [AuthCoordinator.loginUi]     (verifies + persists tokens).
+///
+/// Throws on rejection for ui/simple (bad credentials or wrong auth mode); the
+/// caller surfaces the error.
+Future<void> performSignIn(
+  WidgetRef ref, {
+  required AuthType authType,
+  required String serverBaseUrl,
+  required String username,
+  required String password,
+}) async {
+  ref.read(authUsernameProvider.notifier).update(username);
+  final store = ref.read(authCredentialsStoreProvider.notifier);
+  if (authType != AuthType.uiLogin) await store.clearUiLoginTokens();
+  if (authType != AuthType.simpleLogin) await store.clearSimpleLoginCookie();
+  if (authType != AuthType.basic) await store.clearBasicCredentials();
+
+  final coordinator = ref.read(authCoordinatorProvider.notifier);
+  switch (authType) {
+    case AuthType.basic:
+      await ref
+          .read(credentialsProvider.notifier)
+          .set('Basic ${base64.encode(utf8.encode('$username:$password'))}');
+    case AuthType.simpleLogin:
+      await coordinator.loginSimple(
+        serverBaseUrl: serverBaseUrl,
+        username: username,
+        password: password,
+      );
+    case AuthType.uiLogin:
+      await coordinator.loginUi(
+        gqlClient: ref.read(graphQlClientProvider),
+        username: username,
+        password: password,
+      );
+    case AuthType.none:
+      return;
+  }
+  ref.read(needsReauthProvider.notifier).set(false);
+}

--- a/lib/src/features/onboarding/presentation/onboarding_screen.dart
+++ b/lib/src/features/onboarding/presentation/onboarding_screen.dart
@@ -581,25 +581,31 @@ class _ServerStep extends HookConsumerWidget {
         // Auth sub-form, revealed only when the server needs a login.
         if (state.value == _TestState.needsLogin) ...[
           const SizedBox(height: 12),
-          DropdownButtonFormField<AuthType>(
-            initialValue: authChoice.value,
-            decoration: InputDecoration(
-              labelText: context.l10n.onboardingAuthMode,
-              border: const OutlineInputBorder(),
-              prefixIcon: const Icon(Icons.shield_rounded),
-            ),
-            items: [
-              DropdownMenuItem(
+          // M3 DropdownMenu (not the legacy DropdownButtonFormField, whose menu
+          // anchors the selected item over the field and can open upward over
+          // other content, wider than the field). This opens below, sized to
+          // the field. Keyed by the selection so it re-seeds if changed.
+          DropdownMenu<AuthType>(
+            key: ValueKey(authChoice.value),
+            initialSelection: authChoice.value,
+            expandedInsets: EdgeInsets.zero,
+            requestFocusOnTap: false,
+            label: Text(context.l10n.onboardingAuthMode),
+            leadingIcon: const Icon(Icons.shield_rounded),
+            inputDecorationTheme:
+                const InputDecorationTheme(border: OutlineInputBorder()),
+            dropdownMenuEntries: [
+              DropdownMenuEntry(
                   value: AuthType.basic,
-                  child: Text(context.l10n.onboardingAuthModeBasic)),
-              DropdownMenuItem(
+                  label: context.l10n.onboardingAuthModeBasic),
+              DropdownMenuEntry(
                   value: AuthType.simpleLogin,
-                  child: Text(context.l10n.onboardingAuthModeSimple)),
-              DropdownMenuItem(
+                  label: context.l10n.onboardingAuthModeSimple),
+              DropdownMenuEntry(
                   value: AuthType.uiLogin,
-                  child: Text(context.l10n.onboardingAuthModeUi)),
+                  label: context.l10n.onboardingAuthModeUi),
             ],
-            onChanged: (m) {
+            onSelected: (m) {
               if (m != null) {
                 authChoice.value = m;
                 credsRejected.value = false;

--- a/lib/src/features/onboarding/presentation/onboarding_screen.dart
+++ b/lib/src/features/onboarding/presentation/onboarding_screen.dart
@@ -4,8 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import 'dart:convert';
-
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -23,11 +21,10 @@ import '../../../utils/launch_url_in_web.dart';
 import '../../../utils/misc/toast/toast.dart';
 import '../../../utils/theme/brand.dart';
 import '../../about/data/about_repository.dart';
-import '../../auth/data/auth_coordinator.dart';
+import '../../auth/presentation/sign_in_action.dart';
 import '../../settings/presentation/appearance/widgets/app_theme_selector/app_theme_selector.dart';
 import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
-import '../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
 import '../data/onboarding_complete.dart';
 import '../data/server_discovery.dart';
 import '../data/server_resolver.dart';
@@ -171,8 +168,9 @@ class _StepDots extends StatelessWidget {
             width: i == active ? 22 : 8,
             height: 8,
             decoration: BoxDecoration(
-              color:
-                  i == active ? cs.primary : cs.onSurface.withValues(alpha: 0.22),
+              color: i == active
+                  ? cs.primary
+                  : cs.onSurface.withValues(alpha: 0.22),
               borderRadius: BorderRadius.circular(4),
             ),
           ),
@@ -326,57 +324,40 @@ class _ServerStep extends HookConsumerWidget {
       if (urlController.text != url) urlController.text = url;
     }
 
-    // Validate the entered credentials against [base] using [authChoice].
-    // Persists and returns true on success.
+    // Validate + commit the entered credentials against [base] using
+    // [authChoice], via the SAME performSignIn the Connection settings screen
+    // uses — the wizard must not run its own login path. Returns true
+    // on success; a thrown rejection (bad creds / wrong auth mode) reads as
+    // false. [client] is retained for the connection-probe callers above.
     Future<bool> validateCredentials(String base, http.Client client) async {
       final user = userController.text.trim();
       final pass = passController.text;
       if (user.isEmpty || pass.isEmpty) return false;
-      final coord = ref.read(authCoordinatorProvider.notifier);
-      try {
-        switch (authChoice.value) {
-          case AuthType.basic:
-            // Two gates: basicAuthConfirms proves it's really Suwayomi AND the
-            // Basic creds pass the transport (closes the "random 401 host"
-            // trap); authProbeAuthorized proves those creds actually authorise
-            // the @RequireAuth API. The second gate is what stops a wrong auth
-            // type "succeeding" against a ui_login/simple_login server, whose
-            // public aboutServer answers regardless of credentials.
-            if (!await basicAuthConfirms(base,
-                client: client, username: user, password: pass)) {
-              return false;
-            }
-            if (!await authProbeAuthorized(base,
-                client: client, basic: '$user:$pass')) {
-              return false;
-            }
-            await ref.read(credentialsProvider.notifier).set(
-                'Basic ${base64.encode(utf8.encode('$user:$pass'))}');
-          case AuthType.simpleLogin:
-            final cookie = await coord.verifySimpleCredentials(
-                serverBaseUrl: base, username: user, password: pass);
-            if (!await authProbeAuthorized(base,
-                client: client, cookie: cookie)) {
-              return false;
-            }
-            await coord.loginSimple(
-                serverBaseUrl: base, username: user, password: pass);
-          case AuthType.uiLogin:
-            final tokens = await coord.verifyUiCredentials(
-                gqlClient: ref.read(graphQlClientProvider),
-                username: user,
-                password: pass);
-            if (!await authProbeAuthorized(base,
-                client: client, bearer: tokens.accessToken)) {
-              return false;
-            }
-            await coord.loginUi(
-                gqlClient: ref.read(graphQlClientProvider),
-                username: user,
-                password: pass);
-          case AuthType.none:
-            return false;
+      if (authChoice.value == AuthType.none) return false;
+      // Basic auth has no login round-trip that can fail, so the wizard
+      // pre-flights it before committing: confirm it's really Suwayomi over
+      // Basic AND that these creds actually authorise the @RequireAuth API —
+      // otherwise picking the wrong auth type would "succeed" against a server
+      // whose public aboutServer answers regardless of credentials. ui/simple
+      // need no pre-flight: performSignIn's login round-trip throws on rejection.
+      if (authChoice.value == AuthType.basic) {
+        if (!await basicAuthConfirms(base,
+            client: client, username: user, password: pass)) {
+          return false;
         }
+        if (!await authProbeAuthorized(base,
+            client: client, basic: '$user:$pass')) {
+          return false;
+        }
+      }
+      try {
+        await performSignIn(
+          ref,
+          authType: authChoice.value,
+          serverBaseUrl: base,
+          username: user,
+          password: pass,
+        );
       } catch (_) {
         return false;
       }
@@ -589,8 +570,13 @@ class _ServerStep extends HookConsumerWidget {
           style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(46)),
         ),
         const SizedBox(height: 12),
-        ..._buildTestStatus(context, cs, state.value, resolvedUrl.value,
-            version.value, errorDetail.value,
+        ..._buildTestStatus(
+            context,
+            cs,
+            state.value,
+            resolvedUrl.value,
+            version.value,
+            errorDetail.value,
             shouldSuggestHttps(urlController.text.trim())),
         // Auth sub-form, revealed only when the server needs a login.
         if (state.value == _TestState.needsLogin) ...[
@@ -661,7 +647,8 @@ class _ServerStep extends HookConsumerWidget {
                     child: CircularProgressIndicator(strokeWidth: 2))
                 : const Icon(Icons.login_rounded),
             label: Text(context.l10n.onboardingSignIn),
-            style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(46)),
+            style:
+                FilledButton.styleFrom(minimumSize: const Size.fromHeight(46)),
           ),
         ],
         const SizedBox(height: 8),

--- a/lib/src/features/settings/presentation/connection/inline_auth_section.dart
+++ b/lib/src/features/settings/presentation/connection/inline_auth_section.dart
@@ -185,20 +185,24 @@ class InlineAuthSection extends HookConsumerWidget {
       children: [
         SectionTitle(title: context.l10n.authentication),
         pad(
-          DropdownButtonFormField<AuthType>(
-            initialValue: authType,
-            decoration: InputDecoration(
-              labelText: context.l10n.authType,
-              border: const OutlineInputBorder(),
-              prefixIcon: const Icon(Icons.security_rounded),
-            ),
-            items: AuthType.values
-                .map((t) => DropdownMenuItem(
-                      value: t,
-                      child: Text(t.toLocale(context)),
-                    ))
+          // M3 DropdownMenu (not the legacy DropdownButtonFormField, whose menu
+          // anchors the selected item over the field and can open upward, wider
+          // than the field). Opens below, sized to the field. Keyed by authType
+          // so it re-seeds when the auth mode is changed elsewhere (e.g. logout).
+          DropdownMenu<AuthType>(
+            key: ValueKey(authType),
+            initialSelection: authType,
+            expandedInsets: EdgeInsets.zero,
+            requestFocusOnTap: false,
+            label: Text(context.l10n.authType),
+            leadingIcon: const Icon(Icons.security_rounded),
+            inputDecorationTheme:
+                const InputDecorationTheme(border: OutlineInputBorder()),
+            dropdownMenuEntries: AuthType.values
+                .map((t) =>
+                    DropdownMenuEntry(value: t, label: t.toLocale(context)))
                 .toList(),
-            onChanged: onAuthModeChanged,
+            onSelected: onAuthModeChanged,
           ),
         ),
         if (authType != AuthType.none) ...[

--- a/lib/src/features/settings/presentation/connection/inline_auth_section.dart
+++ b/lib/src/features/settings/presentation/connection/inline_auth_section.dart
@@ -4,8 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -16,13 +14,13 @@ import '../../../../constants/enum.dart';
 import '../../../../features/auth/data/auth_coordinator.dart';
 import '../../../../features/auth/data/auth_credentials_store.dart';
 import '../../../../features/auth/data/auth_state.dart';
+import '../../../../features/auth/presentation/sign_in_action.dart';
 import '../../../../global_providers/global_providers.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/section_title.dart';
 import '../server/widget/client/server_port_tile/server_port_tile.dart';
 import '../server/widget/client/server_url_tile/server_url_tile.dart';
-import '../server/widget/credential_popup/credentials_popup.dart';
 import '../server/widget/credential_popup/login_credentials_popup.dart';
 
 /// Connection-screen authentication, state-aware:
@@ -33,9 +31,6 @@ import '../server/widget/credential_popup/login_credentials_popup.dart';
 ///                             the same shape as the first-run (FTUE) flow.
 class InlineAuthSection extends HookConsumerWidget {
   const InlineAuthSection({super.key});
-
-  String _basicHeader(String user, String pass) =>
-      'Basic ${base64.encode(utf8.encode('$user:$pass'))}';
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -61,13 +56,6 @@ class InlineAuthSection extends HookConsumerWidget {
           port: ref.read(serverPortProvider),
           addPort: ref.read(serverPortToggleProvider).ifNull(),
         );
-
-    Future<void> clearOtherCreds(AuthType keep) async {
-      final store = ref.read(authCredentialsStoreProvider.notifier);
-      if (keep != AuthType.uiLogin) await store.clearUiLoginTokens();
-      if (keep != AuthType.simpleLogin) await store.clearSimpleLoginCookie();
-      if (keep != AuthType.basic) await store.clearBasicCredentials();
-    }
 
     // Validate the entered credentials WITHOUT committing them.
     Future<void> testConnection() async {
@@ -114,32 +102,14 @@ class InlineAuthSection extends HookConsumerWidget {
       busy.value = true;
       message.value = null;
       try {
-        final user = username.text.trim();
-        ref.read(authUsernameProvider.notifier).update(user);
-        await clearOtherCreds(authType);
-        final coordinator = ref.read(authCoordinatorProvider.notifier);
-        switch (authType) {
-          case AuthType.basic:
-            await ref
-                .read(credentialsProvider.notifier)
-                .set(_basicHeader(user, password.text));
-          case AuthType.simpleLogin:
-            await coordinator.loginSimple(
-              serverBaseUrl: resolvedBaseUrl(),
-              username: user,
-              password: password.text,
-            );
-          case AuthType.uiLogin:
-            await coordinator.loginUi(
-              gqlClient: ref.read(graphQlClientProvider),
-              username: user,
-              password: password.text,
-            );
-          case AuthType.none:
-            break;
-        }
+        await performSignIn(
+          ref,
+          authType: authType,
+          serverBaseUrl: resolvedBaseUrl(),
+          username: username.text.trim(),
+          password: password.text,
+        );
         if (!context.mounted) return;
-        ref.read(needsReauthProvider.notifier).set(false);
         password.clear();
         isError.value = false;
         message.value = null;
@@ -290,7 +260,8 @@ class InlineAuthSection extends HookConsumerWidget {
               children: [
                 Expanded(
                   child: OutlinedButton.icon(
-                    onPressed: (busy.value || testing.value) ? null : testConnection,
+                    onPressed:
+                        (busy.value || testing.value) ? null : testConnection,
                     icon: testing.value
                         ? const SizedBox(
                             width: 16,
@@ -328,8 +299,7 @@ String _failureText(BuildContext context, TestConnectionFailureKind kind) =>
     switch (kind) {
       TestConnectionFailureKind.network =>
         context.l10n.authTestConnectionFailedNetwork,
-      TestConnectionFailureKind.tls =>
-        context.l10n.authTestConnectionFailedTls,
+      TestConnectionFailureKind.tls => context.l10n.authTestConnectionFailedTls,
       TestConnectionFailureKind.invalidCredentials =>
         context.l10n.authTestConnectionFailedAuth,
       TestConnectionFailureKind.wrongAuthMode =>


### PR DESCRIPTION
Two fixes to the server-auth UI shared by the first-run wizard and the Connection settings screen.

**One shared sign-in routine.** The first-run wizard ran its own login path: for UI/Simple Login it fired the login round-trip and then re-verified with a second, hand-built authorization probe (a bare HTTP client with redirects disabled). On servers behind a reverse proxy or a redirect that the app's real client handles but the bare probe does not, that probe rejected valid credentials — so sign-in failed in the wizard yet worked from More → Connection, which has no such probe. Both surfaces now call one `performSignIn` helper: clear the other modes' stored credentials, then commit via the canonical `loginUi`/`loginSimple` (or store the Basic header). UI/Simple are proven by the login round-trip itself, so the redundant probe is gone. Basic has no login round-trip, so the wizard keeps a pre-flight that confirms the credentials authorize the API before finishing — without it, choosing the wrong auth type could complete onboarding with a broken configuration.

**Auth-mode dropdown position & width.** The picker used `DropdownButtonFormField`, whose menu anchors the selected item over the field — so with the last option selected it opened upward over the text above it — and sized the menu to the inner button, spilling past the field to both screen edges. Replaced with the Material 3 `DropdownMenu`, which opens below the field at the field's own width; keyed by the selected value so it stays in sync when the auth mode changes elsewhere.