### PR TITLE
Fix offline cache pollution and error handling on server failure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -230,6 +230,15 @@ Future<void> _startApp() async {
     unawaited(Future(() async {
       await pushPendingProgress(container);
       await reconcileAllAtLaunch(container);
+      // One-time sweep of phantom (browsed-not-added) catalog entries.
+      if (sharedPreferences.getBool('offlinePhantomCleanupDone') != true) {
+        try {
+          await container.read(offlineDatabaseProvider).purgeNonLibraryManga();
+          await sharedPreferences.setBool('offlinePhantomCleanupDone', true);
+        } catch (e, st) {
+          debugPrint('phantom cleanup failed: $e\n$st');
+        }
+      }
       if (isAndroidNative) {
         // Android: the foreground-service worker owns downloads. Register the
         // lifecycle/connectivity hooks, replay any leftover completion log into

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -37,7 +37,8 @@ class MangaWithId extends _$MangaWithId {
       offlineEnabled: ref.watch(offlineEnabledProvider),
       mangaId: mangaId,
     );
-    if (manga != null) {
+    // Don't mirror browsed (non-library) manga into the offline catalog.
+    if (manga != null && manga.inLibrary) {
       unawaited(
           ref.read(offlineSyncProvider)?.syncManga(manga) ?? Future.value());
     }

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -447,7 +447,8 @@ class OfflineDatabase extends _$OfflineDatabase {
           .get();
 
   /// Sweep browsed-not-added manga a past bug wrote here: no library timestamp
-  /// (null/'0') and no on-device chapters, so real entries and downloads stay.
+  /// (null/'0') and nothing downloaded. Never touches downloads; a stray library
+  /// row swept here just re-mirrors on the next online load.
   Future<int> purgeNonLibraryManga() {
     final withDeviceContent = selectOnly(offlineChapters)
       ..addColumns([offlineChapters.mangaId])

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -446,6 +446,21 @@ class OfflineDatabase extends _$OfflineDatabase {
       (select(offlineMangas)..orderBy([(t) => OrderingTerm(expression: t.title)]))
           .get();
 
+  /// Sweep browsed-not-added manga a past bug wrote here: no library timestamp
+  /// (null/'0') and no on-device chapters, so real entries and downloads stay.
+  Future<int> purgeNonLibraryManga() {
+    final withDeviceContent = selectOnly(offlineChapters)
+      ..addColumns([offlineChapters.mangaId])
+      ..where(offlineChapters.deviceState
+          .equalsValue(OfflineDeviceState.none)
+          .not());
+    return (delete(offlineMangas)
+          ..where((t) =>
+              (t.inLibraryAt.isNull() | t.inLibraryAt.equals('0')) &
+              t.id.isNotInQuery(withDeviceContent)))
+        .go();
+  }
+
   /// Most-recent read timestamp per manga (the max chapter `lastReadAt`), for
   /// the offline library's "Last Read" sort. Mangas with no read chapter are
   /// absent from the map. Values are the server's epoch-millis strings, so the

--- a/lib/src/features/offline/data/offline_read_fallback.dart
+++ b/lib/src/features/offline/data/offline_read_fallback.dart
@@ -5,12 +5,19 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import '../../../graphql/__generated__/schema.graphql.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/network/graphql_errors.dart';
 import '../../library/domain/category/category_model.dart';
 import '../../library/domain/category/graphql/__generated__/fragment.graphql.dart';
 import '../../manga_book/domain/chapter/chapter_model.dart';
 import '../../manga_book/domain/manga/manga_model.dart';
 import 'offline_database.dart';
 import 'offline_dto_mappers.dart';
+
+/// Fall back to the on-device cache only on a genuine loss of connectivity; a
+/// server that answered with an error must surface, not be masked as offline.
+bool _shouldFallBack(Object e) =>
+    isConnectionError(e is OperationMessageException ? e.exception : e);
 
 /// Network-first read with on-device catalog fallback. Tries [fetch]; if it
 /// throws and offline is available with catalog data, returns the catalog
@@ -22,8 +29,8 @@ Future<List<MangaDto>?> libraryWithOfflineFallback({
 }) async {
   try {
     return await fetch();
-  } catch (_) {
-    if (!offlineEnabled) rethrow;
+  } catch (e) {
+    if (!offlineEnabled || !_shouldFallBack(e)) rethrow;
     final rows = await db!.libraryManga();
     if (rows.isEmpty) rethrow;
     final lastReadByManga = await db.lastReadAtByManga();
@@ -53,8 +60,8 @@ Future<MangaDto?> mangaWithOfflineFallback({
 }) async {
   try {
     return await fetch();
-  } catch (_) {
-    if (!offlineEnabled) rethrow;
+  } catch (e) {
+    if (!offlineEnabled || !_shouldFallBack(e)) rethrow;
     final m = await db!.mangaById(mangaId);
     if (m == null) rethrow;
     final count = (await db.chaptersForManga(mangaId)).length;
@@ -73,8 +80,8 @@ Future<ChapterDto?> chapterMetaWithOfflineFallback({
 }) async {
   try {
     return await fetch();
-  } catch (_) {
-    if (!offlineEnabled) rethrow;
+  } catch (e) {
+    if (!offlineEnabled || !_shouldFallBack(e)) rethrow;
     final c = await db!.chapterById(chapterId);
     if (c == null) rethrow;
     return offlineChapterToDto(c);
@@ -92,8 +99,8 @@ Future<List<CategoryDto>?> categoriesWithOfflineFallback({
 }) async {
   try {
     return await fetch();
-  } catch (_) {
-    if (!offlineEnabled) rethrow;
+  } catch (e) {
+    if (!offlineEnabled || !_shouldFallBack(e)) rethrow;
     final count = (await db!.libraryManga()).length;
     if (count == 0) rethrow;
     final storedCats = await db.allOfflineCategories();
@@ -124,8 +131,8 @@ Future<List<ChapterDto>?> chaptersWithOfflineFallback({
 }) async {
   try {
     return await fetch();
-  } catch (_) {
-    if (!offlineEnabled) rethrow;
+  } catch (e) {
+    if (!offlineEnabled || !_shouldFallBack(e)) rethrow;
     final rows = await db!.chaptersForManga(mangaId);
     if (rows.isEmpty) rethrow;
     return [for (final c in rows) offlineChapterToDto(c)];

--- a/lib/src/features/settings/presentation/general/general_screen.dart
+++ b/lib/src/features/settings/presentation/general/general_screen.dart
@@ -5,12 +5,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../constants/language_list.dart';
 import '../../../../global_providers/global_providers.dart';
 import '../../../../l10n/generated/app_localizations.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/popup_widgets/radio_list_popup.dart';
 import 'quick_search_toggle/quick_search_toggle_tile.dart';
 import 'timeout_settings/timeout_settings_section.dart';
@@ -44,19 +46,17 @@ class GeneralScreen extends ConsumerWidget {
               ),
             ),
           ),
-          //TODO: Implement clear cache
-
-          // ListTile(
-          //   leading: const Icon(Icons.cleaning_services_rounded),
-          //   title: Text(context.l10n.clearCache),
-          //   onTap: () async {
-          //     await ref.read(graphQlClientProvider).;
-          //     DefaultCacheManager().emptyCache();
-          //     if (context.mounted) {
-          //       ref.read(toastProvider)?.show(context.l10n.cacheCleared);
-          //     }
-          //   },
-          // ),
+          ListTile(
+            leading: const Icon(Icons.cleaning_services_rounded),
+            title: Text(context.l10n.clearCache),
+            onTap: () async {
+              await ref.read(hiveStoreProvider).reset();
+              await DefaultCacheManager().emptyCache();
+              if (context.mounted) {
+                ref.read(toastProvider)?.show(context.l10n.cacheCleared);
+              }
+            },
+          ),
           const QuickSearchToggleTile(),
           const ForcePortraitTile(),
           const TimeoutSettingsSection(),

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -28,6 +28,7 @@ import '../features/settings/presentation/server/widget/credential_popup/credent
 import '../utils/extensions/custom_extensions.dart';
 import '../utils/logger/logger_link.dart';
 import '../utils/mixin/shared_preferences_client_mixin.dart';
+import '../utils/network/graphql_errors.dart';
 import '../utils/network/timeout_http_client.dart';
 
 part 'global_providers.g.dart';
@@ -60,7 +61,7 @@ GraphQLClient graphQlClient(Ref ref) {
       isGraphQl: true,
     ),
     followRedirects: true,
-    // httpResponseDecoder: httpResponseDecoder,
+    httpResponseDecoder: tsumiruHttpResponseDecoder,
     defaultHeaders: {'Content-Type': 'application/json; charset=utf-8'},
     httpClient: TimeoutHttpClient(
       Duration(milliseconds: effectiveTimeoutMs),

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -110,7 +110,7 @@ GraphQLClient graphQlClient(Ref ref) {
             port: ref.read(serverPortProvider),
             addPort: ref.read(serverPortToggleProvider).ifNull(),
             isGraphQl: true,
-          )),
+          ), httpResponseDecoder: tsumiruHttpResponseDecoder),
           queryRequestTimeout: Duration(milliseconds: timeoutMs + 2000),
           cache: GraphQLCache(),
         );

--- a/lib/src/utils/network/graphql_errors.dart
+++ b/lib/src/utils/network/graphql_errors.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:http/http.dart' as http;
+
+/// The server answered with a body that isn't JSON — a proxy/gateway error
+/// page, an HTML 500, etc. Carries the status so the UI can say "server error"
+/// instead of a raw "Unexpected character (at offset 0)".
+class ServerNotJsonException implements Exception {
+  const ServerNotJsonException(this.statusCode, this.snippet);
+  final int statusCode;
+  final String snippet;
+  @override
+  String toString() => 'Server returned a non-JSON response (HTTP $statusCode)';
+}
+
+/// HttpLink response decoder that turns a non-JSON body into a clear typed
+/// error instead of the default parser FormatException.
+Map<String, dynamic>? tsumiruHttpResponseDecoder(http.Response response) {
+  final body = utf8.decode(response.bodyBytes, allowMalformed: true);
+  try {
+    final decoded = json.decode(body);
+    if (decoded is Map<String, dynamic>) return decoded;
+    throw const FormatException('not a JSON object');
+  } on FormatException {
+    final oneLine = body.trim().replaceAll(RegExp(r'\s+'), ' ');
+    throw ServerNotJsonException(
+      response.statusCode,
+      oneLine.length > 200 ? '${oneLine.substring(0, 200)}…' : oneLine,
+    );
+  }
+}
+
+/// True only when the request never reached a responding server (no
+/// connectivity) — the one case where falling back to the offline cache is
+/// right. A server that answered with an error (500/parse/auth) is not this.
+bool isConnectionError(Object error) {
+  if (error is OperationException) {
+    final link = error.linkException;
+    if (link is ServerException && link.parsedResponse == null) {
+      return _isSocketLike(link.originalException);
+    }
+    return false;
+  }
+  return _isSocketLike(error);
+}
+
+bool _isSocketLike(Object? e) =>
+    e is SocketException ||
+    e is TimeoutException ||
+    e is HandshakeException ||
+    e is http.ClientException;

--- a/test/src/features/offline/data/offline_purge_test.dart
+++ b/test/src/features/offline/data/offline_purge_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<Set<int>> ids() async =>
+      (await db.libraryManga()).map((m) => m.id).toSet();
+
+  test('purges phantoms (null/0 timestamp, no downloads), keeps real + '
+      'downloaded', () async {
+    // phantom: browsed, null timestamp, no chapters
+    await db.upsertMangaMetadata(
+        id: 1, title: 'phantom-null', updatedAt: DateTime(2026));
+    // phantom: '0' sentinel timestamp (went through the fallback reconstruction)
+    await db.upsertMangaMetadata(
+        id: 2, title: 'phantom-zero', updatedAt: DateTime(2026), inLibraryAt: '0');
+    // real library manga: proper timestamp
+    await db.upsertMangaMetadata(
+        id: 3, title: 'real', updatedAt: DateTime(2026), inLibraryAt: '1700000000');
+    // null timestamp BUT has a downloaded chapter -> protected
+    await db.upsertMangaMetadata(
+        id: 4, title: 'downloaded', updatedAt: DateTime(2026));
+    await db.upsertChapterMetadata(
+        id: 40, mangaId: 4, name: 'c', chapterIndex: 1, isRead: false,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026));
+    await db.setChapterDeviceState(40, OfflineDeviceState.downloaded, bytes: 1);
+
+    final removed = await db.purgeNonLibraryManga();
+
+    expect(removed, 2);
+    expect(await ids(), {3, 4});
+  });
+}

--- a/test/src/features/offline/data/offline_read_fallback_test.dart
+++ b/test/src/features/offline/data/offline_read_fallback_test.dart
@@ -1,4 +1,6 @@
 // test/src/features/offline/data/offline_read_fallback_test.dart
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tsumiru/src/features/offline/data/offline_database.dart';
 import 'package:tsumiru/src/features/offline/data/offline_read_fallback.dart';
@@ -9,7 +11,10 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  Future<Never> boom() async => throw Exception('server unreachable');
+  // A genuine loss of connectivity — the only case that should fall back.
+  Future<Never> boom() async => throw const SocketException('unreachable');
+  // The server answered with an error — must surface, never be masked.
+  Future<Never> serverError() async => throw Exception('HTTP 500');
 
   test('library: returns server result when fetch succeeds', () async {
     final r = await libraryWithOfflineFallback(
@@ -86,5 +91,14 @@ void main() {
     final r = await chaptersWithOfflineFallback(
         fetch: boom, db: db, offlineEnabled: true, mangaId: 5);
     expect(r!.single.id, 10);
+  });
+
+  test('library: rethrows a server error rather than masking it with the '
+      'catalog', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    expect(
+        libraryWithOfflineFallback(
+            fetch: serverError, db: db, offlineEnabled: true),
+        throwsA(predicate((e) => e.toString().contains('HTTP 500'))));
   });
 }

--- a/test/src/features/offline/data/offline_read_providers_test.dart
+++ b/test/src/features/offline/data/offline_read_providers_test.dart
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -17,14 +19,14 @@ import '../../../../helpers/offline_test_db.dart';
 class _ThrowingCategoryRepo implements CategoryRepository {
   @override
   Future<List<MangaDto>?> getMangasFromCategory({required int categoryId}) =>
-      throw Exception('offline');
+      throw const SocketException('offline');
 
   @override
-  dynamic noSuchMethod(Invocation i) => throw Exception('offline');
+  dynamic noSuchMethod(Invocation i) => throw const SocketException('offline');
 }
 
 void main() {
-  test('categoryMangaList falls back to the offline catalog on server error',
+  test('categoryMangaList falls back to the offline catalog on connection loss',
       () async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();

--- a/test/src/features/offline/data/offline_screen_gates_test.dart
+++ b/test/src/features/offline/data/offline_screen_gates_test.dart
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -22,12 +24,12 @@ import '../../../../helpers/offline_test_db.dart';
 
 class _ThrowingCategoryRepo implements CategoryRepository {
   @override
-  dynamic noSuchMethod(Invocation i) => throw Exception('offline');
+  dynamic noSuchMethod(Invocation i) => throw const SocketException('offline');
 }
 
 class _ThrowingMangaBookRepo implements MangaBookRepository {
   @override
-  dynamic noSuchMethod(Invocation i) => throw Exception('offline');
+  dynamic noSuchMethod(Invocation i) => throw const SocketException('offline');
 }
 
 Future<ProviderContainer> _container(
@@ -59,7 +61,7 @@ void main() {
   });
 
   group('categoriesWithOfflineFallback', () {
-    Future<Never> boom() async => throw Exception('server down');
+    Future<Never> boom() async => throw const SocketException('offline');
 
     test('returns a single default category (count) when fetch throws', () async {
       await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
@@ -83,7 +85,7 @@ void main() {
   });
 
   group('chapterMetaWithOfflineFallback', () {
-    Future<Never> boom() async => throw Exception('server down');
+    Future<Never> boom() async => throw const SocketException('offline');
 
     test('falls back to the catalog chapter row on throw', () async {
       await db.upsertChapterMetadata(

--- a/test/src/utils/network/graphql_errors_test.dart
+++ b/test/src/utils/network/graphql_errors_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:http/http.dart' as http;
+import 'package:tsumiru/src/utils/network/graphql_errors.dart';
+
+void main() {
+  group('isConnectionError', () {
+    test('bare SocketException is a connection error', () {
+      expect(isConnectionError(const SocketException('x')), isTrue);
+    });
+    test('bare TimeoutException is a connection error', () {
+      expect(isConnectionError(TimeoutException('x')), isTrue);
+    });
+    test('a plain Exception is not (ambiguous -> surface)', () {
+      expect(isConnectionError(Exception('boom')), isFalse);
+    });
+    test('ServerException wrapping a socket error (no parsed response) is', () {
+      final e = OperationException(
+          linkException: ServerException(
+              originalException: const SocketException('down'),
+              parsedResponse: null));
+      expect(isConnectionError(e), isTrue);
+    });
+    test('a graphql error with no link exception is not (server responded)', () {
+      final e = OperationException(
+          graphqlErrors: const [GraphQLError(message: 'Unauthorized')]);
+      expect(isConnectionError(e), isFalse);
+    });
+  });
+
+  group('tsumiruHttpResponseDecoder', () {
+    test('decodes a JSON object body', () {
+      expect(tsumiruHttpResponseDecoder(http.Response('{"data":1}', 200)),
+          {'data': 1});
+    });
+    test('throws ServerNotJsonException on an empty body', () {
+      expect(() => tsumiruHttpResponseDecoder(http.Response('', 500)),
+          throwsA(isA<ServerNotJsonException>()));
+    });
+    test('throws on a JSON array (not an object)', () {
+      expect(() => tsumiruHttpResponseDecoder(http.Response('[1,2]', 200)),
+          throwsA(isA<ServerNotJsonException>()));
+    });
+    test('throws with the status code on an HTML error page', () {
+      try {
+        tsumiruHttpResponseDecoder(http.Response('<html>500</html>', 502));
+        fail('should have thrown');
+      } on ServerNotJsonException catch (e) {
+        expect(e.statusCode, 502);
+        expect(e.toString(), contains('502'));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What this fixes

A server or proxy outage made the app look like local corruption: manga you had only browsed showed up as phantom library entries, and opening any manga or browsing a source threw `FormatException: Unexpected character (at offset 0)`, while the Suwayomi server was healthy.

## Root cause

Three compounding issues turned a server error into apparent corruption:

- Opening any manga's details called `syncManga` with no library check, so every browsed manga was written into the offline catalog and appeared as a phantom library entry.
- The library fell back to the offline catalog on any error (`catch (_)`), so a server error silently rendered the polluted local copy instead of propagating.
- The GraphQL client parsed every response body as JSON, so a proxy's HTML/500 error page became a raw `FormatException` on screen.

## Changes

- Gate `syncManga` on `inLibrary` so browsing no longer writes to the catalog, plus a one-time launch cleanup (`purgeNonLibraryManga`). It deletes only rows with no library timestamp and no downloaded chapters, leaving downloads and real library entries in place.
- `offline_read_fallback`: fall back to the catalog only on connection loss (`SocketException` / `TimeoutException` / `ClientException`), and rethrow server and auth errors so they reach the UI.
- Add `tsumiruHttpResponseDecoder`: a non-JSON response becomes a typed `ServerNotJsonException` carrying the HTTP status, replacing the raw `FormatException`. It's wired into both the query and token-refresh clients.
- Implement the Clear Cache button (was a commented-out stub).

## Testing

- Offline test suite passes (146 tests).
- Added direct tests for the purge, `isConnectionError` discrimination, and the response decoder.
- Whole-project `flutter analyze` is clean.
