### PR TITLE
Don't render a chip for blank genres

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -307,7 +307,9 @@ class MangaDescription extends HookConsumerWidget {
               spacing: 8,
               runSpacing: 8,
               children: [
-                ...manga.genre.map<Widget>((e) => BrandChip(label: e)),
+                ...manga.genre
+                    .where((e) => e.isNotBlank)
+                    .map<Widget>((e) => BrandChip(label: e)),
               ],
             ),
           )
@@ -318,7 +320,7 @@ class MangaDescription extends HookConsumerWidget {
               scrollDirection: Axis.horizontal,
               child: Row(
                 children: [
-                  ...manga.genre.map<Widget>(
+                  ...manga.genre.where((e) => e.isNotBlank).map<Widget>(
                     (e) => Padding(
                       padding: KEdgeInsets.h4.size,
                       child: BrandChip(label: e),


### PR DESCRIPTION
Some sources return an empty-string genre (e.g. Manhwa18 returns `[""]`). On the manga details screen it rendered as a lone colored dot: a chip with an empty label, colored from the label hash, which for an empty string is hue 0 (red).

Filter blank genres before building the chips, at both the expanded and collapsed render sites.

Cosmetic; no release planned yet.