### PR TITLE
Manga details: tracker sync on bulk mark-read, fresh UI after actions, open in source or server

### DIFF
--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -28,6 +30,7 @@ import '../../../offline/data/offline_database.dart';
 import '../../../offline/data/offline_download_providers.dart';
 import '../../../offline/data/offline_repository.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
+import '../../../tracking/domain/track_progress_gate.dart';
 import 'controller/library_controller.dart';
 
 class CategoryMangaList extends HookConsumerWidget {
@@ -90,6 +93,16 @@ class CategoryMangaList extends HookConsumerWidget {
         if (cids.isNotEmpty) {
           await repo.modifyBulkChapters(
               ChapterBatch(ids: cids, patch: ChapterChange(isRead: read)));
+          // Marking a whole series read here bypasses the reader, so push the
+          // new progress to the bound tracker(s) explicitly (manual path).
+          if (read) {
+            unawaited(maybeTrackProgressOnReadFetch(
+              ref,
+              mangaId: id,
+              isRead: true,
+              manual: true,
+            ));
+          }
         }
       }
       refresh();
@@ -186,7 +199,8 @@ class CategoryMangaList extends HookConsumerWidget {
                       final ids = selection.value.toList();
                       if (ids.length > 1 &&
                           !await confirmBulkDownload(context,
-                              summary: '${ids.length} series', toDevice: true)) {
+                              summary: '${ids.length} series',
+                              toDevice: true)) {
                         return;
                       }
                       selection.value = const {};
@@ -223,8 +237,8 @@ class CategoryMangaList extends HookConsumerWidget {
                       }
                       if (context.mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                          content:
-                              Text('Downloading ${ids.length} series to server'),
+                          content: Text(
+                              'Downloading ${ids.length} series to server'),
                         ));
                       }
                     },
@@ -233,8 +247,7 @@ class CategoryMangaList extends HookConsumerWidget {
                       // multi-manga category editing is a follow-up.
                       if (selection.value.length == 1) {
                         final id = selection.value.first;
-                        final manga =
-                            items.firstWhere((m) => m.id == id);
+                        final manga = items.firstWhere((m) => m.id == id);
                         selection.value = const {};
                         await showDialog(
                           context: context,

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -15,7 +15,6 @@ import '../../../../constants/app_sizes.dart';
 import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/launch_url_in_web.dart';
-import '../../../../utils/misc/app_utils.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../utils/theme/brand.dart';
 import '../../../../widgets/emoticons.dart';
@@ -25,6 +24,7 @@ import '../../../migration/domain/migration_models.dart';
 import '../../domain/chapter/chapter_model.dart';
 import '../../widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart';
 import 'controller/manga_details_controller.dart';
+import 'server_web_url.dart';
 import 'widgets/big_screen_manga_details.dart';
 import 'widgets/chapter_download_presets_button.dart';
 import 'widgets/edit_manga_category_dialog.dart';
@@ -81,8 +81,15 @@ class MangaDetailsScreen extends HookConsumerWidget {
       }
       await mangaRefresh(onlineFetch);
       await chapterListRefresh(onlineFetch);
-      if (context.mounted && onlineFetch) {
-        if (manga.hasError) {
+      if (onlineFetch) {
+        // mangaRefresh only invalidates; await the actual refetch and report ITS
+        // result. Reading the captured `manga` (stale) or the provider right
+        // after invalidation (still loading) would announce "Updated" even when
+        // the fetch ultimately failed.
+        final result =
+            await AsyncValue.guard(() => ref.read(mangaProvider.future));
+        if (!context.mounted) return;
+        if (result.hasError) {
           ref.read(toastProvider)?.showError(
                 context.l10n.errorSomethingWentWrong,
               );
@@ -108,6 +115,16 @@ class MangaDetailsScreen extends HookConsumerWidget {
       MigrationGlobalSearchRoute(
         $extra: MigrationRouteData(sourceManga: manga),
       ).push(context);
+    }
+
+    void openInBrowser(String url) =>
+        launchUrlInWeb(context, url, ref.read(toastProvider));
+
+    // Open the manga's page in the Suwayomi server's own WebUI (vs the source
+    // site's realUrl). No-ops if no server is configured.
+    void openOnServer() {
+      final url = serverMangaWebUrl(ref, mangaId);
+      if (url != null) openInBrowser(url);
     }
 
     return PopScope(
@@ -187,7 +204,8 @@ class MangaDetailsScreen extends HookConsumerWidget {
                                     begin: Alignment.topCenter,
                                     end: Alignment.bottomCenter,
                                     colors: [
-                                      Colors.black.withValues(alpha: 0.45 * (1 - t)),
+                                      Colors.black
+                                          .withValues(alpha: 0.45 * (1 - t)),
                                       Colors.transparent,
                                     ],
                                   ),
@@ -200,105 +218,114 @@ class MangaDetailsScreen extends HookConsumerWidget {
                           child: Text(data?.title ?? context.l10n.manga),
                         ),
                         actions: [
-                    if (context.isTablet) ...[
-                      IconButton(
-                        onPressed: () => refresh(true),
-                        icon: const Icon(Icons.refresh_rounded),
-                      ),
-                      IconButton(
-                        onPressed: () => showDialog(
-                          context: context,
-                          builder: (context) =>
-                              EditMangaCategoryDialog(mangaId: mangaId),
-                        ),
-                        icon: const Icon(Icons.category_rounded),
-                      ),
-                      IconButton(
-                        onPressed: () => startMigration(context, mangaId, data),
-                        icon: const Icon(Icons.swap_horiz_rounded),
-                        tooltip: context.l10n.migrate,
-                      ),
-                      IconButton(
-                        onPressed: AppUtils.returnIf(
-                          data!.realUrl != null,
-                          () => launchUrlInWeb(
-                            context,
-                            data.realUrl!,
-                            ref.read(toastProvider),
-                          ),
-                        ),
-                        icon: const Icon(Icons.open_in_new_rounded),
-                      )
-                    ],
-                    ChapterDownloadPresetsButton(
-                      chapterList: chapterList,
-                      refresh: refresh,
-                    ),
-                    Builder(
-                      builder: (context) => IconButton(
-                        onPressed: () {
-                          if (context.isTablet) {
-                            Scaffold.of(context).openEndDrawer();
-                          } else {
-                            showModalBottomSheet(
-                              context: context,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: KBorderRadius.rT16.radius,
-                              ),
-                              clipBehavior: Clip.hardEdge,
-                              builder: (_) =>
-                                  MangaChapterOrganizer(mangaId: mangaId),
-                            );
-                          }
-                        },
-                        icon: const Icon(Icons.filter_list_rounded),
-                      ),
-                    ),
-                    if (!context.isTablet)
-                      PopupMenuButton(
-                        shape: RoundedRectangleBorder(
-                          borderRadius: KBorderRadius.r16.radius,
-                        ),
-                        icon: const Icon(Icons.more_vert_rounded),
-                        itemBuilder: (context) => [
-                          PopupMenuItem(
-                            onTap: () => Future.microtask(
-                              () {
-                                if (!context.mounted) return null;
-                                return showDialog(
-                                  context: context,
-                                  builder: (context) =>
-                                      EditMangaCategoryDialog(mangaId: mangaId),
-                                );
-                              },
+                          if (context.isTablet) ...[
+                            IconButton(
+                              onPressed: () => refresh(true),
+                              icon: const Icon(Icons.refresh_rounded),
                             ),
-                            child: Text(context.l10n.editCategory),
-                          ),
-                          PopupMenuItem(
-                            onTap: () => startMigration(context, mangaId, data),
-                            child: Row(
-                              children: [
-                                const Icon(Icons.swap_horiz_rounded),
-                                const SizedBox(width: 8),
-                                Text(context.l10n.migrate),
+                            IconButton(
+                              onPressed: () => showDialog(
+                                context: context,
+                                builder: (context) =>
+                                    EditMangaCategoryDialog(mangaId: mangaId),
+                              ),
+                              icon: const Icon(Icons.category_rounded),
+                            ),
+                            IconButton(
+                              onPressed: () =>
+                                  startMigration(context, mangaId, data),
+                              icon: const Icon(Icons.swap_horiz_rounded),
+                              tooltip: context.l10n.migrate,
+                            ),
+                            PopupMenuButton<void>(
+                              icon: const Icon(Icons.open_in_new_rounded),
+                              tooltip: context.l10n.openInWeb,
+                              itemBuilder: (context) => [
+                                if (data?.realUrl != null)
+                                  PopupMenuItem(
+                                    onTap: () => openInBrowser(data!.realUrl!),
+                                    child:
+                                        Text(context.l10n.openSourceInBrowser),
+                                  ),
+                                PopupMenuItem(
+                                  onTap: openOnServer,
+                                  child: Text(context.l10n.openOnServer),
+                                ),
                               ],
+                            )
+                          ],
+                          ChapterDownloadPresetsButton(
+                            chapterList: chapterList,
+                            refresh: refresh,
+                          ),
+                          Builder(
+                            builder: (context) => IconButton(
+                              onPressed: () {
+                                if (context.isTablet) {
+                                  Scaffold.of(context).openEndDrawer();
+                                } else {
+                                  showModalBottomSheet(
+                                    context: context,
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: KBorderRadius.rT16.radius,
+                                    ),
+                                    clipBehavior: Clip.hardEdge,
+                                    builder: (_) =>
+                                        MangaChapterOrganizer(mangaId: mangaId),
+                                  );
+                                }
+                              },
+                              icon: const Icon(Icons.filter_list_rounded),
                             ),
                           ),
-                          PopupMenuItem(
-                            onTap: () => refresh(true),
-                            child: Text(context.l10n.refresh),
-                          ),
-                          if (data?.realUrl != null)
-                            PopupMenuItem(
-                              onTap: () => launchUrlInWeb(
-                                context,
-                                data!.realUrl!,
-                                ref.read(toastProvider),
+                          if (!context.isTablet)
+                            PopupMenuButton(
+                              shape: RoundedRectangleBorder(
+                                borderRadius: KBorderRadius.r16.radius,
                               ),
-                              child: Text(context.l10n.openInWeb),
-                            ),
-                        ],
-                      )
+                              icon: const Icon(Icons.more_vert_rounded),
+                              itemBuilder: (context) => [
+                                PopupMenuItem(
+                                  onTap: () => Future.microtask(
+                                    () {
+                                      if (!context.mounted) return null;
+                                      return showDialog(
+                                        context: context,
+                                        builder: (context) =>
+                                            EditMangaCategoryDialog(
+                                                mangaId: mangaId),
+                                      );
+                                    },
+                                  ),
+                                  child: Text(context.l10n.editCategory),
+                                ),
+                                PopupMenuItem(
+                                  onTap: () =>
+                                      startMigration(context, mangaId, data),
+                                  child: Row(
+                                    children: [
+                                      const Icon(Icons.swap_horiz_rounded),
+                                      const SizedBox(width: 8),
+                                      Text(context.l10n.migrate),
+                                    ],
+                                  ),
+                                ),
+                                PopupMenuItem(
+                                  onTap: () => refresh(true),
+                                  child: Text(context.l10n.refresh),
+                                ),
+                                if (data?.realUrl != null)
+                                  PopupMenuItem(
+                                    onTap: () => openInBrowser(data!.realUrl!),
+                                    child:
+                                        Text(context.l10n.openSourceInBrowser),
+                                  ),
+                                PopupMenuItem(
+                                  onTap: openOnServer,
+                                  child: Text(context.l10n.openOnServer),
+                                ),
+                              ],
+                            )
                         ],
                       );
                     },
@@ -330,40 +357,40 @@ class MangaDetailsScreen extends HookConsumerWidget {
           body: Stack(
             children: [
               NotificationListener<ScrollNotification>(
-            onNotification: (n) {
-              if (n.metrics.axis == Axis.vertical) {
-                scrollPx.value = n.metrics.pixels;
-              }
-              return false;
-            },
-            child: data != null
-              ? context.isTablet
-                  ? BigScreenMangaDetails(
-                      chapterList: filteredChapterList,
-                      manga: data,
-                      mangaId: mangaId,
-                      onRefresh: refresh,
-                      onDescriptionRefresh: mangaRefresh,
-                      onListRefresh: chapterListRefresh,
-                      selectedChapters: selectedChapters,
-                    )
-                  : SmallScreenMangaDetails(
-                      chapterList: filteredChapterList,
-                      manga: data,
-                      mangaId: mangaId,
-                      onRefresh: refresh,
-                      onDescriptionRefresh: mangaRefresh,
-                      onListRefresh: chapterListRefresh,
-                      selectedChapters: selectedChapters,
-                    )
-              : Emoticons(
-                  title: context.l10n.noMangaFound,
-                  button: TextButton(
-                    onPressed: refresh,
-                    child: Text(context.l10n.refresh),
-                  ),
-                ),
-          ),
+                onNotification: (n) {
+                  if (n.metrics.axis == Axis.vertical) {
+                    scrollPx.value = n.metrics.pixels;
+                  }
+                  return false;
+                },
+                child: data != null
+                    ? context.isTablet
+                        ? BigScreenMangaDetails(
+                            chapterList: filteredChapterList,
+                            manga: data,
+                            mangaId: mangaId,
+                            onRefresh: refresh,
+                            onDescriptionRefresh: mangaRefresh,
+                            onListRefresh: chapterListRefresh,
+                            selectedChapters: selectedChapters,
+                          )
+                        : SmallScreenMangaDetails(
+                            chapterList: filteredChapterList,
+                            manga: data,
+                            mangaId: mangaId,
+                            onRefresh: refresh,
+                            onDescriptionRefresh: mangaRefresh,
+                            onListRefresh: chapterListRefresh,
+                            selectedChapters: selectedChapters,
+                          )
+                    : Emoticons(
+                        title: context.l10n.noMangaFound,
+                        button: TextButton(
+                          onPressed: refresh,
+                          child: Text(context.l10n.refresh),
+                        ),
+                      ),
+              ),
               if (selectedChapters.value.isNotEmpty)
                 Positioned(
                   left: 0,
@@ -373,7 +400,6 @@ class MangaDetailsScreen extends HookConsumerWidget {
                     afterOptionSelected: chapterListRefresh,
                     selectedChapters: selectedChapters,
                     chapterList: filteredChapterList.value,
-                    mangaId: mangaId,
                   ),
                 ),
             ],

--- a/lib/src/features/manga_book/presentation/manga_details/server_web_url.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/server_web_url.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../constants/endpoints.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import '../../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+
+/// The manga's page in the Suwayomi server's own WebUI (vs the source site's
+/// realUrl) — built from the server web root, no /api segment. Returns null
+/// when no server is configured. Shared by the manga-details open-in-browser
+/// actions and the description's "Web View" button.
+String? serverMangaWebUrl(WidgetRef ref, int mangaId) {
+  final base = Endpoints.baseApi(
+    baseUrl: ref.read(serverUrlProvider),
+    port: ref.read(serverPortProvider),
+    addPort: ref.read(serverPortToggleProvider).ifNull(),
+    appendApiToUrl: false,
+  );
+  if (base.isBlank) return null;
+  final root = base.endsWith('/') ? base.substring(0, base.length - 1) : base;
+  return '$root/manga/$mangaId';
+}

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -25,6 +25,7 @@ import '../../../../offline/presentation/series_offline_button.dart';
 import '../../../../tracking/presentation/hub/track_sheet.dart';
 import '../../../domain/manga/manga_model.dart';
 import '../controller/next_update_controller.dart';
+import '../server_web_url.dart';
 import 'manga_action_button.dart';
 
 class MangaDescription extends HookConsumerWidget {
@@ -39,6 +40,46 @@ class MangaDescription extends HookConsumerWidget {
   final AsyncCallback refresh;
   final AsyncCallback removeMangaFromLibrary;
   final AsyncCallback addMangaToLibrary;
+
+  /// "Web View" → choose the source site (realUrl) or the Suwayomi server's
+  /// WebUI page for this manga. With no source page, opens the server directly.
+  void _openInBrowser(BuildContext context, WidgetRef ref) {
+    final toast = ref.read(toastProvider);
+    final serverUrl = serverMangaWebUrl(ref, manga.id);
+    if (manga.realUrl.isBlank) {
+      if (serverUrl != null) launchUrlInWeb(context, serverUrl, toast);
+      return;
+    }
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.public_rounded),
+              title: Text(sheetContext.l10n.openSourceInBrowser),
+              onTap: () {
+                Navigator.pop(sheetContext);
+                launchUrlInWeb(context, manga.realUrl ?? '', toast);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.dns_rounded),
+              title: Text(sheetContext.l10n.openOnServer),
+              onTap: () {
+                Navigator.pop(sheetContext);
+                if (serverUrl != null) {
+                  launchUrlInWeb(context, serverUrl, toast);
+                }
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isExpanded = useState(context.isTablet);
@@ -46,8 +87,7 @@ class MangaDescription extends HookConsumerWidget {
     final surface = context.theme.scaffoldBackgroundColor;
     final inLibrary = manga.inLibrary.ifNull();
 
-    final prediction =
-        ref.watch(mangaNextUpdateProvider(mangaId: manga.id));
+    final prediction = ref.watch(mangaNextUpdateProvider(mangaId: manga.id));
     final soonDays = manga.status == Enum$MangaStatus.COMPLETED
         ? null
         : prediction?.daysUntil(DateTime.now());
@@ -63,8 +103,7 @@ class MangaDescription extends HookConsumerWidget {
                 content: Text(
                   context.l10n.smartUpdateExpected(
                     context.l10n.dayCount(soonDays),
-                    context.l10n
-                        .dayCount(prediction?.intervalDays ?? 7),
+                    context.l10n.dayCount(prediction?.intervalDays ?? 7),
                   ),
                 ),
                 actions: [
@@ -200,23 +239,19 @@ class MangaDescription extends HookConsumerWidget {
                     active: manga.trackRecords.totalCount > 0,
                     icon: const Icon(Icons.sync_rounded),
                     label: context.l10n.tracking,
-                    onPressed: () => showTrackSheet(context, manga.id, mangaTitle: manga.title),
+                    onPressed: () => showTrackSheet(context, manga.id,
+                        mangaTitle: manga.title),
                   ),
                 ),
                 if (offlineEnabled)
                   Expanded(child: SeriesOfflineButton(mangaId: manga.id)),
-                if (manga.realUrl.isNotBlank)
-                  Expanded(
-                    child: MangaActionButton(
-                      icon: const Icon(Icons.public_rounded),
-                      label: context.l10n.webView,
-                      onPressed: () => launchUrlInWeb(
-                        context,
-                        (manga.realUrl ?? ""),
-                        ref.read(toastProvider),
-                      ),
-                    ),
+                Expanded(
+                  child: MangaActionButton(
+                    icon: const Icon(Icons.public_rounded),
+                    label: context.l10n.webView,
+                    onPressed: () => _openInBrowser(context, ref),
                   ),
+                ),
               ],
             ),
           );

--- a/lib/src/features/manga_book/presentation/updates/updates_screen.dart
+++ b/lib/src/features/manga_book/presentation/updates/updates_screen.dart
@@ -169,17 +169,21 @@ class UpdatesScreen extends HookConsumerWidget {
                 updatePair: () async {
                   final chapter = await ref
                       .refresh(chapterProvider(chapterId: item.id).future);
-                  try {
-                    controller.itemList = [...?controller.itemList]
-                      ..replaceRange(index, index + 1, [
-                        item.copyWith(
-                          isDownloaded: chapter?.isDownloaded,
-                          lastPageRead: chapter?.lastPageRead,
-                        ),
-                      ]);
-                  } catch (e) {
-                    //
-                  }
+                  // Locate the row by id, not the captured build-time index —
+                  // the list may have changed (paging/refresh) while the reader
+                  // was open, so an index-based patch could hit the wrong row.
+                  final list = [...?controller.itemList];
+                  final i = list.indexWhere((e) => e.id == item.id);
+                  if (i < 0) return;
+                  list[i] = list[i].copyWith(
+                    // Upgrade-only: reading never un-reads, so a stale/slow
+                    // refetch that still reports unread must not flip an
+                    // already-read row back. Only ever grey it out.
+                    isRead: (chapter?.isRead ?? false) || list[i].isRead,
+                    isDownloaded: chapter?.isDownloaded,
+                    lastPageRead: chapter?.lastPageRead,
+                  );
+                  controller.itemList = list;
                 },
                 isSelected: selectedChapters.value.containsKey(item.id),
                 canTapSelect: selectedChapters.value.isNotEmpty,

--- a/lib/src/features/manga_book/presentation/updates/widgets/chapter_manga_list_tile.dart
+++ b/lib/src/features/manga_book/presentation/updates/widgets/chapter_manga_list_tile.dart
@@ -41,15 +41,20 @@ class ChapterMangaListTile extends StatelessWidget {
           ? (context.isDarkMode ? Colors.grey.shade700 : Colors.grey.shade300)
           : Colors.transparent,
       child: InkWell(
-        onTap: () {
+        onTap: () async {
           if (canTapSelect) {
             toggleSelect(chapterWithMangaDto);
           } else {
-            ReaderRoute(
+            await ReaderRoute(
               mangaId: manga.id,
               chapterId: chapterWithMangaDto.id,
               showReaderLayoutAnimation: true,
             ).push(context);
+            // Refresh this row on return so a chapter read in the reader greys
+            // out here (its read state, download, and progress are re-fetched).
+            // Guard mounted: the user may have left Updates while reading.
+            if (!context.mounted) return;
+            await updatePair();
           }
         },
         onLongPress: () => toggleSelect(chapterWithMangaDto),
@@ -97,7 +102,8 @@ class ChapterMangaListTile extends StatelessWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        color: color ?? context.theme.colorScheme.onSurfaceVariant,
+                        color:
+                            color ?? context.theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
                   ],

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -15,28 +15,28 @@ import '../../../../utils/misc/toast/toast.dart';
 import '../../../offline/data/offline_download_providers.dart';
 import '../../../tracking/domain/track_progress_gate.dart';
 import '../../data/manga_book/manga_book_repository.dart';
+import '../../domain/chapter/chapter_model.dart';
 import '../../domain/chapter_batch/chapter_batch_model.dart';
 
 class MultiChaptersActionIcon extends ConsumerWidget {
   const MultiChaptersActionIcon({
     this.iconData,
-    required this.chapterList,
+    required this.chapters,
     required this.change,
     required this.refresh,
     this.icon,
-    this.mangaId,
     super.key,
   });
-  final List<int> chapterList;
+
+  /// The selected chapters. Carrying the full [ChapterDto] (not just ids) lets
+  /// a mark-read sync each affected manga to its tracker and honour the
+  /// delete-on-manual-read setting per chapter — correctly even when the
+  /// selection spans multiple manga (e.g. the updates screen).
+  final List<ChapterDto> chapters;
   final ChapterChange change;
   final AsyncValueSetter<bool> refresh;
   final IconData? iconData;
   final Widget? icon;
-  /// When non-null, fires [maybeTrackProgressOnReadFetch] after marking read.
-  /// Pass only for single-manga contexts (e.g. the manga-details screen).
-  /// Omit (null) for multi-manga contexts (e.g. the updates screen) where the
-  /// chapters may belong to different manga.
-  final int? mangaId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -46,7 +46,7 @@ class MultiChaptersActionIcon extends ConsumerWidget {
         final result = await AsyncValue.guard(
           () => ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
                 ChapterBatch(
-                  ids: chapterList,
+                  ids: [for (final c in chapters) c.id],
                   patch: change,
                 ),
               ),
@@ -54,21 +54,23 @@ class MultiChaptersActionIcon extends ConsumerWidget {
         if (context.mounted) {
           result.showToastOnError(ref.read(toastProvider));
         }
-        // Fire tracker sync when this is a mark-read action on a single manga.
-        final isMarkRead = change.isRead == true;
-        final id = mangaId;
-        if (!result.hasError && isMarkRead && id != null) {
-          unawaited(maybeTrackProgressOnReadFetch(
-            ref,
-            mangaId: id,
-            isRead: true,
-            manual: true,
-          ));
-          // Delete the on-device copies once read, if the user opted in.
-          for (final cid in chapterList) {
-            unawaited(maybeDeleteOnManualLocal(ref, chapterId: cid));
-            unawaited(
-                maybeDeleteOnManualServer(ref, mangaId: id, chapterId: cid));
+        // On a successful mark-read, sync each affected manga to its tracker and
+        // honour the delete-on-manual-read setting — keyed off each chapter's
+        // own mangaId, so a multi-manga selection (updates screen) syncs them
+        // all instead of being silently skipped.
+        if (!result.hasError && change.isRead == true) {
+          for (final mangaId in {for (final c in chapters) c.mangaId}) {
+            unawaited(maybeTrackProgressOnReadFetch(
+              ref,
+              mangaId: mangaId,
+              isRead: true,
+              manual: true,
+            ));
+          }
+          for (final c in chapters) {
+            unawaited(maybeDeleteOnManualLocal(ref, chapterId: c.id));
+            unawaited(maybeDeleteOnManualServer(ref,
+                mangaId: c.mangaId, chapterId: c.id));
           }
         }
         await refresh(true);

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -26,18 +26,15 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
     required this.selectedChapters,
     required this.afterOptionSelected,
     this.chapterList,
-    this.mangaId,
   });
 
   final ValueNotifier<Map<int, ChapterDto>> selectedChapters;
   final AsyncCallback afterOptionSelected;
   final List<ChapterDto>? chapterList;
-  /// When non-null, tracker progress is fired after a mark-read action.
-  /// Pass only from single-manga screens (manga-details). Omit from
-  /// multi-manga screens (updates) where chapters span different manga.
-  final int? mangaId;
 
   List<int> get selectedChapterList => selectedChapters.value.keys.toList();
+  List<ChapterDto> get selectedChapterDtos =>
+      selectedChapters.value.values.toList();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -72,14 +69,13 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
         ),
         MultiChaptersActionIcon(
           iconData: Icons.done_all_rounded,
-          chapterList: selectedChapterList,
+          chapters: selectedChapterDtos,
           change: ChapterChange(isRead: true, lastPageRead: 0),
           refresh: refresh,
-          mangaId: mangaId,
         ),
         MultiChaptersActionIcon(
           iconData: Icons.remove_done_rounded,
-          chapterList: selectedChapterList,
+          chapters: selectedChapterDtos,
           change: ChapterChange(isRead: false),
           refresh: refresh,
         ),

--- a/lib/src/features/tracking/domain/track_progress_gate.dart
+++ b/lib/src/features/tracking/domain/track_progress_gate.dart
@@ -31,24 +31,23 @@ bool shouldTrackProgress({
     trackRecordCount > 0 &&
     (manual ? enabledManualMarkRead : enabledAfterReading);
 
-/// Wiring helper — reads toggle settings, fetches the track-record count for
-/// [mangaId] from the Riverpod cache, and fires
-/// [TrackerRepository.trackProgress] when [shouldTrackProgress] is true.
+/// Core: fires [TrackerRepository.trackProgress] when [shouldTrackProgress]
+/// passes. Takes already-captured dependencies (no [WidgetRef]), so it is safe
+/// to await even after the originating widget has disposed — the fire-and-forget
+/// callers below capture everything from `ref` BEFORE their first await.
 ///
-/// Fire-and-forget: errors are surfaced as an error toast and swallowed so
-/// that a tracker hiccup never interrupts the reading experience.
-Future<void> maybeTrackProgressOnRead(
-  WidgetRef ref, {
+/// Errors are surfaced as a toast and swallowed so a tracker hiccup never
+/// interrupts reading.
+Future<void> _pushTrackProgressIfEnabled({
+  required TrackerRepository repo,
+  required Toast? toast,
   required int mangaId,
   required bool isRead,
   required bool manual,
+  required bool enabledAfterReading,
+  required bool enabledManualMarkRead,
   required int trackRecordCount,
 }) async {
-  final enabledAfterReading =
-      ref.read(updateProgressAfterReadingProvider).ifNull();
-  final enabledManualMarkRead =
-      ref.read(updateProgressManualMarkReadProvider).ifNull();
-
   if (!shouldTrackProgress(
     isRead: isRead,
     enabledAfterReading: enabledAfterReading,
@@ -58,29 +57,70 @@ Future<void> maybeTrackProgressOnRead(
   )) {
     return;
   }
-
-  final result = await AsyncValue.guard(
-    () => ref.read(trackerRepositoryProvider).trackProgress(mangaId),
-  );
-  result.showToastOnError(ref.read(toastProvider), withMicrotask: true);
+  final result = await AsyncValue.guard(() => repo.trackProgress(mangaId));
+  result.showToastOnError(toast, withMicrotask: true);
 }
 
+/// Wiring helper for call sites that already have the track-record count in
+/// scope. Captures `ref` synchronously, then defers to the no-`ref` core.
+Future<void> maybeTrackProgressOnRead(
+  WidgetRef ref, {
+  required int mangaId,
+  required bool isRead,
+  required bool manual,
+  required int trackRecordCount,
+}) =>
+    _pushTrackProgressIfEnabled(
+      repo: ref.read(trackerRepositoryProvider),
+      toast: ref.read(toastProvider),
+      enabledAfterReading:
+          ref.read(updateProgressAfterReadingProvider).ifNull(),
+      enabledManualMarkRead:
+          ref.read(updateProgressManualMarkReadProvider).ifNull(),
+      mangaId: mangaId,
+      isRead: isRead,
+      manual: manual,
+      trackRecordCount: trackRecordCount,
+    );
+
 /// Convenience overload for call sites that don't have the track-record count
-/// in scope. Looks it up via [mangaTrackRecordsProvider] (uses cached value;
-/// does not issue a new network request if already loaded).
+/// in scope (library / updates bulk mark-read). FETCHES the records — issuing a
+/// network request if they aren't cached — because those screens mark chapters
+/// read without the manga-details screen ever loading the records, so a
+/// cache-only read would see zero bound trackers and wrongly skip the sync.
+/// All `ref` reads happen up front (before any await) so it stays safe when
+/// fired-and-forgotten as the originating widget disposes.
 Future<void> maybeTrackProgressOnReadFetch(
   WidgetRef ref, {
   required int mangaId,
   required bool isRead,
   required bool manual,
 }) async {
-  final records =
-      ref.read(mangaTrackRecordsProvider(mangaId: mangaId)).valueOrNull ?? [];
-  await maybeTrackProgressOnRead(
-    ref,
+  final repo = ref.read(trackerRepositoryProvider);
+  final toast = ref.read(toastProvider);
+  final enabledAfterReading =
+      ref.read(updateProgressAfterReadingProvider).ifNull();
+  final enabledManualMarkRead =
+      ref.read(updateProgressManualMarkReadProvider).ifNull();
+  // Cheap gate BEFORE the records fetch: the reader calls this on every page
+  // turn ([isRead] is false until the last page), so skip the network
+  // round-trip entirely unless this is a read event with its toggle enabled.
+  // The full gate (incl. trackRecordCount) still runs below once fetched.
+  if (!isRead || !(manual ? enabledManualMarkRead : enabledAfterReading)) {
+    return;
+  }
+  final recordsFuture =
+      ref.read(mangaTrackRecordsProvider(mangaId: mangaId).future);
+
+  final records = await AsyncValue.guard(() => recordsFuture);
+  await _pushTrackProgressIfEnabled(
+    repo: repo,
+    toast: toast,
+    enabledAfterReading: enabledAfterReading,
+    enabledManualMarkRead: enabledManualMarkRead,
     mangaId: mangaId,
     isRead: isRead,
     manual: manual,
-    trackRecordCount: records.length,
+    trackRecordCount: records.valueOrNull?.length ?? 0,
   );
 }


### PR DESCRIPTION
Three fixes that all touch the manga-details screen (kept together because they interleave in the same file):

- Bulk "mark read" from the library/updates lists now pushes progress to bound trackers, which it previously skipped because the track records were not loaded.
- The details screen and updates list now refresh their state after actions instead of showing stale read/added status, and the refresh toast only reports success when the refetch actually succeeded.
- "Web View" (all three entry points) now lets you choose between the source site and the Suwayomi server WebUI page for the manga, opening the server directly when there is no source page.