### PR TITLE
Hide NSFW sources, not just extensions, when "Show NSFW" is off

### DIFF
--- a/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
+++ b/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
@@ -10,6 +10,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../../../constants/db_keys.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+import '../../../../settings/presentation/browse/widgets/show_nsfw_switch/show_nsfw_switch.dart';
 import '../../../data/source_repository/source_repository.dart';
 import '../../../domain/source/source_model.dart';
 
@@ -18,6 +19,20 @@ part 'source_controller.g.dart';
 @riverpod
 Future<List<SourceDto>?> sourceList(Ref ref) =>
     ref.watch(sourceRepositoryProvider).getSourceList();
+
+/// The source list with NSFW sources removed when "Show NSFW" is off. Every
+/// displayed source list derives from this (the grouped/filtered map, the
+/// pinned section, global search, migration), so the toggle hides NSFW sources
+/// everywhere — matching how the extensions list already behaves. Defaults to
+/// showing NSFW (no filtering) when the setting is unset.
+@riverpod
+AsyncValue<List<SourceDto>?> visibleSourceList(Ref ref) {
+  final showNsfw = ref.watch(showNSFWProvider).ifNull(true);
+  return ref.watch(sourceListProvider).copyWithData(
+        (list) =>
+            list == null || showNsfw ? list : [...list.where((e) => !e.isNsfw)],
+      );
+}
 
 int _byName(SourceDto a, SourceDto b) =>
     a.name.toLowerCase().compareTo(b.name.toLowerCase());
@@ -55,12 +70,12 @@ Map<String, List<SourceDto>> groupSourcesByLanguage(
 /// Pinned sources, surfaced as their own top section regardless of the active
 /// language filter.
 @riverpod
-List<SourceDto> pinnedSources(Ref ref) =>
-    pinnedSourcesFrom(ref.watch(sourceListProvider).valueOrNull ?? const []);
+List<SourceDto> pinnedSources(Ref ref) => pinnedSourcesFrom(
+    ref.watch(visibleSourceListProvider).valueOrNull ?? const []);
 
 @riverpod
 AsyncValue<Map<String, List<SourceDto>>> sourceMap(Ref ref) {
-  final sourceListData = ref.watch(sourceListProvider);
+  final sourceListData = ref.watch(visibleSourceListProvider);
   final sourceLastUsed = ref.watch(sourceLastUsedProvider);
   return sourceListData.copyWithData(
     (data) => groupSourcesByLanguage(data ?? const [], sourceLastUsed),

--- a/lib/src/features/migration/controller/migration_controller.dart
+++ b/lib/src/features/migration/controller/migration_controller.dart
@@ -17,6 +17,7 @@ import '../../library/presentation/library/controller/library_controller.dart';
 import '../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
 import '../../manga_book/domain/manga/manga_model.dart';
 import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import '../../settings/presentation/browse/widgets/show_nsfw_switch/show_nsfw_switch.dart';
 import '../data/migration_repository.dart';
 import '../domain/migration_models.dart';
 
@@ -26,7 +27,21 @@ part 'migration_controller.g.dart';
 class MigrationSources extends _$MigrationSources {
   @override
   Future<List<MigrationSource>?> build({required int mangaId}) async {
-    return ref.watch(migrationRepositoryProvider).getMigrationSources(mangaId);
+    final sources = await ref
+        .watch(migrationRepositoryProvider)
+        .getMigrationSources(mangaId);
+    if (sources == null) return null;
+    // Respect "Show NSFW" here too: MigrationSource carries no nsfw flag, so
+    // exclude any migration source whose id is a known NSFW source. Defaults to
+    // showing NSFW (no filtering) when the setting is unset, matching the
+    // Sources/Extensions lists.
+    if (ref.watch(showNSFWProvider).ifNull(true)) return sources;
+    final nsfwIds = {
+      for (final e
+          in await ref.watch(sourceListProvider.future) ?? const <SourceDto>[])
+        if (e.isNsfw) e.id,
+    };
+    return [...sources.where((e) => !nsfwIds.contains(e.id))];
   }
 
   Future<void> refresh() async {


### PR DESCRIPTION
The "Show NSFW" toggle filtered the extension list but not the source list, so disabling it still left NSFW sources visible in the source list, global search, and the migration source picker. Apply the same NSFW filter to sources everywhere they're listed.