### PR TITLE
Legible unread badge in the Monochrome theme

### DIFF
--- a/lib/src/utils/theme/app_color_scheme.dart
+++ b/lib/src/utils/theme/app_color_scheme.dart
@@ -15,7 +15,12 @@ ColorScheme schemeFromTokens(ThemeTokens t, Brightness brightness) {
     brightness: brightness,
     // Brand accents (verbatim)
     primary: t.accent,
-    onPrimary: Colors.white,
+    // Contrast against the accent, not always white: a light accent (e.g. the
+    // Monochrome theme's near-white grey) needs dark text so the unread-count
+    // badge and other primary-filled elements stay legible.
+    onPrimary: ThemeData.estimateBrightnessForColor(t.accent) == Brightness.light
+        ? Colors.black
+        : Colors.white,
     primaryContainer: mix(t.accent, t.bg, 0.72),
     onPrimaryContainer: t.accent,
     secondary: t.accent2,

--- a/test/src/utils/theme/app_color_scheme_test.dart
+++ b/test/src/utils/theme/app_color_scheme_test.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/app_theme.dart';
+import 'package:tsumiru/src/utils/theme/app_color_scheme.dart';
+import 'package:tsumiru/src/utils/theme/theme_tokens.dart';
+
+void main() {
+  ColorScheme darkScheme(AppTheme theme) =>
+      schemeFromTokens(tokensFor(theme, Brightness.dark), Brightness.dark);
+
+  test('Monochrome dark: onPrimary is dark against its light-grey accent', () {
+    final scheme = darkScheme(AppTheme.mono);
+    // The accent is a near-white grey, so white text was illegible (#105).
+    expect(scheme.primary.computeLuminance(), greaterThan(0.5),
+        reason: 'the Monochrome accent should be light');
+    expect(scheme.onPrimary, Colors.black);
+  });
+
+  test('Indigo Night (the dark-accent brand) keeps white onPrimary', () {
+    // No regression for a genuinely dark accent.
+    expect(darkScheme(AppTheme.indigoNight).onPrimary, Colors.white);
+  });
+
+  test('every dark theme: onPrimary genuinely contrasts primary', () {
+    for (final theme in AppTheme.values) {
+      if (theme == AppTheme.custom) continue; // custom is ColorScheme.fromSeed
+      final scheme = darkScheme(theme);
+      final contrast = (scheme.primary.computeLuminance() -
+              scheme.onPrimary.computeLuminance())
+          .abs();
+      expect(contrast, greaterThan(0.3),
+          reason: '$theme: primary/onPrimary too close ($contrast)');
+    }
+  });
+}


### PR DESCRIPTION
Closes #105.

The unread-count badge text was illegible on the Monochrome dark theme: `onPrimary` was hardcoded white, and Monochrome's accent is a near-white grey, so it was white-on-light.

Fix: derive `onPrimary` from the accent's brightness (dark text on a light accent, white on a dark one). Dark-accent themes like Indigo Night are unchanged; the fix also quietly corrects the same low-contrast on the other light-accent themes (Terminal, Nord, Dracula, etc.) rather than only Monochrome, since that's the correct behaviour and only improves readability.

Test asserts Monochrome flips to dark text, Indigo keeps white, and every theme's primary/onPrimary genuinely contrast (>0.3 luminance).