### PR TITLE
Per-category include-in-update toggle

### DIFF
--- a/lib/src/features/settings/presentation/library/library_settings_screen.dart
+++ b/lib/src/features/settings/presentation/library/library_settings_screen.dart
@@ -15,11 +15,14 @@ import '../../../../widgets/emoticons.dart';
 import '../../../../widgets/input_popup/domain/settings_prop_type.dart';
 import '../../../../widgets/input_popup/settings_prop_tile.dart';
 import '../../../../widgets/section_title.dart';
+import '../../../library/domain/category/category_model.dart';
+import '../../../library/presentation/category/controller/edit_category_controller.dart';
 import '../../controller/server_controller.dart';
 import '../../domain/settings/settings.dart';
 import 'data/library_settings_repository.dart';
 import 'widgets/refresh_chapters_from_source_tile/refresh_chapters_from_source_tile.dart';
 import 'widgets/skip_updating_entries_popup.dart';
+import 'widgets/update_categories_dialog.dart';
 
 class LibrarySettingsScreen extends ConsumerWidget {
   const LibrarySettingsScreen({super.key});
@@ -28,6 +31,8 @@ class LibrarySettingsScreen extends ConsumerWidget {
   Widget build(context, ref) {
     final repository = ref.watch(librarySettingsRepositoryProvider);
     final serverSettings = ref.watch(settingsProvider);
+    final categories = ref.watch(categoryControllerProvider).valueOrNull ??
+        const <CategoryDto>[];
 
     return ListTileTheme(
       data: const ListTileThemeData(
@@ -129,6 +134,15 @@ class LibrarySettingsScreen extends ConsumerWidget {
                     onTap: () => showDialog(
                       context: context,
                       builder: (context) => const SkipUpdatingEntriesPopup(),
+                    ),
+                  ),
+                  ListTile(
+                    title: Text(context.l10n.updateCategories),
+                    subtitle: Text(
+                        libraryUpdateCategoriesSummary(context, categories)),
+                    onTap: () => showDialog<void>(
+                      context: context,
+                      builder: (_) => const UpdateCategoriesDialog(),
                     ),
                   ),
                   // SectionTitle(title: context.l10n.advanced),

--- a/lib/src/features/settings/presentation/library/widgets/update_categories_dialog.dart
+++ b/lib/src/features/settings/presentation/library/widgets/update_categories_dialog.dart
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../graphql/__generated__/schema.graphql.dart';
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../widgets/popup_widgets/pop_button.dart';
+import '../../../../library/domain/category/category_model.dart';
+import '../../../../library/presentation/category/controller/edit_category_controller.dart';
+
+/// Normalises a category's include/exclude flag to the three values we cycle
+/// (graphql_codegen adds a `$unknown` member we never surface).
+Enum$IncludeOrExclude coerceInclude(Enum$IncludeOrExclude? v) =>
+    v == Enum$IncludeOrExclude.INCLUDE || v == Enum$IncludeOrExclude.EXCLUDE
+        ? v!
+        : Enum$IncludeOrExclude.UNSET;
+
+/// Summary line for the "Categories" row under Settings → Library → Global
+/// update. "All categories" when nothing is included/excluded, else a short
+/// "Included … / Excluded …" string.
+String libraryUpdateCategoriesSummary(
+    BuildContext context, List<CategoryDto> categories) {
+  final included = categories
+      .where((c) => c.includeInUpdate == Enum$IncludeOrExclude.INCLUDE)
+      .map((c) => c.name);
+  final excluded = categories
+      .where((c) => c.includeInUpdate == Enum$IncludeOrExclude.EXCLUDE)
+      .map((c) => c.name);
+  if (included.isEmpty && excluded.isEmpty) {
+    return context.l10n.updateCategoriesAll;
+  }
+  final parts = <String>[
+    if (included.isNotEmpty)
+      context.l10n.updateCategoriesIncluded(included.join(', ')),
+    if (excluded.isNotEmpty)
+      context.l10n.updateCategoriesExcluded(excluded.join(', ')),
+  ];
+  return parts.join(' · ');
+}
+
+/// Tri-state (default / include / exclude) picker for which categories are
+/// checked during a global library update — the Suwayomi `includeInUpdate`
+/// flag per category. Tapping a row cycles default → include → exclude →
+/// default.
+class UpdateCategoriesDialog extends ConsumerWidget {
+  const UpdateCategoriesDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categories = ref.watch(categoryControllerProvider);
+    return categories.when(
+      loading: () => const AlertDialog(
+        content: SizedBox(
+            height: 80, child: Center(child: CircularProgressIndicator())),
+      ),
+      error: (_, __) => AlertDialog(
+        title: Text(context.l10n.updateCategories),
+        content: Text(context.l10n.errorSomethingWentWrong),
+        actions: const [PopButton()],
+      ),
+      data: (cats) => _Body(categories: cats ?? const []),
+    );
+  }
+}
+
+class _Body extends HookConsumerWidget {
+  const _Body({required this.categories});
+
+  final List<CategoryDto> categories;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Seeded once from the loaded list (the parent only builds this with data).
+    final state = useState<Map<int, Enum$IncludeOrExclude>>({
+      for (final c in categories) c.id: coerceInclude(c.includeInUpdate),
+    });
+
+    void cycle(int id) {
+      final cur = state.value[id] ?? Enum$IncludeOrExclude.UNSET;
+      final next = switch (cur) {
+        Enum$IncludeOrExclude.UNSET => Enum$IncludeOrExclude.INCLUDE,
+        Enum$IncludeOrExclude.INCLUDE => Enum$IncludeOrExclude.EXCLUDE,
+        _ => Enum$IncludeOrExclude.UNSET,
+      };
+      state.value = {...state.value, id: next};
+    }
+
+    // Flutter tri-state checkbox: true ✓ = include, null – = exclude,
+    // false (empty) = default/unset.
+    bool? checkboxValue(Enum$IncludeOrExclude v) => switch (v) {
+          Enum$IncludeOrExclude.INCLUDE => true,
+          Enum$IncludeOrExclude.EXCLUDE => null,
+          _ => false,
+        };
+
+    Future<void> save() async {
+      final controller = ref.read(categoryControllerProvider.notifier);
+      for (final c in categories) {
+        final next = state.value[c.id] ?? Enum$IncludeOrExclude.UNSET;
+        if (next != coerceInclude(c.includeInUpdate)) {
+          await controller.editCategory(
+              c.id, CategoryUpdate(includeInUpdate: next));
+        }
+      }
+      ref.invalidate(categoryControllerProvider);
+    }
+
+    return AlertDialog(
+      title: Text(context.l10n.updateCategories),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+              child: Text(
+                context.l10n.updateCategoriesHint,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: context.theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            Flexible(
+              child: categories.isEmpty
+                  ? Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Text(context.l10n.updateCategoriesAll),
+                    )
+                  : ListView(
+                      shrinkWrap: true,
+                      children: [
+                        for (final c in categories)
+                          CheckboxListTile(
+                            dense: true,
+                            tristate: true,
+                            controlAffinity: ListTileControlAffinity.leading,
+                            value: checkboxValue(
+                                state.value[c.id] ?? Enum$IncludeOrExclude.UNSET),
+                            title: Text(c.name),
+                            onChanged: (_) => cycle(c.id),
+                          ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        const PopButton(),
+        ElevatedButton(
+          onPressed: () async {
+            await save();
+            if (context.mounted) Navigator.pop(context);
+          },
+          child: Text(context.l10n.save),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1332,7 +1332,7 @@
             }
         }
     },
-    "updateCategories": "Categories",
+    "updateCategories": "Categories to update",
     "updateCategoriesAll": "All categories",
     "updateCategoriesHint": "Only included categories are checked during a global library update (exclude always wins). Tap to cycle: ✓ include · – exclude · empty default.",
     "updateCategoriesIncluded": "Included: {names}",

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1332,6 +1332,25 @@
             }
         }
     },
+    "updateCategories": "Categories",
+    "updateCategoriesAll": "All categories",
+    "updateCategoriesHint": "Only included categories are checked during a global library update (exclude always wins). Tap to cycle: ✓ include · – exclude · empty default.",
+    "updateCategoriesIncluded": "Included: {names}",
+    "@updateCategoriesIncluded": {
+        "placeholders": {
+            "names": {
+                "type": "String"
+            }
+        }
+    },
+    "updateCategoriesExcluded": "Excluded: {names}",
+    "@updateCategoriesExcluded": {
+        "placeholders": {
+            "names": {
+                "type": "String"
+            }
+        }
+    },
     "autoWebtoonSnack": "Reading webtoon style",
     "@autoWebtoonSnack": {
         "description": "Toast when Auto Webtoon Mode switches a long-strip series to the webtoon reader (SY eh_auto_webtoon_snack)"

--- a/test/src/features/settings/library/update_categories_summary_test.dart
+++ b/test/src/features/settings/library/update_categories_summary_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/library/domain/category/category_model.dart';
+import 'package:tsumiru/src/features/library/domain/category/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/settings/presentation/library/widgets/update_categories_dialog.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+CategoryDto _cat(int id, String name, Enum$IncludeOrExclude includeInUpdate) =>
+    Fragment$CategoryDto(
+      defaultCategory: false,
+      id: id,
+      includeInDownload: Enum$IncludeOrExclude.UNSET,
+      includeInUpdate: includeInUpdate,
+      name: name,
+      order: id,
+      mangas: Fragment$CategoryDto$mangas(totalCount: 0),
+      meta: const [],
+    );
+
+/// Pumps a throwaway widget so we get a real BuildContext with the app's
+/// localizations, then evaluates [libraryUpdateCategoriesSummary] against it.
+Future<String> _summaryFor(
+    WidgetTester tester, List<CategoryDto> categories) async {
+  late String result;
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (context) {
+          result = libraryUpdateCategoriesSummary(context, categories);
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  );
+  await tester.pump();
+  return result;
+}
+
+void main() {
+  group('libraryUpdateCategoriesSummary', () {
+    testWidgets('reports "All categories" when nothing is set', (tester) async {
+      final summary = await _summaryFor(tester, [
+        _cat(1, 'Action', Enum$IncludeOrExclude.UNSET),
+        _cat(2, 'Comedy', Enum$IncludeOrExclude.UNSET),
+      ]);
+      expect(summary, 'All categories');
+    });
+
+    testWidgets('reports "All categories" for an empty list', (tester) async {
+      final summary = await _summaryFor(tester, const []);
+      expect(summary, 'All categories');
+    });
+
+    testWidgets('lists included and excluded categories', (tester) async {
+      final summary = await _summaryFor(tester, [
+        _cat(1, 'Action', Enum$IncludeOrExclude.INCLUDE),
+        _cat(2, 'Comedy', Enum$IncludeOrExclude.EXCLUDE),
+        _cat(3, 'Drama', Enum$IncludeOrExclude.UNSET),
+      ]);
+      expect(summary, 'Included: Action · Excluded: Comedy');
+    });
+
+    testWidgets('only included when nothing is excluded', (tester) async {
+      final summary = await _summaryFor(tester, [
+        _cat(1, 'Action', Enum$IncludeOrExclude.INCLUDE),
+        _cat(2, 'Comedy', Enum$IncludeOrExclude.INCLUDE),
+      ]);
+      expect(summary, 'Included: Action, Comedy');
+    });
+  });
+}


### PR DESCRIPTION
Closes #114.

A per-category "include in global library update" toggle — the update-side twin of the existing auto-download categories picker. Tri-state (default / include / exclude) list under Settings → Library → Global update, writing each category's `includeInUpdate` flag so a global update only checks the chosen categories. The server field and mutation already existed; this surfaces them, mirroring the download-side dialog (#54).

- New `UpdateCategoriesDialog` + `libraryUpdateCategoriesSummary`, mirroring the auto-download dialog against `includeInUpdate`.
- Wired into the Library settings 'Global update' section with a summary subtitle.
- Test for the summary (all-categories, included/excluded, included-only).