### PR TITLE
Stamp the app version into the Flatpak metainfo at package time

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -72,6 +72,15 @@ jobs:
           path: flatpak/bundle
       - name: Import GPG signing key
         run: echo "${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}" | gpg --batch --import
+      - name: Stamp the app version into the AppStream metainfo
+        # The checked-in <releases> list goes stale the moment it's written;
+        # generate the current entry from pubspec.yaml at package time instead.
+        run: |
+          version="$(sed -n 's/^version: \([0-9.]*\)+.*/\1/p' pubspec.yaml)"
+          today="$(date -u +%F)"
+          entry="<releases>\n    <release version=\"$version\" date=\"$today\">\n      <url>https://github.com/Suwayomi/Suwayomi-Tsumiru/releases/tag/v$version</url>\n    </release>\n  </releases>"
+          perl -0pi -e "s|<releases>.*</releases>|$entry|s" flatpak/io.github.aaronbamblett.tsumiru.metainfo.xml
+          grep -A3 "<releases>" flatpak/io.github.aaronbamblett.tsumiru.metainfo.xml | head -5
       - uses: andyholmes/flatter@main
         with:
           files: flatpak/io.github.aaronbamblett.tsumiru.yml


### PR DESCRIPTION
Installing the v0.8.0 Flatpak reports version **0.4.1**: the checked-in `<releases>` list in the metainfo was hand-written once (2026-06-19) and never updated, and AppStream metadata is what `flatpak list` and software centers display.

The Flatpak workflow now regenerates the `<releases>` block at package time from `pubspec.yaml` (version) and the build date, with a link to the GitHub release. Works for tag builds and manual dispatches alike, and the checked-in list can never go stale again. Stamp logic dry-run tested locally (valid XML, correct 0.8.0 entry).

After merge: re-run the Flatpak workflow on main to republish the repo with the corrected metadata.