### PR TITLE
Offline keep-mode choice in library selection, mode shown on title, instant queue clear

### DIFF
--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -26,9 +26,9 @@ import '../../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../../manga_book/domain/manga/manga_model.dart';
 import '../../../manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart';
-import '../../../offline/data/offline_database.dart';
 import '../../../offline/data/offline_download_providers.dart';
 import '../../../offline/data/offline_repository.dart';
+import '../../../offline/presentation/keep_rule_picker.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
 import '../../../tracking/domain/track_progress_gate.dart';
 import 'controller/library_controller.dart';
@@ -197,7 +197,13 @@ class CategoryMangaList extends HookConsumerWidget {
                     onMarkUnread: () => markSelection(false),
                     onKeepOffline: () async {
                       final ids = selection.value.toList();
+                      // Let the user choose how much to keep (next-N / all-unread
+                      // / all) instead of silently downloading every chapter —
+                      // picking "all" across a read library can queue thousands.
+                      final picked = await pickOfflineKeepRule(context);
+                      if (picked == null) return;
                       if (ids.length > 1 &&
+                          context.mounted &&
                           !await confirmBulkDownload(context,
                               summary: '${ids.length} series',
                               toDevice: true)) {
@@ -206,7 +212,7 @@ class CategoryMangaList extends HookConsumerWidget {
                       selection.value = const {};
                       final db = ref.read(offlineDatabaseProvider);
                       for (final id in ids) {
-                        await db.setKeepRule(id, OfflineKeepRule.all, 3);
+                        await db.setKeepRule(id, picked.rule, picked.count);
                         await reconcileMangaWidget(ref, id);
                       }
                       if (context.mounted) {

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -70,6 +70,18 @@ class DownloadsMap extends _$DownloadsMap {
         .reorderDownload(chapterId, to);
     state = getStateFromUpdates(downloadStatusDto);
   }
+
+  /// Clear the whole server download queue and empty the local map immediately.
+  /// The clear mutation doesn't reliably emit a per-chapter DEQUEUED stream for
+  /// a bulk clear, so without this the list stayed frozen until a manual
+  /// refresh (#73). Empty optimistically for instant feedback, then refetch the
+  /// authoritative status so a later rebuild can't resurrect the stale queue
+  /// from the cached snapshot.
+  Future<void> clearAll() async {
+    await ref.read(downloadsRepositoryProvider).clearDownloads();
+    state = {};
+    ref.invalidate(downloadStatusProvider);
+  }
 }
 
 @riverpod

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -15,7 +15,6 @@ import '../../../../widgets/emoticons.dart';
 import '../../../offline/data/offline_download_providers.dart';
 import '../../../offline/data/offline_settings_providers.dart';
 import '../../../offline/presentation/offline_files_view.dart';
-import '../../data/downloads/downloads_repository.dart';
 import '../../domain/downloads/downloads_model.dart';
 import 'controller/downloads_controller.dart';
 import 'widgets/download_progress_list_tile.dart';
@@ -51,7 +50,7 @@ class DownloadsScreen extends HookConsumerWidget {
           if (!onDeviceTab && (downloadsChapterIds).isNotBlank)
             IconButton(
               onPressed: () => AsyncValue.guard(
-                ref.read(downloadsRepositoryProvider).clearDownloads,
+                ref.read(downloadsMapProvider.notifier).clearAll,
               ),
               icon: const Icon(Icons.delete_sweep_rounded),
             ),

--- a/lib/src/features/offline/presentation/keep_rule_picker.dart
+++ b/lib/src/features/offline/presentation/keep_rule_picker.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../../utils/extensions/custom_extensions.dart';
+import '../data/offline_database.dart';
+
+/// Rolling-buffer sizes offered for the "keep next N unread" rule.
+const kOfflineBufferSizes = [5, 10, 25];
+
+/// Bottom sheet that lets the user choose an offline keep-rule (how much of a
+/// series to hold on the device). Returns the chosen rule + count, or null if
+/// dismissed. Shared by the per-series sheet, the library multi-select Offline
+/// action, and the download-subscriptions management page so they stay in sync.
+Future<({OfflineKeepRule rule, int count})?> pickOfflineKeepRule(
+  BuildContext context,
+) {
+  return showModalBottomSheet<({OfflineKeepRule rule, int count})>(
+    context: context,
+    showDragHandle: true,
+    builder: (sheetContext) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final n in kOfflineBufferSizes)
+            ListTile(
+              leading: const Icon(Icons.bookmark_add_outlined),
+              title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+              onTap: () => Navigator.pop(
+                  sheetContext, (rule: OfflineKeepRule.nUnread, count: n)),
+            ),
+          ListTile(
+            leading: const Icon(Icons.menu_book_outlined),
+            title: Text(sheetContext.l10n.keepOfflineAllUnread),
+            onTap: () => Navigator.pop(
+                sheetContext, (rule: OfflineKeepRule.allUnread, count: 3)),
+          ),
+          ListTile(
+            leading: const Icon(Icons.library_books_outlined),
+            title: Text(sheetContext.l10n.keepOfflineAll),
+            onTap: () => Navigator.pop(
+                sheetContext, (rule: OfflineKeepRule.all, count: 3)),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/src/features/offline/presentation/offline_files_view.dart
+++ b/lib/src/features/offline/presentation/offline_files_view.dart
@@ -16,6 +16,7 @@ import '../../../widgets/server_image.dart';
 import '../data/offline_database.dart';
 import '../data/offline_download_providers.dart';
 import '../data/offline_repository.dart';
+import 'keep_rule_picker.dart';
 import 'offline_settings_format.dart';
 
 typedef _SeriesRow = ({OfflineManga manga, int downloaded, int inFlight, int bytes});
@@ -313,39 +314,8 @@ class OfflineFilesView extends HookConsumerWidget {
   }
 
   Future<({OfflineKeepRule rule, int count})?> _pickRule(
-      BuildContext context) {
-    return showModalBottomSheet<({OfflineKeepRule rule, int count})>(
-      context: context,
-      showDragHandle: true,
-      builder: (sheetContext) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            for (final n in _bufferSizes)
-              ListTile(
-                leading: const Icon(Icons.bookmark_add_outlined),
-                title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
-                onTap: () => Navigator.pop(
-                    sheetContext, (rule: OfflineKeepRule.nUnread, count: n)),
-              ),
-            ListTile(
-              leading: const Icon(Icons.menu_book_outlined),
-              title: Text(sheetContext.l10n.keepOfflineAllUnread),
-              onTap: () => Navigator.pop(
-                  sheetContext, (rule: OfflineKeepRule.allUnread, count: 3)),
-            ),
-            ListTile(
-              leading: const Icon(Icons.library_books_outlined),
-              title: Text(sheetContext.l10n.keepOfflineAll),
-              onTap: () => Navigator.pop(
-                  sheetContext, (rule: OfflineKeepRule.all, count: 3)),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+          BuildContext context) =>
+      pickOfflineKeepRule(context);
 
   Future<bool> _confirm(BuildContext context, String message) async {
     return await showDialog<bool>(

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -33,6 +33,9 @@ class SeriesOfflineButton extends ConsumerWidget {
     final inFlight = progress?.inFlight ?? 0;
     final onDevice = downloaded > 0;
     final downloading = inFlight > 0;
+    // Surface the active keep-rule on the button so users can see at a glance
+    // why a series keeps re-downloading, without opening the sheet (#74).
+    final config = ref.watch(mangaKeepConfigProvider(mangaId)).valueOrNull;
     return MangaActionButton(
       active: onDevice || downloading,
       icon: downloading
@@ -45,12 +48,24 @@ class SeriesOfflineButton extends ConsumerWidget {
               : Icons.download_for_offline_outlined),
       label: downloading
           ? context.l10n.offlineDownloadingCount(inFlight)
-          : onDevice
-              ? context.l10n.offlineOnDevice
-              : context.l10n.offlineDownloadAction,
+          : _ruleLabel(context, config?.rule, config?.count) ??
+              (onDevice
+                  ? context.l10n.offlineOnDevice
+                  : context.l10n.offlineDownloadAction),
       onPressed: () => _openSheet(context, ref, onDevice),
     );
   }
+
+  /// Label for an active keep-rule, or null when no rule is set (rule off) so
+  /// the caller falls back to the generic on-device / download label.
+  String? _ruleLabel(BuildContext context, OfflineKeepRule? rule, int? count) =>
+      switch (rule) {
+        OfflineKeepRule.all => context.l10n.keepOfflineAll,
+        OfflineKeepRule.allUnread => context.l10n.keepOfflineAllUnread,
+        OfflineKeepRule.nUnread =>
+          context.l10n.keepOfflineNextUnread(count ?? 5),
+        OfflineKeepRule.off || null => null,
+      };
 
   void _openSheet(BuildContext context, WidgetRef ref, bool onDevice) {
     final config = ref.read(mangaKeepConfigProvider(mangaId)).valueOrNull ??


### PR DESCRIPTION
Three offline/downloads fixes from user reports.

**Library multi-select "Offline" now asks how much to keep (#72).** The action was hardcoded to Keep-all, so selecting it across a read library queued every chapter — a user accidentally pulled thousands. It now opens the keep-mode picker (next-N unread / all unread / all), the same sheet the title page uses, before queueing anything.

**The active keep-mode is shown on the title (#74).** It was only visible inside the per-series sheet, so a series that re-downloaded on every restart gave no hint why. The per-series Offline button now reads the active mode ("Keep all unread", etc.) instead of a generic "On device".

**Clearing the server download queue updates immediately (#73).** The queue is only mutated by the per-chapter update stream, and a bulk clear doesn't reliably emit one, so the list stayed frozen until a manual refresh. Clear now empties the list optimistically and refetches the authoritative status so a later rebuild can't resurrect the stale queue.

Also extracts the keep-mode picker into a shared `pickOfflineKeepRule` helper so the library, title sheet, and Downloads → On device page stay in sync.

Verified on-device: keep-mode picker appears and applies across a multi-selection, the title button reflects the chosen mode, and clearing the queue empties the list instantly.

Closes #72, #73; addresses #74.