### PR TITLE
Web onboarding: detect server auth so the login step actually appears

### DIFF
--- a/lib/src/features/onboarding/data/server_resolver.dart
+++ b/lib/src/features/onboarding/data/server_resolver.dart
@@ -513,7 +513,7 @@ Future<ProbeResult> probeServer(
   // Auth probe (request B). Failure here doesn't sink the candidate — we can
   // still confirm Suwayomi from request A and assume auth-required if B is
   // unreadable.
-  String authBody = '';
+  String? authBody;
   try {
     final (_, body) = await _sendNoRedirect(
       client,
@@ -523,12 +523,27 @@ Future<ProbeResult> probeServer(
     );
     authBody = body;
   } catch (_) {
-    authBody = '';
+    authBody = null;
   }
 
-  final classified =
-      classifyProbeBody(url: baseUrl, aboutBody: aboutBody, authBody: authBody);
-  if (classified != null) return classified;
+  final classified = classifyProbeBody(
+      url: baseUrl, aboutBody: aboutBody, authBody: authBody ?? '');
+  if (classified != null) {
+    if (authBody == null && classified.confirmed) {
+      // B unreadable: we can't prove the server is open, and reading it as
+      // open would onboard an auth server with no login step.
+      return ProbeResult(
+        url: classified.url,
+        confirmed: true,
+        reached: true,
+        basicGated: false,
+        authMode: ProbeAuthMode.authRequired,
+        serverName: classified.serverName,
+        serverVersion: classified.serverVersion,
+      );
+    }
+    return classified;
+  }
 
   return ProbeResult.reachedUnconfirmed(baseUrl);
 }
@@ -660,6 +675,33 @@ String normalisedFallbackUrl(String rawInput) {
   final first = connectionCandidates(input);
   if (first.isNotEmpty) return first.first;
   return 'http://$input';
+}
+
+/// Web "Test connection" auth detection. The full [probeServer] protocol can't
+/// run in a browser (redirects can't be switched off), but the auth probe
+/// itself can: POST [kAuthProbeQuery] with redirects left on and read the
+/// body. Unreadable / 401 / 403 reads as auth-required — the caller has
+/// already confirmed `aboutServer`, and a dead read here must never onboard an
+/// auth server without its login step.
+Future<bool> webAuthRequired(
+  String baseUrl, {
+  required http.Client client,
+  Duration timeout = const Duration(seconds: 4),
+}) async {
+  final uri = graphqlUriFor(baseUrl);
+  try {
+    final resp = await client
+        .post(
+          uri,
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode({'query': kAuthProbeQuery}),
+        )
+        .timeout(timeout);
+    if (resp.statusCode == 401 || resp.statusCode == 403) return true;
+    return _bodyIndicatesUnauthorised(resp.body);
+  } catch (_) {
+    return true;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/src/features/onboarding/presentation/onboarding_screen.dart
+++ b/lib/src/features/onboarding/presentation/onboarding_screen.dart
@@ -365,12 +365,18 @@ class _ServerStep extends HookConsumerWidget {
       return true;
     }
 
-    // Web can't run the redirect-OFF/short-timeout probe (CORS), so test
-    // exactly what's typed via the about/version query.
+    // Web can't run the redirect-OFF candidate ladder, so test the typed
+    // address (scheme filled in — a scheme-less URL would resolve relative to
+    // the page origin) via the about query, then detect auth with the same
+    // @RequireAuth probe the native resolver uses.
     Future<void> testWeb() async {
-      final url = urlController.text.trim();
-      if (url.isBlank) return;
+      final typed = urlController.text.trim();
+      if (typed.isBlank) return;
+      final url = normalisedFallbackUrl(typed);
       state.value = _TestState.testing;
+      version.value = null;
+      errorDetail.value = null;
+      credsRejected.value = false;
       onVerifiedChanged(false);
       ref.read(serverPortToggleProvider.notifier).update(false);
       ref.read(serverUrlProvider.notifier).update(url);
@@ -381,11 +387,29 @@ class _ServerStep extends HookConsumerWidget {
         errorDetail.value = result.error?.toString();
         state.value = _TestState.failed;
         onVerifiedChanged(false);
-      } else {
-        version.value = result.value?.version;
-        resolvedUrl.value = url;
-        state.value = _TestState.connected;
-        onVerifiedChanged(true);
+        return;
+      }
+      version.value = result.value?.version;
+      resolvedUrl.value = url;
+      final client = ref.read(onboardingHttpClientProvider)();
+      try {
+        if (!await webAuthRequired(url, client: client)) {
+          state.value = _TestState.connected;
+          onVerifiedChanged(true);
+          return;
+        }
+        final hasCreds = userController.text.trim().isNotEmpty &&
+            passController.text.isNotEmpty;
+        if (hasCreds && await validateCredentials(url, client)) {
+          state.value = _TestState.connected;
+          onVerifiedChanged(true);
+        } else {
+          if (hasCreds) credsRejected.value = true;
+          state.value = _TestState.needsLogin;
+          onVerifiedChanged(false);
+        }
+      } finally {
+        client.close();
       }
     }
 
@@ -701,7 +725,9 @@ List<Widget> _buildTestStatus(
           color: Colors.green,
           icon: Icons.check_circle_rounded,
           text: (version != null && version.isNotEmpty)
-              ? context.l10n.onboardingConnected(version)
+              // The server reports "v2.3.x"; the l10n string adds its own "v".
+              ? context.l10n.onboardingConnected(
+                  version.startsWith('v') ? version.substring(1) : version)
               : context.l10n.onboardingResolvedAddress(addr ?? ''),
         ),
         if (addr != null) ...[

--- a/test/onboarding/server_resolver_test.dart
+++ b/test/onboarding/server_resolver_test.dart
@@ -411,6 +411,68 @@ void main() {
       expect(r.confirmed, isFalse);
       expect(r.reached, isTrue);
     });
+
+    test('auth probe unreadable (request throws) → assume authRequired',
+        () async {
+      // The doc contract: "assume auth-required if B is unreadable". An open
+      // read here onboards an auth server with no login step → Unauthorized
+      // on first real query.
+      var calls = 0;
+      final mock = MockClient.streaming((request, bodyStream) async {
+        calls++;
+        if (calls == 1) {
+          return http.StreamedResponse(
+              Stream.value(utf8.encode(_aboutOk)), 200);
+        }
+        throw http.ClientException('boom');
+      });
+      final r = await probeServer('http://h:4567', client: mock);
+      expect(r.confirmed, isTrue);
+      expect(r.authMode, ProbeAuthMode.authRequired);
+    });
+  });
+
+  group('webAuthRequired — the web Test-connection auth probe', () {
+    test('unauthorized errors body → true', () async {
+      final mock = MockClient((_) async =>
+          http.Response(_authUnauthorized, 200));
+      expect(
+          await webAuthRequired('http://h:4568', client: mock), isTrue);
+    });
+
+    test('open data body → false', () async {
+      final mock = MockClient((_) async => http.Response(_authOpen, 200));
+      expect(
+          await webAuthRequired('http://h:4568', client: mock), isFalse);
+    });
+
+    test('401 status → true', () async {
+      final mock = MockClient((_) async => http.Response('', 401));
+      expect(
+          await webAuthRequired('http://h:4568', client: mock), isTrue);
+    });
+
+    test('transport failure → true (safe default; about already confirmed)',
+        () async {
+      final mock = MockClient((_) async =>
+          throw http.ClientException('network'));
+      expect(
+          await webAuthRequired('http://h:4568', client: mock), isTrue);
+    });
+
+    test('posts the @RequireAuth probe to /api/graphql with redirects ON',
+        () async {
+      late http.Request seen;
+      final mock = MockClient((req) async {
+        seen = req;
+        return http.Response(_authOpen, 200);
+      });
+      await webAuthRequired('http://h:4568/base', client: mock);
+      expect(seen.url.toString(), 'http://h:4568/base/api/graphql');
+      expect(seen.body, contains('downloadStatus'));
+      // Browsers cannot disable redirect-following; the web probe must not try.
+      expect(seen.followRedirects, isTrue);
+    });
   });
 
   group('shouldSuggestHttps — reverse-proxy hint only when https not tried', () {


### PR DESCRIPTION
On web, the onboarding Test-connection path only ran the auth-exempt `aboutServer` query. Against a UI_LOGIN server it reported **connected**, the wizard finished without ever showing the login form, and the first real query after onboarding failed with `UnauthorizedException` (screenshot-verified on a live v2.3.2223 server).

**Fix:** after `aboutServer` confirms on web, run the same `@RequireAuth` probe the native resolver uses (`downloadStatus`, redirects left on — browsers can't disable them) via a new `webAuthRequired` helper, and route into the existing needs-login flow.

Also in this change:
- **Scheme fill-in on web**: a bare `host:port` input was passed through untouched, so the browser resolved it against the page origin and the test failed misleadingly. Web now normalises through `normalisedFallbackUrl` like the escape path does.
- **Native resolver safety default**: an unreadable auth probe (request B throws) previously classified as *open*, contradicting its own doc comment ("assume auth-required if B is unreadable") — an open read onboards an auth server loginless, the worse failure. Code now matches the comment.
- **Cosmetic**: the connected banner showed "Suwayomi vv2.3.2223" (server already prefixes `v`, the l10n string added another).

**Tests:** 6 new unit tests (probe-B-unreadable → authRequired; `webAuthRequired` against unauthorized/open/401/transport-failure bodies + wire shape). All 74 onboarding tests pass.

**Live verification:** drove the web build's full wizard against a real UI_LOGIN server — bare address in, "This server needs a login" shown, UI-login sign-in accepted, library loads with no Unauthorized.