### PR TITLE
Light-mode cover titles and a working Re-authenticate button

### DIFF
--- a/lib/src/features/auth/presentation/reauth_banner.dart
+++ b/lib/src/features/auth/presentation/reauth_banner.dart
@@ -7,12 +7,15 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../constants/db_keys.dart';
 import '../../../constants/enum.dart';
 import '../../../global_providers/global_providers.dart';
+import '../../../routes/router_config.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../settings/presentation/server/widget/credential_popup/login_credentials_popup.dart';
 import '../data/auth_lifecycle_observer.dart';
 import '../data/auth_state.dart';
+
 
 /// Layout-neutral host that surfaces a re-auth `MaterialBanner` via
 /// `ScaffoldMessenger` when the session has expired. Returns its child
@@ -66,19 +69,27 @@ class _ReauthBannerHostState extends ConsumerState<ReauthBannerHost> {
   }
 
   MaterialBanner _buildBanner() {
-    final authType = ref.read(authTypeKeyProvider);
+    // Fall back to the stored default (as the GraphQL clients do) so a
+    // not-yet-hydrated pref reads as its real value, not null.
+    final authType =
+        ref.read(authTypeKeyProvider) ?? DBKeys.authType.initial;
     return MaterialBanner(
       content: Text(context.l10n.authSessionExpired),
       leading: const Icon(Icons.warning_amber_rounded),
       actions: [
         TextButton(
+          // The button must never be a dead end. For a known credential mode
+          // pop the quick login dialog; otherwise send the user to the
+          // Connection screen, where they can set the mode and sign in.
           onPressed: () {
             if (authType == AuthType.simpleLogin ||
                 authType == AuthType.uiLogin) {
               showDialog(
                 context: context,
-                builder: (_) => LoginCredentialsPopup(authType: authType!),
+                builder: (_) => LoginCredentialsPopup(authType: authType),
               );
+            } else {
+              const ConnectionRoute().go(context);
             }
           },
           child: Text(context.l10n.authReauthenticate),

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -126,6 +126,15 @@ class MangaCoverGridTile extends StatelessWidget {
                     manga.title,
                     overflow: TextOverflow.ellipsis,
                     maxLines: 2,
+                    // Drawn on the cover art, not the theme surface: always
+                    // white over the black scrim, shadowed for light covers
+                    // (Komikku's CoverTextOverlay values).
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 12,
+                      height: 1.5,
+                      shadows: [Shadow(color: Colors.black, blurRadius: 4)],
+                    ),
                   ),
                   // The button shares the footer row: the title takes the
                   // remaining width, so it can never sit under the button.
@@ -153,14 +162,16 @@ class MangaCoverGridTile extends StatelessWidget {
                             )
                           ]
                         : null,
+                    // Theme-independent scrim (Komikku: transparent → 67%
+                    // black over the bottom third) — the title always reads
+                    // white-on-dark in both light and dark mode.
                     gradient: showTitle
-                        ? LinearGradient(
-                            begin: Alignment.center,
+                        ? const LinearGradient(
+                            begin: Alignment(0, 1 / 3),
                             end: Alignment.bottomCenter,
                             colors: [
-                              context.theme.canvasColor.withValues(alpha: 0),
-                              context.theme.canvasColor.withValues(alpha: 0.4),
-                              context.theme.canvasColor.withValues(alpha: 0.9),
+                              Colors.transparent,
+                              Color(0xAA000000),
                             ],
                           )
                         : null,


### PR DESCRIPTION
Two on-device-reported fixes:

**Grid cover titles unreadable in light mode.** The title and its fade strip both followed the theme, so light mode drew dark text over dark cover art. Now matches Komikku's cover overlay: theme-independent transparent-to-black scrim (`0xAA000000`) over the bottom third, white 12sp title with a black shadow. Identical in both modes; dark mode gains readability on light covers from the shadow.

**Session-expired banner's Re-authenticate button could do nothing.** It only opened the login dialog when the stored auth type was Simple or UI login — but the default is `AuthType.none` and a fresh install can leave the pref unhydrated, so the tap was silently ignored (reproduced after an Obtainium reinstall). It now applies the same `?? DBKeys.authType.initial` fallback the GraphQL clients use, and routes to the Connection screen whenever the quick dialog doesn't apply.

Both verified on-device.