### PR TITLE
Point What's New and update checks at the canonical repo

### DIFF
--- a/lib/src/constants/urls.dart
+++ b/lib/src/constants/urls.dart
@@ -5,13 +5,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 enum AppUrls {
-  sorayomiGithubUrl(url: "https://github.com/tsumiru-app/tsumiru"),
+  sorayomiGithubUrl(url: "https://github.com/Suwayomi/Suwayomi-Tsumiru"),
   sorayomiLatestReleaseUrl(
-      url: "https://github.com/tsumiru-app/tsumiru/releases/latest"),
+      url: "https://github.com/Suwayomi/Suwayomi-Tsumiru/releases/latest"),
   tachideskHelp(url: "https://tsumiru-app.github.io/docs/guides/getting-started"),
-  sorayomiWhatsNew(url: "https://tsumiru-app.github.io/changelogs/"),
+  // What's New points at the GitHub Releases page so it always shows the
+  // current release notes — the old docs-site changelog was hand-maintained and
+  // went stale (stuck at v0.6.1 while the app shipped v0.7.1).
+  sorayomiWhatsNew(url: "https://github.com/Suwayomi/Suwayomi-Tsumiru/releases"),
   sorayomiLatestReleaseApiUrl(
-    url: "https://api.github.com/repos/tsumiru-app/tsumiru/releases/latest",
+    url: "https://api.github.com/repos/Suwayomi/Suwayomi-Tsumiru/releases/latest",
   ),
   flareSolverr(
       url:


### PR DESCRIPTION
The in-app **What's New** opened the docs-site changelog (`tsumiru-app.github.io/changelogs`), which is hand-maintained and had gone stale at v0.6.1 while the app shipped v0.7.1 — so a current build linked users to old release notes. It now opens the **GitHub Releases page**, which always reflects the latest release and its real notes.

While in there: the GitHub, latest-release, and **in-app update-check** URLs still referenced the pre-handoff `tsumiru-app/tsumiru` repo. They now point at `Suwayomi/Suwayomi-Tsumiru`, so the update check no longer depends on the old repo continuing to mirror releases.

Both new URLs verified to resolve (HTTP 200). `tachideskHelp` is left as-is since the docs/help site is still legitimately hosted at `tsumiru-app.github.io`.