### PR TITLE
Don't mark a short webtoon chapter read on open

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_utils.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_utils.dart
@@ -59,9 +59,13 @@ class InfinityContinuousUtils {
     // Content is "scrolled" once page 0's top has left the viewport top (or page
     // 0 is gone entirely). If it's still parked at rest, the reader is at the
     // start, not the end, no matter how much of the chapter happens to fit.
+    // Tolerate float-noise around 0 (a settled page 0 can report a tiny
+    // negative) so it isn't misread as "scrolled" — which would re-open the
+    // mark-read-on-open bug.
+    const restEps = 0.0015;
     final firstPage = positions.where((p) => p.index == 0);
     final restingAtTop =
-        firstPage.isNotEmpty && firstPage.first.itemLeadingEdge >= 0;
+        firstPage.isNotEmpty && firstPage.first.itemLeadingEdge >= -restEps;
 
     // total - 1 is the last loaded page; itemTrailingEdge <= 1.0 means its
     // bottom sits at or above the viewport bottom, i.e. the end is reached.

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_utils.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_utils.dart
@@ -36,13 +36,19 @@ class InfinityContinuousUtils {
   /// The global page index the reader is "on" for progress, given the visible
   /// [positions] (already filtered to those on screen) and [total] loaded pages.
   ///
-  /// Normally the page showing the greatest visible area. But when the last
-  /// page's bottom has reached the viewport bottom ([ItemPosition.itemTrailingEdge]
-  /// <= 1.0), the reader is scrolled as far as it goes, so that last page is
-  /// current even if a taller earlier page still shows more area. Without this,
-  /// short trailing pages (e.g. a small credits page that lets three pages share
-  /// the screen) leave progress stuck one short and the last chapter never marks
-  /// read (#100). Returns null when nothing is visible.
+  /// Normally the page showing the greatest visible area. But when the reader is
+  /// scrolled to the very end — the last page's bottom has reached the viewport
+  /// bottom ([ItemPosition.itemTrailingEdge] <= 1.0) — that last page is current
+  /// even if a taller earlier page still shows more area. Without this, short
+  /// trailing pages (e.g. a small credits page that lets three pages share the
+  /// screen) leave progress stuck one short and the last chapter never marks
+  /// read (#100).
+  ///
+  /// The override is gated on the content actually being scrolled: if page 0 is
+  /// still resting at or below the viewport top (a short chapter that simply
+  /// fits on screen at rest), it does NOT fire — otherwise opening such a
+  /// chapter would mark it read immediately, firing delete-on-read and a false
+  /// tracker bump before anything is read. Returns null when nothing is visible.
   static int? selectCurrentIndex(
     List<ItemPosition> positions,
     int total, {
@@ -50,10 +56,18 @@ class InfinityContinuousUtils {
   }) {
     if (positions.isEmpty) return null;
 
+    // Content is "scrolled" once page 0's top has left the viewport top (or page
+    // 0 is gone entirely). If it's still parked at rest, the reader is at the
+    // start, not the end, no matter how much of the chapter happens to fit.
+    final firstPage = positions.where((p) => p.index == 0);
+    final restingAtTop =
+        firstPage.isNotEmpty && firstPage.first.itemLeadingEdge >= 0;
+
     // total - 1 is the last loaded page; itemTrailingEdge <= 1.0 means its
     // bottom sits at or above the viewport bottom, i.e. the end is reached.
     final lastPage = positions.where((p) => p.index == total - 1);
     if (total > 1 &&
+        !restingAtTop &&
         lastPage.isNotEmpty &&
         lastPage.first.itemTrailingEdge <= 1.0) {
       return total - 1;

--- a/test/manga_book/reader/continuous_current_index_test.dart
+++ b/test/manga_book/reader/continuous_current_index_test.dart
@@ -48,6 +48,29 @@ void main() {
       expect(_select(positions, 34), 32);
     });
 
+    test('short chapter resting at the top does NOT complete on open', () {
+      // A 3-page chapter that fully fits the viewport, freshly opened: page 0 is
+      // parked at the top (leadingEdge 0). Must NOT return the last page, or the
+      // chapter marks read on open (false tracker bump + delete-on-read).
+      final positions = [
+        _p(0, 0.0, 0.33),
+        _p(1, 0.33, 0.66),
+        _p(2, 0.66, 0.9), // last page bottom within viewport, but at rest
+      ];
+      expect(_select(positions, 3), 0);
+    });
+
+    test('scrolled to the end of a short chapter (page 0 leaving) completes', () {
+      // Same short chapter, but now scrolled: page 0 has slid above the viewport
+      // top (leadingEdge < 0) — the user reached the end, so it completes.
+      final positions = [
+        _p(0, -0.5, 0.2),
+        _p(1, 0.2, 0.6),
+        _p(2, 0.6, 0.9),
+      ];
+      expect(_select(positions, 3), 2);
+    });
+
     test('empty positions → null', () {
       expect(_select(const [], 34), isNull);
     });


### PR DESCRIPTION
Follow-up to #158. That change treated the last page as current once its bottom reached the viewport — but a short chapter that fully fits the screen meets that condition **at rest**, so opening it marked the chapter read immediately, firing delete-on-read and a false tracker bump before anything was read. Realistic on landscape / desktop / web where several short pages fit at once.

Fix: gate the last-page override on the content actually being scrolled — if page 0 is still resting at or below the viewport top, the reader is at the start, not the end, so the last page does not become current. The #100 behavior (scroll to the end of a chapter with short trailing pages) is preserved.

Added regression tests: a short chapter resting at the top returns page 0 (no completion on open); the same chapter scrolled (page 0 leaving the top) completes.