### PR TITLE
Reflect category edits in the library and surface failures

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart
@@ -9,10 +9,12 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../../constants/app_sizes.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/misc/toast/toast.dart';
 import '../../../../../widgets/async_buttons/async_checkbox_list_tile.dart';
 import '../../../../../widgets/popup_widgets/pop_button.dart';
 import '../../../../library/domain/category/category_model.dart';
 import '../../../../library/presentation/category/controller/edit_category_controller.dart';
+import '../../../../library/presentation/library/controller/library_manga_list.dart';
 import '../../../data/manga_book/manga_book_repository.dart';
 import '../controller/manga_details_controller.dart';
 
@@ -63,7 +65,7 @@ class EditMangaCategoryDialog extends HookConsumerWidget {
                             if (category.id != 0)
                               AsyncCheckboxListTile(
                                 onChanged: (value) async {
-                                  await AsyncValue.guard(
+                                  final result = await AsyncValue.guard(
                                     () => value.ifNull()
                                         ? ref
                                             .read(mangaBookRepositoryProvider)
@@ -74,8 +76,22 @@ class EditMangaCategoryDialog extends HookConsumerWidget {
                                             .removeMangaFromCategory(
                                                 mangaId, category.id),
                                   );
+                                  // A swallowed failure here is what made the
+                                  // change look saved (optimistic checkbox) while
+                                  // nothing persisted — surface it so the user
+                                  // knows to retry.
+                                  if (result.hasError) {
+                                    ref
+                                        .read(toastProvider)
+                                        ?.showError(result.error.toString());
+                                  }
                                   ref.read(provider.notifier).refresh();
                                   ref.invalidate(categoryControllerProvider);
+                                  // The library's category tabs all filter one
+                                  // libraryMangaListProvider; without this the
+                                  // manga keeps its stale categories and never
+                                  // shows under the new tab.
+                                  ref.invalidate(libraryMangaListProvider);
                                 },
                                 value: selectedCategoryList?.containsKey(
                                       "${category.id}",

--- a/test/src/features/manga_book/manga_details/edit_manga_category_dialog_test.dart
+++ b/test/src/features/manga_book/manga_details/edit_manga_category_dialog_test.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/library/domain/category/category_model.dart';
+import 'package:tsumiru/src/features/library/domain/category/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/library/presentation/category/controller/edit_category_controller.dart';
+import 'package:tsumiru/src/features/library/presentation/library/controller/library_manga_list.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+CategoryDto _cat({required int id, required String name}) => Fragment$CategoryDto(
+      defaultCategory: false,
+      id: id,
+      includeInDownload: Enum$IncludeOrExclude.UNSET,
+      includeInUpdate: Enum$IncludeOrExclude.UNSET,
+      name: name,
+      order: id,
+      mangas: Fragment$CategoryDto$mangas(totalCount: 0),
+      meta: const [],
+    );
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _RecordingMangaBookRepo extends MangaBookRepository {
+  _RecordingMangaBookRepo({this.failAdd = false}) : super(_dummyClient());
+
+  final bool failAdd;
+  final List<int> added = <int>[];
+  List<CategoryDto> current = <CategoryDto>[];
+
+  @override
+  Future<List<CategoryDto>?> getMangaCategoryList({required int mangaId}) async =>
+      current;
+
+  @override
+  Future<void> addMangaToCategory(int mangaId, int categoryId) async {
+    if (failAdd) throw Exception('offline — mutation failed');
+    added.add(categoryId);
+  }
+
+  @override
+  Future<void> removeMangaFromCategory(int mangaId, int categoryId) async {}
+}
+
+class _FixedCategories extends CategoryController {
+  @override
+  Future<List<CategoryDto>?> build() async => [_cat(id: 2, name: 'Pornhwa')];
+}
+
+Widget _app(ProviderContainer container) => UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const Scaffold(body: EditMangaCategoryDialog(mangaId: 76)),
+      ),
+    );
+
+void main() {
+  testWidgets(
+      'toggling a category persists via the repo and re-fetches the library',
+      (tester) async {
+    final repo = _RecordingMangaBookRepo();
+    var libraryBuilds = 0;
+    final container = ProviderContainer(overrides: [
+      mangaBookRepositoryProvider.overrideWithValue(repo),
+      categoryControllerProvider.overrideWith(() => _FixedCategories()),
+      libraryMangaListProvider.overrideWith((ref) async {
+        libraryBuilds++;
+        return const <MangaDto>[];
+      }),
+    ]);
+    addTearDown(container.dispose);
+    // Keep the library source alive so an invalidation actually rebuilds it.
+    container.listen(libraryMangaListProvider, (_, __) {}, fireImmediately: true);
+
+    await tester.pumpWidget(_app(container));
+    await tester.pumpAndSettle();
+    expect(libraryBuilds, 1);
+
+    await tester.tap(find.text('Pornhwa'));
+    await tester.pumpAndSettle();
+
+    // The change persisted through the repo (the mutation actually ran)...
+    expect(repo.added, contains(2));
+    // ...and the library's single source list was invalidated + rebuilt, so
+    // the manga will show under the new category tab (the reported bug).
+    expect(libraryBuilds, 2);
+  });
+
+  testWidgets('a failed toggle still refreshes the library without crashing',
+      (tester) async {
+    final repo = _RecordingMangaBookRepo(failAdd: true);
+    var libraryBuilds = 0;
+    final container = ProviderContainer(overrides: [
+      mangaBookRepositoryProvider.overrideWithValue(repo),
+      categoryControllerProvider.overrideWith(() => _FixedCategories()),
+      libraryMangaListProvider.overrideWith((ref) async {
+        libraryBuilds++;
+        return const <MangaDto>[];
+      }),
+    ]);
+    addTearDown(container.dispose);
+    container.listen(libraryMangaListProvider, (_, __) {}, fireImmediately: true);
+
+    await tester.pumpWidget(_app(container));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Pornhwa'));
+    await tester.pumpAndSettle();
+
+    // The failure was surfaced (not swallowed), and the flow completed: the
+    // library still re-fetched, so the checkbox reverts to the true state.
+    expect(repo.added, isEmpty);
+    expect(libraryBuilds, 2);
+  });
+}


### PR DESCRIPTION
Editing a manga's categories (long-press in the library, or from the manga page) updated the category metadata and the manga's own category query, but never invalidated `libraryMangaListProvider` — the single server-backed list every category tab is filtered from. So the manga kept its stale categories in memory and never appeared under the newly-checked category until an app restart.

The save was also wrapped in `AsyncValue.guard` with no feedback, so a mutation that never landed still looked saved (the checkbox flips optimistically).

- Invalidate `libraryMangaListProvider` after a category toggle so the change shows across all category tabs immediately.
- Surface a failed save via an error toast instead of swallowing it silently.
- Verified the server-side mutation itself is correct against a live Suwayomi server; the defect was entirely client-side refresh + error handling.
- Two regression tests: a successful toggle persists through the repo and re-fetches the library; a failed toggle surfaces the error and still refreshes without crashing.