### PR TITLE
Timeout model: full-length retry attempts, retry on by default, migrate everyone

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'src/constants/enum.dart';
+import 'src/constants/timeout_constants.dart';
 import 'src/features/about/presentation/about/controllers/about_controller.dart';
 import 'src/features/auth/data/auth_coordinator.dart';
 import 'src/features/auth/data/auth_credentials_store.dart';
@@ -161,6 +162,23 @@ Future<void> _startApp() async {
     }
   } catch (e, st) {
     debugPrint('lastRead sort direction migration failed: $e\n$st');
+  }
+
+  // 3.6) One-time: the old request-timeout model was broken twice over (a
+  //    hidden 5s graphql-layer cap the setting never reached, and retries
+  //    subdivided into delay-sized attempts). Any saved value was tuned
+  //    against that broken behavior, so move EVERY install to the new model:
+  //    30s timeout, auto-retry on. Deliberate full override, per Aaron.
+  try {
+    const migratedKey = 'requestTimeout30sMigrated';
+    if (sharedPreferences.getBool(migratedKey) != true) {
+      await sharedPreferences.setInt(
+          'serverRequestTimeout', TimeoutConstants.requestTimeoutDefaultMs);
+      await sharedPreferences.setBool('autoRefreshOnTimeout', true);
+      await sharedPreferences.setBool(migratedKey, true);
+    }
+  } catch (e, st) {
+    debugPrint('request timeout migration failed: $e\n$st');
   }
 
   // 4) Preload both auth providers BEFORE the first frame so synchronous reads

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -86,9 +86,11 @@ enum DBKeys {
   historyRetentionDays(90),
   // Timeout Settings
   // 30s matches Komikku's source read timeout; pages proxied live from a
-  // source routinely exceed 5s on first fetch.
+  // source routinely exceed 5s on first fetch. Kept in sync with
+  // TimeoutConstants.requestTimeoutDefaultMs (enum initializers can't
+  // reference it directly).
   serverRequestTimeout(30000), // milliseconds
-  autoRefreshOnTimeout(false),
+  autoRefreshOnTimeout(true),
   autoRefreshRetryDelay(1000), // milliseconds
   // Offline safety-net settings
   offlineTimeEvictEnabled(false),

--- a/lib/src/constants/timeout_constants.dart
+++ b/lib/src/constants/timeout_constants.dart
@@ -1,10 +1,17 @@
 /// TimeoutSettings constant values
 /// Values are stored in milliseconds.
 class TimeoutConstants {
-  // Server request timeout
-  static const int requestTimeoutDefaultMs = 5000;
+  // Server request timeout. 30s default matches Komikku's source read
+  // timeout; the 120s ceiling matches its whole-call cap. Each retry attempt
+  // gets the FULL timeout: short rapid-fire attempts abort client-side while
+  // the server keeps fetching, and stacked aborted fetches have been observed
+  // to drive a Suwayomi server to 2GB RAM / 70% CPU (Discord, 2026-07-03).
+  static const int requestTimeoutDefaultMs = 30000;
   static const int requestTimeoutMinMs = 1000;
-  static const int requestTimeoutMaxMs = 30000;
+  static const int requestTimeoutMaxMs = 120000;
+
+  // Full-length attempts, at most this many retries after the first try.
+  static const int autoRefreshMaxRetries = 2;
 
   // Auto-refresh retry delay
   static const int autoRefreshRetryDelayDefaultMs = 1000;

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -14,6 +14,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../constants/db_keys.dart';
+import '../constants/timeout_constants.dart';
 import '../constants/endpoints.dart';
 import '../constants/enum.dart';
 import '../features/auth/data/auth_coordinator.dart';
@@ -43,13 +44,13 @@ GraphQLClient graphQlClient(Ref ref) {
   final retryDelayMs = ref.watch(autoRefreshRetryDelayProvider) ??
       DBKeys.autoRefreshRetryDelay.initial as int;
 
-  final effectiveTimeoutMs = autoRetry
-      ? (retryDelayMs < timeoutMs ? retryDelayMs : timeoutMs)
-      : timeoutMs;
-
-  final retryCount = autoRetry
-      ? ((timeoutMs / retryDelayMs).ceil() - 1).clamp(0, 10)
-      : 0; // cap at 10 retries for safety
+  // Every attempt gets the FULL timeout. Subdividing the budget into
+  // delay-sized attempts (the old model) rapid-fires aborts while the server
+  // keeps fetching each one from the source; the stacked fetches have been
+  // observed to drive a server to 2GB RAM / 70% CPU. Few, full-length
+  // attempts keep retry pressure bounded.
+  final effectiveTimeoutMs = timeoutMs;
+  final retryCount = autoRetry ? TimeoutConstants.autoRefreshMaxRetries : 0;
 
   Link link = HttpLink(
     Endpoints.baseApi(
@@ -131,9 +132,12 @@ GraphQLClient graphQlClient(Ref ref) {
     ),
     // The package layers its own query timeout (default 5s) on top of the
     // HTTP client's; without this the Server Request Timeout setting can't
-    // reach past 5s ("TimeoutException ... No stream event"). The 2s grace
-    // keeps the HTTP layer (and its retries) resolving first.
-    queryRequestTimeout: Duration(milliseconds: timeoutMs + 2000),
+    // reach past 5s ("TimeoutException ... No stream event"). Sized to cover
+    // the HTTP layer's whole retry window plus 2s grace, so the HTTP layer
+    // always resolves first and keeps its error semantics.
+    queryRequestTimeout: Duration(
+        milliseconds:
+            timeoutMs * (retryCount + 1) + retryDelayMs * retryCount + 2000),
     cache: GraphQLCache(store: ref.watch(hiveStoreProvider)),
   );
 }


### PR DESCRIPTION
Completes #92 per the Discord feedback loop (#suwayomi-tsumiru):

**The retry storm (real user report):** enabling Auto Refresh with timeout 10s / delay 5s drove a Suwayomi server from ~500MB to 2GB RAM at 50-70% CPU, recovering slowly after revert. Cause: the old model subdivides the timeout into delay-sized attempts and aborts them rapid-fire, but an aborted client request doesn't stop the server's in-flight source fetch, so retries stack concurrent fetches server-side.

Changes:
- **Full-length attempts**: every attempt gets the entire configured timeout; auto-retry adds at most **2** further attempts (`TimeoutConstants.autoRefreshMaxRetries`). Worst case per request: 3 spaced attempts, not a storm.
- **Both layers hooked**: the graphql-package timeout is sized to the whole retry window (attempts x timeout + delays + 2s grace) so the HTTP layer always resolves first.
- **Auto-retry defaults ON** (safe with the bounded model; retries after a full-length timeout are exactly when the server has likely finished and cached the page).
- **Setting ceiling 30s -> 120s** (Komikku's whole-call cap; Komikku exposes no user setting at all, hardcoding 30s read / 120s call).
- **One-time migration for every install** — including custom values, which were tuned against broken behavior: timeout to 30s, auto-retry on. Guarded by `requestTimeout30sMigrated`.

All 643 tests pass; analyzer clean.