### PR TITLE
Update first-party GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.flutter_version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
       # Install Android dependencies
       - name: Install Android dependencies
         if: matrix.target == 'android'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: "zulu"
           java-version: "17.x"
@@ -67,7 +67,7 @@ jobs:
 
       # Recreating the project
       - run: flutter doctor -v
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       # - run: flutter create .
       - run: flutter pub get
       - run: flutter gen-l10n
@@ -182,7 +182,7 @@ jobs:
           Move-Item "${{ env.pkg_name }}-${{ github.ref_name }}-${{ matrix.target }}-x64.msi" "${env:GITHUB_WORKSPACE}"
 
       - name: Add packaged build to release draft
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: false

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -52,7 +52,7 @@ jobs:
             target: windows
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3 # Only works with v2
+      - uses: actions/checkout@v5 # Only works with v2
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
 
       # Recreating the project
       - run: flutter doctor -v
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       # - run: flutter create .
       - run: flutter pub get
       - run: flutter gen-l10n


### PR DESCRIPTION
GitHub has made Node 24 the default Actions runtime and is removing Node 20 entirely this fall (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Actions pinned to a Node 20 runtime log a deprecation warning now and will break once it's removed.

Move every first-party `actions/*` to a current major across all workflows:
- `actions/checkout` v3/v4 → **v5**
- `actions/setup-java` v3 → **v4** (same `distribution: zulu` / `java-version: 17` inputs)
- `softprops/action-gh-release` v1 → **v2**

The live workflows (`pr-checks`, `release-fork`, `flatpak`) were the ones emitting the warning on every run; the manual-only `publish`/`web` workflows are updated too so nothing breaks when Node 20 is pulled. Third-party actions in those dormant workflows are left as-is.