### PR TITLE
Bump version to 0.8.0+37

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.7.2+36
+version: 0.8.0+37
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Release prep for v0.8.0: reader settings system (#84), library organizer rework (#82), web onboarding auth fix (#85), tsumiru.app link updates (#83).