### PR TITLE
Merge Downloads and Offline settings into one tabbed screen

### DIFF
--- a/lib/src/features/offline/presentation/offline_settings_screen.dart
+++ b/lib/src/features/offline/presentation/offline_settings_screen.dart
@@ -16,6 +16,140 @@ import '../data/offline_repository.dart';
 import '../data/offline_settings_providers.dart';
 import 'offline_settings_format.dart';
 
+/// The on-device (offline) download + storage settings, as a flat list of tiles
+/// so it can be composed into the Downloads screen's "On-device" tab. Returns a
+/// single "not available" note when the offline feature is disabled.
+List<Widget> buildOnDeviceStorageTiles(BuildContext context, WidgetRef ref) {
+  if (!ref.watch(offlineEnabledProvider)) {
+    return [
+      Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(context.l10n.offlineNotAvailable),
+      ),
+    ];
+  }
+  return [
+    SectionTitle(title: context.l10n.offlineStorageSection),
+    ListTile(
+      title: Text(context.l10n.offlineStorageUsage),
+      subtitle: Text(
+        formatBytes(ref.watch(offlineUsageBytesProvider).valueOrNull ?? 0),
+      ),
+    ),
+    ListTile(
+      title: Text(context.l10n.offlineRemoveAllDownloads),
+      onTap: () async {
+        final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            content: Text(context.l10n.offlineRemoveAllConfirm),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: Text(context.l10n.cancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: Text(context.l10n.delete),
+              ),
+            ],
+          ),
+        );
+        if (confirmed != true) return;
+        if (!context.mounted) return;
+        final db = ref.read(offlineDatabaseProvider);
+        try {
+          for (final m in await db.libraryManga()) {
+            for (final ch in await db.downloadedChaptersForManga(m.id)) {
+              try {
+                await deleteChapterFromDevice(ref, ch.id);
+              } catch (_) {}
+            }
+          }
+        } finally {
+          ref.invalidate(offlineUsageBytesProvider);
+        }
+      },
+    ),
+    SectionTitle(title: context.l10n.offlineDownloadsSection),
+    SettingsPropTile(
+      title: context.l10n.downloadOverWifiOnly,
+      type: SettingsPropType.switchTile(
+        value: ref.watch(offlineWifiOnlyProvider) ?? true,
+        onChanged: (v) async {
+          ref.read(offlineWifiOnlyProvider.notifier).update(v);
+          return null;
+        },
+      ),
+    ),
+    SettingsPropTile(
+      title: context.l10n.offlineConcurrencyLabel,
+      subtitle: context.l10n.offlineConcurrencyValue(
+          ref.watch(offlineDownloadConcurrencyProvider) ?? 2),
+      type: SettingsPropType.numberSlider(
+        min: 1,
+        max: 8,
+        value: ref.watch(offlineDownloadConcurrencyProvider) ?? 2,
+        onChanged: (v) async {
+          ref.read(offlineDownloadConcurrencyProvider.notifier).update(v);
+          return null;
+        },
+      ),
+    ),
+    SectionTitle(title: context.l10n.offlineSafetyNets),
+    SettingsPropTile(
+      title: context.l10n.offlineStorageCapEnable,
+      type: SettingsPropType.switchTile(
+        value: ref.watch(offlineStorageCapEnabledProvider) ?? false,
+        onChanged: (v) async {
+          ref.read(offlineStorageCapEnabledProvider.notifier).update(v);
+          return null;
+        },
+      ),
+    ),
+    SettingsPropTile(
+      title: context.l10n.offlineStorageCapLimit,
+      subtitle: context.l10n
+          .offlineMegabytes(ref.watch(offlineStorageCapMbProvider) ?? 2000),
+      type: SettingsPropType.numberSlider(
+        min: 100,
+        max: 50000,
+        value: ref.watch(offlineStorageCapMbProvider) ?? 2000,
+        onChanged: (v) async {
+          ref.read(offlineStorageCapMbProvider.notifier).update(v);
+          return null;
+        },
+      ),
+    ),
+    SettingsPropTile(
+      title: context.l10n.offlineTimeEvictEnable,
+      type: SettingsPropType.switchTile(
+        value: ref.watch(offlineTimeEvictEnabledProvider) ?? false,
+        onChanged: (v) async {
+          ref.read(offlineTimeEvictEnabledProvider.notifier).update(v);
+          return null;
+        },
+      ),
+    ),
+    SettingsPropTile(
+      title: context.l10n.offlineKeepDaysLabel,
+      subtitle:
+          context.l10n.offlineDays(ref.watch(offlineKeepDaysProvider) ?? 30),
+      type: SettingsPropType.numberSlider(
+        min: 1,
+        max: 365,
+        value: ref.watch(offlineKeepDaysProvider) ?? 30,
+        onChanged: (v) async {
+          ref.read(offlineKeepDaysProvider.notifier).update(v);
+          return null;
+        },
+      ),
+    ),
+  ];
+}
+
+/// Standalone screen kept for the existing route; the same tiles are also shown
+/// in the Downloads screen's "On-device" tab via [buildOnDeviceStorageTiles].
 class OfflineSettingsScreen extends ConsumerWidget {
   const OfflineSettingsScreen({super.key});
 
@@ -26,142 +160,8 @@ class OfflineSettingsScreen extends ConsumerWidget {
         subtitleTextStyle: TextStyle(color: Colors.grey),
       ),
       child: Scaffold(
-        appBar: AppBar(title: Text(context.l10n.offline)),
-        body: ref.watch(offlineEnabledProvider)
-            ? ListView(
-                children: [
-                  SectionTitle(title: context.l10n.offlineStorageSection),
-                  ListTile(
-                    title: Text(context.l10n.offlineStorageUsage),
-                    subtitle: Text(
-                      formatBytes(
-                          ref.watch(offlineUsageBytesProvider).valueOrNull ??
-                              0),
-                    ),
-                  ),
-                  ListTile(
-                    title: Text(context.l10n.offlineRemoveAllDownloads),
-                    onTap: () async {
-                      final confirmed = await showDialog<bool>(
-                        context: context,
-                        builder: (ctx) => AlertDialog(
-                          content: Text(context.l10n.offlineRemoveAllConfirm),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.pop(ctx, false),
-                              child: Text(context.l10n.cancel),
-                            ),
-                            TextButton(
-                              onPressed: () => Navigator.pop(ctx, true),
-                              child: Text(context.l10n.delete),
-                            ),
-                          ],
-                        ),
-                      );
-                      if (confirmed != true) return;
-                      if (!context.mounted) return;
-                      final db = ref.read(offlineDatabaseProvider);
-                      try {
-                        for (final m in await db.libraryManga()) {
-                          for (final ch
-                              in await db.downloadedChaptersForManga(m.id)) {
-                            try {
-                              await deleteChapterFromDevice(ref, ch.id);
-                            } catch (_) {}
-                          }
-                        }
-                      } finally {
-                        ref.invalidate(offlineUsageBytesProvider);
-                      }
-                    },
-                  ),
-                  SectionTitle(title: context.l10n.offlineDownloadsSection),
-                  SettingsPropTile(
-                    title: context.l10n.downloadOverWifiOnly,
-                    type: SettingsPropType.switchTile(
-                      value: ref.watch(offlineWifiOnlyProvider) ?? true,
-                      onChanged: (v) async {
-                        ref.read(offlineWifiOnlyProvider.notifier).update(v);
-                        return null;
-                      },
-                    ),
-                  ),
-                  SettingsPropTile(
-                    title: context.l10n.offlineConcurrencyLabel,
-                    subtitle: context.l10n.offlineConcurrencyValue(
-                        ref.watch(offlineDownloadConcurrencyProvider) ?? 2),
-                    type: SettingsPropType.numberSlider(
-                      min: 1,
-                      max: 8,
-                      value: ref.watch(offlineDownloadConcurrencyProvider) ?? 2,
-                      onChanged: (v) async {
-                        ref
-                            .read(offlineDownloadConcurrencyProvider.notifier)
-                            .update(v);
-                        return null;
-                      },
-                    ),
-                  ),
-                  SectionTitle(title: context.l10n.offlineSafetyNets),
-                  SettingsPropTile(
-                    title: context.l10n.offlineStorageCapEnable,
-                    type: SettingsPropType.switchTile(
-                      value:
-                          ref.watch(offlineStorageCapEnabledProvider) ?? false,
-                      onChanged: (v) async {
-                        ref
-                            .read(offlineStorageCapEnabledProvider.notifier)
-                            .update(v);
-                        return null;
-                      },
-                    ),
-                  ),
-                  SettingsPropTile(
-                    title: context.l10n.offlineStorageCapLimit,
-                    subtitle: context.l10n.offlineMegabytes(
-                        ref.watch(offlineStorageCapMbProvider) ?? 2000),
-                    type: SettingsPropType.numberSlider(
-                      min: 100,
-                      max: 50000,
-                      value: ref.watch(offlineStorageCapMbProvider) ?? 2000,
-                      onChanged: (v) async {
-                        ref
-                            .read(offlineStorageCapMbProvider.notifier)
-                            .update(v);
-                        return null;
-                      },
-                    ),
-                  ),
-                  SettingsPropTile(
-                    title: context.l10n.offlineTimeEvictEnable,
-                    type: SettingsPropType.switchTile(
-                      value:
-                          ref.watch(offlineTimeEvictEnabledProvider) ?? false,
-                      onChanged: (v) async {
-                        ref
-                            .read(offlineTimeEvictEnabledProvider.notifier)
-                            .update(v);
-                        return null;
-                      },
-                    ),
-                  ),
-                  SettingsPropTile(
-                    title: context.l10n.offlineKeepDaysLabel,
-                    subtitle: context.l10n
-                        .offlineDays(ref.watch(offlineKeepDaysProvider) ?? 30),
-                    type: SettingsPropType.numberSlider(
-                      min: 1,
-                      max: 365,
-                      value: ref.watch(offlineKeepDaysProvider) ?? 30,
-                      onChanged: (v) async {
-                        ref.read(offlineKeepDaysProvider.notifier).update(v);
-                        return null;
-                      },
-                    ),
-                  ),
-                ],
-              )
-            : Center(child: Text(context.l10n.offlineNotAvailable)),
+        appBar: AppBar(title: Text(context.l10n.onDeviceDownloads)),
+        body: ListView(children: buildOnDeviceStorageTiles(context, ref)),
       ),
     );
   }

--- a/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
+++ b/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
@@ -9,6 +9,7 @@ import '../../../../widgets/popup_widgets/radio_list_popup.dart';
 import '../../../../widgets/section_title.dart';
 import '../../../library/domain/category/category_model.dart';
 import '../../../library/presentation/category/controller/edit_category_controller.dart';
+import '../../../offline/presentation/offline_settings_screen.dart';
 import '../../controller/server_controller.dart';
 import '../../domain/settings/settings.dart';
 import 'data/delete_chapters_settings_repository.dart';
@@ -83,133 +84,171 @@ List<Widget> _deleteSection(
       ),
     ];
 
-class DownloadsSettingsScreen extends ConsumerWidget {
+/// Downloads settings, split into two tabs:
+///   * Server — what the Suwayomi server downloads from sources.
+///   * On-device — copies kept on this phone (Wi-Fi-only, storage, deletion).
+class DownloadsSettingsScreen extends StatelessWidget {
   const DownloadsSettingsScreen({super.key});
 
   @override
-  Widget build(context, ref) {
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: ListTileTheme(
+        data: const ListTileThemeData(
+          subtitleTextStyle: TextStyle(color: Colors.grey),
+        ),
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(context.l10n.downloads),
+            bottom: TabBar(
+              tabs: [
+                Tab(text: context.l10n.downloadsServerTab),
+                Tab(text: context.l10n.downloadsOnDeviceTab),
+              ],
+            ),
+          ),
+          body: const TabBarView(
+            children: [
+              _ServerDownloadsTab(),
+              _OnDeviceDownloadsTab(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Server-side downloads: where/how the server stores chapters, auto-download,
+/// and the server copy's delete rules.
+class _ServerDownloadsTab extends ConsumerWidget {
+  const _ServerDownloadsTab();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final repository = ref.watch(downloadsSettingsRepositoryProvider);
     final serverSettings = ref.watch(settingsProvider);
-    // On-device delete settings (local prefs — offline-safe).
-    final localDelete = ref.watch(localDeleteSettingsProvider);
-    // Server delete settings (the WebUI's, from global meta).
     final serverDelete =
         ref.watch(deleteChaptersSettingsControllerProvider).valueOrNull ??
             const DeleteChaptersSettings();
     final serverDeleteController =
         ref.read(deleteChaptersSettingsControllerProvider.notifier);
-    // Categories for the auto-download include/exclude row (Komikku parity).
-    final categories =
-        ref.watch(categoryControllerProvider).valueOrNull ?? const <CategoryDto>[];
-    return ListTileTheme(
-      data: const ListTileThemeData(
-        subtitleTextStyle: TextStyle(color: Colors.grey),
+    final categories = ref.watch(categoryControllerProvider).valueOrNull ??
+        const <CategoryDto>[];
+    return RefreshIndicator(
+      onRefresh: () => ref.refresh(settingsProvider.future),
+      child: serverSettings.showUiWhenData(
+        context,
+        (data) {
+          final DownloadsSettingsDto? downloadsSettingsDto = data;
+          if (downloadsSettingsDto == null) {
+            return Emoticons(
+              title: context.l10n.noPropFound(context.l10n.settings),
+            );
+          }
+          return ListView(
+            children: [
+              SectionTitle(title: context.l10n.general),
+              SettingsPropTile(
+                title: context.l10n.downloadLocation,
+                description: context.l10n.downloadLocationHint,
+                type: SettingsPropType.textField(
+                  hintText:
+                      context.l10n.enterProp(context.l10n.downloadLocation),
+                  value: downloadsSettingsDto.downloadsPath,
+                  onChanged: repository.updateDownloadsLocation,
+                ),
+                subtitle: downloadsSettingsDto.downloadsPath,
+              ),
+              SettingsPropTile(
+                title: context.l10n.saveAsCBZArchive,
+                type: SettingsPropType.switchTile(
+                  value: downloadsSettingsDto.downloadAsCbz,
+                  onChanged: repository.updateDownloadAsCbz,
+                ),
+              ),
+              // Server downloads (shared with the web interface). Default off.
+              ..._deleteSection(
+                context,
+                title: context.l10n.deleteServerDownloads,
+                description: context.l10n.deleteServerDownloadsDescription,
+                settings: serverDelete,
+                onManual: serverDeleteController.setDeleteManuallyMarkedRead,
+                onWhileReading: serverDeleteController.setDeleteWhileReading,
+                onBookmark: serverDeleteController.setDeleteWithBookmark,
+              ),
+              SectionTitle(title: context.l10n.autoDownload),
+              SettingsPropTile(
+                title: context.l10n.autoDownloadNewChapters,
+                type: SettingsPropType.switchTile(
+                  value: downloadsSettingsDto.autoDownloadNewChapters,
+                  onChanged: repository.toggleAutoDownloadNewChapters,
+                ),
+              ),
+              SettingsPropTile(
+                title: context.l10n.chapterDownloadLimit,
+                description: context.l10n.chapterDownloadLimitDesc,
+                type: SettingsPropType.numberSlider(
+                  value: downloadsSettingsDto.autoDownloadNewChaptersLimit,
+                  min: 0,
+                  max: 20,
+                  onChanged: repository.updateAutoDownloadNewChaptersLimit,
+                ),
+                subtitle: context.l10n.nChapters(
+                    downloadsSettingsDto.autoDownloadNewChaptersLimit),
+              ),
+              SettingsPropTile(
+                title: context.l10n.excludeEntryWithUnreadChapters,
+                type: SettingsPropType.switchTile(
+                  value: downloadsSettingsDto.excludeEntryWithUnreadChapters,
+                  onChanged: repository.toggleExcludeEntryWithUnreadChapters,
+                ),
+              ),
+              ListTile(
+                enabled: downloadsSettingsDto.autoDownloadNewChapters,
+                title: Text(context.l10n.autoDownloadCategories),
+                subtitle:
+                    Text(autoDownloadCategoriesSummary(context, categories)),
+                onTap: () => showDialog<void>(
+                  context: context,
+                  builder: (_) => const AutoDownloadCategoriesDialog(),
+                ),
+              ),
+            ],
+          );
+        },
       ),
-      child: Scaffold(
-        appBar: AppBar(title: Text(context.l10n.downloads)),
-        body: RefreshIndicator(
-          onRefresh: () => ref.refresh(settingsProvider.future),
-          child: serverSettings.showUiWhenData(
-            context,
-            (data) {
-              final DownloadsSettingsDto? downloadsSettingsDto = data;
-              if (downloadsSettingsDto == null) {
-                return Emoticons(
-                  title: context.l10n.noPropFound(context.l10n.settings),
-                );
-              }
-              return ListView(
-                children: [
-                  SectionTitle(title: context.l10n.general),
-                  SettingsPropTile(
-                    title: context.l10n.downloadLocation,
-                    description: context.l10n.downloadLocationHint,
-                    type: SettingsPropType.textField(
-                      hintText:
-                          context.l10n.enterProp(context.l10n.downloadLocation),
-                      value: downloadsSettingsDto.downloadsPath,
-                      onChanged: repository.updateDownloadsLocation,
-                    ),
-                    subtitle: downloadsSettingsDto.downloadsPath,
-                  ),
-                  SettingsPropTile(
-                    title: context.l10n.saveAsCBZArchive,
-                    type: SettingsPropType.switchTile(
-                      value: downloadsSettingsDto.downloadAsCbz,
-                      onChanged: repository.updateDownloadAsCbz,
-                    ),
-                  ),
-                  // On-device downloads (this phone). Independent, default off.
-                  ..._deleteSection(
-                    context,
-                    title: context.l10n.deleteOnDeviceDownloads,
-                    description: context.l10n.deleteOnDeviceDownloadsDescription,
-                    settings: localDelete,
-                    onManual: (v) async => ref
-                        .read(localDeleteManuallyMarkedReadProvider.notifier)
-                        .update(v),
-                    onWhileReading: (v) => ref
-                        .read(localDeleteWhileReadingProvider.notifier)
-                        .update(v),
-                    onBookmark: (v) async => ref
-                        .read(localDeleteWithBookmarkProvider.notifier)
-                        .update(v),
-                  ),
-                  // Server downloads (shared with the web interface). Default off.
-                  ..._deleteSection(
-                    context,
-                    title: context.l10n.deleteServerDownloads,
-                    description: context.l10n.deleteServerDownloadsDescription,
-                    settings: serverDelete,
-                    onManual: serverDeleteController.setDeleteManuallyMarkedRead,
-                    onWhileReading: serverDeleteController.setDeleteWhileReading,
-                    onBookmark: serverDeleteController.setDeleteWithBookmark,
-                  ),
-                  SectionTitle(title: context.l10n.autoDownload),
-                  SettingsPropTile(
-                    title: context.l10n.autoDownloadNewChapters,
-                    type: SettingsPropType.switchTile(
-                      value: downloadsSettingsDto.autoDownloadNewChapters,
-                      onChanged: repository.toggleAutoDownloadNewChapters,
-                    ),
-                  ),
-                  SettingsPropTile(
-                    title: context.l10n.chapterDownloadLimit,
-                    description: context.l10n.chapterDownloadLimitDesc,
-                    type: SettingsPropType.numberSlider(
-                      value: downloadsSettingsDto.autoDownloadNewChaptersLimit,
-                      min: 0,
-                      max: 20,
-                      onChanged: repository.updateAutoDownloadNewChaptersLimit,
-                    ),
-                    subtitle: context.l10n.nChapters(
-                        downloadsSettingsDto.autoDownloadNewChaptersLimit),
-                  ),
-                  SettingsPropTile(
-                    title: context.l10n.excludeEntryWithUnreadChapters,
-                    type: SettingsPropType.switchTile(
-                      value:
-                          downloadsSettingsDto.excludeEntryWithUnreadChapters,
-                      onChanged:
-                          repository.toggleExcludeEntryWithUnreadChapters,
-                    ),
-                  ),
-                  ListTile(
-                    enabled: downloadsSettingsDto.autoDownloadNewChapters,
-                    title: Text(context.l10n.autoDownloadCategories),
-                    subtitle: Text(
-                        autoDownloadCategoriesSummary(context, categories)),
-                    onTap: () => showDialog<void>(
-                      context: context,
-                      builder: (_) => const AutoDownloadCategoriesDialog(),
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
+    );
+  }
+}
+
+/// On-device downloads: this phone's copies — the on-device delete rules plus
+/// Wi-Fi-only, concurrency, and storage management.
+class _OnDeviceDownloadsTab extends ConsumerWidget {
+  const _OnDeviceDownloadsTab();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final localDelete = ref.watch(localDeleteSettingsProvider);
+    return ListView(
+      children: [
+        // On-device downloads (this phone). Independent, default off.
+        ..._deleteSection(
+          context,
+          title: context.l10n.deleteOnDeviceDownloads,
+          description: context.l10n.deleteOnDeviceDownloadsDescription,
+          settings: localDelete,
+          onManual: (v) async => ref
+              .read(localDeleteManuallyMarkedReadProvider.notifier)
+              .update(v),
+          onWhileReading: (v) =>
+              ref.read(localDeleteWhileReadingProvider.notifier).update(v),
+          onBookmark: (v) async =>
+              ref.read(localDeleteWithBookmarkProvider.notifier).update(v),
         ),
-      ),
+        ...buildOnDeviceStorageTiles(context, ref),
+      ],
     );
   }
 }

--- a/lib/src/features/settings/presentation/settings/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings/settings_screen.dart
@@ -42,12 +42,9 @@ class SettingsScreen extends StatelessWidget {
           ListTile(
             title: Text(context.l10n.downloads),
             leading: const Icon(Icons.download_rounded),
+            // On-device (offline) downloads are now the "On-device" tab inside
+            // this screen, so there's no separate "Offline" entry.
             onTap: () => const DownloadsSettingsRoute().go(context),
-          ),
-          ListTile(
-            title: Text(context.l10n.offline),
-            leading: const Icon(Icons.offline_pin_rounded),
-            onTap: () => const OfflineSettingsRoute().go(context),
           ),
           ListTile(
             title: Text(context.l10n.reader),


### PR DESCRIPTION
The separate "Downloads" (server) and "Offline" (on-device) settings screens were confusing and the Offline one was easy to miss. Combine them into a single Downloads screen with two clearly-labelled tabs - Server and On device - and drop the standalone Offline entry.