### PR TITLE
Build all platforms weekly so release-day breakage surfaces early

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -26,6 +26,11 @@ name: Release (fork)
 
 on:
   workflow_dispatch:
+  # Weekly all-platform dry run: catches iOS/macOS breakage before release day
+  # (the PR check builds a single platform). Without a tag ref, the
+  # release-attach and publish steps are skipped, so nothing is published.
+  schedule:
+    - cron: '0 6 * * 1'
   push:
     tags:
       - "v*.*.*"


### PR DESCRIPTION
The v0.8.0 tag was the first time iOS/macOS built since #84 landed, and both broke (#88). The PR check builds one platform, so Apple-platform breakage stays invisible until a release.

The release workflow's build matrix already runs cleanly without a tag (the attach/publish steps are tag-gated), so a weekly `schedule` trigger on it is a full six-platform dry run with nothing published. Monday 06:00 UTC.