### PR TITLE
Tighten README, release template, and store copy

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -1,4 +1,4 @@
-A fast, multiplatform reader for your [Suwayomi](https://suwayomi.org/) server.
+A manga and webtoon reader for your [Suwayomi](https://suwayomi.org/) server.
 
 ## What's new in vX.Y.Z
 

--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -15,16 +15,16 @@ flatpak install tsumiru io.github.aaronbamblett.tsumiru
 ```
 > Added the `tsumiru` remote before? It may still point at the old `tsumiru-app.github.io` URL. Run `flatpak remote-delete tsumiru` first, then the commands above.
 
-**Linux - AppImage (portable):** download the `…-linux-x86_64.AppImage` below, `chmod +x`, run.
+**Linux - AppImage (portable):** download the `…-linux-x86_64.AppImage` below, mark it executable (`chmod +x`), and run it.
 
 **Android:** grab the universal APK (or a per-ABI build). **Windows / macOS / Web:** attached below.
 
-**iOS (sideload only — advanced):** the `…-ios.ipa` below is **unsigned**, so you can't just download and open it. Apple requires every app to be signed to your own account first, using one of these tools:
+**iOS (sideload only, advanced):** the `…-ios.ipa` below is **unsigned**, so you can't just download and open it. Apple requires every app to be signed to your own account first, using one of these tools:
 
-- **[SideStore](https://sidestore.io/)** — signs and refreshes the app *on-device*, no computer needed after setup. Best choice for most people.
-- **[AltStore](https://altstore.io/)** — also signs the app, but it expires every 7 days and only auto-refreshes while a computer running AltServer is powered on and on the same Wi-Fi as your phone.
-- **[TrollStore](https://ios.cfw.guide/installing-trollstore/)** — permanent install with no expiry, but only works on older iPhones/iOS versions with the required vulnerability.
+- **[SideStore](https://sidestore.io/):** signs and refreshes the app *on-device*, no computer needed after setup. For most people this is the best option.
+- **[AltStore](https://altstore.io/):** also signs the app, but it expires every 7 days and only auto-refreshes while a computer running AltServer is powered on and on the same Wi-Fi as your phone.
+- **[TrollStore](https://ios.cfw.guide/installing-trollstore/):** permanent install with no expiry, but only works on older iPhones/iOS versions with the required vulnerability.
 
-With SideStore or AltStore the app must be re-signed periodically (the tools automate this); only TrollStore avoids that. There is no App Store build.
+With SideStore or AltStore the app must be re-signed periodically (the tools automate this). Only TrollStore avoids that. There is no App Store build.
 
 Full docs at [tsumiru.app](https://tsumiru.app/).

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ flutter build apk            # or: linux / windows / macos / web
 
 ## Credits & license
 
-Tsumiru stands on the work of the [Suwayomi](https://github.com/Suwayomi) project,
-including [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) and the client
-Tsumiru grew from. Huge thanks to those maintainers and contributors.
+Tsumiru stands on the work of the [Suwayomi](https://github.com/Suwayomi) project:
+[Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi) (the client Tsumiru
+grew from) and [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) (the server
+it talks to). Huge thanks to those maintainers and contributors.
 
 Licensed under the **Mozilla Public License 2.0** (see [LICENSE](LICENSE)). As with the
 upstream project, source files retain their MPL-2.0 headers.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 <div align="center">
 
-[![Platform](https://img.shields.io/badge/platform-Android%20%7C%20Linux%20%7C%20Windows%20%7C%20macOS%20%7C%20Web-lightgrey)](https://github.com/tsumiru-app/tsumiru/releases)
+[![Platform](https://img.shields.io/badge/platform-Android%20%7C%20Linux%20%7C%20Windows%20%7C%20macOS%20%7C%20Web-lightgrey)](https://github.com/Suwayomi/Suwayomi-Tsumiru/releases)
 [![License: MPL-2.0](https://img.shields.io/badge/license-MPL--2.0-blue)](LICENSE)
-[![Latest release](https://img.shields.io/github/v/release/tsumiru-app/tsumiru?label=download)](https://github.com/tsumiru-app/tsumiru/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/Suwayomi/Suwayomi-Tsumiru?label=download)](https://github.com/Suwayomi/Suwayomi-Tsumiru/releases/latest)
 
 </div>
 
 <p align="center">
-A polished, native client for reading manga &amp; manhwa from a
-<a href="https://github.com/Suwayomi/Suwayomi-Server">Suwayomi-Server</a> instance —
+A native client for reading manga &amp; manhwa from a
+<a href="https://github.com/Suwayomi/Suwayomi-Server">Suwayomi-Server</a> instance,
 built for long webtoon binges on your phone.
 </p>
 
@@ -25,9 +25,9 @@ built for long webtoon binges on your phone.
 
 ## What it is
 
-Tsumiru is an enhanced fork of [Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi),
+Tsumiru is a fork of [Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi),
 the Flutter client for the self-hosted [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server)
-manga server. It connects to a server you already run — it is a reader, not a server.
+manga server. It connects to a Suwayomi server you already run. Tsumiru itself is only the reader (the server handles sources and downloads).
 
 Runs on **Android, Linux, Windows, macOS, and Web**.
 
@@ -39,19 +39,19 @@ This fork focuses on making it a great daily driver, especially for **webtoon / 
 - **Rebuilt webtoon reader:** multi-chapter continuous scrolling tuned for long manhwa strips, with pinch-to-zoom that keeps working while you scroll.
 - **First-run onboarding:** a guided setup that finds your Suwayomi server on the network and walks you through connecting it.
 - **Incognito mode:** pause reading history while you catch up, plus hideable library categories (Komikku parity).
-- **13 curated themes:** hand-tuned palettes, a custom accent colour, and an AMOLED mode.
+- **13 built-in themes:** plus a custom accent colour and an AMOLED black mode.
 - **Native authentication:** `simple_login` and `ui_login`, with credentials kept in your device's secure storage.
-- **Flexible library:** sort by last read, last chapter date, or total chapters; filter by reading status and bookmarks; and queue chapters fast with bulk-download presets.
+- **Flexible library:** sort by last read, last chapter date, or total chapters; filter by reading status and bookmarks; and queue whole chapter ranges with bulk-download presets.
 
 ## Download
 
 Grab the latest build for your platform from the
-[**Releases**](https://github.com/tsumiru-app/tsumiru/releases/latest) page
+[**Releases**](https://github.com/Suwayomi/Suwayomi-Tsumiru/releases/latest) page
 (Android APKs — universal + per-ABI — plus Linux, Windows, macOS, and Web).
 
 **Android, with auto-updates:** add this repo to
 [Obtainium](https://github.com/ImranR98/Obtainium) and it will install and keep
-Tsumiru updated straight from GitHub Releases — no app store needed.
+Tsumiru updated straight from GitHub Releases (no app store needed).
 
 ## Requirements
 
@@ -76,5 +76,5 @@ Tsumiru stands on the work of the [Suwayomi](https://github.com/Suwayomi) projec
 forks) and [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) (the server it
 talks to). Huge thanks to those maintainers and contributors.
 
-Licensed under the **Mozilla Public License 2.0** — see [LICENSE](LICENSE). As with the
+Licensed under the **Mozilla Public License 2.0** (see [LICENSE](LICENSE)). As with the
 upstream project, source files retain their MPL-2.0 headers.

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ built for long webtoon binges on your phone.
 
 ## What it is
 
-Tsumiru is a fork of [Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi),
-the Flutter client for the self-hosted [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server)
-manga server. It connects to a Suwayomi server you already run. Tsumiru itself is only the reader (the server handles sources and downloads).
+Tsumiru is a Flutter client for [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server),
+the self-hosted manga server. You point it at a server you already run. Tsumiru itself
+is only the reader (the server handles sources and downloads).
 
 Runs on **Android, Linux, Windows, macOS, and Web**.
 
-## What's different from upstream Sorayomi
+## Feature highlights
 
-This fork focuses on making it a great daily driver, especially for **webtoon / manhwa** reading:
+Tsumiru is built for daily reading, especially **webtoons / manhwa**:
 
 - **Offline reading:** download chapters to your device and read them with no connection to your server. Tsumiru keeps an on-device catalog with auto-keep rules and falls back to local copies automatically when the server isn't reachable.
 - **Rebuilt webtoon reader:** multi-chapter continuous scrolling tuned for long manhwa strips, with pinch-to-zoom that keeps working while you scroll.
@@ -71,10 +71,9 @@ flutter build apk            # or: linux / windows / macos / web
 
 ## Credits & license
 
-Tsumiru stands on the work of the [Suwayomi](https://github.com/Suwayomi) project:
-[Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi) (the client this
-forks) and [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) (the server it
-talks to). Huge thanks to those maintainers and contributors.
+Tsumiru stands on the work of the [Suwayomi](https://github.com/Suwayomi) project,
+including [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) and the client
+Tsumiru grew from. Huge thanks to those maintainers and contributors.
 
 Licensed under the **Mozilla Public License 2.0** (see [LICENSE](LICENSE)). As with the
 upstream project, source files retain their MPL-2.0 headers.

--- a/flatpak/io.github.aaronbamblett.tsumiru.desktop
+++ b/flatpak/io.github.aaronbamblett.tsumiru.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Tsumiru
-Comment=A fast, multiplatform reader for your Suwayomi server
+Comment=A manga and webtoon reader for your Suwayomi server
 Exec=tsumiru
 Icon=io.github.aaronbamblett.tsumiru
 Terminal=false

--- a/flatpak/io.github.aaronbamblett.tsumiru.metainfo.xml
+++ b/flatpak/io.github.aaronbamblett.tsumiru.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.github.aaronbamblett.tsumiru</id>
   <name>Tsumiru</name>
-  <summary>A fast, multiplatform reader for your Suwayomi server</summary>
+  <summary>Manga and webtoon reader for your Suwayomi server</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
   <developer id="io.github.aaronbamblett">

--- a/flatpak/io.github.aaronbamblett.tsumiru.metainfo.xml
+++ b/flatpak/io.github.aaronbamblett.tsumiru.metainfo.xml
@@ -11,7 +11,7 @@
   <description>
     <p>
       Tsumiru is a client for a Suwayomi (Tachidesk) server. Your sources,
-      extensions, downloads, and library all live on your own server — Tsumiru
+      extensions, downloads, and library all live on your own server. Tsumiru
       is the reader you point at it, so the same library is available on every
       device.
     </p>
@@ -24,7 +24,7 @@
   </description>
   <launchable type="desktop-id">io.github.aaronbamblett.tsumiru.desktop</launchable>
   <url type="homepage">https://tsumiru.app/</url>
-  <url type="bugtracker">https://github.com/tsumiru-app/tsumiru/issues</url>
+  <url type="bugtracker">https://github.com/Suwayomi/Suwayomi-Tsumiru/issues</url>
   <url type="help">https://tsumiru.app/docs/guides/getting-started</url>
   <content_rating type="oars-1.1"/>
   <releases>


### PR DESCRIPTION
Copy pass across the repo's user-facing text:

- README: tighter opening (client-for-Suwayomi-Server up front), stale `tsumiru-app/tsumiru` badge/links fixed, adjective trims.
- Release notes template: punctuation cleanup in the Install section, clearer AppImage instructions.
- Tagline is now **"A manga and webtoon reader for your Suwayomi server"** across the template, desktop entry, and AppStream summary.
- Store metadata: bugtracker URL fixed to the current repo.