### PR TITLE
Revert the category checkbox when a toggle fails

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart
@@ -65,32 +65,32 @@ class EditMangaCategoryDialog extends HookConsumerWidget {
                             if (category.id != 0)
                               AsyncCheckboxListTile(
                                 onChanged: (value) async {
-                                  final result = await AsyncValue.guard(
-                                    () => value.ifNull()
-                                        ? ref
-                                            .read(mangaBookRepositoryProvider)
-                                            .addMangaToCategory(
-                                                mangaId, category.id)
-                                        : ref
-                                            .read(mangaBookRepositoryProvider)
-                                            .removeMangaFromCategory(
-                                                mangaId, category.id),
-                                  );
-                                  // A swallowed failure here is what made the
-                                  // change look saved (optimistic checkbox) while
-                                  // nothing persisted — surface it so the user
-                                  // knows to retry.
-                                  if (result.hasError) {
-                                    ref
-                                        .read(toastProvider)
-                                        ?.showError(result.error.toString());
+                                  // Capture before the await so a dialog
+                                  // dismissed mid-request never touches a
+                                  // deactivated ref.
+                                  final toast = ref.read(toastProvider);
+                                  final repo =
+                                      ref.read(mangaBookRepositoryProvider);
+                                  try {
+                                    value
+                                        ? await repo.addMangaToCategory(
+                                            mangaId, category.id)
+                                        : await repo.removeMangaFromCategory(
+                                            mangaId, category.id);
+                                  } catch (e) {
+                                    // Surface the failure and rethrow so the
+                                    // checkbox reverts to its true (unchanged)
+                                    // state instead of showing a save that never
+                                    // landed.
+                                    toast?.showError(e.toString());
+                                    rethrow;
                                   }
+                                  // Success: reflect it in this dialog and across
+                                  // the library's category tabs (all filter one
+                                  // libraryMangaListProvider). Skipped on failure
+                                  // so a no-op toggle doesn't refetch the library.
                                   ref.read(provider.notifier).refresh();
                                   ref.invalidate(categoryControllerProvider);
-                                  // The library's category tabs all filter one
-                                  // libraryMangaListProvider; without this the
-                                  // manga keeps its stale categories and never
-                                  // shows under the new tab.
                                   ref.invalidate(libraryMangaListProvider);
                                 },
                                 value: selectedCategoryList?.containsKey(

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart
@@ -65,9 +65,9 @@ class EditMangaCategoryDialog extends HookConsumerWidget {
                             if (category.id != 0)
                               AsyncCheckboxListTile(
                                 onChanged: (value) async {
-                                  // Capture before the await so a dialog
-                                  // dismissed mid-request never touches a
-                                  // deactivated ref.
+                                  // Capture the toast before the await so the
+                                  // error path can report even if the dialog is
+                                  // gone by the time the request returns.
                                   final toast = ref.read(toastProvider);
                                   final repo =
                                       ref.read(mangaBookRepositoryProvider);
@@ -89,6 +89,10 @@ class EditMangaCategoryDialog extends HookConsumerWidget {
                                   // the library's category tabs (all filter one
                                   // libraryMangaListProvider). Skipped on failure
                                   // so a no-op toggle doesn't refetch the library.
+                                  // If the dialog was dismissed mid-request the
+                                  // caller refreshes on close, so bail rather than
+                                  // touch a deactivated ref.
+                                  if (!context.mounted) return;
                                   ref.read(provider.notifier).refresh();
                                   ref.invalidate(categoryControllerProvider);
                                   ref.invalidate(libraryMangaListProvider);

--- a/lib/src/widgets/async_buttons/async_checkbox_list_tile.dart
+++ b/lib/src/widgets/async_buttons/async_checkbox_list_tile.dart
@@ -21,30 +21,37 @@ class AsyncCheckboxListTile extends HookWidget {
 
   /// Runs the change. The checkbox flips optimistically before this is awaited
   /// and reverts if it throws — so a failed toggle doesn't leave the box showing
-  /// a state that never persisted.
+  /// a state that never persisted. Callers own user-facing error reporting; the
+  /// throw is only used here to trigger the revert.
   final Future<void> Function(bool)? onChanged;
   final Widget title;
   @override
   Widget build(BuildContext context) {
     final localValue = useState(value);
+    final inFlight = useState(false);
     useEffect(() {
       localValue.value = value;
       return null;
     }, [value]);
     return CheckboxListTile(
-      value: localValue.value,
-      onChanged: onChanged != null
+      // Disabled while a change is in flight so overlapping toggles can't leave
+      // the revert pointing at a stale, mid-flight value.
+      onChanged: onChanged != null && !inFlight.value
           ? (val) async {
               final previous = localValue.value;
               final next = val.ifNull();
               localValue.value = next;
+              inFlight.value = true;
               try {
                 await onChanged!(next);
               } catch (_) {
                 localValue.value = previous;
+              } finally {
+                inFlight.value = false;
               }
             }
           : null,
+      value: localValue.value,
       title: title,
     );
   }

--- a/lib/src/widgets/async_buttons/async_checkbox_list_tile.dart
+++ b/lib/src/widgets/async_buttons/async_checkbox_list_tile.dart
@@ -18,7 +18,11 @@ class AsyncCheckboxListTile extends HookWidget {
   });
 
   final bool value;
-  final ValueChanged<bool>? onChanged;
+
+  /// Runs the change. The checkbox flips optimistically before this is awaited
+  /// and reverts if it throws — so a failed toggle doesn't leave the box showing
+  /// a state that never persisted.
+  final Future<void> Function(bool)? onChanged;
   final Widget title;
   @override
   Widget build(BuildContext context) {
@@ -30,9 +34,15 @@ class AsyncCheckboxListTile extends HookWidget {
     return CheckboxListTile(
       value: localValue.value,
       onChanged: onChanged != null
-          ? (val) {
-              localValue.value = (val.ifNull());
-              onChanged!(val.ifNull());
+          ? (val) async {
+              final previous = localValue.value;
+              final next = val.ifNull();
+              localValue.value = next;
+              try {
+                await onChanged!(next);
+              } catch (_) {
+                localValue.value = previous;
+              }
             }
           : null,
       title: title,

--- a/test/src/features/manga_book/manga_details/edit_manga_category_dialog_test.dart
+++ b/test/src/features/manga_book/manga_details/edit_manga_category_dialog_test.dart
@@ -101,7 +101,7 @@ void main() {
     expect(libraryBuilds, 2);
   });
 
-  testWidgets('a failed toggle still refreshes the library without crashing',
+  testWidgets('a failed toggle reverts the checkbox and does not refetch',
       (tester) async {
     final repo = _RecordingMangaBookRepo(failAdd: true);
     var libraryBuilds = 0;
@@ -122,9 +122,18 @@ void main() {
     await tester.tap(find.text('Pornhwa'));
     await tester.pumpAndSettle();
 
-    // The failure was surfaced (not swallowed), and the flow completed: the
-    // library still re-fetched, so the checkbox reverts to the true state.
     expect(repo.added, isEmpty);
-    expect(libraryBuilds, 2);
+    // The optimistic tick flipped the box; the failure reverts it, so it does
+    // not show a save that never landed.
+    final tile = tester.widget<CheckboxListTile>(
+      find.ancestor(
+        of: find.text('Pornhwa'),
+        matching: find.byType(CheckboxListTile),
+      ),
+    );
+    expect(tile.value, isFalse);
+    // Nothing changed on the server, so the library is not re-fetched (only the
+    // initial fireImmediately build ran).
+    expect(libraryBuilds, 1);
   });
 }


### PR DESCRIPTION
Follow-up to #156, from an adversarial review of that PR.

Three fixes to the edit-categories dialog:
- **Revert on failure.** `AsyncCheckboxListTile` flipped optimistically and never reverted, so a failed save left the box checked while the toast said it failed. It now awaits the change and reverts if it throws.
- **Dispose safety.** The toast and repository are captured before the await, so dismissing the dialog while a request is in flight can't use a deactivated ref.
- **No refetch on a no-op.** The library is invalidated only on success, so a failed toggle no longer triggers a full-library refetch + sync pass.

Test updated to assert the checkbox reverts and the library is not re-fetched on failure.