### PR TITLE
Make the Server Request Timeout setting actually govern queries

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -85,7 +85,9 @@ enum DBKeys {
   historyEnabled(true),
   historyRetentionDays(90),
   // Timeout Settings
-  serverRequestTimeout(5000), // milliseconds
+  // 30s matches Komikku's source read timeout; pages proxied live from a
+  // source routinely exceed 5s on first fetch.
+  serverRequestTimeout(30000), // milliseconds
   autoRefreshOnTimeout(false),
   autoRefreshRetryDelay(1000), // milliseconds
   // Offline safety-net settings

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -109,6 +109,7 @@ GraphQLClient graphQlClient(Ref ref) {
             addPort: ref.read(serverPortToggleProvider).ifNull(),
             isGraphQl: true,
           )),
+          queryRequestTimeout: Duration(milliseconds: timeoutMs + 2000),
           cache: GraphQLCache(),
         );
         return await ref
@@ -128,6 +129,11 @@ GraphQLClient graphQlClient(Ref ref) {
     defaultPolicies: DefaultPolicies(
       query: Policies(fetch: FetchPolicy.noCache),
     ),
+    // The package layers its own query timeout (default 5s) on top of the
+    // HTTP client's; without this the Server Request Timeout setting can't
+    // reach past 5s ("TimeoutException ... No stream event"). The 2s grace
+    // keeps the HTTP layer (and its retries) resolving first.
+    queryRequestTimeout: Duration(milliseconds: timeoutMs + 2000),
     cache: GraphQLCache(store: ref.watch(hiveStoreProvider)),
   );
 }
@@ -201,11 +207,15 @@ GraphQLClient graphQlSubscriptionClient(Ref ref) {
   ref.onDispose(() => unawaited(wsLink.dispose().catchError((_) {})));
 
   final loggerLink = LoggerLink();
+  final timeoutMs = ref.watch(serverRequestTimeoutProvider) ??
+      DBKeys.serverRequestTimeout.initial as int;
   return GraphQLClient(
     link: loggerLink.concat(wsLink),
     defaultPolicies: DefaultPolicies(
       query: Policies(fetch: FetchPolicy.noCache),
     ),
+    // Same package-level timeout as the query client (default is a hard 5s).
+    queryRequestTimeout: Duration(milliseconds: timeoutMs + 2000),
     cache: GraphQLCache(store: ref.watch(hiveStoreProvider)),
   );
 }


### PR DESCRIPTION
Discord reports (#suwayomi-tsumiru): `TimeoutException after 0:00:05.000000: No stream event` when reading non-downloaded chapters, and **raising Settings → General → Server Request Timeout doesn't help**.

Root cause, reproduced against a deliberately slow (8s) fake server: the `graphql` package applies its own `queryRequestTimeout` — **default 5 seconds**, emitted as a stream timeout, hence the exact error text — on top of our `TimeoutHttpClient`. The app never configured it, so the user setting only governed the HTTP layer and the package cut every query at 5s regardless. Platform-independent (reporter is on Linux desktop).

Fix:
- Pass the Server Request Timeout setting into `queryRequestTimeout` on all three `GraphQLClient` constructions (query, subscription, token-refresh), with 2s grace so the HTTP layer's retry loop always resolves first and keeps its error semantics.
- Raise the default from 5s to **30s** — Komikku ships connect/read 30s with a 120s call ceiling (`NetworkHelper.kt`), and a page proxied live from a source routinely exceeds 5s on first fetch (the server caches it afterward, which is why retry-spamming eventually worked).

Verification: scratch reproduction hits a local server that sleeps 8s — package-default config fails at 5.0s with the exact reported message; the new configuration completes at 8.1s. Full test suite passes (643).