### PR TITLE
Bump version to 0.8.2+39

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.8.1+38
+version: 0.8.2+39
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Version bump for the v0.8.2 release (offline cache pollution + server-failure error handling, #96).