### PR TITLE
Seamless multi-chapter paged reader

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -234,10 +234,11 @@ class ReaderScreen extends HookConsumerWidget {
       SystemChrome.setEnabledSystemUIMode(
         hiddenChromeUiMode(fullscreen: fullscreen),
       );
-      return () => SystemChrome.setEnabledSystemUIMode(
-            SystemUiMode.manual,
-            overlays: SystemUiOverlay.values,
-          );
+      // Don't restore the OS bars on dispose: a chapter change is a
+      // pushReplacement (old screen disposes as the new one mounts), so
+      // restoring here flashes the system bars mid-transition. They're restored
+      // on a real exit in the pop handler below instead.
+      return null;
     }, []);
 
     // Draw reader content into the display cutout (notch/punch-hole) when opted
@@ -284,6 +285,12 @@ class ReaderScreen extends HookConsumerWidget {
     return PopScope(
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop) {
+          // Leaving the reader for real — bring the OS bars back (kept hidden
+          // across chapter transitions by dropping the dispose-time restore).
+          SystemChrome.setEnabledSystemUIMode(
+            SystemUiMode.manual,
+            overlays: SystemUiOverlay.values,
+          );
           // Flush the latest page reached so progress isn't lost to a pending
           // debounce when you back out. AWAIT it so the read write lands before
           // we invalidate the lists below — otherwise they re-fetch the stale

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -38,7 +38,7 @@ import 'controller/display_cutout.dart';
 import 'controller/reader_controller.dart';
 import 'widgets/chrome/reader_chrome.dart';
 import 'widgets/reader_mode/continuous_reader_mode.dart';
-import 'widgets/reader_mode/single_page_reader_mode.dart';
+import 'widgets/reader_mode/multichapter_paged_reader_mode.dart';
 
 class ReaderScreen extends HookConsumerWidget {
   const ReaderScreen({
@@ -338,7 +338,7 @@ class ReaderScreen extends HookConsumerWidget {
                       return switch (autoWebtoon
                           ? ReaderMode.webtoon
                           : data.metaData.readerMode ?? defaultReaderMode) {
-                        ReaderMode.singleVertical => SinglePageReaderMode(
+                        ReaderMode.singleVertical => MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
@@ -350,7 +350,7 @@ class ReaderScreen extends HookConsumerWidget {
                           ),
                         ReaderMode.singleHorizontalRTL ||
                         ReaderMode.continuousHorizontalRTL =>
-                          SinglePageReaderMode(
+                          MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
@@ -362,7 +362,7 @@ class ReaderScreen extends HookConsumerWidget {
                           ),
                         ReaderMode.singleHorizontalLTR ||
                         ReaderMode.continuousHorizontalLTR =>
-                          SinglePageReaderMode(
+                          MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
@@ -392,7 +392,7 @@ class ReaderScreen extends HookConsumerWidget {
                               defaultReaderMode ?? ReaderMode.webtoon) {
                             ReaderMode.singleHorizontalLTR ||
                             ReaderMode.continuousHorizontalLTR =>
-                              SinglePageReaderMode(
+                              MultiChapterPagedReaderMode(
                                 chapter: chapterData,
                                 manga: data,
                                 onPageChanged: onPageChanged,
@@ -401,7 +401,7 @@ class ReaderScreen extends HookConsumerWidget {
                               ),
                             ReaderMode.singleHorizontalRTL ||
                             ReaderMode.continuousHorizontalRTL =>
-                              SinglePageReaderMode(
+                              MultiChapterPagedReaderMode(
                                 chapter: chapterData,
                                 manga: data,
                                 onPageChanged: onPageChanged,
@@ -411,7 +411,7 @@ class ReaderScreen extends HookConsumerWidget {
                                 chapterPages: chapterPagesData,
                                 openAtEnd: openAtEnd,
                               ),
-                            ReaderMode.singleVertical => SinglePageReaderMode(
+                            ReaderMode.singleVertical => MultiChapterPagedReaderMode(
                                 chapter: chapterData,
                                 manga: data,
                                 onPageChanged: onPageChanged,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -221,7 +221,15 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       }
     }
 
+    // The first run is the on-mount restore, not a page turn — skip it so
+    // opening a chapter already sitting on its last page (e.g. paging back into
+    // it, or openAtEnd) doesn't mark it read and wipe the resume point.
+    final initialProgressConsumed = useRef<bool>(false);
     useEffect(() {
+      if (!initialProgressConsumed.value) {
+        initialProgressConsumed.value = true;
+        return null;
+      }
       scheduleVisibleProgress(
           currentVisibleChapter.value.id, currentChapterPageIndex.value);
       return null;

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -79,6 +79,20 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     bool readerToastsEnabled() =>
         ref.read(readerFeedbackToastsProvider).ifNull(true);
 
+    // Chapter loads are kicked off from a hook effect, where reading an
+    // inherited widget (context.l10n, which the feedback toasts use) throws
+    // `_debugIsInitHook`. Defer the toast to a post-frame so it runs in a safe
+    // phase, and never let a feedback failure abort the load itself.
+    void deferFeedback(VoidCallback show) {
+      if (!readerToastsEnabled()) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+        try {
+          show();
+        } catch (_) {}
+      });
+    }
+
     final controller = useMemoized(() => PagedReaderController());
     final settings = ref.watch(readerEffectiveSettingsProvider(manga.id));
 
@@ -245,10 +259,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       if (staged != null && staged.any((e) => e.chapterId == next.id)) return;
       loadingNext.value = true;
       try {
-        if (context.mounted && readerToastsEnabled()) {
-          InfinityContinuousFeedback.showLoadingNextChapterFeedback(
-              context, next.name);
-        }
+        deferFeedback(() => InfinityContinuousFeedback
+            .showLoadingNextChapterFeedback(context, next.name));
         final pages =
             await ref.read(chapterPagesProvider(chapterId: next.id).future);
         if (pages == null) {
@@ -261,10 +273,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           ...base,
           (pages: pages, chapter: next, chapterId: next.id),
         ];
-        if (context.mounted && readerToastsEnabled()) {
-          InfinityContinuousFeedback.showNextChapterLoadedFeedback(
-              context, next.name);
-        }
+        deferFeedback(() => InfinityContinuousFeedback
+            .showNextChapterLoadedFeedback(context, next.name));
       } catch (_) {
         hasReachedEnd.value = true;
       } finally {
@@ -279,10 +289,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       if (staged != null && staged.any((e) => e.chapterId == prev.id)) return;
       loadingPrevious.value = true;
       try {
-        if (context.mounted && readerToastsEnabled()) {
-          InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
-              context, prev.name);
-        }
+        deferFeedback(() => InfinityContinuousFeedback
+            .showLoadingPreviousChapterFeedback(context, prev.name));
         final pages =
             await ref.read(chapterPagesProvider(chapterId: prev.id).future);
         if (pages == null) {
@@ -295,10 +303,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           (pages: pages, chapter: prev, chapterId: prev.id),
           ...base,
         ];
-        if (context.mounted && readerToastsEnabled()) {
-          InfinityContinuousFeedback.showPreviousChapterLoadedFeedback(
-              context, prev.name);
-        }
+        deferFeedback(() => InfinityContinuousFeedback
+            .showPreviousChapterLoadedFeedback(context, prev.name));
       } catch (_) {
         hasReachedStart.value = true;
       } finally {

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -18,6 +18,7 @@ import '../../../../../offline/data/offline_repository.dart';
 import '../../../../../settings/presentation/incognito/incognito_mode.dart';
 import '../../../../../settings/presentation/reader/widgets/reader_feedback_toasts_tile/reader_feedback_toasts_tile.dart';
 import '../../../../../tracking/domain/track_progress_gate.dart';
+import '../../../../data/manga_book/manga_book_repository.dart';
 import '../../../../domain/chapter/chapter_model.dart';
 import '../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../domain/manga/manga_model.dart';
@@ -232,6 +233,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     final offlineEnabledForFlush = ref.read(offlineEnabledProvider);
     final offlineDbForFlush =
         offlineEnabledForFlush ? ref.read(offlineDatabaseProvider) : null;
+    final repoForFlush = ref.read(mangaBookRepositoryProvider);
     final incognitoForFlush = ref.read(incognitoModeProvider);
     useEffect(() {
       return () {
@@ -239,14 +241,22 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         final p = latestProgress.value;
         if (p == null) return;
         if (completedChapterIds.value.contains(p.chapterId)) return;
-        if (incognitoForFlush || offlineDbForFlush == null) return;
+        if (incognitoForFlush) return;
         final lc = loadedById(p.chapterId);
         final pageCount = lc?.pages.pages.length ?? 0;
         final isCompletion = pageCount > 0 && p.rel >= pageCount - 1;
-        unawaited(offlineDbForFlush
-            .setChapterProgress(p.chapterId,
-                lastPageRead: isCompletion ? 0 : p.rel, isRead: isCompletion)
-            .catchError((_) {}));
+        // Flush through the offline-safe path — the on-device catalog when
+        // downloaded, otherwise the server repository — so leaving mid-chapter
+        // saves the spot even with offline disabled (the single-chapter reader
+        // did this via its PopScope flush; the offline-DB-only flush dropped it).
+        unawaited(recordReadingProgressWithDependencies(
+          offlineEnabled: offlineEnabledForFlush,
+          offlineDatabase: offlineDbForFlush,
+          repository: repoForFlush,
+          chapterId: p.chapterId,
+          lastPageRead: isCompletion ? 0 : p.rel,
+          isRead: isCompletion,
+        ).catchError((_) {}));
       };
     }, const []);
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -1,0 +1,629 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../../constants/enum.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../history/presentation/history_controller.dart';
+import '../../../../../offline/data/offline_download_providers.dart';
+import '../../../../../offline/data/offline_repository.dart';
+import '../../../../../settings/presentation/incognito/incognito_mode.dart';
+import '../../../../../settings/presentation/reader/widgets/reader_feedback_toasts_tile/reader_feedback_toasts_tile.dart';
+import '../../../../../tracking/domain/track_progress_gate.dart';
+import '../../../../domain/chapter/chapter_model.dart';
+import '../../../../domain/chapter_page/chapter_page_model.dart';
+import '../../../../domain/manga/manga_model.dart';
+import '../../../manga_details/controller/manga_details_controller.dart';
+import '../../controller/reader_controller.dart';
+import '../../controller/reader_settings_model.dart';
+import '../../utils/reader_initial_page.dart';
+import '../reader_wrapper.dart';
+import 'infinity_continuous/infinity_continuous_feedback.dart';
+import 'infinity_continuous/infinity_continuous_utils.dart';
+import 'paged_display_window.dart';
+import 'paged_reader_viewport.dart';
+import 'paged_spread_mapping.dart';
+
+typedef _LoadedChapter = ({
+  ChapterPagesDto pages,
+  ChapterDto chapter,
+  int chapterId,
+});
+
+/// Multi-chapter paged reader (LTR/RTL/vertical, single & double-page).
+///
+/// The paged counterpart of [MultiChapterContinuousReaderMode]: prev/current/
+/// next chapters live in ONE [PagedReaderViewport], so crossing a chapter
+/// boundary is a page turn inside the same pager (no `pushReplacement`, no route
+/// slide, no per-chapter system-UI toggle). This host owns chapter loading, the
+/// per-visible-chapter progress engine, and the idle-gated window swap; the
+/// viewport owns the gesture/zoom/snap machinery.
+class MultiChapterPagedReaderMode extends HookConsumerWidget {
+  const MultiChapterPagedReaderMode({
+    super.key,
+    required this.manga,
+    required this.chapter,
+    required this.chapterPages,
+    this.onPageChanged,
+    this.reverse = false,
+    this.scrollDirection = Axis.horizontal,
+    this.showReaderLayoutAnimation = false,
+    this.effectiveReaderMode,
+    this.openAtEnd = false,
+  });
+
+  final MangaDto manga;
+  final ChapterDto chapter;
+  final ChapterPagesDto chapterPages;
+
+  /// Accepted for signature parity with the single-chapter reader; this host
+  /// owns progress itself (like the webtoon multi-chapter reader) and ignores
+  /// it — ReaderScreen's debounce stays inert for this path.
+  final ValueSetter<int>? onPageChanged;
+  final bool reverse;
+  final Axis scrollDirection;
+  final bool showReaderLayoutAnimation;
+  final ReaderMode? effectiveReaderMode;
+  final bool openAtEnd;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    bool readerToastsEnabled() =>
+        ref.read(readerFeedbackToastsProvider).ifNull(true);
+
+    final controller = useMemoized(() => PagedReaderController());
+    final settings = ref.watch(readerEffectiveSettingsProvider(manga.id));
+
+    final isHorizontal = scrollDirection == Axis.horizontal;
+    final isLandscape = context.width > context.height;
+    final wantDouble = isHorizontal &&
+        (settings.pageLayout == PageLayout.doublePages ||
+            (settings.pageLayout == PageLayout.automatic && isLandscape) ||
+            settings.trueDualPageSpread);
+    final splitWide = settings.dualPageSplitPaged && isHorizontal;
+    final splitInvert = settings.dualPageInvertPaged;
+    final reversePair = settings.invertDoublePages != reverse;
+    final (pageFit, pageSize) =
+        settings.imageScaleType.pagedFit(context.width, context.height);
+
+    final loadedChapters = useState<List<_LoadedChapter>>([
+      (pages: chapterPages, chapter: chapter, chapterId: chapter.id),
+    ]);
+    // Mirror so the once-bound callbacks always read the latest list.
+    final loadedRef = useRef<List<_LoadedChapter>>(loadedChapters.value);
+    loadedRef.value = loadedChapters.value;
+
+    // Per-chapter wide (landscape) pages, discovered as images resolve. Keyed by
+    // chapterId so two chapters can each have a wide page 0.
+    final widePages = useState<Map<int, Set<int>>>(const {});
+
+    final currentVisibleChapter = useState<ChapterDto>(chapter);
+    final initialChapterPageIndex = readerInitialPageIndex(
+      chapter: chapter,
+      chapterPages: chapterPages,
+      openAtEnd: openAtEnd,
+    );
+    final currentChapterPageIndex = useState<int>(initialChapterPageIndex);
+
+    final loadingNext = useState(false);
+    final loadingPrevious = useState(false);
+    final hasReachedEnd = useState(false);
+    final hasReachedStart = useState(false);
+    final lastEndFeedbackTime = useRef<DateTime?>(null);
+    final lastStartFeedbackTime = useRef<DateTime?>(null);
+    final completedChapterIds = useRef<Set<int>>({});
+
+    // Direction of the last position change, so a chapter loads only when the
+    // user reads TOWARD its edge — never on initial open of a short chapter.
+    final lastProgress = useRef<({int id, int rel})?>(null);
+
+    // A window swap staged by a completed load, applied only when the viewport
+    // is idle (onIdle) so it never disrupts an in-progress drag/animation. A
+    // prepend shifts every index; committing mid-gesture would jump the page.
+    final pending = useRef<List<_LoadedChapter>?>(null);
+
+    final nextPrevChapterPair =
+        useState<({ChapterDto? first, ChapterDto? second})?>(null);
+    useEffect(() {
+      try {
+        nextPrevChapterPair.value = ref.read(
+          getNextAndPreviousChaptersProvider(
+            mangaId: manga.id,
+            chapterId: currentVisibleChapter.value.id,
+          ),
+        );
+      } catch (_) {
+        nextPrevChapterPair.value = null;
+      }
+      return null;
+    }, [currentVisibleChapter.value.id]);
+
+    _LoadedChapter? loadedById(int id) {
+      for (final c in loadedRef.value) {
+        if (c.chapterId == id) return c;
+      }
+      return null;
+    }
+
+    // --- reading-progress recording (per VISIBLE chapter) ----------------
+    // Ported from MultiChapterContinuousReaderMode: record progress for the
+    // chapter currently on screen, not the chapter the reader was opened with,
+    // through the offline-safe recordReadingProgress path.
+    final progressDebounce = useRef<Timer?>(null);
+    final latestProgress = useRef<({int chapterId, int rel})?>(null);
+
+    Future<void> writeVisibleProgress(int chapterId, int rel) async {
+      if (ref.read(incognitoModeProvider)) return;
+      if (chapterId != currentVisibleChapter.value.id) return;
+      if (completedChapterIds.value.contains(chapterId)) return;
+      final lc = loadedById(chapterId);
+      if (lc == null) return;
+      if (lc.chapter.isRead.ifNull()) return;
+      final pageCount = lc.pages.pages.length;
+      final completed = rel >= (pageCount - 1) && pageCount > 0;
+      if (!completed &&
+          lc.chapter.lastPageRead.getValueOnNullOrNegative() >= rel) {
+        return;
+      }
+      await recordReadingProgress(
+        ref,
+        chapterId: chapterId,
+        lastPageRead: completed ? 0 : rel,
+        isRead: completed,
+      );
+      if (completed && !completedChapterIds.value.contains(chapterId)) {
+        completedChapterIds.value = {...completedChapterIds.value, chapterId};
+        unawaited(maybeTrackProgressOnReadFetch(ref,
+            mangaId: manga.id, isRead: true, manual: false));
+        unawaited(maybeDeleteOnReadLocal(ref,
+            mangaId: manga.id, readChapterId: chapterId));
+        unawaited(maybeDeleteOnReadServer(ref,
+            mangaId: manga.id, readChapterId: chapterId));
+      }
+      ref.invalidate(readingHistoryProvider);
+    }
+
+    void scheduleVisibleProgress(int chapterId, int rel) {
+      if (ref.read(incognitoModeProvider)) return;
+      latestProgress.value = (chapterId: chapterId, rel: rel);
+      progressDebounce.value?.cancel();
+      final pageCount = loadedById(chapterId)?.pages.pages.length ?? 0;
+      if (rel >= (pageCount - 1) && pageCount > 0) {
+        unawaited(writeVisibleProgress(chapterId, rel));
+      } else {
+        progressDebounce.value = Timer(
+          const Duration(seconds: 2),
+          () => unawaited(writeVisibleProgress(chapterId, rel)),
+        );
+      }
+    }
+
+    useEffect(() {
+      scheduleVisibleProgress(
+          currentVisibleChapter.value.id, currentChapterPageIndex.value);
+      return null;
+    }, [currentChapterPageIndex.value, currentVisibleChapter.value.id]);
+
+    // Flush any pending debounced progress on teardown, straight to the on-
+    // device catalog (captured at build so it never touches ref while
+    // disposing). Ported verbatim from the webtoon reader.
+    final offlineEnabledForFlush = ref.read(offlineEnabledProvider);
+    final offlineDbForFlush =
+        offlineEnabledForFlush ? ref.read(offlineDatabaseProvider) : null;
+    final incognitoForFlush = ref.read(incognitoModeProvider);
+    useEffect(() {
+      return () {
+        progressDebounce.value?.cancel();
+        final p = latestProgress.value;
+        if (p == null) return;
+        if (completedChapterIds.value.contains(p.chapterId)) return;
+        if (incognitoForFlush || offlineDbForFlush == null) return;
+        final lc = loadedById(p.chapterId);
+        final pageCount = lc?.pages.pages.length ?? 0;
+        final isCompletion = pageCount > 0 && p.rel >= pageCount - 1;
+        unawaited(offlineDbForFlush
+            .setChapterProgress(p.chapterId,
+                lastPageRead: isCompletion ? 0 : p.rel, isRead: isCompletion)
+            .catchError((_) {}));
+      };
+    }, const []);
+
+    // --- chapter loading (staged; committed on viewport idle) ------------
+
+    Future<void> loadNextChapter(ChapterDto next) async {
+      if (loadingNext.value || hasReachedEnd.value) return;
+      if (loadedRef.value.any((e) => e.chapterId == next.id)) return;
+      final staged = pending.value;
+      if (staged != null && staged.any((e) => e.chapterId == next.id)) return;
+      loadingNext.value = true;
+      try {
+        if (context.mounted && readerToastsEnabled()) {
+          InfinityContinuousFeedback.showLoadingNextChapterFeedback(
+              context, next.name);
+        }
+        final pages =
+            await ref.read(chapterPagesProvider(chapterId: next.id).future);
+        if (pages == null) {
+          hasReachedEnd.value = true;
+          return;
+        }
+        if (loadedRef.value.any((e) => e.chapterId == next.id)) return;
+        final base = pending.value ?? loadedRef.value;
+        pending.value = [
+          ...base,
+          (pages: pages, chapter: next, chapterId: next.id),
+        ];
+        if (context.mounted && readerToastsEnabled()) {
+          InfinityContinuousFeedback.showNextChapterLoadedFeedback(
+              context, next.name);
+        }
+      } catch (_) {
+        hasReachedEnd.value = true;
+      } finally {
+        loadingNext.value = false;
+      }
+    }
+
+    Future<void> loadPreviousChapter(ChapterDto prev) async {
+      if (loadingPrevious.value || hasReachedStart.value) return;
+      if (loadedRef.value.any((e) => e.chapterId == prev.id)) return;
+      final staged = pending.value;
+      if (staged != null && staged.any((e) => e.chapterId == prev.id)) return;
+      loadingPrevious.value = true;
+      try {
+        if (context.mounted && readerToastsEnabled()) {
+          InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
+              context, prev.name);
+        }
+        final pages =
+            await ref.read(chapterPagesProvider(chapterId: prev.id).future);
+        if (pages == null) {
+          hasReachedStart.value = true;
+          return;
+        }
+        if (loadedRef.value.any((e) => e.chapterId == prev.id)) return;
+        final base = pending.value ?? loadedRef.value;
+        pending.value = [
+          (pages: pages, chapter: prev, chapterId: prev.id),
+          ...base,
+        ];
+        if (context.mounted && readerToastsEnabled()) {
+          InfinityContinuousFeedback.showPreviousChapterLoadedFeedback(
+              context, prev.name);
+        }
+      } catch (_) {
+        hasReachedStart.value = true;
+      } finally {
+        loadingPrevious.value = false;
+      }
+    }
+
+    // Commit a staged swap while the viewport is idle. Deferred to a microtask
+    // so it never runs inside the viewport's own build/re-anchor pass (a
+    // setState-during-build). Idempotent: the first run clears `pending`.
+    void commitPendingIfAny() {
+      if (pending.value == null) return;
+      Future.microtask(() {
+        if (!context.mounted) return;
+        final p = pending.value;
+        if (p == null) return;
+        pending.value = null;
+        loadedChapters.value = p;
+      });
+    }
+
+    // Preload the neighbour the user is reading toward, Komikku-style: within
+    // ~5 pages of the visible chapter's far edge and moving that way.
+    useEffect(() {
+      final visibleId = currentVisibleChapter.value.id;
+      final rel = currentChapterPageIndex.value;
+      final prev = lastProgress.value;
+      lastProgress.value = (id: visibleId, rel: rel);
+      final lc = loadedById(visibleId);
+      if (lc == null || prev == null) return null; // no direction yet
+      final count = lc.pages.pages.length;
+      final pair = nextPrevChapterPair.value;
+
+      int posOf(int id) => loadedRef.value.indexWhere((e) => e.chapterId == id);
+      final curPos = posOf(visibleId);
+      final prevPos = posOf(prev.id);
+      final movingForward =
+          curPos != prevPos ? curPos > prevPos : rel > prev.rel;
+      final movingBackward =
+          curPos != prevPos ? curPos < prevPos : rel < prev.rel;
+
+      if (movingForward &&
+          loadedRef.value.isNotEmpty &&
+          loadedRef.value.last.chapterId == visibleId &&
+          rel >= count - 5 &&
+          pair?.first != null) {
+        unawaited(loadNextChapter(pair!.first!));
+      }
+      if (movingBackward &&
+          loadedRef.value.isNotEmpty &&
+          loadedRef.value.first.chapterId == visibleId &&
+          rel <= 4 &&
+          pair?.second != null) {
+        unawaited(loadPreviousChapter(pair!.second!));
+      }
+      return null;
+    }, [currentChapterPageIndex.value, currentVisibleChapter.value.id]);
+
+    // --- display window --------------------------------------------------
+
+    // Window-edge adjacency: whether an unloaded chapter sits before the first
+    // / after the last loaded chapter, so we show a boundary card there.
+    final firstLoadedId = loadedChapters.value.first.chapterId;
+    final lastLoadedId = loadedChapters.value.last.chapterId;
+    final headAdjacency = ref.watch(getNextAndPreviousChaptersProvider(
+        mangaId: manga.id, chapterId: firstLoadedId));
+    final tailAdjacency = ref.watch(getNextAndPreviousChaptersProvider(
+        mangaId: manga.id, chapterId: lastLoadedId));
+    final prevChapterExists = headAdjacency?.second != null;
+    final nextChapterExists = tailAdjacency?.first != null;
+
+    final window = useMemoized(
+      () {
+        final windowChapters = <WindowChapter>[
+          for (final lc in loadedChapters.value)
+            WindowChapter(
+              chapterId: lc.chapterId,
+              chapterName: lc.chapter.name,
+              mapping: buildSpreadMapping(
+                pageCount: lc.pages.pages.length,
+                doublePages: wantDouble,
+                splitWide: splitWide,
+                splitInvert: splitInvert,
+                isWide: (raw) =>
+                    (widePages.value[lc.chapterId] ?? const {}).contains(raw),
+              ),
+              pages: lc.pages.pages,
+            ),
+        ];
+        return buildPagedDisplayWindow(
+          chapters: windowChapters,
+          forceTransition: settings.alwaysShowChapterTransition,
+          leadingTransition: prevChapterExists,
+          trailingTransition: nextChapterExists,
+        );
+      },
+      [
+        loadedChapters.value,
+        wantDouble,
+        splitWide,
+        splitInvert,
+        widePages.value,
+        settings.alwaysShowChapterTransition,
+        prevChapterExists,
+        nextChapterExists,
+      ],
+    );
+
+    // First-build display index for the opening chapter's initial page. Computed
+    // once against the first window (opening chapter only).
+    final initialDisplayIndex = useMemoized(() {
+      final raw = initialChapterPageIndex;
+      final d = window.chapterRawToDisplay(chapter.id, raw);
+      return d >= 0 ? d : window.firstDisplayOf(chapter.id).clamp(0, 1 << 30);
+    }, const []);
+
+    // --- viewport callbacks ----------------------------------------------
+
+    void onChapterPageChanged(int chapterId, int raw) {
+      if (currentVisibleChapter.value.id != chapterId) {
+        final loaded = loadedRef.value;
+        final prevId = currentVisibleChapter.value.id;
+        final prevPos = loaded.indexWhere((e) => e.chapterId == prevId);
+        final newPos = loaded.indexWhere((e) => e.chapterId == chapterId);
+        if (newPos >= 0) {
+          currentVisibleChapter.value = loaded[newPos].chapter;
+          // Forward boundary crossing: the chapter just left is finished.
+          if (prevPos >= 0 && newPos > prevPos) {
+            _markChapterRead(
+                ref, manga.id, loaded[prevPos].chapter, completedChapterIds,
+                context);
+          }
+        }
+      }
+      if (currentChapterPageIndex.value != raw) {
+        currentChapterPageIndex.value = raw;
+      }
+    }
+
+    void onPageWide(int chapterId, int raw, bool wide) {
+      if (!wide) return;
+      final current = widePages.value[chapterId] ?? const <int>{};
+      if (current.contains(raw)) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+        final now = widePages.value[chapterId] ?? const <int>{};
+        if (now.contains(raw)) return;
+        widePages.value = {
+          ...widePages.value,
+          chapterId: {...now, raw},
+        };
+      });
+    }
+
+    void onReachedEndEdge() {
+      if (nextChapterExists) return; // more to load — no end feedback
+      if (!context.mounted || !readerToastsEnabled()) return;
+      InfinityContinuousFeedback.showEndOfMangaFeedback(
+          context, lastEndFeedbackTime);
+    }
+
+    void onReachedStartEdge() {
+      if (prevChapterExists) return;
+      if (!context.mounted || !readerToastsEnabled()) return;
+      InfinityContinuousFeedback.showStartOfMangaFeedback(
+          context, lastStartFeedbackTime);
+    }
+
+    String nameForChapter(int? id) {
+      if (id == null) return '';
+      for (final lc in loadedRef.value) {
+        if (lc.chapterId == id) return lc.chapter.name;
+      }
+      return '';
+    }
+
+    Widget transitionBuilder(TransitionDisplay t) {
+      // End card shows the finished chapter; start/interior show the chapter
+      // being entered.
+      final name = t.isEnd
+          ? nameForChapter(t.fromChapterId)
+          : nameForChapter(t.toChapterId);
+      return _PagedChapterTransition(
+        chapterName: name,
+        isChapterStart: !t.isEnd,
+      );
+    }
+
+    // --- ReaderWrapper (fed the VISIBLE-chapter view) --------------------
+
+    final visibleChapterPages = InfinityContinuousUtils.createChapterPagesDto(
+        loadedChapters.value, currentVisibleChapter.value, chapterPages);
+
+    List<int>? spreadPageIndexes;
+    final visibleWindowChapter =
+        window.chapterById(currentVisibleChapter.value.id);
+    if (visibleWindowChapter != null && !visibleWindowChapter.mapping.isEmpty) {
+      final mapping = visibleWindowChapter.mapping;
+      final entry =
+          mapping.entries[mapping.rawToDisplay(currentChapterPageIndex.value)];
+      final second = entry.second;
+      if (second != null && second.raw != entry.first.raw) {
+        spreadPageIndexes = reversePair
+            ? [second.raw, entry.first.raw]
+            : [entry.first.raw, second.raw];
+      }
+    }
+
+    final wrapperReaderMode =
+        effectiveReaderMode ?? _pagedReaderMode(scrollDirection, reverse);
+
+    return ReaderWrapper(
+      scrollDirection: scrollDirection,
+      chapter: currentVisibleChapter.value,
+      manga: manga,
+      chapterPages: visibleChapterPages,
+      currentIndex: currentChapterPageIndex.value,
+      onChanged: controller.jumpToRaw,
+      showReaderLayoutAnimation: showReaderLayoutAnimation,
+      onPrevious: controller.previous,
+      onNext: controller.next,
+      childHandlesGestures: true,
+      handlesOwnChapterNavigation: true,
+      isAtFirstBoundary: () => controller.isAtFirst,
+      isAtLastBoundary: () => controller.isAtLast,
+      spreadPageIndexes: spreadPageIndexes,
+      effectiveReaderMode: wrapperReaderMode,
+      child: PagedReaderViewport(
+        controller: controller,
+        window: window,
+        initialDisplayIndex: initialDisplayIndex,
+        axis: scrollDirection,
+        reverse: reverse,
+        animateTransitions: settings.animatePageTransitions,
+        pageFit: pageFit,
+        pageSize: pageSize,
+        centerMargin: settings.centerMarginType,
+        rotateWide: settings.rotateWidePages,
+        rotateWideInvert: settings.rotateWideInvert,
+        reversePair: reversePair,
+        cropBorders: settings.cropBorders,
+        onPageWide: onPageWide,
+        onChapterPageChanged: onChapterPageChanged,
+        transitionBuilder: transitionBuilder,
+        onIdle: commitPendingIfAny,
+        onReachedStartEdge: onReachedStartEdge,
+        onReachedEndEdge: onReachedEndEdge,
+        pinchEnabled: settings.pinchToZoom,
+        doubleTapToZoom: settings.doubleTapToZoom,
+        disableZoomIn: false,
+        disableZoomOut: settings.disableZoomOut,
+        navigateToPan: settings.navigateToPan,
+      ),
+    );
+  }
+}
+
+ReaderMode _pagedReaderMode(Axis axis, bool reverse) {
+  if (axis == Axis.vertical) return ReaderMode.singleVertical;
+  return reverse
+      ? ReaderMode.singleHorizontalRTL
+      : ReaderMode.singleHorizontalLTR;
+}
+
+/// Mark [chapter] read once and reconcile the relevant providers, tracking
+/// already-marked ids so repeated boundary crossings don't re-fire the mutation.
+/// Ported from MultiChapterContinuousReaderMode.
+void _markChapterRead(
+  WidgetRef ref,
+  int mangaId,
+  ChapterDto chapter,
+  ObjectRef<Set<int>> completedChapterIds,
+  BuildContext context,
+) {
+  if (ref.read(incognitoModeProvider)) return;
+  if (chapter.isRead.ifNull()) return;
+  if (completedChapterIds.value.contains(chapter.id)) return;
+  completedChapterIds.value = {...completedChapterIds.value, chapter.id};
+  unawaited(recordReadingProgress(
+    ref,
+    chapterId: chapter.id,
+    lastPageRead: 0,
+    isRead: true,
+  ).then((_) {
+    if (!context.mounted) return;
+    unawaited(maybeTrackProgressOnReadFetch(
+      ref,
+      mangaId: mangaId,
+      isRead: true,
+      manual: false,
+    ));
+    unawaited(maybeDeleteOnReadLocal(
+      ref,
+      mangaId: mangaId,
+      readChapterId: chapter.id,
+    ));
+    unawaited(maybeDeleteOnReadServer(
+      ref,
+      mangaId: mangaId,
+      readChapterId: chapter.id,
+    ));
+  }));
+  // Deliberately do NOT invalidate chapterProvider / mangaChapterList here —
+  // that would remount the reader mid-read. Read-state is tracked in-session
+  // via completedChapterIds; ReaderScreen refreshes on exit (its PopScope).
+}
+
+class _PagedChapterTransition extends StatelessWidget {
+  const _PagedChapterTransition({
+    required this.chapterName,
+    required this.isChapterStart,
+  });
+
+  final String chapterName;
+  final bool isChapterStart;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SingleChildScrollView(
+        child: InfinityContinuousChapterSeparator(
+          chapterName: chapterName,
+          isChapterStart: isChapterStart,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_display_window.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_display_window.dart
@@ -162,6 +162,15 @@ class PagedDisplayWindow {
     }
     return -1;
   }
+
+  /// The last display position belonging to [chapterId], or -1 if absent.
+  int lastDisplayOf(int chapterId) {
+    for (var i = items.length - 1; i >= 0; i--) {
+      final item = items[i];
+      if (item is SpreadDisplay && item.chapterId == chapterId) return i;
+    }
+    return -1;
+  }
 }
 
 /// Builds the multi-chapter display list from an ordered (reading order) list of

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_display_window.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_display_window.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Pure multi-chapter display list for the paged viewer.
+///
+/// The paged viewport shows prev/current/next chapters in ONE continuous pager
+/// (like Komikku's PagerViewer) instead of rebuilding the reader per chapter.
+/// This composes each loaded chapter's [SpreadMapping] into a single display
+/// list, inserting a virtual transition entry between chapters, and translates
+/// display-index ↔ (chapterId, raw page). Kept pure (no Flutter deps) so the
+/// index contract is unit-tested.
+library;
+
+import 'paged_spread_mapping.dart';
+
+/// One loaded chapter in the window: its spread mapping plus the raw page URLs
+/// the spreads address.
+class WindowChapter {
+  const WindowChapter({
+    required this.chapterId,
+    required this.chapterName,
+    required this.mapping,
+    required this.pages,
+    this.hasGapBefore = false,
+  });
+
+  final int chapterId;
+  final String chapterName;
+  final SpreadMapping mapping;
+  final List<String> pages;
+
+  /// True when there are missing (unloaded/absent) chapters between this chapter
+  /// and the previous one in the window — forces a transition entry even when
+  /// transitions are otherwise seamless.
+  final bool hasGapBefore;
+}
+
+/// One position in the paged display list: either a spread of a chapter's pages
+/// or a virtual chapter-boundary transition.
+sealed class DisplayItem {
+  const DisplayItem();
+}
+
+/// A spread (single page, double-page pair, or split-wide half) belonging to
+/// [chapterId]; [entry] addresses that chapter's raw pages.
+class SpreadDisplay extends DisplayItem {
+  const SpreadDisplay({required this.chapterId, required this.entry});
+
+  final int chapterId;
+  final SpreadEntry entry;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SpreadDisplay &&
+      other.chapterId == chapterId &&
+      other.entry == entry;
+
+  @override
+  int get hashCode => Object.hash(chapterId, entry);
+
+  @override
+  String toString() => 'SpreadDisplay($chapterId, $entry)';
+}
+
+/// A virtual chapter-boundary card. [fromChapterId] is the chapter being left
+/// (null at the very start of the window), [toChapterId] the one entered (null
+/// at the very end / when the neighbour isn't loaded yet).
+class TransitionDisplay extends DisplayItem {
+  const TransitionDisplay({this.fromChapterId, this.toChapterId});
+
+  final int? fromChapterId;
+  final int? toChapterId;
+
+  bool get isStart => fromChapterId == null;
+  bool get isEnd => toChapterId == null;
+
+  @override
+  bool operator ==(Object other) =>
+      other is TransitionDisplay &&
+      other.fromChapterId == fromChapterId &&
+      other.toChapterId == toChapterId;
+
+  @override
+  int get hashCode => Object.hash(fromChapterId, toChapterId);
+
+  @override
+  String toString() => 'TransitionDisplay($fromChapterId -> $toChapterId)';
+}
+
+/// The built multi-chapter display list plus the display ↔ (chapter, raw)
+/// translation the viewer needs.
+class PagedDisplayWindow {
+  const PagedDisplayWindow(this.items, this._chapters);
+
+  final List<DisplayItem> items;
+  final List<WindowChapter> _chapters;
+
+  int get length => items.length;
+  bool get isEmpty => items.isEmpty;
+
+  List<WindowChapter> get chapters => _chapters;
+
+  WindowChapter? chapterById(int chapterId) {
+    for (final c in _chapters) {
+      if (c.chapterId == chapterId) return c;
+    }
+    return null;
+  }
+
+  /// The page URLs for the chapter shown at [displayIndex], or null for a
+  /// transition / out-of-range slot.
+  List<String>? pagesAt(int displayIndex) {
+    final item = _itemAt(displayIndex);
+    if (item is! SpreadDisplay) return null;
+    return chapterById(item.chapterId)?.pages;
+  }
+
+  DisplayItem? _itemAt(int displayIndex) {
+    if (displayIndex < 0 || displayIndex >= items.length) return null;
+    return items[displayIndex];
+  }
+
+  /// display position → the (chapter, furthest raw page) it shows, for
+  /// read-progress. Null for a transition slot or out-of-range index.
+  ({int chapterId, int raw})? displayToChapterProgressRaw(int displayIndex) {
+    final item = _itemAt(displayIndex);
+    if (item is! SpreadDisplay) return null;
+    return (chapterId: item.chapterId, raw: item.entry.progressRaw);
+  }
+
+  /// display position → the (chapter, reading-first raw page) it shows — the
+  /// seekbar contract. Null for a transition slot or out-of-range index.
+  ({int chapterId, int raw})? displayToChapterRaw(int displayIndex) {
+    final item = _itemAt(displayIndex);
+    if (item is! SpreadDisplay) return null;
+    return (chapterId: item.chapterId, raw: item.entry.primaryRaw);
+  }
+
+  /// (chapter, raw) → the display position that shows it. Matches either page of
+  /// a pair. Returns -1 when the chapter isn't in the window.
+  int chapterRawToDisplay(int chapterId, int rawIndex) {
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      if (item is SpreadDisplay &&
+          item.chapterId == chapterId &&
+          (item.entry.first.raw == rawIndex ||
+              item.entry.second?.raw == rawIndex)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /// The first display position belonging to [chapterId], or -1 if absent.
+  int firstDisplayOf(int chapterId) {
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      if (item is SpreadDisplay && item.chapterId == chapterId) return i;
+    }
+    return -1;
+  }
+}
+
+/// Builds the multi-chapter display list from an ordered (reading order) list of
+/// loaded chapters.
+///
+/// - A transition entry is inserted between two consecutive chapters when
+///   [forceTransition] is set (the `alwaysShowChapterTransition` setting) or the
+///   later chapter reports [WindowChapter.hasGapBefore]. Otherwise the crossing
+///   is seamless (last spread of one chapter directly precedes the first of the
+///   next), matching Komikku's PagerViewerAdapter.
+/// - [leadingTransition] / [trailingTransition] add a boundary card before the
+///   first / after the last chapter — used at the window edges where a further
+///   chapter exists to load, or to show end/start-of-manga.
+PagedDisplayWindow buildPagedDisplayWindow({
+  required List<WindowChapter> chapters,
+  required bool forceTransition,
+  bool leadingTransition = false,
+  bool trailingTransition = false,
+}) {
+  final items = <DisplayItem>[];
+  if (chapters.isEmpty) return PagedDisplayWindow(items, chapters);
+
+  if (leadingTransition) {
+    items.add(TransitionDisplay(toChapterId: chapters.first.chapterId));
+  }
+
+  for (var c = 0; c < chapters.length; c++) {
+    final chapter = chapters[c];
+    if (c > 0 && (forceTransition || chapter.hasGapBefore)) {
+      items.add(TransitionDisplay(
+        fromChapterId: chapters[c - 1].chapterId,
+        toChapterId: chapter.chapterId,
+      ));
+    }
+    for (final entry in chapter.mapping.entries) {
+      items.add(SpreadDisplay(chapterId: chapter.chapterId, entry: entry));
+    }
+  }
+
+  if (trailingTransition) {
+    items.add(TransitionDisplay(fromChapterId: chapters.last.chapterId));
+  }
+
+  return PagedDisplayWindow(items, chapters);
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -774,12 +774,28 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   }
 
   void _animateThroughBoundary(int direction) {
+    // Only slide the page off-screen if there's a chapter to land on. Without
+    // this, reaching the last page of the last chapter animates the page fully
+    // out — flashing an empty slot — before discovering there's nowhere to go
+    // and bouncing back. When a chapter exists, keep the slide-then-navigate.
+    if (!_hasBoundaryChapter(direction)) {
+      _animateOffsetTo(0);
+      return;
+    }
     final targetOffset = -direction * _axisSign * _axisExtent;
     _animateOffsetTo(targetOffset, onComplete: () {
       if (!mounted) return;
       final movedChapter = _requestBoundaryMove(direction);
       if (!movedChapter) _animateOffsetTo(0);
     });
+  }
+
+  bool _hasBoundaryChapter(int direction) {
+    final callbacks = ReaderInputScope.maybeOf(context);
+    if (callbacks == null) return false;
+    return direction < 0
+        ? callbacks.hasPreviousBoundary()
+        : callbacks.hasNextBoundary();
   }
 
   void _moveFromBoundary(int delta) {

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -14,6 +14,7 @@ import '../../../../../../constants/enum.dart';
 import '../../../../../../widgets/custom_circular_progress_indicator.dart';
 import '../reader_wrapper.dart';
 import 'double_page_view.dart';
+import 'paged_display_window.dart';
 import 'paged_spread_mapping.dart';
 
 enum _DragOwner { page, pager }
@@ -42,12 +43,19 @@ class PagedReaderController {
   bool get isAtLast => _state?.isAtLastDisplay ?? false;
 }
 
+/// Continuous multi-chapter paged viewport.
+///
+/// Renders a [PagedDisplayWindow] — the prev/current/next chapters composed
+/// into ONE display list with virtual transition cards between them — so paging
+/// across a chapter boundary is just a page turn inside the same pager (no route
+/// rebuild). The host swaps in a fresh window (append/prepend a chapter) and
+/// this widget re-anchors to the same content on [didUpdateWidget]. Progress is
+/// reported as `(chapterId, raw)` so the host can address the VISIBLE chapter.
 class PagedReaderViewport extends StatefulWidget {
   const PagedReaderViewport({
     super.key,
     required this.controller,
-    required this.mapping,
-    required this.pages,
+    required this.window,
     required this.initialDisplayIndex,
     required this.axis,
     required this.reverse,
@@ -60,19 +68,20 @@ class PagedReaderViewport extends StatefulWidget {
     required this.reversePair,
     required this.cropBorders,
     required this.onPageWide,
-    required this.onRawPageChanged,
+    required this.onChapterPageChanged,
+    required this.transitionBuilder,
     required this.pinchEnabled,
     required this.doubleTapToZoom,
     required this.disableZoomIn,
     required this.disableZoomOut,
     required this.navigateToPan,
-    this.previousBoundary,
-    this.nextBoundary,
+    this.onIdle,
+    this.onReachedStartEdge,
+    this.onReachedEndEdge,
   });
 
   final PagedReaderController controller;
-  final SpreadMapping mapping;
-  final List<String> pages;
+  final PagedDisplayWindow window;
   final int initialDisplayIndex;
   final Axis axis;
   final bool reverse;
@@ -84,15 +93,34 @@ class PagedReaderViewport extends StatefulWidget {
   final bool rotateWideInvert;
   final bool reversePair;
   final bool cropBorders;
-  final void Function(int raw, bool isWide) onPageWide;
-  final ValueChanged<int> onRawPageChanged;
+
+  /// Reports a wide (landscape) page for the given chapter so the host can
+  /// re-chunk that chapter's mapping. Chapter-scoped: two chapters can each
+  /// have a wide page 0.
+  final void Function(int chapterId, int raw, bool isWide) onPageWide;
+
+  /// Reports the current reading position as `(chapterId, furthest raw page)`
+  /// — the read-progress contract, addressed to the visible chapter.
+  final void Function(int chapterId, int raw) onChapterPageChanged;
+
+  /// Builds the card shown for a virtual chapter-boundary transition slot.
+  final Widget Function(TransitionDisplay) transitionBuilder;
+
+  /// Fired whenever the viewport settles onto a page (mount, page turn, jump,
+  /// re-anchor, or a bounce). The host uses this to apply an idle-gated window
+  /// swap without disrupting an in-progress drag/animation.
+  final VoidCallback? onIdle;
+
+  /// The outer edges of the window just bounce; these let the host surface
+  /// start/end-of-manga feedback.
+  final VoidCallback? onReachedStartEdge;
+  final VoidCallback? onReachedEndEdge;
+
   final bool pinchEnabled;
   final bool doubleTapToZoom;
   final bool disableZoomIn;
   final bool disableZoomOut;
   final bool navigateToPan;
-  final Widget? previousBoundary;
-  final Widget? nextBoundary;
 
   @override
   State<PagedReaderViewport> createState() => _PagedReaderViewportState();
@@ -125,10 +153,11 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   double _dragOffset = 0;
   Size _viewportSize = Size.zero;
   final Map<int, Offset> _pointers = {};
-  // Keyed by page identity (the entry's first unit), not display index — a late
-  // wide page re-chunks the mapping and shifts display indices, which would
-  // otherwise bind a page's zoom/pan state to whatever page later takes its slot.
-  final Map<PageUnit, _PageZoomController> _zoomControllers = {};
+  // Keyed by (chapterId, page identity), not display index — a late wide page
+  // re-chunks a chapter's mapping and shifts display indices, and two chapters
+  // can share a raw index, so the chapter disambiguates equal raws.
+  final Map<({int chapterId, PageUnit unit}), _PageZoomController>
+      _zoomControllers = {};
 
   Offset? _lastSinglePosition;
   Offset _totalDrag = Offset.zero;
@@ -191,17 +220,11 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       oldWidget.controller._detach(this);
       widget.controller._attach(this);
     }
-    if (oldWidget.mapping != widget.mapping) {
-      final wasBoundary =
-          _displayIndex < 0 || _displayIndex >= oldWidget.mapping.length;
-      if (wasBoundary) {
-        _displayIndex = _clampDisplay(widget.initialDisplayIndex);
-      } else {
-        final raw = oldWidget.mapping.displayToRaw(_displayIndex);
-        _displayIndex = _clampDisplay(widget.mapping.rawToDisplay(raw));
-      }
-      _dragOffset = 0;
-      _emitRawPage();
+    // The host makes a NEW window instance per swap (append/prepend). Re-anchor
+    // to the same content so a prepend that shifts every index doesn't jump the
+    // page the user is reading.
+    if (!identical(oldWidget.window, widget.window)) {
+      _reanchor(oldWidget.window);
     }
     _syncZoomBounds();
   }
@@ -219,10 +242,31 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     super.dispose();
   }
 
+  void _reanchor(PagedDisplayWindow oldWindow) {
+    final item = (_displayIndex >= 0 && _displayIndex < oldWindow.length)
+        ? oldWindow.items[_displayIndex]
+        : null;
+    var target = -1;
+    if (item is SpreadDisplay) {
+      target =
+          widget.window.chapterRawToDisplay(item.chapterId, item.entry.first.raw);
+    } else if (item is TransitionDisplay) {
+      final anchor = item.toChapterId ?? item.fromChapterId;
+      if (anchor != null) target = widget.window.firstDisplayOf(anchor);
+    }
+    _displayIndex =
+        target >= 0 ? target : _clampDisplay(widget.initialDisplayIndex);
+    _dragOffset = 0;
+    _emitRawPage();
+  }
+
   void jumpToRaw(int rawIndex) {
     _stopPanAnimation();
-    final target = _clampDisplay(widget.mapping.rawToDisplay(rawIndex));
-    if (target == _displayIndex) {
+    final chapterId = _currentChapterId();
+    final target = chapterId == null
+        ? -1
+        : widget.window.chapterRawToDisplay(chapterId, rawIndex);
+    if (target < 0 || target == _displayIndex) {
       _emitRawPage();
       return;
     }
@@ -236,48 +280,59 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   void moveByCommand(int delta) {
     if (delta == 0 || _pageAnimation.isAnimating) return;
     _stopPanAnimation();
-    if (_isBoundaryDisplay(_displayIndex)) {
-      _moveFromBoundary(delta);
-      return;
-    }
     if (widget.navigateToPan && _panCurrentPage(_commandPanDirection(delta))) {
       return;
     }
     _animateToDisplay(_displayIndex + delta);
   }
 
-  bool get isAtFirstDisplay =>
-      widget.previousBoundary != null ? _displayIndex < 0 : _displayIndex <= 0;
+  bool get isAtFirstDisplay => _displayIndex <= 0;
 
-  bool get isAtLastDisplay => !widget.mapping.isEmpty
-      ? widget.nextBoundary != null
-          ? _displayIndex >= widget.mapping.length
-          : _displayIndex >= widget.mapping.length - 1
-      : false;
+  bool get isAtLastDisplay =>
+      !widget.window.isEmpty && _displayIndex >= widget.window.length - 1;
 
   int _clampDisplay(int index) {
-    if (widget.mapping.isEmpty) return 0;
-    return index.clamp(0, widget.mapping.length - 1).toInt();
+    if (widget.window.isEmpty) return 0;
+    return index.clamp(0, widget.window.length - 1).toInt();
   }
+
+  void _notifyIdle() => widget.onIdle?.call();
 
   void _emitRawPage() {
-    if (widget.mapping.isEmpty || _isBoundaryDisplay(_displayIndex)) return;
-    widget.onRawPageChanged(widget.mapping.displayToProgressRaw(_displayIndex));
+    if (widget.window.isEmpty) {
+      _notifyIdle();
+      return;
+    }
+    final progress = widget.window.displayToChapterProgressRaw(_displayIndex);
+    if (progress != null) {
+      widget.onChapterPageChanged(progress.chapterId, progress.raw);
+    }
+    _notifyIdle();
   }
 
-  bool _isPreviousBoundary(int index) => index < 0;
-
-  bool _isNextBoundary(int index) => index >= widget.mapping.length;
-
-  bool _isBoundaryDisplay(int index) =>
-      _isPreviousBoundary(index) || _isNextBoundary(index);
-
-  bool _hasDisplayEntry(int index) {
-    if (index >= 0 && index < widget.mapping.length) return true;
-    if (index == -1) return widget.previousBoundary != null;
-    if (index == widget.mapping.length) return widget.nextBoundary != null;
-    return false;
+  /// True when [index] is a transition card or out of range — no zoom / pages /
+  /// long-press there.
+  bool _isTransitionSlot(int index) {
+    if (index < 0 || index >= widget.window.length) return true;
+    return widget.window.items[index] is! SpreadDisplay;
   }
+
+  /// The chapter shown at the current slot; scans outward when the slot is a
+  /// transition card so a seek still resolves to a chapter.
+  int? _currentChapterId() {
+    final here = widget.window.displayToChapterRaw(_displayIndex);
+    if (here != null) return here.chapterId;
+    for (var d = 1; d < widget.window.length; d++) {
+      final before = widget.window.displayToChapterRaw(_displayIndex - d);
+      if (before != null) return before.chapterId;
+      final after = widget.window.displayToChapterRaw(_displayIndex + d);
+      if (after != null) return after.chapterId;
+    }
+    return null;
+  }
+
+  bool _hasDisplayEntry(int index) =>
+      index >= 0 && index < widget.window.length;
 
   void _syncZoomBounds() {
     for (final controller in _zoomControllers.values) {
@@ -301,7 +356,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       : _viewportSize.height;
 
   _PageZoomController? get _currentZoomOrNull {
-    if (_isBoundaryDisplay(_displayIndex)) return null;
+    if (_isTransitionSlot(_displayIndex)) return null;
     return _zoomControllerFor(_displayIndex)
       ..configure(
         minScale: _minScale,
@@ -310,14 +365,16 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       );
   }
 
-  _PageZoomController _zoomControllerFor(int displayIndex) =>
-      _zoomControllers.putIfAbsent(
-        widget.mapping.entries[displayIndex].first,
-        () => _PageZoomController(
-          minScale: _minScale,
-          maxScale: _maxScale,
-        ),
-      );
+  _PageZoomController _zoomControllerFor(int displayIndex) {
+    final item = widget.window.items[displayIndex] as SpreadDisplay;
+    return _zoomControllers.putIfAbsent(
+      (chapterId: item.chapterId, unit: item.entry.first),
+      () => _PageZoomController(
+        minScale: _minScale,
+        maxScale: _maxScale,
+      ),
+    );
+  }
 
   void _onPointerDown(PointerDownEvent event) {
     // A touch that lands mid-settle is an interrupt, not a nav tap — remember
@@ -489,7 +546,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   }
 
   void _startLongPressTimer(Offset position) {
-    if (_isBoundaryDisplay(_displayIndex)) return;
+    if (_isTransitionSlot(_displayIndex)) return;
     _longPressTimer?.cancel();
     _longPressTimer = Timer(_longPressDelay, () {
       if (!mounted ||
@@ -674,14 +731,6 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
 
   void _settleDrag({double releaseVelocity = 0}) {
     if (_axisExtent <= 0) return;
-    final boundaryDirection =
-        _boundaryMoveDirection(releaseVelocity: releaseVelocity);
-    if (boundaryDirection != null) {
-      final movedChapter = _requestBoundaryMove(boundaryDirection);
-      if (!movedChapter) _animateOffsetTo(0);
-      return;
-    }
-
     final signedDistance = -_dragOffset * _axisSign;
     final signedVelocity = -releaseVelocity * _axisSign;
     if (signedDistance.abs() > _touchSlop &&
@@ -704,9 +753,9 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     _animateOffsetTo(0);
   }
 
-  // One display slot (single page or a full spread) always travels a full
-  // viewport, so the turn threshold is the full extent for both — halving it
-  // for spreads made them commit a turn at half the drag distance.
+  // One display slot (single page, spread, or transition card) always travels a
+  // full viewport, so the turn threshold is the full extent — halving it for
+  // spreads made them commit a turn at half the drag distance.
   double get _pageTurnExtent => _axisExtent;
 
   double _mainAxisDelta(Offset offset) =>
@@ -753,8 +802,16 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   }
 
   void _animateToDisplay(int targetDisplay) {
-    if (!_hasDisplayEntry(targetDisplay)) {
-      _animateThroughBoundary(targetDisplay < 0 ? -1 : 1);
+    // The window's OUTER edges just bounce (the host surfaces start/end-of-manga
+    // feedback). Interior transition cards are ordinary slots and page normally.
+    if (targetDisplay < 0) {
+      widget.onReachedStartEdge?.call();
+      _animateOffsetTo(0);
+      return;
+    }
+    if (targetDisplay >= widget.window.length) {
+      widget.onReachedEndEdge?.call();
+      _animateOffsetTo(0);
       return;
     }
     final delta = targetDisplay - _displayIndex;
@@ -773,52 +830,10 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     });
   }
 
-  void _animateThroughBoundary(int direction) {
-    // Only slide the page off-screen if there's a chapter to land on. Without
-    // this, reaching the last page of the last chapter animates the page fully
-    // out — flashing an empty slot — before discovering there's nowhere to go
-    // and bouncing back. When a chapter exists, keep the slide-then-navigate.
-    if (!_hasBoundaryChapter(direction)) {
-      _animateOffsetTo(0);
-      return;
-    }
-    final targetOffset = -direction * _axisSign * _axisExtent;
-    _animateOffsetTo(targetOffset, onComplete: () {
-      if (!mounted) return;
-      final movedChapter = _requestBoundaryMove(direction);
-      if (!movedChapter) _animateOffsetTo(0);
+  void _applyPagerDragDelta(double dragDelta) {
+    setState(() {
+      _dragOffset += dragDelta;
     });
-  }
-
-  bool _hasBoundaryChapter(int direction) {
-    final callbacks = ReaderInputScope.maybeOf(context);
-    if (callbacks == null) return false;
-    return direction < 0
-        ? callbacks.hasPreviousBoundary()
-        : callbacks.hasNextBoundary();
-  }
-
-  void _moveFromBoundary(int delta) {
-    if (_displayIndex < 0) {
-      if (delta < 0) {
-        _requestBoundaryMove(-1);
-      } else {
-        _animateToDisplay(0);
-      }
-      return;
-    }
-    if (delta > 0) {
-      _requestBoundaryMove(1);
-    } else {
-      _animateToDisplay(widget.mapping.length - 1);
-    }
-  }
-
-  bool _requestBoundaryMove(int direction) {
-    final callbacks = ReaderInputScope.maybeOf(context);
-    return direction < 0
-        ? callbacks?.onPreviousBoundary() ?? false
-        : callbacks?.onNextBoundary() ?? false;
   }
 
   void _animateOffsetTo(double target, {VoidCallback? onComplete}) {
@@ -826,9 +841,9 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     if (duration == Duration.zero || _axisExtent <= 0) {
       setState(() => _dragOffset = target == 0 ? 0 : target);
       onComplete?.call();
-      // onComplete may navigate to another chapter (pushReplacement) and tear
-      // this down — don't setState afterwards if we're gone.
+      // onComplete may re-anchor/tear down — don't setState afterwards if gone.
       if (target != 0 && mounted) setState(() => _dragOffset = 0);
+      if (target == 0) _notifyIdle();
       return;
     }
     _pageAnimation
@@ -842,41 +857,10 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     _pageAnimation.forward().whenCompleteOrCancel(() {
       if (!mounted) return;
       onComplete?.call();
-      if (target == 0) setState(() => _dragOffset = 0);
-    });
-  }
-
-  int? _boundaryMoveDirection({double releaseVelocity = 0}) {
-    if (!_isBoundaryDisplay(_displayIndex)) return null;
-
-    final signedDistance = -_mainAxisDelta(_totalDrag) * _axisSign;
-    final signedVelocity = -releaseVelocity * _axisSign;
-    final signedProgress = signedDistance / _axisExtent;
-
-    if (_isNextBoundary(_displayIndex) &&
-        (signedProgress > _pageTurnThreshold ||
-            signedVelocity > _pageTurnVelocity)) {
-      return 1;
-    }
-    if (_isPreviousBoundary(_displayIndex) &&
-        (signedProgress < -_pageTurnThreshold ||
-            signedVelocity < -_pageTurnVelocity)) {
-      return -1;
-    }
-    return null;
-  }
-
-  double _clampBoundaryOverrun(double offset) {
-    if (!_isBoundaryDisplay(_displayIndex)) return offset;
-    final signedDistance = -offset * _axisSign;
-    if (_isNextBoundary(_displayIndex) && signedDistance > 0) return 0;
-    if (_isPreviousBoundary(_displayIndex) && signedDistance < 0) return 0;
-    return offset;
-  }
-
-  void _applyPagerDragDelta(double dragDelta) {
-    setState(() {
-      _dragOffset = _clampBoundaryOverrun(_dragOffset + dragDelta);
+      if (target == 0) {
+        setState(() => _dragOffset = 0);
+        _notifyIdle();
+      }
     });
   }
 
@@ -909,7 +893,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
 
   @override
   Widget build(BuildContext context) {
-    if (widget.mapping.isEmpty || widget.pages.isEmpty) {
+    if (widget.window.isEmpty) {
       return const Center(child: CenterSorayomiShimmerIndicator());
     }
     return LayoutBuilder(
@@ -957,24 +941,24 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       (index - _displayIndex) * _axisExtent * _axisSign + _dragOffset;
 
   Widget _buildDisplayEntry(int index) {
-    if (index == -1) {
-      return widget.previousBoundary ?? const SizedBox.shrink();
+    final item = widget.window.items[index];
+    if (item is TransitionDisplay) {
+      return widget.transitionBuilder(item);
     }
-    if (index == widget.mapping.length) {
-      return widget.nextBoundary ?? const SizedBox.shrink();
-    }
+    final spread = item as SpreadDisplay;
     return _ZoomedDisplayEntry(
       controller: _zoomControllerFor(index),
       child: DoublePageView(
-        entry: widget.mapping.entries[index],
-        pages: widget.pages,
+        entry: spread.entry,
+        pages: widget.window.pagesAt(index)!,
         pageFit: widget.pageFit,
         pageSize: widget.pageSize,
         centerMargin: widget.centerMargin,
         rotateWide: widget.rotateWide,
         rotateWideInvert: widget.rotateWideInvert,
         reversePair: widget.reversePair,
-        onPageWide: widget.onPageWide,
+        onPageWide: (raw, wide) =>
+            widget.onPageWide(spread.chapterId, raw, wide),
         cropBorders: widget.cropBorders,
       ),
     );

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -143,6 +143,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   static const Duration _maxSettleDuration = Duration(milliseconds: 180);
   static const Duration _minSettleDuration = Duration(milliseconds: 70);
   static const Duration _panFlingDuration = Duration(milliseconds: 400);
+  static const Duration _doubleTapZoomDuration = Duration(milliseconds: 200);
   static const Curve _settleCurve = Curves.easeOutCubic;
 
   late int _displayIndex;
@@ -177,6 +178,10 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   VelocityTracker? _velocityTracker;
   int? _velocityPointer;
   _PageZoomController? _panAnimationTarget;
+  late final AnimationController _zoomAnimation;
+  Animation<double>? _zoomScaleTween;
+  Animation<Offset>? _zoomOffsetTween;
+  _PageZoomController? _zoomAnimationTarget;
 
   @override
   void initState() {
@@ -204,6 +209,22 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
           status == AnimationStatus.dismissed) {
         _panTween = null;
         _panAnimationTarget = null;
+      }
+    });
+    _zoomAnimation = AnimationController(vsync: this);
+    _zoomAnimation.addListener(() {
+      final target = _zoomAnimationTarget;
+      final scale = _zoomScaleTween?.value;
+      final offset = _zoomOffsetTween?.value;
+      if (target == null || scale == null || offset == null) return;
+      target.setScaleOffset(scale, offset);
+    });
+    _zoomAnimation.addStatusListener((status) {
+      if (status == AnimationStatus.completed ||
+          status == AnimationStatus.dismissed) {
+        _zoomScaleTween = null;
+        _zoomOffsetTween = null;
+        _zoomAnimationTarget = null;
       }
     });
     widget.controller._attach(this);
@@ -234,6 +255,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     widget.controller._detach(this);
     _pageAnimation.dispose();
     _panAnimation.dispose();
+    _zoomAnimation.dispose();
     _longPressTimer?.cancel();
     _singleTapTimer?.cancel();
     for (final controller in _zoomControllers.values) {
@@ -394,6 +416,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     }
     _pageAnimation.stop();
     _stopPanAnimation();
+    _stopZoomAnimation();
     _singleTapTimer?.cancel();
     _pointers[event.pointer] = event.localPosition;
     if (_pointers.length == 1) {
@@ -653,7 +676,24 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     final target = zoom.scale > _neutralScale + 0.05
         ? _neutralScale
         : math.min(2.0, _maxScale);
-    zoom.setScaleAround(target, position);
+    _animateZoomTo(zoom, zoom.scaleAroundTarget(target, position));
+  }
+
+  /// Animate a page's zoom to a target scale/offset (double-tap), so it eases
+  /// in instead of snapping — matching the webtoon reader's zoom feel.
+  void _animateZoomTo(
+      _PageZoomController zoom, ({double scale, Offset offset}) end) {
+    _zoomAnimation.stop();
+    _zoomAnimationTarget = zoom;
+    _zoomScaleTween = Tween<double>(begin: zoom.scale, end: end.scale).animate(
+        CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic));
+    _zoomOffsetTween = Tween<Offset>(begin: zoom.offset, end: end.offset)
+        .animate(
+            CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic));
+    _zoomAnimation
+      ..duration = _doubleTapZoomDuration
+      ..reset()
+      ..forward();
   }
 
   void _handleSingleTap(Offset position) {
@@ -807,6 +847,14 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     _panAnimation.stop();
     _panTween = null;
     _panAnimationTarget = null;
+  }
+
+  void _stopZoomAnimation() {
+    if (!_zoomAnimation.isAnimating) return;
+    _zoomAnimation.stop();
+    _zoomScaleTween = null;
+    _zoomOffsetTween = null;
+    _zoomAnimationTarget = null;
   }
 
   void _animateToDisplay(int targetDisplay) {
@@ -1069,18 +1117,28 @@ class _PageZoomController extends ChangeNotifier {
   }
 
   void setScaleAround(double targetScale, Offset focal) {
+    final t = scaleAroundTarget(targetScale, focal);
+    setScaleOffset(t.scale, t.offset);
+  }
+
+  /// The (scale, offset) that [setScaleAround] would land on — without applying
+  /// it, so the viewport can animate toward it.
+  ({double scale, Offset offset}) scaleAroundTarget(
+      double targetScale, Offset focal) {
     final nextScale = targetScale.clamp(minScale, maxScale).toDouble();
-    if (nextScale <= 1.001) {
-      _scale = nextScale;
-      _offset = Offset.zero;
-      notifyListeners();
-      return;
-    }
+    if (nextScale <= 1.001) return (scale: nextScale, offset: Offset.zero);
     final scaleRatio = nextScale / _scale;
     final viewportCenter = Offset(_viewport.width / 2, _viewport.height / 2);
     final focalFromCenter = focal - viewportCenter - _offset;
-    _scale = nextScale;
-    _offset = _clampOffset(_offset - focalFromCenter * (scaleRatio - 1));
+    return (
+      scale: nextScale,
+      offset: _clampOffset(_offset - focalFromCenter * (scaleRatio - 1)),
+    );
+  }
+
+  void setScaleOffset(double scale, Offset offset) {
+    _scale = scale.clamp(minScale, maxScale).toDouble();
+    _offset = _scale <= 1.001 ? Offset.zero : _clampOffset(offset);
     notifyListeners();
   }
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -251,8 +251,16 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       target =
           widget.window.chapterRawToDisplay(item.chapterId, item.entry.first.raw);
     } else if (item is TransitionDisplay) {
-      final anchor = item.toChapterId ?? item.fromChapterId;
-      if (anchor != null) target = widget.window.firstDisplayOf(anchor);
+      // Anchor to the chapter being ENTERED (its first page). For an
+      // end-of-window "next chapter" card that doesn't know its target yet, fall
+      // back to the LAST page of the chapter just finished — never its first,
+      // which would throw the reader back to that chapter's start.
+      if (item.toChapterId != null) {
+        target = widget.window.firstDisplayOf(item.toChapterId!);
+      }
+      if (target < 0 && item.fromChapterId != null) {
+        target = widget.window.lastDisplayOf(item.fromChapterId!);
+      }
     }
     _displayIndex =
         target >= 0 ? target : _clampDisplay(widget.initialDisplayIndex);

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -683,7 +683,14 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   /// in instead of snapping — matching the webtoon reader's zoom feel.
   void _animateZoomTo(
       _PageZoomController zoom, ({double scale, Offset offset}) end) {
-    _zoomAnimation.stop();
+    // reset() drives the controller to `dismissed`, which fires the status
+    // listener that clears these tweens — so it has to run BEFORE we build them.
+    // A second double-tap arrives with the controller sitting at `completed`, so
+    // resetting after assignment would null the tweens it just created and the
+    // zoom would never animate (page stuck zoomed).
+    _zoomAnimation
+      ..stop()
+      ..reset();
     _zoomAnimationTarget = zoom;
     _zoomScaleTween = Tween<double>(begin: zoom.scale, end: end.scale).animate(
         CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic));
@@ -692,7 +699,6 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
             CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic));
     _zoomAnimation
       ..duration = _doubleTapZoomDuration
-      ..reset()
       ..forward();
   }
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
@@ -20,6 +20,7 @@ import '../../controller/reader_settings_model.dart';
 import '../../utils/reader_initial_page.dart';
 import '../reader_wrapper.dart';
 import 'infinity_continuous/infinity_continuous_feedback.dart';
+import 'paged_display_window.dart';
 import 'paged_reader_viewport.dart';
 import 'paged_spread_mapping.dart';
 
@@ -28,6 +29,10 @@ import 'paged_spread_mapping.dart';
 Duration pagedNavDuration({required bool animate}) =>
     animate ? kDuration : kInstantDuration;
 
+/// Single-chapter paged host (fallback). The primary paged path is
+/// [MultiChapterPagedReaderMode], which crosses chapter boundaries seamlessly;
+/// this variant wraps a one-chapter [PagedDisplayWindow] and relies on the
+/// wrapper's `pushReplacement` boundary crossing.
 class SinglePageReaderMode extends HookConsumerWidget {
   const SinglePageReaderMode({
     super.key,
@@ -90,18 +95,37 @@ class SinglePageReaderMode extends HookConsumerWidget {
       ],
     );
 
+    final showChapterTransition = settings.alwaysShowChapterTransition;
+    final window = useMemoized(
+      () => buildPagedDisplayWindow(
+        chapters: [
+          WindowChapter(
+            chapterId: chapter.id,
+            chapterName: chapter.name,
+            mapping: mapping,
+            pages: chapterPages.pages,
+          ),
+        ],
+        forceTransition: false,
+        leadingTransition: showChapterTransition,
+        trailingTransition: showChapterTransition,
+      ),
+      [mapping, chapterPages.pages, showChapterTransition, chapter.id],
+    );
+
     final initialRaw = readerInitialPageIndex(
       chapter: chapter,
       chapterPages: chapterPages,
       openAtEnd: openAtEnd,
     );
-    final initialDisplay = mapping.rawToDisplay(initialRaw);
+    final rawToDisplay = window.chapterRawToDisplay(chapter.id, initialRaw);
+    final initialDisplay =
+        rawToDisplay >= 0 ? rawToDisplay : window.firstDisplayOf(chapter.id);
     // Seed the tracked page from the initial spread's furthest page so the
     // viewport's mount emit (which reports that page) doesn't rewind the
     // seekbar or double-fire onPageChanged.
-    final initialProgressRaw = mapping.isEmpty
-        ? initialRaw
-        : mapping.displayToProgressRaw(initialDisplay);
+    final initialProgressRaw =
+        window.displayToChapterProgressRaw(initialDisplay)?.raw ?? initialRaw;
     final currentIndex = useState(initialProgressRaw);
 
     useEffect(() {
@@ -121,7 +145,7 @@ class SinglePageReaderMode extends HookConsumerWidget {
       return null;
     }, [currentIndex.value, chapterPages.pages.length]);
 
-    void onPageWide(int raw, bool wide) {
+    void onPageWide(int chapterId, int raw, bool wide) {
       if (!wide || widePages.value.contains(raw)) return;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!context.mounted || widePages.value.contains(raw)) return;
@@ -137,7 +161,6 @@ class SinglePageReaderMode extends HookConsumerWidget {
       currentIndex.value,
       reversePair: reversePair,
     );
-    final showChapterTransition = settings.alwaysShowChapterTransition;
     final wrapperReaderMode =
         effectiveReaderMode ?? _singlePageReaderMode(scrollDirection, reverse);
 
@@ -158,8 +181,7 @@ class SinglePageReaderMode extends HookConsumerWidget {
       effectiveReaderMode: wrapperReaderMode,
       child: PagedReaderViewport(
         controller: controller,
-        mapping: mapping,
-        pages: chapterPages.pages,
+        window: window,
         initialDisplayIndex: initialDisplay,
         axis: scrollDirection,
         reverse: reverse,
@@ -172,27 +194,19 @@ class SinglePageReaderMode extends HookConsumerWidget {
         reversePair: reversePair,
         cropBorders: settings.cropBorders,
         onPageWide: onPageWide,
-        onRawPageChanged: (raw) {
+        onChapterPageChanged: (chapterId, raw) {
           if (raw == currentIndex.value) return;
           currentIndex.value = raw;
         },
+        transitionBuilder: (t) => _PagedChapterTransition(
+          chapterName: chapter.name,
+          isChapterStart: !t.isEnd,
+        ),
         pinchEnabled: settings.pinchToZoom,
         doubleTapToZoom: settings.doubleTapToZoom,
         disableZoomIn: false,
         disableZoomOut: settings.disableZoomOut,
         navigateToPan: settings.navigateToPan,
-        previousBoundary: showChapterTransition
-            ? _PagedChapterTransition(
-                chapterName: chapter.name,
-                isChapterStart: true,
-              )
-            : null,
-        nextBoundary: showChapterTransition
-            ? _PagedChapterTransition(
-                chapterName: chapter.name,
-                isChapterStart: false,
-              )
-            : null,
       ),
     );
   }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -140,6 +140,7 @@ class ReaderWrapper extends HookConsumerWidget {
     this.isAtLastBoundary,
     this.spreadPageIndexes,
     this.effectiveReaderMode,
+    this.handlesOwnChapterNavigation = false,
   });
   final Widget child;
   final MangaDto manga;
@@ -158,6 +159,12 @@ class ReaderWrapper extends HookConsumerWidget {
   final bool Function()? isAtLastBoundary;
   final List<int>? spreadPageIndexes;
   final ReaderMode? effectiveReaderMode;
+
+  /// When true the child (a multi-chapter host) crosses chapter boundaries
+  /// itself inside one continuous pager, so the reading-flow boundary must NOT
+  /// `pushReplacement` a fresh chapter — it falls through to the child's
+  /// onNext/onPrevious instead.
+  final bool handlesOwnChapterNavigation;
 
   bool _shouldUseVerticalTransition(ReaderMode readerMode) {
     switch (readerMode) {
@@ -423,11 +430,15 @@ class ReaderWrapper extends HookConsumerWidget {
     }
 
     bool tryNextChapter() {
+      // Host owns in-window chapter crossing: don't push a fresh route; let the
+      // reading-flow boundary fall through to the child's controller.
+      if (handlesOwnChapterNavigation) return false;
       if (!canSwipeAcrossChapterBoundary) return false;
       return pushNextChapter();
     }
 
     bool tryPreviousChapter() {
+      if (handlesOwnChapterNavigation) return false;
       if (!canSwipeAcrossChapterBoundary) return false;
       return pushPreviousChapter();
     }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -61,6 +61,8 @@ class ReaderInputCallbacks {
     required this.navigationLayout,
     required this.tapInvert,
     required this.smallerTapZones,
+    this.hasNextBoundary = _noBoundaryNavigation,
+    this.hasPreviousBoundary = _noBoundaryNavigation,
   });
 
   final VoidCallback onTap;
@@ -75,6 +77,12 @@ class ReaderInputCallbacks {
   final ReaderNavigationLayout navigationLayout;
   final TapInvert tapInvert;
   final bool smallerTapZones;
+
+  /// Whether an adjacent chapter exists to move to — lets the paged viewport
+  /// decide before animating, so it doesn't slide a page fully off-screen only
+  /// to bounce back when there's no chapter there.
+  final bool Function() hasNextBoundary;
+  final bool Function() hasPreviousBoundary;
 }
 
 class ReaderInputScope extends InheritedWidget {
@@ -546,6 +554,12 @@ class ReaderWrapper extends HookConsumerWidget {
                           onPrevious: onReaderPrevious,
                           onNextBoundary: tryNextChapter,
                           onPreviousBoundary: tryPreviousChapter,
+                          hasNextBoundary: () =>
+                              canSwipeAcrossChapterBoundary &&
+                              nextPrevChapterPair?.first != null,
+                          hasPreviousBoundary: () =>
+                              canSwipeAcrossChapterBoundary &&
+                              nextPrevChapterPair?.second != null,
                           mangaReaderNavigationLayout:
                               mangaReaderNavigationLayout,
                           mangaTapInvert: mangaTapInvert,
@@ -821,6 +835,8 @@ class ReaderView extends HookConsumerWidget {
     this.mangaTapInvert,
     this.onNextBoundary = _noBoundaryNavigation,
     this.onPreviousBoundary = _noBoundaryNavigation,
+    this.hasNextBoundary = _noBoundaryNavigation,
+    this.hasPreviousBoundary = _noBoundaryNavigation,
     required this.readerSwipeChapterToggle,
     required this.lastPageSwipeEnabled,
     required this.resolvedReaderMode,
@@ -842,6 +858,8 @@ class ReaderView extends HookConsumerWidget {
   final VoidCallback onPrevious;
   final bool Function() onNextBoundary;
   final bool Function() onPreviousBoundary;
+  final bool Function() hasNextBoundary;
+  final bool Function() hasPreviousBoundary;
   final ({ChapterDto? first, ChapterDto? second})? prevNextChapterPair;
   final ReaderNavigationLayout mangaReaderNavigationLayout;
   final TapInvert? mangaTapInvert;
@@ -952,6 +970,8 @@ class ReaderView extends HookConsumerWidget {
           onPrevious: onPrevious,
           onNextBoundary: onNextBoundary,
           onPreviousBoundary: onPreviousBoundary,
+          hasNextBoundary: hasNextBoundary,
+          hasPreviousBoundary: hasPreviousBoundary,
           navigationLayout: layout,
           tapInvert: tapInvert,
           smallerTapZones: smallerTapZones,

--- a/test/src/features/manga_book/reader/multichapter_paged_crossing_test.dart
+++ b/test/src/features/manga_book/reader/multichapter_paged_crossing_test.dart
@@ -6,6 +6,7 @@
 
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -58,7 +59,74 @@ ReaderInputCallbacks _callbacks() => ReaderInputCallbacks(
       smallerTapZones: false,
     );
 
+double _largestScale(WidgetTester tester) {
+  var best = 1.0;
+  for (final t in tester.widgetList<Transform>(find.byType(Transform))) {
+    final s = t.transform.storage;
+    final sx = math.sqrt(s[0] * s[0] + s[1] * s[1]);
+    if (sx > best) best = sx;
+  }
+  return best;
+}
+
 void main() {
+  testWidgets('double-tap zoom animates instead of snapping', (tester) async {
+    final window = buildPagedDisplayWindow(
+      chapters: [_chapter(1, 1)],
+      forceTransition: false,
+    );
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReaderInputScope(
+          callbacks: _callbacks(),
+          child: SizedBox(
+            width: 300,
+            height: 500,
+            child: PagedReaderViewport(
+              controller: PagedReaderController(),
+              window: window,
+              initialDisplayIndex: 0,
+              axis: Axis.horizontal,
+              reverse: false,
+              animateTransitions: true,
+              pageFit: BoxFit.contain,
+              pageSize: null,
+              centerMargin: CenterMarginType.none,
+              rotateWide: false,
+              rotateWideInvert: false,
+              reversePair: false,
+              cropBorders: false,
+              onPageWide: (_, __, ___) {},
+              onChapterPageChanged: (_, __) {},
+              transitionBuilder: (_) => const SizedBox.shrink(),
+              pinchEnabled: true,
+              doubleTapToZoom: true,
+              disableZoomIn: false,
+              disableZoomOut: false,
+              navigateToPan: true,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final center = tester.getCenter(find.byType(PagedReaderViewport));
+    await tester.tapAt(center);
+    await tester.pump(const Duration(milliseconds: 40));
+    await tester.tapAt(center); // second tap → double-tap-to-zoom
+    // Part-way through the 200ms zoom: scaled up, but not yet at the 2x target.
+    await tester.pump(const Duration(milliseconds: 1));
+    await tester.pump(const Duration(milliseconds: 90));
+    final mid = _largestScale(tester);
+    expect(mid, greaterThan(1.02), reason: 'zoom did not start ($mid)');
+    expect(mid, lessThan(1.98), reason: 'zoom snapped instantly ($mid)');
+
+    await tester.pumpAndSettle();
+    expect(_largestScale(tester), closeTo(2.0, 0.05));
+  });
+
   testWidgets('paging crosses from chapter 1 into chapter 2 in one window',
       (tester) async {
     // Both chapters already loaded, seamless (no transition between them).

--- a/test/src/features/manga_book/reader/multichapter_paged_crossing_test.dart
+++ b/test/src/features/manga_book/reader/multichapter_paged_crossing_test.dart
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_display_window.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_spread_mapping.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart';
+
+const _png1x1 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+List<String> _localPages(int count, String tag) {
+  final dir = Directory.systemTemp.createTempSync('tsumiru-mc-$tag-');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final bytes = base64Decode(_png1x1);
+  return [
+    for (var i = 0; i < count; i++)
+      (File('${dir.path}/$i.png')..writeAsBytesSync(bytes)).uri.toString(),
+  ];
+}
+
+WindowChapter _chapter(int id, int pageCount) => WindowChapter(
+      chapterId: id,
+      chapterName: 'Chapter $id',
+      mapping: buildSpreadMapping(
+        pageCount: pageCount,
+        doublePages: false,
+        splitWide: false,
+        splitInvert: false,
+        isWide: (_) => false,
+      ),
+      pages: _localPages(pageCount, 'c$id'),
+    );
+
+ReaderInputCallbacks _callbacks() => ReaderInputCallbacks(
+      onTap: () {},
+      onLongPressStart: (_) {},
+      onLongPressMoveUpdate: (_) {},
+      onLongPressEnd: () {},
+      onLongPressCancel: () {},
+      onNext: () {},
+      onPrevious: () {},
+      onNextBoundary: () => false,
+      onPreviousBoundary: () => false,
+      navigationLayout: ReaderNavigationLayout.disabled,
+      tapInvert: TapInvert.none,
+      smallerTapZones: false,
+    );
+
+void main() {
+  testWidgets('paging crosses from chapter 1 into chapter 2 in one window',
+      (tester) async {
+    // Both chapters already loaded, seamless (no transition between them).
+    final window = buildPagedDisplayWindow(
+      chapters: [_chapter(1, 3), _chapter(2, 3)],
+      forceTransition: false,
+    );
+    // items: c1:0 c1:1 c1:2 c2:0 c2:1 c2:2  (6 slots)
+    expect(window.length, 6);
+
+    final reported = <({int chapterId, int raw})>[];
+    final controller = PagedReaderController();
+
+    final viewport = ReaderInputScope(
+      callbacks: _callbacks(),
+      child: SizedBox(
+        width: 300,
+        height: 500,
+        child: PagedReaderViewport(
+          controller: controller,
+          window: window,
+          initialDisplayIndex: 0,
+          axis: Axis.horizontal,
+          reverse: false,
+          animateTransitions: false,
+          pageFit: BoxFit.contain,
+          pageSize: null,
+          centerMargin: CenterMarginType.none,
+          rotateWide: false,
+          rotateWideInvert: false,
+          reversePair: false,
+          cropBorders: false,
+          onPageWide: (_, __, ___) {},
+          onChapterPageChanged: (chapterId, raw) =>
+              reported.add((chapterId: chapterId, raw: raw)),
+          transitionBuilder: (_) => const SizedBox.shrink(),
+          pinchEnabled: true,
+          doubleTapToZoom: true,
+          disableZoomIn: false,
+          disableZoomOut: false,
+          navigateToPan: true,
+        ),
+      ),
+    );
+    await tester.pumpWidget(
+      Directionality(textDirection: TextDirection.ltr, child: viewport),
+    );
+    await tester.pump();
+
+    // Fling forward five times: c1:0 -> c1:1 -> c1:2 -> c2:0 -> c2:1 -> c2:2.
+    for (var i = 0; i < 5; i++) {
+      await tester.timedDrag(
+        find.byType(PagedReaderViewport),
+        const Offset(-90, 0),
+        const Duration(milliseconds: 80),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    // We must have crossed into chapter 2.
+    expect(reported.any((e) => e.chapterId == 2), isTrue,
+        reason: 'paging never crossed into chapter 2; reported=$reported');
+    // And landed on chapter 2's last page.
+    expect(reported.last, (chapterId: 2, raw: 2));
+  });
+
+  testWidgets('a window swap while on a boundary card does not jump to start',
+      (tester) async {
+    final reported = <({int chapterId, int raw})>[];
+    final controller = PagedReaderController();
+
+    Widget viewportWith(PagedDisplayWindow window) => ReaderInputScope(
+          callbacks: _callbacks(),
+          child: SizedBox(
+            width: 300,
+            height: 500,
+            child: PagedReaderViewport(
+              controller: controller,
+              window: window,
+              initialDisplayIndex: 0,
+              axis: Axis.horizontal,
+              reverse: false,
+              animateTransitions: false,
+              pageFit: BoxFit.contain,
+              pageSize: null,
+              centerMargin: CenterMarginType.none,
+              rotateWide: false,
+              rotateWideInvert: false,
+              reversePair: false,
+              cropBorders: false,
+              onPageWide: (_, __, ___) {},
+              onChapterPageChanged: (chapterId, raw) =>
+                  reported.add((chapterId: chapterId, raw: raw)),
+              transitionBuilder: (_) => const SizedBox.shrink(),
+              pinchEnabled: true,
+              doubleTapToZoom: true,
+              disableZoomIn: false,
+              disableZoomOut: false,
+              navigateToPan: true,
+            ),
+          ),
+        );
+
+    // Only chapter 1 loaded, with a trailing "next chapter" card at the edge.
+    final window1 = buildPagedDisplayWindow(
+      chapters: [_chapter(1, 2)],
+      forceTransition: false,
+      trailingTransition: true,
+    );
+    // items: c1:0 c1:1 T(end)  (3 slots)
+    await tester.pumpWidget(
+      Directionality(textDirection: TextDirection.ltr, child: viewportWith(window1)),
+    );
+    await tester.pump();
+
+    // Page forward onto the last real page, then onto the trailing card.
+    for (var i = 0; i < 2; i++) {
+      await tester.timedDrag(
+        find.byType(PagedReaderViewport),
+        const Offset(-90, 0),
+        const Duration(milliseconds: 80),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    // Now chapter 2 loads in — swap the window.
+    final window2 = buildPagedDisplayWindow(
+      chapters: [_chapter(1, 2), _chapter(2, 2)],
+      forceTransition: false,
+    );
+    reported.clear();
+    await tester.pumpWidget(
+      Directionality(textDirection: TextDirection.ltr, child: viewportWith(window2)),
+    );
+    await tester.pumpAndSettle();
+
+    // The re-anchor must keep us at the boundary (end of ch1 / start of ch2),
+    // NOT throw us back to chapter 1 page 0.
+    expect(reported.isNotEmpty, isTrue);
+    expect(reported.last, isNot((chapterId: 1, raw: 0)),
+        reason: 're-anchor jumped to the start; reported=$reported');
+  });
+}

--- a/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
+++ b/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
@@ -211,4 +211,81 @@ void main() {
       reason: 'chapter 1 was not marked read on the forward crossing',
     );
   });
+
+  Future<_RecordingRepo> _pumpSingleChapter(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    SharedPreferences.setMockInitialValues(const {});
+    final prefs = await SharedPreferences.getInstance();
+    final repo = _RecordingRepo();
+    final ch1 = _chapter(id: 1, sourceOrder: 1, pageCount: 3);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          mangaBookRepositoryProvider.overrideWithValue(repo),
+          mangaWithIdProvider(mangaId: 1)
+              .overrideWith(() => _FakeMangaWithId(_manga())),
+          chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
+          chapterPagesProvider(chapterId: 1)
+              .overrideWith((ref) => _pages(1, 3)),
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+              .overrideWithValue(null),
+          trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
+          updateProgressAfterReadingProvider
+              .overrideWith(() => _FixedToggle(false)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ReaderScreen(mangaId: 1, chapterId: 1),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return repo;
+  }
+
+  testWidgets('saves the visible page after the debounce', (tester) async {
+    final repo = await _pumpSingleChapter(tester);
+
+    // Turn to page 2 (index 1).
+    await tester.timedDrag(find.byType(PagedReaderViewport),
+        const Offset(-400, 0), const Duration(milliseconds: 80));
+    await tester.pumpAndSettle();
+    expect(find.text('2 / 3'), findsOneWidget);
+
+    // Let the 2s progress debounce fire.
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(
+      repo.putChapterCalls.any((c) =>
+          c.chapterId == 1 && c.patch.lastPageRead == 1 && c.patch.isRead == false),
+      isTrue,
+      reason: 'debounced progress for page 2 was not saved; ${repo.putChapterCalls}',
+    );
+  });
+
+  testWidgets('flushes the visible page on exit before the debounce fires',
+      (tester) async {
+    final repo = await _pumpSingleChapter(tester);
+
+    await tester.timedDrag(find.byType(PagedReaderViewport),
+        const Offset(-400, 0), const Duration(milliseconds: 80));
+    await tester.pumpAndSettle();
+    expect(find.text('2 / 3'), findsOneWidget);
+
+    // Leave the reader well within the 2s debounce window.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(
+      repo.putChapterCalls.any((c) => c.chapterId == 1 && c.patch.lastPageRead == 1),
+      isTrue,
+      reason: 'progress was not flushed on exit; ${repo.putChapterCalls}',
+    );
+  });
 }

--- a/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
+++ b/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_page/chapter_page_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/reader_screen.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/domain/tracking_settings_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+const _png1x1 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+class _FakeMangaWithId extends MangaWithId {
+  _FakeMangaWithId(this.manga);
+  final MangaDto? manga;
+  @override
+  Future<MangaDto?> build({required int mangaId}) async => manga;
+}
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _FakeTrackerRepository extends TrackerRepository {
+  _FakeTrackerRepository() : super(_dummyClient());
+  @override
+  Future<void> trackProgress(int mangaId) async {}
+}
+
+class _FixedToggle extends UpdateProgressAfterReading {
+  _FixedToggle(this._value);
+  final bool _value;
+  @override
+  bool? build() => _value;
+}
+
+class _RecordingRepo extends Fake implements MangaBookRepository {
+  final putChapterCalls = <({int chapterId, ChapterChange patch})>[];
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {
+    putChapterCalls.add((chapterId: chapterId, patch: patch));
+  }
+}
+
+List<String> _localPages(int count, String tag) {
+  final dir = Directory.systemTemp.createTempSync('tsumiru-e2e-$tag-');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final bytes = base64Decode(_png1x1);
+  return [
+    for (var i = 0; i < count; i++)
+      (File('${dir.path}/$i.png')..writeAsBytesSync(bytes)).uri.toString(),
+  ];
+}
+
+MangaDto _manga() => Fragment$MangaDto(
+      id: 1,
+      title: 'Test Manga',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 2),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: ReaderMode.singleHorizontalLTR.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 2,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
+
+ChapterDto _chapter({
+  required int id,
+  required int sourceOrder,
+  required int pageCount,
+}) =>
+    Fragment$ChapterDto(
+      chapterNumber: sourceOrder.toDouble(),
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: 'Chapter $id',
+      pageCount: pageCount,
+      sourceOrder: sourceOrder,
+      uploadDate: '0',
+      url: '/chapter/$id',
+      meta: const [],
+    );
+
+ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
+      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+      pages: _localPages(count, 'c$id'),
+    );
+
+void main() {
+  testWidgets('paged reader loads and crosses into the next chapter in-place',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    SharedPreferences.setMockInitialValues(const {});
+    final prefs = await SharedPreferences.getInstance();
+    final repo = _RecordingRepo();
+
+    final ch1 = _chapter(id: 1, sourceOrder: 1, pageCount: 3);
+    final ch2 = _chapter(id: 2, sourceOrder: 2, pageCount: 2);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          mangaBookRepositoryProvider.overrideWithValue(repo),
+          mangaWithIdProvider(mangaId: 1)
+              .overrideWith(() => _FakeMangaWithId(_manga())),
+          chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
+          chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
+          chapterPagesProvider(chapterId: 1)
+              .overrideWith((ref) => _pages(1, 3)),
+          chapterPagesProvider(chapterId: 2)
+              .overrideWith((ref) => _pages(2, 2)),
+          // Chapter 1 has a next (chapter 2); chapter 2 has a previous (1).
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+              .overrideWithValue((first: ch2, second: null)),
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
+              .overrideWithValue((first: null, second: ch1)),
+          // Keep the external tracker path inert in the test.
+          trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
+          updateProgressAfterReadingProvider.overrideWith(() => _FixedToggle(false)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ReaderScreen(mangaId: 1, chapterId: 1),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Opens on chapter 1 (3 pages).
+    expect(find.text('1 / 3'), findsOneWidget);
+
+    // Read forward through chapter 1. The host preloads chapter 2 near the edge,
+    // commits the window swap on idle, and paging flows straight into it.
+    for (var i = 0; i < 6; i++) {
+      await tester.timedDrag(
+        find.byType(PagedReaderViewport),
+        const Offset(-400, 0),
+        const Duration(milliseconds: 80),
+      );
+      await tester.pumpAndSettle();
+      // Let the async chapter load + idle-gated commit settle.
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.pumpAndSettle();
+    }
+
+    expect(tester.takeException(), isNull);
+
+    // We must have crossed into chapter 2 — its page count (2) now drives the
+    // seekbar, which never shows "/ 2" while reading the 3-page chapter 1.
+    expect(find.textContaining('/ 2'), findsOneWidget,
+        reason: 'reader never crossed into chapter 2');
+
+    // Crossing the boundary forward marks chapter 1 read.
+    expect(
+      repo.putChapterCalls.any((c) => c.chapterId == 1 && c.patch.isRead == true),
+      isTrue,
+      reason: 'chapter 1 was not marked read on the forward crossing',
+    );
+  });
+}

--- a/test/src/features/manga_book/reader/paged_display_window_test.dart
+++ b/test/src/features/manga_book/reader/paged_display_window_test.dart
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_display_window.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_spread_mapping.dart';
+
+/// Build a loaded chapter with [pageCount] pages, page URLs like `cID-pN`.
+WindowChapter chapter(
+  int id, {
+  required int pageCount,
+  bool doublePages = false,
+  bool hasGapBefore = false,
+}) {
+  return WindowChapter(
+    chapterId: id,
+    chapterName: 'Chapter $id',
+    mapping: buildSpreadMapping(
+      pageCount: pageCount,
+      doublePages: doublePages,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    ),
+    pages: [for (var i = 0; i < pageCount; i++) 'c$id-p$i'],
+    hasGapBefore: hasGapBefore,
+  );
+}
+
+/// Compact description of each display slot: "cID:raw" for a spread's primary
+/// raw, or "T(from>to)" for a transition.
+List<String> shape(PagedDisplayWindow w) => [
+      for (final item in w.items)
+        switch (item) {
+          SpreadDisplay(:final chapterId, :final entry) =>
+            'c$chapterId:${entry.primaryRaw}',
+          TransitionDisplay(:final fromChapterId, :final toChapterId) =>
+            'T($fromChapterId>$toChapterId)',
+        },
+    ];
+
+void main() {
+  group('single chapter — no transitions', () {
+    test('spreads only, addressing round-trips', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [chapter(7, pageCount: 3)],
+        forceTransition: false,
+      );
+      expect(w.length, 3);
+      expect(shape(w), ['c7:0', 'c7:1', 'c7:2']);
+      for (var raw = 0; raw < 3; raw++) {
+        expect(w.chapterRawToDisplay(7, raw), raw);
+        expect(w.displayToChapterRaw(raw), (chapterId: 7, raw: raw));
+      }
+      expect(w.firstDisplayOf(7), 0);
+      expect(w.pagesAt(1), ['c7-p0', 'c7-p1', 'c7-p2']);
+    });
+
+    test('empty window', () {
+      final w = buildPagedDisplayWindow(chapters: [], forceTransition: false);
+      expect(w.isEmpty, isTrue);
+      expect(w.displayToChapterRaw(0), isNull);
+      expect(w.chapterRawToDisplay(1, 0), -1);
+    });
+  });
+
+  group('two chapters', () {
+    test('seamless: no transition between loaded chapters', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [chapter(1, pageCount: 2), chapter(2, pageCount: 2)],
+        forceTransition: false,
+      );
+      // Last spread of ch1 sits directly before the first of ch2.
+      expect(shape(w), ['c1:0', 'c1:1', 'c2:0', 'c2:1']);
+      expect(w.displayToChapterRaw(1), (chapterId: 1, raw: 1));
+      expect(w.displayToChapterRaw(2), (chapterId: 2, raw: 0));
+      expect(w.chapterRawToDisplay(2, 0), 2);
+      expect(w.firstDisplayOf(2), 2);
+    });
+
+    test('forceTransition inserts a boundary card between them', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [chapter(1, pageCount: 2), chapter(2, pageCount: 2)],
+        forceTransition: true,
+      );
+      expect(shape(w), ['c1:0', 'c1:1', 'T(1>2)', 'c2:0', 'c2:1']);
+      // The transition slot has no page mapping.
+      expect(w.displayToChapterRaw(2), isNull);
+      expect(w.displayToChapterProgressRaw(2), isNull);
+      expect(w.pagesAt(2), isNull);
+      // Chapter 2's pages start after the transition.
+      expect(w.firstDisplayOf(2), 3);
+      expect(w.chapterRawToDisplay(2, 1), 4);
+    });
+
+    test('hasGapBefore forces a transition even when seamless', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [
+          chapter(1, pageCount: 1),
+          chapter(5, pageCount: 1, hasGapBefore: true),
+        ],
+        forceTransition: false,
+      );
+      expect(shape(w), ['c1:0', 'T(1>5)', 'c5:0']);
+    });
+  });
+
+  group('leading / trailing edge transitions', () {
+    test('leading and trailing boundary cards wrap the window', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [chapter(3, pageCount: 2)],
+        forceTransition: false,
+        leadingTransition: true,
+        trailingTransition: true,
+      );
+      expect(shape(w), ['T(null>3)', 'c3:0', 'c3:1', 'T(3>null)']);
+      final lead = w.items.first as TransitionDisplay;
+      final tail = w.items.last as TransitionDisplay;
+      expect(lead.isStart, isTrue);
+      expect(tail.isEnd, isTrue);
+      // Chapter pages are offset by the leading card.
+      expect(w.firstDisplayOf(3), 1);
+      expect(w.chapterRawToDisplay(3, 1), 2);
+      expect(w.displayToChapterRaw(0), isNull); // leading transition
+    });
+  });
+
+  group('double-page across chapters', () {
+    test('progress raw is the furthest page of each spread, per chapter', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [
+          chapter(1, pageCount: 4, doublePages: true), // (0,1)(2,3)
+          chapter(2, pageCount: 4, doublePages: true), // (0,1)(2,3)
+        ],
+        forceTransition: false,
+      );
+      // 2 spreads per chapter, seamless.
+      expect(shape(w), ['c1:0', 'c1:2', 'c2:0', 'c2:2']);
+      // Seekbar (primary) vs progress (furthest) raw.
+      expect(w.displayToChapterRaw(1), (chapterId: 1, raw: 2));
+      expect(w.displayToChapterProgressRaw(1), (chapterId: 1, raw: 3));
+      // Second page of a pair maps to that pair.
+      expect(w.chapterRawToDisplay(1, 3), 1);
+      expect(w.chapterRawToDisplay(2, 1), 2);
+      // Last spread of ch2 reports ch2's last page for progress → can mark read.
+      expect(w.displayToChapterProgressRaw(3), (chapterId: 2, raw: 3));
+    });
+  });
+
+  group('lookups for absent content', () {
+    test('chapterRawToDisplay returns -1 for a chapter not in the window', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [chapter(1, pageCount: 2)],
+        forceTransition: false,
+      );
+      expect(w.chapterRawToDisplay(99, 0), -1);
+      expect(w.firstDisplayOf(99), -1);
+    });
+
+    test('out-of-range display indexes never throw', () {
+      final w = buildPagedDisplayWindow(
+        chapters: [chapter(1, pageCount: 2)],
+        forceTransition: false,
+      );
+      expect(w.displayToChapterRaw(-1), isNull);
+      expect(w.displayToChapterRaw(999), isNull);
+      expect(w.pagesAt(999), isNull);
+    });
+  });
+}

--- a/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
+++ b/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
@@ -12,6 +12,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_display_window.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_spread_mapping.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart';
@@ -74,7 +75,27 @@ Future<void> _pumpViewport(
   bool animateTransitions = false,
   Widget? previousBoundary,
   Widget? nextBoundary,
+  VoidCallback? onReachedStartEdge,
+  VoidCallback? onReachedEndEdge,
+  void Function(int chapterId, int raw, bool isWide)? onPageWide,
 }) async {
+  // The viewport now renders a PagedDisplayWindow instead of a bare
+  // mapping+pages pair. These single-chapter tests wrap the mapping in a
+  // one-chapter window; a leading/trailing transition card stands in for the
+  // old previousBoundary/nextBoundary widgets (rendered via transitionBuilder).
+  final window = buildPagedDisplayWindow(
+    chapters: [
+      WindowChapter(
+        chapterId: 1,
+        chapterName: 'c1',
+        mapping: mapping,
+        pages: pages,
+      ),
+    ],
+    forceTransition: false,
+    leadingTransition: previousBoundary != null,
+    trailingTransition: nextBoundary != null,
+  );
   final viewport = ReaderInputScope(
     callbacks: callbacks,
     child: SizedBox(
@@ -82,8 +103,7 @@ Future<void> _pumpViewport(
       height: 500,
       child: PagedReaderViewport(
         controller: controller,
-        mapping: mapping,
-        pages: pages,
+        window: window,
         initialDisplayIndex: initialDisplayIndex,
         axis: Axis.horizontal,
         reverse: reverse,
@@ -95,15 +115,18 @@ Future<void> _pumpViewport(
         rotateWideInvert: false,
         reversePair: false,
         cropBorders: false,
-        onPageWide: (_, __) {},
-        onRawPageChanged: onRawPageChanged,
+        onPageWide: onPageWide ?? (_, __, ___) {},
+        onChapterPageChanged: (_, raw) => onRawPageChanged(raw),
+        transitionBuilder: (transition) => transition.isStart
+            ? (previousBoundary ?? const SizedBox.shrink())
+            : (nextBoundary ?? const SizedBox.shrink()),
         pinchEnabled: true,
         doubleTapToZoom: true,
         disableZoomIn: false,
         disableZoomOut: disableZoomOut,
         navigateToPan: true,
-        previousBoundary: previousBoundary,
-        nextBoundary: nextBoundary,
+        onReachedStartEdge: onReachedStartEdge,
+        onReachedEndEdge: onReachedEndEdge,
       ),
     ),
   );
@@ -153,7 +176,11 @@ Future<void> _doubleTapViewport(WidgetTester tester) async {
   await tester.tap(target);
   await tester.pump(const Duration(milliseconds: 80));
   await tester.tap(target);
-  await tester.pump(const Duration(milliseconds: 280));
+  // Double-tap zoom now animates. A single pump only seeds the animation
+  // controller's tick epoch (elapsed 0), so pump once to start it then settle
+  // it to its target scale.
+  await tester.pump();
+  await tester.pumpAndSettle();
 }
 
 Future<void> _pinchViewportIn(WidgetTester tester) async {
@@ -207,8 +234,11 @@ void main() {
     expect(reported, [1]);
   });
 
-  testWidgets('next command at the last display uses boundary navigation',
+  testWidgets('next command at the last display hits the end edge',
       (tester) async {
+    // migrated: the viewport no longer performs the chapter move itself (that's
+    // the host's job now). At the window's outer end it fires onReachedEndEdge —
+    // the new edge signal that replaces the old onNextBoundary handoff.
     final pages = _localPages(3);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -218,7 +248,7 @@ void main() {
       isWide: (_) => false,
     );
     final controller = PagedReaderController();
-    var boundaryHits = 0;
+    var endEdgeHits = 0;
 
     await _pumpViewport(
       tester,
@@ -227,22 +257,21 @@ void main() {
       pages: pages,
       initialDisplayIndex: 2,
       onRawPageChanged: (_) {},
-      callbacks: _callbacks(
-        onNextBoundary: () {
-          boundaryHits += 1;
-          return true;
-        },
-      ),
+      callbacks: _callbacks(),
+      onReachedEndEdge: () => endEdgeHits += 1,
     );
 
     controller.next();
     await tester.pump();
 
-    expect(boundaryHits, 1);
+    expect(endEdgeHits, 1);
   });
 
   testWidgets('next command lands on the chapter transition first',
       (tester) async {
+    // migrated: the trailing transition card is now an ordinary in-window slot
+    // (via transitionBuilder), so the first next() pages onto it and only the
+    // next() past it reaches the window's end edge (onReachedEndEdge).
     final pages = _localPages(3);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -252,7 +281,7 @@ void main() {
       isWide: (_) => false,
     );
     final controller = PagedReaderController();
-    var boundaryHits = 0;
+    var endEdgeHits = 0;
 
     await _pumpViewport(
       tester,
@@ -261,12 +290,8 @@ void main() {
       pages: pages,
       initialDisplayIndex: 2,
       onRawPageChanged: (_) {},
-      callbacks: _callbacks(
-        onNextBoundary: () {
-          boundaryHits += 1;
-          return true;
-        },
-      ),
+      callbacks: _callbacks(),
+      onReachedEndEdge: () => endEdgeHits += 1,
       nextBoundary: const Text('Finished'),
     );
 
@@ -277,16 +302,18 @@ void main() {
 
     expect(find.text('Finished'), findsOneWidget);
     expect(controller.isAtLast, isTrue);
-    expect(boundaryHits, 0);
+    expect(endEdgeHits, 0);
 
     controller.next();
     await tester.pumpAndSettle();
 
-    expect(boundaryHits, 1);
+    expect(endEdgeHits, 1);
   });
 
-  testWidgets('last display swipe settles through the chapter boundary',
-      (tester) async {
+  testWidgets('last display swipe hits the end edge', (tester) async {
+    // migrated: a fling past the last page reaches the window's outer end, which
+    // the viewport signals synchronously via onReachedEndEdge (then bounces).
+    // The chapter move itself is now driven by the host off that signal.
     final pages = _localPages(3);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -296,7 +323,7 @@ void main() {
       isWide: (_) => false,
     );
     final controller = PagedReaderController();
-    var boundaryHits = 0;
+    var endEdgeHits = 0;
 
     await _pumpViewport(
       tester,
@@ -305,12 +332,8 @@ void main() {
       pages: pages,
       initialDisplayIndex: 2,
       onRawPageChanged: (_) {},
-      callbacks: _callbacks(
-        onNextBoundary: () {
-          boundaryHits += 1;
-          return true;
-        },
-      ),
+      callbacks: _callbacks(),
+      onReachedEndEdge: () => endEdgeHits += 1,
       animateTransitions: true,
     );
 
@@ -320,13 +343,19 @@ void main() {
       const Duration(milliseconds: 80),
     );
 
-    expect(boundaryHits, 0);
+    expect(endEdgeHits, 1);
     await tester.pumpAndSettle();
-    expect(boundaryHits, 1);
+    expect(endEdgeHits, 1);
   });
 
-  testWidgets('no adjacent chapter settles back without a boundary slide',
+  testWidgets('window end edge bounces back onto the last page',
       (tester) async {
+    // migrated: the old model gated the boundary move on hasNextBoundary and had
+    // to avoid sliding onto an empty slot. In the new model the window's outer
+    // edge ALWAYS bounces (never slides off) and just reports onReachedEndEdge;
+    // whether a chapter actually follows is the host's decision, not the
+    // viewport's. So the equivalent guarantee is: the edge fires exactly once,
+    // and the reader stays parked on the last page (raw 2).
     final pages = _localPages(3);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -336,7 +365,8 @@ void main() {
       isWide: (_) => false,
     );
     final controller = PagedReaderController();
-    var boundaryAttempts = 0;
+    final reported = <int>[];
+    var endEdgeHits = 0;
 
     await _pumpViewport(
       tester,
@@ -344,14 +374,9 @@ void main() {
       mapping: mapping,
       pages: pages,
       initialDisplayIndex: 2,
-      onRawPageChanged: (_) {},
-      callbacks: _callbacks(
-        onNextBoundary: () {
-          boundaryAttempts += 1;
-          return false;
-        },
-        hasNextBoundary: () => false,
-      ),
+      onRawPageChanged: reported.add,
+      callbacks: _callbacks(),
+      onReachedEndEdge: () => endEdgeHits += 1,
       animateTransitions: true,
     );
 
@@ -362,14 +387,17 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // No chapter to move to: the viewport must not attempt the move at all —
-    // attempting it is what slid the page fully off-screen and flashed an empty
-    // slot before bouncing back.
-    expect(boundaryAttempts, 0);
+    expect(endEdgeHits, 1);
+    // Bounced back to the last page — never advanced to a non-existent slot.
+    expect(reported.last, 2);
+    expect(controller.isAtLast, isTrue);
   });
 
   testWidgets('last display swipe settles on the chapter transition first',
       (tester) async {
+    // migrated: the trailing transition card is an ordinary in-window slot now,
+    // so the first fling pages onto it ('Finished') and only the second fling —
+    // off the window's outer end — trips onReachedEndEdge.
     final pages = _localPages(3);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -379,7 +407,7 @@ void main() {
       isWide: (_) => false,
     );
     final controller = PagedReaderController();
-    var boundaryHits = 0;
+    var endEdgeHits = 0;
 
     await _pumpViewport(
       tester,
@@ -388,12 +416,8 @@ void main() {
       pages: pages,
       initialDisplayIndex: 2,
       onRawPageChanged: (_) {},
-      callbacks: _callbacks(
-        onNextBoundary: () {
-          boundaryHits += 1;
-          return true;
-        },
-      ),
+      callbacks: _callbacks(),
+      onReachedEndEdge: () => endEdgeHits += 1,
       animateTransitions: true,
       nextBoundary: const Text('Finished'),
     );
@@ -406,17 +430,17 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Finished'), findsOneWidget);
-    expect(boundaryHits, 0);
+    expect(endEdgeHits, 0);
 
     await tester.timedDrag(
       find.byType(PagedReaderViewport),
       const Offset(-80, 0),
       const Duration(milliseconds: 80),
     );
-    expect(boundaryHits, 1);
+    expect(endEdgeHits, 1);
     await tester.pumpAndSettle();
 
-    expect(boundaryHits, 1);
+    expect(endEdgeHits, 1);
   });
 
   testWidgets('sub-threshold drag does not turn a double-page spread',
@@ -443,11 +467,13 @@ void main() {
     );
     reported.clear();
 
-    // A slow 80px drag (~0.1 of the viewport) is below the turn threshold — a
+    // migrated: the turn threshold is now the FULL viewport extent for every
+    // slot (spreads no longer turn at half distance), so a sub-threshold drag is
+    // one below ~0.18 of the 300px viewport. A slow 40px drag stays under it — a
     // spread must not commit a turn any easier than a single page does.
     await tester.timedDrag(
       find.byType(PagedReaderViewport),
-      const Offset(-80, 0),
+      const Offset(-40, 0),
       const Duration(milliseconds: 700),
     );
     await tester.pumpAndSettle();

--- a/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
+++ b/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
@@ -35,6 +35,8 @@ ReaderInputCallbacks _callbacks({
   VoidCallback? onTap,
   bool Function()? onNextBoundary,
   bool Function()? onPreviousBoundary,
+  bool Function()? hasNextBoundary,
+  bool Function()? hasPreviousBoundary,
   ValueChanged<Offset>? onLongPressStart,
   VoidCallback? onLongPressEnd,
   VoidCallback? onLongPressCancel,
@@ -49,6 +51,10 @@ ReaderInputCallbacks _callbacks({
       onPrevious: () {},
       onNextBoundary: onNextBoundary ?? () => false,
       onPreviousBoundary: onPreviousBoundary ?? () => false,
+      // Default to "a chapter exists" so boundary-move tests fire; the
+      // no-adjacent-chapter case passes () => false explicitly.
+      hasNextBoundary: hasNextBoundary ?? () => true,
+      hasPreviousBoundary: hasPreviousBoundary ?? () => true,
       navigationLayout: ReaderNavigationLayout.disabled,
       tapInvert: TapInvert.none,
       smallerTapZones: false,
@@ -317,6 +323,49 @@ void main() {
     expect(boundaryHits, 0);
     await tester.pumpAndSettle();
     expect(boundaryHits, 1);
+  });
+
+  testWidgets('no adjacent chapter settles back without a boundary slide',
+      (tester) async {
+    final pages = _localPages(3);
+    final mapping = buildSpreadMapping(
+      pageCount: pages.length,
+      doublePages: false,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    );
+    final controller = PagedReaderController();
+    var boundaryAttempts = 0;
+
+    await _pumpViewport(
+      tester,
+      controller: controller,
+      mapping: mapping,
+      pages: pages,
+      initialDisplayIndex: 2,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(
+        onNextBoundary: () {
+          boundaryAttempts += 1;
+          return false;
+        },
+        hasNextBoundary: () => false,
+      ),
+      animateTransitions: true,
+    );
+
+    await tester.timedDrag(
+      find.byType(PagedReaderViewport),
+      const Offset(-80, 0),
+      const Duration(milliseconds: 80),
+    );
+    await tester.pumpAndSettle();
+
+    // No chapter to move to: the viewport must not attempt the move at all —
+    // attempting it is what slid the page fully off-screen and flashed an empty
+    // slot before bouncing back.
+    expect(boundaryAttempts, 0);
   });
 
   testWidgets('last display swipe settles on the chapter transition first',


### PR DESCRIPTION
## Summary
Paged reading modes (LTR/RTL and single/double-page vertical) now hold the previous, current, and next chapters in one continuous pager and cross chapter boundaries in place. No per-chapter screen rebuild, no route slide, no system-bar flash. This mirrors the webtoon reader's multi-chapter engine so paged and long-strip share the same seamless feel.

## What changed
- New multi-chapter paged host (`MultiChapterPagedReaderMode`): owns chapter loading (preload near an edge, idle-gated window swap), per-visible-chapter progress, and feeds the wrapper the visible-chapter view.
- The paged viewport consumes a `PagedDisplayWindow` (spreads plus virtual transition cards across chapters) and re-anchors on a window swap so a prepend never jumps the page.
- Chapter crossing no longer uses `pushReplacement`.

## Fixes rolled in
- Reading progress now flushes on exit even with offline disabled (the multi-chapter flush was offline-only and dropped the page).
- Opening a chapter on its last page no longer marks it read.
- Double-tap zoom animates instead of snapping, and a second double-tap zooms back out correctly.
- No empty-slot flash past the last page of the last chapter, and the OS bars stay hidden across chapter transitions.

## Tests
- End-to-end test drives the real reader through a live chapter load and asserts it crosses in place, marks the finished chapter read, and saves progress (debounced and on exit).
- Viewport crossing, re-anchor, and double-tap-zoom-animation coverage; the pure display-window model is unit-tested.
- The paged viewport test suite migrated to the new API.
- Full project test suite green (713 tests).
