### PR TITLE
Personal star rating per manga, with library sort and filter

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -141,6 +141,8 @@ enum DBKeys {
   // 2=by status, 3=by track status (reserved; filled in Task 8), 4=ungrouped.
   libraryGroupType(0),
   mangaFilterLewd(null),
+  // Minimum personal star rating to show in the library. 0 = off (show all).
+  mangaFilterMinRating(0),
   filterCategories(false),
   filterCategoriesInclude(<String>[]),
   filterCategoriesExclude(<String>[]),

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -316,7 +316,8 @@ enum MangaSort {
   // Appended (NOT reordered) — MangaSort prefs are stored by enum index, so
   // reordering would corrupt saved sorts. Sort-tab display order is controlled
   // separately (see library_manga_organizer.dart).
-  lastUpdate;
+  lastUpdate,
+  rating;
 
   String toLocale(BuildContext context) => switch (this) {
         MangaSort.alphabetical => context.l10n.mangaSortAlphabetical,
@@ -329,6 +330,7 @@ enum MangaSort {
         MangaSort.random => context.l10n.mangaSortRandom,
         MangaSort.trackerScore => context.l10n.mangaSortTrackerScore,
         MangaSort.lastUpdate => context.l10n.mangaSortLastUpdate,
+        MangaSort.rating => context.l10n.mangaSortRating,
       };
 }
 

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -53,6 +53,7 @@ List<MangaDto> applyLibraryFilterSort(
   required bool? mangaFilterOffline,
   required Set<int> offlineMangaIds,
   required bool? mangaFilterLewd,
+  required int mangaFilterMinRating,
   required bool filterCategories,
   required Set<String> filterCategoriesInclude,
   required Set<String> filterCategoriesExclude,
@@ -90,6 +91,10 @@ List<MangaDto> applyLibraryFilterSort(
     }
     if (mangaFilterLewd != null &&
         (mangaFilterLewd ^ (manga.source?.isNsfw ?? false))) {
+      return false;
+    }
+    if (mangaFilterMinRating > 0 &&
+        (manga.metaData.rating ?? 0) < mangaFilterMinRating) {
       return false;
     }
     if (filterCategories) {
@@ -162,6 +167,9 @@ List<MangaDto> applyLibraryFilterSort(
           MangaSort.lastUpdate =>
             (int.tryParse(m1.chaptersLastFetchedAt ?? '0') ?? 0)
                 .compareTo(int.tryParse(m2.chaptersLastFetchedAt ?? '0') ?? 0),
+          // Personal star rating (0 = unrated, sorts lowest).
+          MangaSort.rating => (m1.metaData.rating ?? 0)
+              .compareTo(m2.metaData.rating ?? 0),
           // Normal order (m1 vs m2): ascending = oldest-read first,
           // descending = newest-read first. (Previously the operands were
           // swapped, which inverted our arrows — our "ascending" showed
@@ -247,6 +255,8 @@ class CategoryMangaListWithQueryAndFilter
               mangaFilterOffline: mangaFilterOffline,
               offlineMangaIds: offlineMangaIds,
               mangaFilterLewd: mangaFilterLewd,
+              mangaFilterMinRating:
+                  ref.watch(libraryMangaFilterMinRatingProvider) ?? 0,
               filterCategories: filterCategories,
               filterCategoriesInclude: filterCategoriesInclude,
               filterCategoriesExclude: filterCategoriesExclude,
@@ -320,6 +330,13 @@ class LibraryMangaFilterLewd extends _$LibraryMangaFilterLewd
     with SharedPreferenceClientMixin<bool> {
   @override
   bool? build() => initialize(DBKeys.mangaFilterLewd);
+}
+
+@riverpod
+class LibraryMangaFilterMinRating extends _$LibraryMangaFilterMinRating
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.mangaFilterMinRating);
 }
 
 @riverpod
@@ -546,6 +563,8 @@ class GroupedMangaListWithQueryAndFilter
               mangaFilterOffline: mangaFilterOffline,
               offlineMangaIds: offlineMangaIds,
               mangaFilterLewd: mangaFilterLewd,
+              mangaFilterMinRating:
+                  ref.watch(libraryMangaFilterMinRatingProvider) ?? 0,
               filterCategories: filterCategories,
               filterCategoriesInclude: filterCategoriesInclude,
               filterCategoriesExclude: filterCategoriesExclude,

--- a/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
@@ -65,9 +65,49 @@ class LibraryMangaFilter extends ConsumerWidget {
           onChanged:
               ref.read(libraryMangaFilterLewdProvider.notifier).update,
         ),
+        _RatingFilterRow(),
         _CategoryFilterRow(),
         _TrackerFilterSection(),
       ],
+    );
+  }
+}
+
+/// Minimum personal star rating to show. Tapping star N sets the threshold to N;
+/// tapping the current threshold clears it (show all).
+class _RatingFilterRow extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final min = ref.watch(libraryMangaFilterMinRatingProvider) ?? 0;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              context.l10n.minimumRating,
+              style: context.theme.textTheme.bodyMedium,
+            ),
+          ),
+          for (int star = 1; star <= 5; star++)
+            InkResponse(
+              radius: 18,
+              onTap: () => ref
+                  .read(libraryMangaFilterMinRatingProvider.notifier)
+                  .update(min == star ? 0 : star),
+              child: Padding(
+                padding: const EdgeInsets.all(2),
+                child: Icon(
+                  star <= min ? Icons.star_rounded : Icons.star_border_rounded,
+                  size: 22,
+                  color: star <= min
+                      ? Colors.amber
+                      : context.theme.unselectedWidgetColor,
+                ),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/features/library/presentation/library/widgets/library_manga_organizer.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_organizer.dart
@@ -19,6 +19,7 @@ import '../../../../tracking/data/tracker_repository.dart';
 /// `MangaSort` enum declaration because that is persisted by index.
 const List<MangaSort> _sortDisplayOrder = [
   MangaSort.alphabetical,
+  MangaSort.rating,
   MangaSort.totalChapters,
   MangaSort.lastRead,
   MangaSort.lastUpdate,

--- a/lib/src/features/manga_book/domain/manga/manga_model.dart
+++ b/lib/src/features/manga_book/domain/manga/manga_model.dart
@@ -61,6 +61,8 @@ class MangaMeta with _$MangaMeta {
     ReaderOrientation? readerOrientation,
     @JsonKey(name: "flutter_readerTapInvert") TapInvert? readerTapInvert,
     @JsonKey(name: "flutter_scanlator") String? scanlator,
+    @JsonKey(name: "flutter_rating", fromJson: MangaMeta.fromJsonToInt)
+    int? rating,
   }) = _MangaMeta;
 
   static bool? fromJsonToBool(dynamic val) => val != null && val is String
@@ -69,6 +71,9 @@ class MangaMeta with _$MangaMeta {
 
   static double? fromJsonToDouble(dynamic val) =>
       val != null && val is String ? double.parse(val) : null;
+
+  static int? fromJsonToInt(dynamic val) =>
+      val is String ? int.tryParse(val) : null;
   factory MangaMeta.fromJson(Map<String, dynamic> json) =>
       _$MangaMetaFromJson(json);
 }
@@ -82,6 +87,7 @@ enum MangaMetaKeys {
   readerOrientation("flutter_readerOrientation"),
   readerTapInvert("flutter_readerTapInvert"),
   scanlator("flutter_scanlator"),
+  rating("flutter_rating"),
   ;
 
   const MangaMetaKeys(this.key);

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -207,6 +207,32 @@ class MangaChapterFilterScanlator extends _$MangaChapterFilterScanlator {
   }
 }
 
+/// Personal 0-5 star rating for a manga, stored in the per-manga meta store
+/// (no server rating field exists). 0 means unrated.
+@riverpod
+class MangaRating extends _$MangaRating {
+  @override
+  int build({required int mangaId}) {
+    final manga = ref.watch(mangaWithIdProvider(mangaId: mangaId));
+    return (manga.valueOrNull?.metaData.rating ?? 0).clamp(0, 5);
+  }
+
+  Future<void> update(int rating) async {
+    final next = rating.clamp(0, 5);
+    await AsyncValue.guard(
+      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
+            mangaId: mangaId,
+            key: MangaMetaKeys.rating.key,
+            // Meta values are String-typed server-side (MangaMetaTypeInput.value
+            // is String!); an int silently fails the mutation.
+            value: '$next',
+          ),
+    );
+    ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
+    state = next;
+  }
+}
+
 @riverpod
 AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
   Ref ref, {

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -28,6 +28,7 @@ import '../../../domain/manga/manga_model.dart';
 import '../controller/next_update_controller.dart';
 import '../server_web_url.dart';
 import 'manga_action_button.dart';
+import 'manga_rating_bar.dart';
 
 class MangaDescription extends HookConsumerWidget {
   const MangaDescription({
@@ -256,6 +257,7 @@ class MangaDescription extends HookConsumerWidget {
             ),
           );
         }),
+        MangaRatingBar(mangaId: manga.id),
         if (manga.description.isNotBlank)
           Padding(
             padding: KEdgeInsets.a16.size,

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_rating_bar.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_rating_bar.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../controller/manga_details_controller.dart';
+
+/// A tappable 0-5 star row for the reader's personal rating of a manga. Tapping
+/// the current top star clears the rating.
+class MangaRatingBar extends ConsumerWidget {
+  const MangaRatingBar({super.key, required this.mangaId});
+
+  final int mangaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rating = ref.watch(mangaRatingProvider(mangaId: mangaId));
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Row(
+        children: [
+          Text(
+            context.l10n.yourRating,
+            style: context.textTheme.titleSmall,
+          ),
+          const Spacer(),
+          for (int star = 1; star <= 5; star++)
+            InkResponse(
+              radius: 20,
+              onTap: () => ref
+                  .read(mangaRatingProvider(mangaId: mangaId).notifier)
+                  .update(rating == star ? 0 : star),
+              child: Padding(
+                padding: const EdgeInsets.all(2),
+                child: Icon(
+                  star <= rating
+                      ? Icons.star_rounded
+                      : Icons.star_border_rounded,
+                  // Conventional amber reads on every theme; the theme accent
+                  // isn't always a sensible star colour.
+                  color: star <= rating ? Colors.amber : null,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1792,6 +1792,8 @@
     "mangaSortLastRead": "Last Read",
     "mangaSortLastUpdated": "Chapter Fetch Date",
     "mangaSortLastUpdate": "Last Update",
+    "mangaSortRating": "Rating",
+    "minimumRating": "Minimum rating",
     "mangaSortRandom": "Random",
     "mangaSortTrackerScore": "Tracker score",
     "mangaSortTotalChapters": "Total Chapters",
@@ -2349,6 +2351,7 @@
         "description": "Empty state for the on-device downloads tab"
     },
     "tracking": "Tracking",
+    "yourRating": "Your rating",
     "@tracking": {
         "description": "Settings entry and screen title for the Tracking screen"
     },

--- a/test/library/apply_manga_filter_test.dart
+++ b/test/library/apply_manga_filter_test.dart
@@ -83,6 +83,7 @@ List<int> _filter(
       mangaFilterOffline: null,
       offlineMangaIds: const {},
       mangaFilterLewd: lewd,
+      mangaFilterMinRating: 0,
       filterCategories: filterCategories,
       filterCategoriesInclude: include,
       filterCategoriesExclude: exclude,

--- a/test/library/tracking_library_test.dart
+++ b/test/library/tracking_library_test.dart
@@ -83,6 +83,7 @@ List<int> _apply(
       mangaFilterOffline: null,
       offlineMangaIds: const {},
       mangaFilterLewd: null,
+      mangaFilterMinRating: 0,
       filterCategories: false,
       filterCategoriesInclude: const {},
       filterCategoriesExclude: const {},

--- a/test/src/features/library/library_rating_sort_filter_test.dart
+++ b/test/src/features/library/library_rating_sort_filter_test.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/library/presentation/library/controller/library_controller.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+
+MangaDto _manga(int id, {int? rating}) => Fragment$MangaDto(
+      id: id,
+      title: 'M$id',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 0),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: rating == null
+          ? const []
+          : [Fragment$MangaDto$meta(key: 'flutter_rating', value: '$rating')],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 0,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/$id',
+    );
+
+List<MangaDto> _run(
+  List<MangaDto> input, {
+  MangaSort sort = MangaSort.alphabetical,
+  bool asc = true,
+  int minRating = 0,
+}) =>
+    applyLibraryFilterSort(
+      input,
+      query: null,
+      mangaFilterUnread: null,
+      mangaFilterDownloaded: null,
+      mangaFilterCompleted: null,
+      mangaFilterStarted: null,
+      mangaFilterBookmarked: null,
+      mangaFilterOffline: null,
+      offlineMangaIds: const {},
+      mangaFilterLewd: null,
+      mangaFilterMinRating: minRating,
+      filterCategories: false,
+      filterCategoriesInclude: const {},
+      filterCategoriesExclude: const {},
+      sortedBy: sort,
+      sortedDirection: asc,
+    );
+
+void main() {
+  final items = [
+    _manga(1, rating: 5),
+    _manga(2, rating: 2),
+    _manga(3), // unrated → 0
+  ];
+
+  test('sort by rating ascending puts unrated first, highest last', () {
+    expect(_run(items, sort: MangaSort.rating, asc: true).map((m) => m.id),
+        [3, 2, 1]);
+  });
+
+  test('sort by rating descending puts highest first', () {
+    expect(_run(items, sort: MangaSort.rating, asc: false).map((m) => m.id),
+        [1, 2, 3]);
+  });
+
+  test('minimum-rating filter excludes lower-rated and unrated', () {
+    expect(_run(items, minRating: 3).map((m) => m.id), [1]);
+    expect(_run(items, minRating: 2).map((m) => m.id), unorderedEquals([1, 2]));
+  });
+
+  test('minimum-rating 0 shows everything', () {
+    expect(_run(items, minRating: 0).length, 3);
+  });
+}

--- a/test/src/features/manga_book/manga_details/manga_rating_test.dart
+++ b/test/src/features/manga_book/manga_details/manga_rating_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _RecordingRepo extends MangaBookRepository {
+  _RecordingRepo() : super(_dummyClient());
+  final List<(int, String, dynamic)> patched = [];
+  @override
+  Future<void> patchMangaMeta({
+    required int mangaId,
+    required String key,
+    required dynamic value,
+  }) async {
+    patched.add((mangaId, key, value));
+  }
+}
+
+class _FakeMangaWithId extends MangaWithId {
+  @override
+  Future<MangaDto?> build({required int mangaId}) async => null;
+}
+
+void main() {
+  group('MangaMeta.rating', () {
+    test('parses an int from the string-backed meta value', () {
+      expect(MangaMeta.fromJson({'flutter_rating': '4'}).rating, 4);
+    });
+    test('is null when absent or unparseable', () {
+      expect(MangaMeta.fromJson(const {}).rating, isNull);
+      expect(MangaMeta.fromJson({'flutter_rating': 'x'}).rating, isNull);
+    });
+  });
+
+  group('mangaRatingProvider', () {
+    test('unrated manga reads 0', () {
+      final c = ProviderContainer(overrides: [
+        mangaWithIdProvider(mangaId: 1).overrideWith(() => _FakeMangaWithId()),
+      ]);
+      addTearDown(c.dispose);
+      expect(c.read(mangaRatingProvider(mangaId: 1)), 0);
+    });
+
+    test('update persists the clamped rating to the meta store', () async {
+      final repo = _RecordingRepo();
+      final c = ProviderContainer(overrides: [
+        mangaBookRepositoryProvider.overrideWithValue(repo),
+        mangaWithIdProvider(mangaId: 1).overrideWith(() => _FakeMangaWithId()),
+      ]);
+      addTearDown(c.dispose);
+
+      await c.read(mangaRatingProvider(mangaId: 1).notifier).update(3);
+      expect(repo.patched, contains((1, 'flutter_rating', '3')));
+
+      // Out-of-range is clamped to 0..5.
+      await c.read(mangaRatingProvider(mangaId: 1).notifier).update(9);
+      expect(repo.patched, contains((1, 'flutter_rating', '5')));
+
+      // Clearing (0) is a valid write.
+      await c.read(mangaRatingProvider(mangaId: 1).notifier).update(0);
+      expect(repo.patched, contains((1, 'flutter_rating', '0')));
+    });
+  });
+}


### PR DESCRIPTION
Closes #143.

A personal **0–5 star rating** on the manga details page, stored in the per-manga meta store (Suwayomi has no rating field) and synced/offline like the reader settings. Tap the current top star to clear it. Filled stars are **amber** so they read on every theme (not the theme accent).

Also **sortable and filterable** in the library:
- **Rating** sort key (unrated sort lowest).
- **Minimum rating** filter — client-side, since the rating is already in the library `MangaDto` meta.

Implementation notes:
- Meta values are `String!` server-side, so the rating stores/reads as a string (`fromJsonToInt` on read). Passing an int silently failed the mutation — that was the initial "tapping does nothing" bug.
- `MangaSort.rating` is appended (index-stable for persisted sort prefs) and added to the sort-tab display order.

Tests: meta parse, provider persist/clamp/clear, sort order (asc/desc), and filter threshold. Reviewed clean.