### PR TITLE
Add a "keep screen on while reading" setting, default on

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../../../constants/enum.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
@@ -18,6 +19,7 @@ import '../../../library/presentation/library/controller/library_controller.dart
 import '../../../offline/data/offline_download_providers.dart';
 import '../../../settings/presentation/incognito/incognito_mode.dart';
 import '../../../settings/presentation/reader/widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
+import '../../../settings/presentation/reader/widgets/reader_keep_screen_on_tile/reader_keep_screen_on_tile.dart';
 import '../../../settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart';
 import '../../../tracking/domain/track_progress_gate.dart';
 import '../../domain/manga/manga_model.dart';
@@ -149,6 +151,19 @@ class ReaderScreen extends HookConsumerWidget {
             overlays: SystemUiOverlay.values,
           );
     }, []);
+
+    // Keep the screen awake while reading when the user opted in. The cleanup
+    // only exists when we actually enabled (returning null when off), so leaving
+    // the reader — or flipping the toggle off mid-read — releases the wakelock
+    // and we never disable one we didn't take. Calls are fire-and-forget and
+    // their errors ignored, so a platform hiccup (e.g. no foreground activity
+    // during a transition) can never crash the reader.
+    final keepScreenOn = ref.watch(keepScreenOnProvider).ifNull(true);
+    useEffect(() {
+      if (!keepScreenOn) return null;
+      WakelockPlus.enable().ignore();
+      return () => WakelockPlus.disable().ignore();
+    }, [keepScreenOn]);
 
     return PopScope(
       onPopInvokedWithResult: (didPop, _) async {

--- a/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
+++ b/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
@@ -17,6 +17,7 @@ import 'widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
 import 'widgets/reader_infinity_scrolling_mode_tile/reader_infinity_scrolling_mode_tile.dart';
 import 'widgets/reader_initial_overlay_tile/reader_initial_overlay_tile.dart';
 import 'widgets/reader_invert_tap_tile/reader_invert_tap_tile.dart';
+import 'widgets/reader_keep_screen_on_tile/reader_keep_screen_on_tile.dart';
 import 'widgets/reader_last_page_swipe_tile/reader_last_page_swipe_tile.dart';
 import 'widgets/reader_magnifier_size_slider/reader_magnifier_size_slider.dart';
 import 'widgets/reader_mode_tile/reader_mode_tile.dart';
@@ -51,6 +52,7 @@ class ReaderSettingsScreen extends ConsumerWidget {
           const ReaderMagnifierSizeSlider(),
           if (!kIsWeb) ...[
             if (Platform.isAndroid || Platform.isIOS) ...[
+              const ReaderKeepScreenOnTile(),
               const ReaderPinchToZoom(),
               const ReaderIgnoreSafeAreaTile(),
             ],

--- a/lib/src/features/settings/presentation/reader/widgets/reader_keep_screen_on_tile/reader_keep_screen_on_tile.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_keep_screen_on_tile/reader_keep_screen_on_tile.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'reader_keep_screen_on_tile.g.dart';
+
+/// Persisted reader preference: keep the device screen awake while reading.
+/// Default ON — reading is low-interaction, so we'd rather hold the screen than
+/// let it sleep mid-page (deviates from Mihon's off-by-default).
+@riverpod
+class KeepScreenOn extends _$KeepScreenOn
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.keepScreenOn);
+}
+
+class ReaderKeepScreenOnTile extends HookConsumerWidget {
+  const ReaderKeepScreenOnTile({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.brightness_high_rounded),
+      title: Text(context.l10n.readerKeepScreenOn),
+      subtitle: Text(context.l10n.readerKeepScreenOnSubtitle),
+      onChanged: ref.read(keepScreenOnProvider.notifier).update,
+      value: ref.watch(keepScreenOnProvider).ifNull(true),
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,6 +16,7 @@ import shared_preferences_foundation
 import sqflite_darwin
 import sqlite3_flutter_libs
 import url_launcher_macos
+import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
@@ -29,4 +30,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1636,6 +1636,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.2.0"
+  wakelock_plus:
+    dependency: "direct main"
+    description:
+      name: wakelock_plus
+      sha256: "61713aa82b7f85c21c9f4cd0a148abd75f38a74ec645fcb1e446f882c82fd09b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
+  wakelock_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_plus_platform_interface
+      sha256: "036deb14cd62f558ca3b73006d52ce049fabcdcb2eddfe0bf0fe4e8a943b5cf2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   cached_network_image: ^3.2.2
   cached_network_image_platform_interface: ^4.0.0
   connectivity_plus: ^6.1.3
+  wakelock_plus: ^1.3.3
   cupertino_icons: ^1.0.5
   drift: ^2.20.0
   extension_type_unions: ^1.0.10


### PR DESCRIPTION
The screen could dim or sleep mid-chapter. Add a reader setting to keep the screen awake while reading (matching Mihon/Komikku defaults, on by default), backed by wakelock_plus.