### PR TITLE
Default on-device downloads to Wi-Fi only

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -64,6 +64,7 @@ enum DBKeys {
   readerFeedbackToasts(true),
   volumeTap(false),
   volumeTapInvert(false),
+  keepScreenOn(true),
   hideEmptyCategory(false),
   // When false (default, Mihon-style), opening an entry shows the chapters the
   // server already has, without re-scraping the source. When true, also refresh
@@ -90,8 +91,9 @@ enum DBKeys {
   // How many chapter pages download at once. Low by default: a self-hosted
   // server saturates fast and starts returning 500/503 under heavy parallelism.
   offlineDownloadConcurrency(2),
-  // Restrict background downloads to Wi-Fi connections only.
-  downloadOnlyOverWifi(false),
+  // Restrict background downloads to Wi-Fi connections only. Default ON so a
+  // fresh install never burns mobile data on downloads unless the user opts in.
+  downloadOnlyOverWifi(true),
   // User-initiated pause of all ON-DEVICE downloads. Persisted (an explicit
   // pause shouldn't silently resume on restart); read synchronously by the
   // download starters to gate every restart path.

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -78,7 +78,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     WidgetsBinding.instance.addObserver(this);
     _workerEventCallback ??= _onWorkerEvent;
     FlutterForegroundTask.addTaskDataCallback(_workerEventCallback!);
-    _connSub ??= Connectivity().onConnectivityChanged.listen(_onConnectivityChanged);
+    _connSub ??=
+        Connectivity().onConnectivityChanged.listen(_onConnectivityChanged);
   }
 
   void dispose() {
@@ -169,8 +170,9 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// Read synchronously so the start gate can't be bypassed by an unhydrated
   /// provider read.
   bool _isPaused() =>
-      _ref.read(sharedPreferencesProvider).getBool(
-          DBKeys.offlineDownloadsPaused.name) ??
+      _ref
+          .read(sharedPreferencesProvider)
+          .getBool(DBKeys.offlineDownloadsPaused.name) ??
       false;
 
   /// Pause all on-device downloads: tell the worker to park the in-flight
@@ -204,7 +206,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   Future<void> onWifiOnlyChanged(bool value) async {
     if (!Platform.isAndroid) return;
     if (await FlutterForegroundTask.isRunningService) {
-      FlutterForegroundTask.sendDataToTask({'op': 'setWifiOnly', 'value': value});
+      FlutterForegroundTask.sendDataToTask(
+          {'op': 'setWifiOnly', 'value': value});
       if (value && await _isMetered()) {
         await FlutterForegroundTask.stopService();
       }
@@ -268,7 +271,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       // completion log, replayed on resume.)
       case 'chapterStart':
         final id = data['chapterId'] as int;
-        unawaited(_db.setChapterDeviceState(id, OfflineDeviceState.downloading));
+        unawaited(
+            _db.setChapterDeviceState(id, OfflineDeviceState.downloading));
         // Record the resolved page total so the progress arc can show a real
         // fraction (only when known + currently unset/0, to avoid clobbering a
         // good catalog value).
@@ -355,7 +359,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       serverBase: _ref.read(serverUrlProvider) ?? '',
       port: _ref.read(serverPortProvider),
       addPort: _ref.read(serverPortToggleProvider).ifNull(),
-      wifiOnly: _ref.read(offlineWifiOnlyProvider) ?? false,
+      wifiOnly: _ref.read(offlineWifiOnlyProvider) ?? true,
       auth: auth,
       baseDir: _paths.baseDir,
     );
@@ -422,7 +426,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// True when Wi-Fi-only is set AND the active connection is metered — the
   /// condition under which we won't start the service.
   Future<bool> _wifiOnlyBlocks() async {
-    if (!(_ref.read(offlineWifiOnlyProvider) ?? false)) return false;
+    if (!(_ref.read(offlineWifiOnlyProvider) ?? true)) return false;
     return _isMetered();
   }
 
@@ -447,14 +451,15 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// future in-worker gate but does not act on connection type today.
   void _onConnectivityChanged(List<ConnectivityResult> result) {
     if (!Platform.isAndroid) return;
-    final wifiOnly = _ref.read(offlineWifiOnlyProvider) ?? false;
+    final wifiOnly = _ref.read(offlineWifiOnlyProvider) ?? true;
     if (!wifiOnly) return;
     final hasUnmetered = result.contains(ConnectivityResult.wifi) ||
         result.contains(ConnectivityResult.ethernet);
     unawaited(() async {
       if (!hasUnmetered) {
         if (await FlutterForegroundTask.isRunningService) {
-          logger.i('Offline: dropped to metered with Wi-Fi-only — stopping FGS');
+          logger
+              .i('Offline: dropped to metered with Wi-Fi-only — stopping FGS');
           await FlutterForegroundTask.stopService();
         }
       } else {
@@ -494,8 +499,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   }) =>
       TokenBroker(
         read: () async {
-          final raw = await FlutterForegroundTask.getData<String>(
-              key: kTokenRecordKey);
+          final raw =
+              await FlutterForegroundTask.getData<String>(key: kTokenRecordKey);
           if (raw != null) {
             return BackgroundTokenRecord.fromJson(
                 jsonDecode(raw) as Map<String, Object?>);

--- a/lib/src/features/offline/presentation/offline_settings_screen.dart
+++ b/lib/src/features/offline/presentation/offline_settings_screen.dart
@@ -45,8 +45,7 @@ class OfflineSettingsScreen extends ConsumerWidget {
                       final confirmed = await showDialog<bool>(
                         context: context,
                         builder: (ctx) => AlertDialog(
-                          content:
-                              Text(context.l10n.offlineRemoveAllConfirm),
+                          content: Text(context.l10n.offlineRemoveAllConfirm),
                           actions: [
                             TextButton(
                               onPressed: () => Navigator.pop(ctx, false),
@@ -80,12 +79,9 @@ class OfflineSettingsScreen extends ConsumerWidget {
                   SettingsPropTile(
                     title: context.l10n.downloadOverWifiOnly,
                     type: SettingsPropType.switchTile(
-                      value:
-                          ref.watch(offlineWifiOnlyProvider) ?? false,
+                      value: ref.watch(offlineWifiOnlyProvider) ?? true,
                       onChanged: (v) async {
-                        ref
-                            .read(offlineWifiOnlyProvider.notifier)
-                            .update(v);
+                        ref.read(offlineWifiOnlyProvider.notifier).update(v);
                         return null;
                       },
                     ),
@@ -97,8 +93,7 @@ class OfflineSettingsScreen extends ConsumerWidget {
                     type: SettingsPropType.numberSlider(
                       min: 1,
                       max: 8,
-                      value:
-                          ref.watch(offlineDownloadConcurrencyProvider) ?? 2,
+                      value: ref.watch(offlineDownloadConcurrencyProvider) ?? 2,
                       onChanged: (v) async {
                         ref
                             .read(offlineDownloadConcurrencyProvider.notifier)
@@ -152,16 +147,14 @@ class OfflineSettingsScreen extends ConsumerWidget {
                   ),
                   SettingsPropTile(
                     title: context.l10n.offlineKeepDaysLabel,
-                    subtitle: context.l10n.offlineDays(
-                        ref.watch(offlineKeepDaysProvider) ?? 30),
+                    subtitle: context.l10n
+                        .offlineDays(ref.watch(offlineKeepDaysProvider) ?? 30),
                     type: SettingsPropType.numberSlider(
                       min: 1,
                       max: 365,
                       value: ref.watch(offlineKeepDaysProvider) ?? 30,
                       onChanged: (v) async {
-                        ref
-                            .read(offlineKeepDaysProvider.notifier)
-                            .update(v);
+                        ref.read(offlineKeepDaysProvider.notifier).update(v);
                         return null;
                       },
                     ),


### PR DESCRIPTION
On-device downloads defaulted to running on any connection, which can burn mobile data unexpectedly. Default the "download over Wi-Fi only" preference to on (users can still turn it off under Downloads -> On-device).