### PR TITLE
Prompt when the default category was deleted

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/widgets/add_to_library_category.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/add_to_library_category.dart
@@ -42,10 +42,8 @@ Future<void> addMangaToLibraryWithCategory(
     await repo.addMangaToLibrary(mangaId);
     await repo.addMangaToCategory(mangaId, match.first.id);
   } else if (pref == 0 || categories.isEmpty) {
-    // Explicit Default/uncategorized, or no categories to choose from. A pref
-    // pointing at a since-deleted category is NOT treated as uncategorized —
-    // it falls through to the picker below, matching the settings screen, which
-    // shows "Always ask" for a missing category.
+    // Explicit Default/uncategorized, or nothing to pick from. A since-deleted
+    // pref is NOT this branch — it falls through to the picker (matches settings).
     await repo.addMangaToLibrary(mangaId);
   } else {
     if (!context.mounted) return;

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/add_to_library_category.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/add_to_library_category.dart
@@ -41,8 +41,11 @@ Future<void> addMangaToLibraryWithCategory(
   if (match.isNotEmpty) {
     await repo.addMangaToLibrary(mangaId);
     await repo.addMangaToCategory(mangaId, match.first.id);
-  } else if (pref != -1 || categories.isEmpty) {
-    // Default/uncategorized, or no categories to choose from.
+  } else if (pref == 0 || categories.isEmpty) {
+    // Explicit Default/uncategorized, or no categories to choose from. A pref
+    // pointing at a since-deleted category is NOT treated as uncategorized —
+    // it falls through to the picker below, matching the settings screen, which
+    // shows "Always ask" for a missing category.
     await repo.addMangaToLibrary(mangaId);
   } else {
     if (!context.mounted) return;

--- a/test/src/features/manga_book/manga_details/add_to_library_category_test.dart
+++ b/test/src/features/manga_book/manga_details/add_to_library_category_test.dart
@@ -150,6 +150,22 @@ void main() {
     expect(repo.addedToCategory, isNot(contains((76, 1))));
   });
 
+  testWidgets('a pref pointing at a deleted category prompts, not silent add',
+      (tester) async {
+    // 9 is not among the fixed categories (0/1/2) — a category the user chose
+    // as default and later deleted. Must fall through to the picker (matching
+    // the settings label) rather than silently adding uncategorized.
+    final repo = _RecordingRepo();
+    final c = _container(repo, 9);
+    addTearDown(c.dispose);
+    await tester.pumpWidget(_harness(c, 76));
+    await tester.tap(find.text('add'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Set categories'), findsOneWidget);
+    expect(repo.addedToLibrary, isEmpty); // nothing added until the user picks
+  });
+
   testWidgets('Always ask + Cancel adds nothing', (tester) async {
     final repo = _RecordingRepo();
     final c = _container(repo, -1);


### PR DESCRIPTION
Follow-up to #157, from the review of that PR.

If a user picks a specific category as their add-to-library default and later deletes it, the settings screen shows **Always ask** (the label falls back for a missing category) but the add path silently added the manga uncategorized — the label and the behavior disagreed.

Now a stale (since-deleted) pref falls through to the **Set categories** picker, matching the label. An explicit *Default*/uncategorized (id 0) still adds silently. Added a test for the deleted-category case.