### PR TITLE
Android Back returns to the home tab instead of exiting

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,12 +11,18 @@
      <!-- Save reader page to gallery (gal). API 30+ uses MediaStore, no perm. -->
      <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
                       android:maxSdkVersion="29" />
+   <!-- Force the legacy back path on all OS versions so Back behaves the same
+        everywhere. Predictive back (default at targetSdk 36 on Android 16) hits
+        unfixed go_router StatefulShellRoute bugs that close the app with a
+        non-empty stack (flutter #145290/#188018). Re-enable once
+        go_router/packages#11910 ships. -->
    <application
         android:label="${appLabel}"
         android:name="${applicationName}"
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:enableOnBackInvokedCallback="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/src/widgets/shell/navigation_shell_screen.dart
+++ b/lib/src/widgets/shell/navigation_shell_screen.dart
@@ -110,8 +110,18 @@ class NavigationShellScreen extends HookConsumerWidget {
       }
     }
 
+    // Branch 0 (Library) is home. Android Back from any other tab returns here
+    // instead of exiting; only Library-at-root exits (#102). goBranch itself
+    // builds no back-stack.
+    const homeBranch = 0;
+    void switchTo(int navBarIndex) {
+      final target = getAdjustedIndex(navBarIndex);
+      child.goBranch(target, initialLocation: target == child.currentIndex);
+    }
+
+    final Widget scaffold;
     if (context.isTablet) {
-      return Scaffold(
+      scaffold = Scaffold(
         // No bottom bar here, so the rail + content would draw under the system
         // navigation controls (and any landscape cutout). SafeArea keeps both
         // out of that unusable strip so the controls never overlap a cover.
@@ -120,10 +130,7 @@ class NavigationShellScreen extends HookConsumerWidget {
             children: [
               BigScreenNavigationBar(
                 selectedIndex: child.currentIndex,
-                onDestinationSelected: (index) => child.goBranch(
-                  getAdjustedIndex(index),
-                  initialLocation: index == child.currentIndex,
-                ),
+                onDestinationSelected: switchTo,
               ),
               Expanded(
                 child: Column(
@@ -138,7 +145,7 @@ class NavigationShellScreen extends HookConsumerWidget {
         ),
       );
     } else {
-      return Scaffold(
+      scaffold = Scaffold(
         body: Column(
           children: [
             Expanded(child: child),
@@ -148,12 +155,27 @@ class NavigationShellScreen extends HookConsumerWidget {
         floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
         bottomNavigationBar: SmallScreenNavigationBar(
           selectedIndex: getReverseAdjustedIndex(child.currentIndex),
-          onDestinationSelected: (index) => child.goBranch(
-            getAdjustedIndex(index),
-            initialLocation: index == child.currentIndex,
-          ),
+          onDestinationSelected: switchTo,
         ),
       );
     }
+
+    // Intercept the hardware Back BEFORE go_router's own handler: go_router
+    // 14.x doesn't route Back to a shell PopScope when a branch is at its root,
+    // so it exits the app instead of returning to the home tab (flutter
+    // #145290/#188018). BackButtonListener fires on the legacy back path (which
+    // the manifest forces on via enableOnBackInvokedCallback=false).
+    return BackButtonListener(
+      onBackButtonPressed: () async {
+        // Within a branch (a pushed route) or on home → let the default handler
+        // pop the route or exit. On any other tab at its root, go home instead.
+        if (child.currentIndex != homeBranch && !GoRouter.of(context).canPop()) {
+          child.goBranch(homeBranch);
+          return true; // handled — do not exit
+        }
+        return false;
+      },
+      child: scaffold,
+    );
   }
 }


### PR DESCRIPTION
Closes #102.

On any non-Library tab, the system Back button closed the app instead of returning to the library.

**Root cause (verified on-device with logging):** go_router 14.x does not route Back to a shell `PopScope` when a `StatefulShellRoute` branch is at its root — the shell PopScope's callback never fired, and Back fell through to an app exit (flutter [#145290](https://github.com/flutter/flutter/issues/145290) / [#188018](https://github.com/flutter/flutter/issues/188018); the go_router fix is unreleased).

**Fix:** intercept Back ahead of go_router with `BackButtonListener` — on a non-home tab with nothing pushed inside the branch, switch to the home branch; otherwise defer so a pushed route pops (manga details, reader) or the home tab exits.

Also set `android:enableOnBackInvokedCallback="false"` so behaviour is identical across OS versions — predictive back defaults **on** at targetSdk 36 (Android 16) and hits the same unfixed go_router bugs. Tradeoff: no predictive-back peek animation; revert once go_router/packages#11910 ships. This also makes an Android 16 device a faithful test stand-in for Android 14/15.

Confirmed on-device (Android 16): Library → More → Back now returns to Library; manga details → Back still returns normally; Library-at-root exits.