### PR TITLE
Optional read-progress bar under library covers

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -37,6 +37,7 @@ enum DBKeys {
   showNSFW(true),
   downloadedBadge(false),
   unreadBadge(true),
+  readProgressBar(false),
   languageBadge(false),
   localBadge(false),
   sourceBadge(false),

--- a/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
@@ -109,6 +109,12 @@ class LibraryMangaDisplay extends ConsumerWidget {
           tristate: false,
         ),
         CustomCheckboxListTile(
+          title: context.l10n.readProgressBar,
+          provider: readProgressBarProvider,
+          onChanged: ref.read(readProgressBarProvider.notifier).update,
+          tristate: false,
+        ),
+        CustomCheckboxListTile(
           title: context.l10n.continueReadingButton,
           provider: showContinueReadingButtonProvider,
           onChanged:

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2096,6 +2096,7 @@
     "unknownManga": "Unknown Manga",
     "unknownSource": "Unknown Source",
     "unread": "Unread",
+    "readProgressBar": "Read progress bar",
     "update": "Update",
     "updateCompleted": "Update Completed",
     "updateFailed": "Failed to update {property}",

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../constants/app_sizes.dart';
 import '../../../constants/gen/assets.gen.dart';
@@ -12,6 +13,7 @@ import '../../../features/manga_book/domain/manga/manga_model.dart';
 import '../../../features/manga_book/presentation/manga_thumbnail_viewer/manga_thumbnail_viewer.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../server_image.dart';
+import '../providers/manga_cover_providers.dart';
 import '../widgets/continue_reading_button.dart';
 import '../widgets/manga_badges.dart';
 
@@ -107,6 +109,12 @@ class MangaCoverGridTile extends StatelessWidget {
                 bottom: 6,
                 child: ContinueReadingButton(onPressed: onContinueReading!),
               ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: _CoverReadProgressBar(manga: manga),
+            ),
           ],
         ),
       ),
@@ -186,5 +194,41 @@ class MangaCoverGridTile extends StatelessWidget {
                   ),
                 ),
         );
+  }
+}
+
+/// Fraction (0..1] of a series that's been read, or null when there's nothing
+/// to show (no chapters, or none read yet). Clamps defensively so odd counts
+/// (unread > total) never produce an out-of-range or negative bar.
+double? coverReadFraction({required int totalChapters, required int unreadCount}) {
+  if (totalChapters <= 0) return null;
+  final read = (totalChapters - unreadCount).clamp(0, totalChapters);
+  return read <= 0 ? null : read / totalChapters;
+}
+
+/// Thin read-progress bar along the bottom edge of a library cover, gated on the
+/// per-user toggle. Percent read is derived client-side from the manga's own
+/// counts, so it needs no server call.
+class _CoverReadProgressBar extends ConsumerWidget {
+  const _CoverReadProgressBar({required this.manga});
+
+  final MangaDto manga;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(readProgressBarProvider).ifNull()) {
+      return const SizedBox.shrink();
+    }
+    final fraction = coverReadFraction(
+      totalChapters: manga.chapters.totalCount,
+      unreadCount: manga.unreadCount.getValueOnNullOrNegative(),
+    );
+    if (fraction == null) return const SizedBox.shrink();
+    return LinearProgressIndicator(
+      value: fraction,
+      minHeight: 3,
+      backgroundColor: Colors.black.withValues(alpha: 0.35),
+      valueColor: AlwaysStoppedAnimation(context.theme.colorScheme.primary),
+    );
   }
 }

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -109,12 +109,13 @@ class MangaCoverGridTile extends StatelessWidget {
                 bottom: 6,
                 child: ContinueReadingButton(onPressed: onContinueReading!),
               ),
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              child: _CoverReadProgressBar(manga: manga),
-            ),
+            if (showBadges)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: _CoverReadProgressBar(manga: manga),
+              ),
           ],
         ),
       ),

--- a/lib/src/widgets/manga_cover/providers/manga_cover_providers.dart
+++ b/lib/src/widgets/manga_cover/providers/manga_cover_providers.dart
@@ -25,6 +25,13 @@ class UnreadBadge extends _$UnreadBadge with SharedPreferenceClientMixin<bool> {
 }
 
 @riverpod
+class ReadProgressBar extends _$ReadProgressBar
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.readProgressBar);
+}
+
+@riverpod
 class ShowContinueReadingButton extends _$ShowContinueReadingButton
     with SharedPreferenceClientMixin<bool> {
   @override

--- a/test/src/widgets/manga_cover/cover_read_fraction_test.dart
+++ b/test/src/widgets/manga_cover/cover_read_fraction_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart';
+
+void main() {
+  group('coverReadFraction', () {
+    test('reports the read fraction', () {
+      expect(coverReadFraction(totalChapters: 10, unreadCount: 3), 0.7);
+    });
+
+    test('fully read is 1.0', () {
+      expect(coverReadFraction(totalChapters: 8, unreadCount: 0), 1.0);
+    });
+
+    test('nothing read yet -> null (no bar)', () {
+      expect(coverReadFraction(totalChapters: 10, unreadCount: 10), isNull);
+    });
+
+    test('no chapters -> null', () {
+      expect(coverReadFraction(totalChapters: 0, unreadCount: 0), isNull);
+    });
+
+    test('unread greater than total clamps instead of going negative', () {
+      expect(coverReadFraction(totalChapters: 5, unreadCount: 9), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #108.

A thin bar along the bottom edge of each library cover showing what percent of the series you've read, so progress is visible across the whole grid at a glance. Optional, toggled alongside the other cover badges under Library display settings (off by default).

- Percent read computed client-side from `MangaDto` (`(chapters.totalCount - unreadCount) / chapters.totalCount`); no server change.
- New `ReadProgressBar` setting (mirrors the existing badge toggles) + a `readProgressBar` DBKey.
- Rendered as a 3px `LinearProgressIndicator` at the cover's bottom edge.
- Fraction math extracted to `coverReadFraction` and unit-tested (partial / fully read / nothing read / no chapters / unread>total clamp).