### PR TITLE
Filter the Sources tab by name

### DIFF
--- a/lib/src/features/browse_center/presentation/browse/browse_screen.dart
+++ b/lib/src/features/browse_center/presentation/browse/browse_screen.dart
@@ -9,12 +9,13 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../constants/app_sizes.dart';
-import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../widgets/search_field.dart';
 import '../extension/controller/extension_controller.dart';
 import '../extension/widgets/extension_language_filter_dialog.dart';
 import '../extension/widgets/install_extension_file.dart';
+import '../source/controller/source_controller.dart'
+    show sourceSearchQueryProvider;
 import '../source/widgets/source_language_filter.dart';
 
 class BrowseScreen extends HookConsumerWidget {
@@ -55,11 +56,7 @@ class BrowseScreen extends HookConsumerWidget {
         actions: [
           IconButton(
             onPressed: () => showSearch.value = (true),
-            icon: Icon(
-              tabController.index == 0
-                  ? Icons.travel_explore_rounded
-                  : Icons.search_rounded,
-            ),
+            icon: const Icon(Icons.search_rounded),
           ),
           if (tabController.index == 1) ...[
             const InstallExtensionFile(),
@@ -93,12 +90,16 @@ class BrowseScreen extends HookConsumerWidget {
                   child: tabController.index == 0
                       ? SearchField(
                           key: const ValueKey(0),
-                          onSubmitted: (value) {
-                            if (value.isNotBlank) {
-                              GlobalSearchRoute(query: value).push(context);
-                            }
+                          initialText: ref.read(sourceSearchQueryProvider),
+                          onChanged: (val) => ref
+                              .read(sourceSearchQueryProvider.notifier)
+                              .update(val),
+                          onClose: () {
+                            ref
+                                .read(sourceSearchQueryProvider.notifier)
+                                .update(null);
+                            showSearch.value = (false);
                           },
-                          onClose: () => showSearch.value = (false),
                         )
                       : SearchField(
                           key: const ValueKey(1),

--- a/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
+++ b/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
@@ -10,6 +10,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../../../constants/db_keys.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+import '../../../../../utils/mixin/state_provider_mixin.dart';
 import '../../../../settings/presentation/browse/widgets/show_nsfw_switch/show_nsfw_switch.dart';
 import '../../../data/source_repository/source_repository.dart';
 import '../../../domain/source/source_model.dart';
@@ -149,6 +150,32 @@ List<SourceDto>? sourceQuery(Ref ref, {String? query}) {
         .toList();
   }
   return sourceMap.values.expand((list) => list).toList();
+}
+
+/// The Sources-tab name filter. Mirrors [ExtensionQuery]: filters the grouped
+/// source map by name while preserving the language grouping, so typing in the
+/// Sources tab narrows the list instead of launching a global search.
+@riverpod
+AsyncValue<Map<String, List<SourceDto>>?> sourceMapFilteredAndQueried(Ref ref) {
+  final sourceMapData = ref.watch(sourceMapFilteredProvider);
+  final sourceMap = {...?sourceMapData.valueOrNull};
+  final query = ref.watch(sourceSearchQueryProvider);
+  if (query.isBlank) return sourceMapData;
+  return sourceMapData.copyWithData(
+    (e) => sourceMap.map<String, List<SourceDto>>(
+      (key, value) => MapEntry(
+        key,
+        value.where((element) => element.name.query(query)).toList(),
+      ),
+    ),
+  );
+}
+
+@riverpod
+class SourceSearchQuery extends _$SourceSearchQuery
+    with StateProviderMixin<String?> {
+  @override
+  String? build() => null;
 }
 
 @riverpod

--- a/lib/src/features/browse_center/presentation/source/source_screen.dart
+++ b/lib/src/features/browse_center/presentation/source/source_screen.dart
@@ -20,8 +20,12 @@ class SourceScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final sourceMapData = ref.watch(sourceMapFilteredProvider);
-    final pinned = ref.watch(pinnedSourcesProvider);
+    final sourceMapData = ref.watch(sourceMapFilteredAndQueriedProvider);
+    final query = ref.watch(sourceSearchQueryProvider);
+    final allPinned = ref.watch(pinnedSourcesProvider);
+    final pinned = query.isBlank
+        ? allPinned
+        : allPinned.where((s) => s.name.query(query)).toList();
 
     final sourceMap = {...?sourceMapData.valueOrNull};
     final localSource = sourceMap.remove("localsourcelang");

--- a/test/src/features/browse_center/presentation/source/source_controller_test.dart
+++ b/test/src/features/browse_center/presentation/source/source_controller_test.dart
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:tsumiru/src/features/browse_center/domain/source/source_model.dart';
 import 'package:tsumiru/src/features/browse_center/presentation/source/controller/source_controller.dart';
 
@@ -81,6 +82,37 @@ void main() {
     test('the last-used source is lifted into a "lastUsed" bucket', () {
       final map = groupSourcesByLanguage(sources, '1'); // MangaDex
       expect(map['lastUsed']!.single.name, 'MangaDex');
+    });
+  });
+
+  group('sourceMapFilteredAndQueried (Sources tab name filter)', () {
+    ProviderContainer containerWith(Map<String, List<SourceDto>> map) {
+      final c = ProviderContainer(overrides: [
+        sourceMapFilteredProvider.overrideWith((ref) => AsyncData(map)),
+      ]);
+      addTearDown(c.dispose);
+      return c;
+    }
+
+    test('a blank query passes the grouped map through unchanged', () {
+      final c = containerWith({
+        'en': [mangaDex, allManga],
+        'ko': [bato],
+      });
+      final out = c.read(sourceMapFilteredAndQueriedProvider).valueOrNull!;
+      expect(out['en']!.map((e) => e.name), ['MangaDex', 'allmanga']);
+      expect(out['ko']!.map((e) => e.name), ['Bato']);
+    });
+
+    test('a query filters each group by source name, keeping grouping', () {
+      final c = containerWith({
+        'en': [mangaDex, allManga],
+        'ko': [bato],
+      });
+      c.read(sourceSearchQueryProvider.notifier).update('dex');
+      final out = c.read(sourceMapFilteredAndQueriedProvider).valueOrNull!;
+      expect(out['en']!.map((e) => e.name), ['MangaDex']);
+      expect(out['ko'], isEmpty);
     });
   });
 }


### PR DESCRIPTION
Closes #129.

Typing in the Sources tab now filters the source list by name (live), matching the Extensions tab and Komikku, instead of launching a global manga search. Global search stays reachable from the library and manga-details screens.

- New `SourceSearchQuery` state + `sourceMapFilteredAndQueried` provider (mirrors `ExtensionQuery`), filtering each language group while keeping grouping.
- Sources search field wired to filter live; search icon changed from the global-search globe to the filter icon; query clears on close.
- Test: blank query passes through; a query filters each group by name.