### PR TITLE
Correct stale repo references in architecture docs

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,12 +1,12 @@
 # Tsumiru Architecture
 
-Tsumiru is a Flutter client for [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) (the Tachidesk backend) — a manga/manhwa reader that runs on Android, Linux, Windows, macOS, and Web. It is its own application (published at `tsumiru-app/tsumiru`), originally based on [Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi), focused on being a great daily-driver, especially for webtoon/manhwa reading.
+Tsumiru is a Flutter client for [Suwayomi-Server](https://github.com/Suwayomi/Suwayomi-Server) (the Tachidesk backend) — a manga/manhwa reader that runs on Android, Linux, Windows, macOS, and Web. It is its own application inside the Suwayomi org (published at `Suwayomi/Suwayomi-Tsumiru`), originally based on [Tachidesk-Sorayomi](https://github.com/Suwayomi/Tachidesk-Sorayomi), and focused on daily reading, especially for webtoon/manhwa.
 
-This directory documents how the app is built and how each subsystem works, so contributors (human or AI) can orient quickly and change code safely.
+This directory documents how the app is built and how each subsystem works, so contributors can orient quickly and change code safely.
 
 ## Read this first
 
-- **[repo-build-release.md](repo-build-release.md)** — remotes, the branch model, the release flow, and the version scheme. **`tsumiru-app/tsumiru` `main` (remote `tsumiru`) is canonical.** Always `git fetch tsumiru` and verify your base against it and the latest release before building or branching.
+- **[repo-build-release.md](repo-build-release.md)** — remotes, the branch model, the release flow, and the version scheme. **`Suwayomi/Suwayomi-Tsumiru` `main` (remote `origin`) is canonical.** Always `git fetch origin` and verify your base against it and the latest release before building or branching.
 
 ## Subsystem maps
 

--- a/docs/architecture/other-features.md
+++ b/docs/architecture/other-features.md
@@ -8,7 +8,7 @@ App/server version info + update checks.
 
 - `data/about_repository.dart` — **two update paths**: `checkUpdate()` hits the **GitHub Releases REST API** directly; `checkServerUpdate()` uses the server's GraphQL `checkForServerUpdates`. Both use `pub_semver`.
 - `controllers/about_controller.dart` — `aboutProvider` (GraphQL `GetAbout`); `packageInfoProvider` is `throw UnimplementedError()` (overridden in `main.dart`).
-- URLs (all in `lib/src/constants/urls.dart`): `sorayomiGithubUrl` = `github.com/tsumiru-app/tsumiru`, `sorayomiLatestReleaseUrl`/`...ApiUrl` (releases + GitHub API), `sorayomiWhatsNew` = GitHub releases page, `tachideskHelp` = `tsumiru.app/docs/...`.
+- URLs (all in `lib/src/constants/urls.dart`): `sorayomiGithubUrl` = `github.com/Suwayomi/Suwayomi-Tsumiru`, `sorayomiLatestReleaseUrl`/`...ApiUrl` (releases + GitHub API), `sorayomiWhatsNew` = GitHub releases page, `tachideskHelp` = `tsumiru.app/docs/...`.
 - **Gotcha:** the update check strips the leading `v` from `tag_name` (`Version.parse(tag.substring(1))`) — a tag format change throws. (This was the crash fixed in `33dbd31`.)
 
 ## history

--- a/docs/architecture/repo-build-release.md
+++ b/docs/architecture/repo-build-release.md
@@ -1,16 +1,16 @@
 # Repo, Build & Release Model
 
-> **The #1 rule:** `tsumiru-app/tsumiru` `main` (git remote `tsumiru`) is the canonical source of truth. **Before building, branching, or releasing, run `git fetch tsumiru` and verify your local base against `tsumiru/main` AND the latest GitHub release.** Building on a stale base produces an app missing the in-app branding, version, and fixes that shipped in the latest release.
+> **The #1 rule:** `Suwayomi/Suwayomi-Tsumiru` `main` is the canonical source of truth. **Before building, branching, or releasing, run `git fetch origin` and verify your local base against `origin/main` and the latest GitHub release.** Building on a stale base produces an app missing the in-app branding, version, and fixes that shipped in the latest release.
 
 ## Remotes & branch model
 
-Tsumiru is its **own application** published at `tsumiru-app/tsumiru` — not a personal fork. It descends from Tachidesk-Sorayomi (kept for attribution and the occasional upstream sync), but the project lives and ships on its own now.
+Tsumiru is its **own application** published at `Suwayomi/Suwayomi-Tsumiru` inside the Suwayomi org. It descends from Tachidesk-Sorayomi (kept for attribution and the occasional upstream sync), but the project lives and ships on its own now.
 
 | Remote | URL | Role |
 |---|---|---|
-| `origin` | `github.com/tsumiru-app/tsumiru` | **The app — canonical.** A fresh `git clone` / `gh repo clone` lands here; `main` and releases are ground truth |
-| `upstream` | `github.com/Suwayomi/Tachidesk-Sorayomi` | The project Tsumiru descends from (attribution / occasional sync) |
-| `ariqpradipa` | `github.com/ariqpradipa/Tachidesk-Sorayomi` | Author of adopted reader PR #362 |
+| `origin` | `github.com/Suwayomi/Suwayomi-Tsumiru` | **The app — canonical.** A fresh `git clone` / `gh repo clone` lands here; `main` and releases are ground truth |
+| `upstream` | `github.com/Suwayomi/Tachidesk-Sorayomi` | Optional remote for the project Tsumiru descends from (attribution / occasional sync) |
+| `ariqpradipa` | `github.com/ariqpradipa/Tachidesk-Sorayomi` | Optional remote for the author of adopted reader PR #362 |
 
 **Workflow:** Tsumiru uses **pull requests** (public project). Branch off `main`, open a PR, let CI gate it, then merge. Branch and commit names are plain/human — no `feat/`-style prefixes. Push/PR-create/merge happen on `origin`.
 

--- a/docs/architecture/shared-infrastructure.md
+++ b/docs/architecture/shared-infrastructure.md
@@ -14,7 +14,7 @@
 ## Constants
 
 - **`enum.dart`:** `AuthType` (none/basic/simpleLogin/uiLogin), `ReaderMode` (8; default webtoon), `ReaderNavigationLayout` (default disabled), `MangaSort` (7; default lastRead), `ChapterSort` (source/uploadDate/fetchedDate), `DisplayMode` (grid/list/descriptiveList), `MangaStatus`, `IncludeOrExclude` (tri-state). Most carry `toLocale(BuildContext)`.
-- **`urls.dart`:** external URLs, rebranded to `tsumiru-app` (`sorayomiGithubUrl`, `...LatestReleaseUrl`, `...ApiUrl`, `tachideskHelp`, `sorayomiWhatsNew`, `flareSolverr`).
+- **`urls.dart`:** external URLs for the Suwayomi-hosted Tsumiru repo, docs site, and related services (`sorayomiGithubUrl`, `...LatestReleaseUrl`, `...ApiUrl`, `tachideskHelp`, `sorayomiWhatsNew`, `flareSolverr`).
 - **`endpoints.dart`:** `Endpoints.baseApi(...)` — the central URL builder (`baseUrl`, `port`, `addPort`, `isGraphQl`, `isWebsocket`); plus per-area URL classes.
 - **`app_constants.dart`:** `kDuration` (500ms), `kInstantDuration`, `kLongDuration`, `kCurve`, magnifier constants, `kDebounceDuration` (500ms), `kPositionPlaceholder` (-1).
 - **`app_sizes.dart`:** `KEdgeInsets` / `KBorderRadius` / `KRadius` tokens; `mangaCoverGridDelegate(double?)`.


### PR DESCRIPTION
Documentation-only. Updates the architecture docs' repo/remote references from the old `tsumiru-app/tsumiru` (remote `tsumiru`) to the canonical `Suwayomi/Suwayomi-Tsumiru` (`origin`), reflecting where the app lives and releases now. No code changes.