### PR TITLE
Bump version to 0.8.1+38

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.8.0+37
+version: 0.8.1+38
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Release prep for v0.8.1: timeout setting fix (#92), timeout/retry model + migration (#93), Flatpak metainfo version stamp (#91).