### PR TITLE
Make crash logs reachable from inside the app

### DIFF
--- a/lib/src/features/settings/presentation/settings/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings/settings_screen.dart
@@ -5,9 +5,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../routes/router_config.dart';
+import '../../../../utils/crash/crash_log.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../utils/misc/toast/toast.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -71,8 +75,37 @@ class SettingsScreen extends StatelessWidget {
             leading: const Icon(Icons.computer_rounded),
             onTap: () => const ServerSettingsRoute().go(context),
           ),
+          const _CopyCrashLogTile(),
         ],
       ),
+    );
+  }
+}
+
+/// Lets a user grab the latest crash/error log for a bug report — it lives in
+/// the app's private files dir, which they can't browse, so we copy it to the
+/// clipboard. Most errors no longer show the full-screen crash page (they're
+/// recoverable), so this is the way to retrieve their log after the fact.
+class _CopyCrashLogTile extends ConsumerWidget {
+  const _CopyCrashLogTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      title: Text(context.l10n.copyCrashLog),
+      subtitle: Text(context.l10n.copyCrashLogSubtitle),
+      leading: const Icon(Icons.bug_report_rounded),
+      onTap: () async {
+        final log = readCrashLog(await initCrashLog());
+        if (!context.mounted) return;
+        final toast = ref.read(toastProvider);
+        if (log == null) {
+          toast?.show(context.l10n.noCrashLog);
+          return;
+        }
+        await Clipboard.setData(ClipboardData(text: log));
+        if (context.mounted) toast?.show(context.l10n.crashLogCopied);
+      },
     );
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -294,6 +294,9 @@
     "@downloading": {
         "description": "Text to show chapters downloading"
     },
+    "@onDeviceDownloads": {
+        "description": "Settings entry: on-device (offline) downloads screen"
+    },
     "@downloads": {
         "description": "Screen title and Navigation text of Downloads screen"
     },
@@ -694,6 +697,12 @@
     "@openInWeb": {
         "description": "Button title text for open the url in web"
     },
+    "@openSourceInBrowser": {
+        "description": "Menu item: open the manga page on the original source website"
+    },
+    "@openOnServer": {
+        "description": "Menu item: open the manga in the Suwayomi server WebUI"
+    },
     "@or": {
         "description": "text literal for word or"
     },
@@ -852,6 +861,12 @@
     },
     "@readerVolumeTapSubtitle": {
         "description": "Switch button Subtitle text for Reader Page Navigation with Volume Tap"
+    },
+    "@readerKeepScreenOn": {
+        "description": "Reader switch tile title: keep the screen awake while reading"
+    },
+    "@readerKeepScreenOnSubtitle": {
+        "description": "Reader switch tile subtitle for keep screen on"
     },
     "@readerIgnoreSafeAreaToggle": {
         "description": "Toggle text to ignore safe area in reader"
@@ -1282,6 +1297,7 @@
       "placeholders": { "n": { "type": "int" } }
     },
     "downloads": "Downloads",
+    "onDeviceDownloads": "On-device downloads",
     "downloadToServer": "Download to server",
     "downloadUnreadChapters": "Unread",
     "@downloadUnreadChapters": { "description": "Bulk-download menu item: queue all unread, not-yet-downloaded chapters." },
@@ -1443,6 +1459,8 @@
     },
     "openFlareSolverr": "Checkout FlareSolverr for information on how to set it up",
     "openInWeb": "Open In Web",
+    "openSourceInBrowser": "Open source page",
+    "openOnServer": "Open on server",
     "or": "or",
     "page": "Page: {number}",
     "parallelSourceRequest": "Parallel source requests",
@@ -1512,6 +1530,8 @@
     "readerVolumeTap": "Volume Keys",
     "readerVolumeTapInvert": "Invert Volume Keys",
     "readerVolumeTapSubtitle": "Navigate with Volume Keys",
+    "readerKeepScreenOn": "Keep screen on",
+    "readerKeepScreenOnSubtitle": "Prevent the screen from sleeping while reading",
     "readerIgnoreSafeAreaToggle": "Ignore Safe Area",
     "readerIgnoreSafeAreaToggleDescription": "Allow content to extend into notch and home indicator areas",
     "reddit": "Reddit",
@@ -1614,6 +1634,10 @@
     "serverPort": "Server Port",
     "serverPortHintText": "Server port",
     "serverSettingsSubtitle": "Configure the Suwayomi server itself.",
+    "copyCrashLog": "Copy crash log",
+    "copyCrashLogSubtitle": "For bug reports — copies the latest error log to the clipboard",
+    "crashLogCopied": "Crash log copied to clipboard",
+    "noCrashLog": "No crash log found",
     "serverUrl": "Server URL",
     "serverUrlHintText": "Server url",
     "serverVersion": "Server version",

--- a/lib/src/utils/crash/crash_log_io.dart
+++ b/lib/src/utils/crash/crash_log_io.dart
@@ -30,3 +30,17 @@ void writeCrashLog(String? path, String content) {
     File(path).writeAsStringSync(content, mode: FileMode.append, flush: true);
   } catch (_) {}
 }
+
+/// Read the whole crash log so the UI can let a user copy it — they can't reach
+/// the app's private files directory themselves. Null if missing/empty.
+String? readCrashLog(String? path) {
+  if (path == null) return null;
+  try {
+    final file = File(path);
+    if (!file.existsSync()) return null;
+    final content = file.readAsStringSync();
+    return content.isEmpty ? null : content;
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/src/utils/crash/crash_log_stub.dart
+++ b/lib/src/utils/crash/crash_log_stub.dart
@@ -8,3 +8,5 @@
 Future<String?> initCrashLog() async => null;
 
 void writeCrashLog(String? path, String content) {}
+
+String? readCrashLog(String? path) => null;

--- a/lib/src/widgets/app_error_app.dart
+++ b/lib/src/widgets/app_error_app.dart
@@ -5,12 +5,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
-/// A self-contained fallback screen shown when the app hits a fatal error —
+import '../utils/crash/crash_log.dart';
+
+/// A self-contained fallback screen shown when the app fails to start —
 /// instead of a blank white window with no clue. Kept dependency-light (its own
 /// [MaterialApp]) so it renders even if the failure happened before/around the
 /// real app's first frame. The full error + stack are written to a log file
-/// ([logPath]) the user can send us.
+/// ([logPath]); the "Copy log" button puts it on the clipboard so a user can
+/// paste it into a bug report without needing to reach the app's private files.
 class AppErrorApp extends StatelessWidget {
   const AppErrorApp({super.key, required this.message, this.logPath});
 
@@ -23,35 +27,56 @@ class AppErrorApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         body: SafeArea(
-          child: Center(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.error_outline_rounded, size: 48),
-                  const SizedBox(height: 16),
-                  const Text(
-                    "Tsumiru couldn't start",
-                    style:
-                        TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 12),
-                  SelectableText(
-                    message,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(fontSize: 13, height: 1.3),
-                  ),
-                  if (logPath != null) ...[
+          child: Builder(
+            builder: (context) => Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.error_outline_rounded, size: 48),
                     const SizedBox(height: 16),
-                    SelectableText(
-                      'A detailed log was saved to:\n$logPath',
+                    const Text(
+                      "Tsumiru couldn't start",
+                      style:
+                          TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
                       textAlign: TextAlign.center,
-                      style: const TextStyle(fontSize: 12),
                     ),
+                    const SizedBox(height: 12),
+                    SelectableText(
+                      message,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontSize: 13, height: 1.3),
+                    ),
+                    const SizedBox(height: 20),
+                    FilledButton.icon(
+                      onPressed: () async {
+                        // The log lives in the app's private files dir, which a
+                        // user can't browse — copy it so they can paste it into
+                        // a bug report. Fall back to the message if unreadable.
+                        final log = readCrashLog(logPath) ?? message;
+                        await Clipboard.setData(ClipboardData(text: log));
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Log copied to clipboard'),
+                            ),
+                          );
+                        }
+                      },
+                      icon: const Icon(Icons.copy_all_rounded),
+                      label: const Text('Copy log'),
+                    ),
+                    if (logPath != null) ...[
+                      const SizedBox(height: 16),
+                      SelectableText(
+                        'Saved to:\n$logPath',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(fontSize: 11),
+                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
When the app hit an error there was no way for a user to retrieve the log without adb. Add a "Copy log" button to the error screen and a "Copy crash log" tile at the bottom of Settings, both copying the on-device crash log to the clipboard.