### PR TITLE
Bump version to 0.7.2+36

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.7.1+35
+version: 0.7.2+36
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Release 0.7.2. Ships the iOS webtoon-scroll fix (#80), the offline selection-mode / instant queue-clear / mode-indicator improvements, and the What's-New + update-check URL fix.