### PR TITLE
Mark the last webtoon page read when short trailing pages end a chapter

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_utils.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_utils.dart
@@ -33,6 +33,47 @@ class InfinityContinuousUtils {
     return (visibleEnd - visibleStart).clamp(0.0, 1.0);
   }
 
+  /// The global page index the reader is "on" for progress, given the visible
+  /// [positions] (already filtered to those on screen) and [total] loaded pages.
+  ///
+  /// Normally the page showing the greatest visible area. But when the last
+  /// page's bottom has reached the viewport bottom ([ItemPosition.itemTrailingEdge]
+  /// <= 1.0), the reader is scrolled as far as it goes, so that last page is
+  /// current even if a taller earlier page still shows more area. Without this,
+  /// short trailing pages (e.g. a small credits page that lets three pages share
+  /// the screen) leave progress stuck one short and the last chapter never marks
+  /// read (#100). Returns null when nothing is visible.
+  static int? selectCurrentIndex(
+    List<ItemPosition> positions,
+    int total, {
+    required double minVisibleAreaThreshold,
+  }) {
+    if (positions.isEmpty) return null;
+
+    // total - 1 is the last loaded page; itemTrailingEdge <= 1.0 means its
+    // bottom sits at or above the viewport bottom, i.e. the end is reached.
+    final lastPage = positions.where((p) => p.index == total - 1);
+    if (total > 1 &&
+        lastPage.isNotEmpty &&
+        lastPage.first.itemTrailingEdge <= 1.0) {
+      return total - 1;
+    }
+
+    ItemPosition? mostVisible;
+    double bestArea = 0.0;
+    for (final p in positions) {
+      final area = calculateVisibleArea(p);
+      if (area > bestArea && area > minVisibleAreaThreshold) {
+        bestArea = area;
+        mostVisible = p;
+      }
+    }
+    mostVisible ??= positions.reduce(
+      (a, b) => a.itemLeadingEdge.abs() <= b.itemLeadingEdge.abs() ? a : b,
+    );
+    return mostVisible.index;
+  }
+
   /// Sum of pages across all loaded chapters.
   static int getTotalPages(
     List<({ChapterPagesDto pages, ChapterDto chapter, int chapterId})>

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -509,23 +509,17 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
             .toList();
         if (positions.isEmpty) return;
 
-        // Most-visible page → current global index.
-        ItemPosition? mostVisible;
-        double bestArea = 0.0;
-        for (final p in positions) {
-          final area = InfinityContinuousUtils.calculateVisibleArea(p);
-          if (area > bestArea &&
-              area > InfinityContinuousConfig.minVisibleAreaThreshold) {
-            bestArea = area;
-            mostVisible = p;
-          }
-        }
-        mostVisible ??= positions.reduce(
-          (a, b) => a.itemLeadingEdge.abs() <= b.itemLeadingEdge.abs() ? a : b,
+        // Most-visible page → current global index (last page wins once its
+        // bottom reaches the viewport, so short trailing pages still complete).
+        final globalIdx = InfinityContinuousUtils.selectCurrentIndex(
+          positions,
+          total,
+          minVisibleAreaThreshold:
+              InfinityContinuousConfig.minVisibleAreaThreshold,
         );
+        if (globalIdx == null) return;
 
         // Map the global index to (chapter, page-within-chapter).
-        final globalIdx = mostVisible.index;
         int cumulative = 0;
         for (final ch in loaded) {
           final count = ch.pages.pages.length;

--- a/test/manga_book/reader/continuous_current_index_test.dart
+++ b/test/manga_book/reader/continuous_current_index_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_utils.dart';
+
+ItemPosition _p(int index, double leading, double trailing) =>
+    ItemPosition(index: index, itemLeadingEdge: leading, itemTrailingEdge: trailing);
+
+int? _select(List<ItemPosition> positions, int total) =>
+    InfinityContinuousUtils.selectCurrentIndex(positions, total,
+        minVisibleAreaThreshold: 0.05);
+
+void main() {
+  group('selectCurrentIndex', () {
+    test('mid-scroll picks the largest visible page', () {
+      // A tall page fills most of the screen; the next barely peeks in.
+      final positions = [
+        _p(10, -0.3, 0.7), // visible area 0.7
+        _p(11, 0.7, 1.6), // visible area ~0.3
+      ];
+      expect(_select(positions, 34), 10);
+    });
+
+    test('#100: at the bottom, a small last page wins over a taller one', () {
+      // Scrolled to the end: page 31 still fills the top, but the two short
+      // trailing pages share the rest — the last page (33) has less area yet
+      // its bottom (0.9) is within the viewport, so it is current.
+      final positions = [
+        _p(31, -0.7, 0.4), // area 0.4 (largest)
+        _p(32, 0.4, 0.65), // area 0.25
+        _p(33, 0.65, 0.9), // last page, area 0.25, bottom reached
+      ];
+      expect(_select(positions, 34), 33);
+    });
+
+    test('last page visible but bottom not yet reached → largest area', () {
+      // The last page is on screen but extends past the viewport bottom
+      // (trailingEdge > 1.0) — the user has not scrolled to the end.
+      final positions = [
+        _p(32, -0.4, 0.5), // area 0.5
+        _p(33, 0.5, 1.5), // last page, bottom still below the fold
+      ];
+      expect(_select(positions, 34), 32);
+    });
+
+    test('empty positions → null', () {
+      expect(_select(const [], 34), isNull);
+    });
+
+    test('single-page total does not force the override', () {
+      expect(_select([_p(0, 0.0, 0.8)], 1), 0);
+    });
+  });
+}


### PR DESCRIPTION
Closes #100.

In the continuous (long-strip) reader, the current page was tracked as the one with the greatest visible area. When a chapter's last pages are short (e.g. a small credits page that lets three pages share the screen), a taller earlier page always won — so progress stuck one short ("33 of 34") and, on the last chapter, it never marked read.

Now once the last page's bottom reaches the viewport (fully scrolled to the end), that page is current regardless of visible area. Mid-scroll selection is unchanged.

The selection logic is extracted into a pure `InfinityContinuousUtils.selectCurrentIndex` helper and unit-tested: the #100 case (short last page at the bottom wins), normal mid-scroll (largest area wins), last-page-visible-but-not-yet-at-bottom (no premature completion), empty, and single-page.