### PR TITLE
Protect offline downloads across a server switch

### DIFF
--- a/docs/architecture/offline.md
+++ b/docs/architecture/offline.md
@@ -47,6 +47,14 @@ Four layers, all driven through one entry point — **`downloadStarterProvider`*
 
 `offline_sync.dart` — `OfflineSync` mirrors GraphQL DTOs into the catalog during normal online use, preserving locally-dirty read progress over incoming server values (an offline read is never overwritten by a stale down-sync). `offline_read_fallback.dart` — five wrappers (`libraryWithOfflineFallback`, `mangaWithOfflineFallback`, `chaptersWithOfflineFallback`, `chapterMetaWithOfflineFallback`, `categoriesWithOfflineFallback`): on a network error, if offline is enabled and the catalog has data, they return mapped local rows (categories synthesise a single "Default" so the Library tab still renders). The reader serves pages via `OfflineRepository.localChapterPages(chapterId)` when `deviceState == downloaded`.
 
+## Server-switch guard
+
+The catalog belongs to one server identity at a time. On first connection, Tsumiru creates a UUID in Suwayomi's server-wide global metadata under `tsumiru_server_instance_id`; later connections read that value through `serverInstanceIdProvider`. `offlineCatalogServerId` stores the UUID after a successful metadata sync. The configured scheme, host, and port are only a route: changing them does not change server identity.
+
+The last verified address-to-UUID pair is cached locally so a cold start without network access can still open an already-verified catalog. A new address must connect and return the server UUID before offline writes or download workers start. `offlineActiveProvider` disables metadata sync, progress writes, reconciliation, and both download workers until identity is verified and matches. A legacy unstamped catalog remains readable offline but is not modified until verification succeeds.
+
+A mismatch with catalog data shows a persistent warning in Library and Offline settings. Dismiss parks the old catalog without exposing or modifying it. Clear stops the foreground worker and main-isolate pump, removes their queued work, wipes every catalog table plus page/cover files, and resets the identity. An empty catalog adopts the active identity without prompting.
+
 ## UI entry points
 
 - **Chapter list** — `presentation/offline_save_button.dart` (`OfflineSaveButton`): per-chapter save / delete with a state-machine icon (queued / downloading / downloaded / error / save).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'src/features/offline/data/offline_background_downloads.dart';
 import 'src/features/offline/data/offline_bootstrap.dart';
 import 'src/features/offline/data/offline_download_providers.dart';
 import 'src/features/offline/data/offline_repository.dart';
+import 'src/features/offline/data/offline_server_identity_repository.dart';
 import 'src/features/onboarding/data/onboarding_complete.dart';
 import 'src/features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import 'src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
@@ -152,8 +153,7 @@ Future<void> _startApp() async {
     if (sharedPreferences.getBool(migratedKey) != true) {
       final sortIdx = sharedPreferences.getInt('mangaSort');
       // mangaSort default is Last-Read, so an unset value means Last-Read too.
-      final onLastRead =
-          sortIdx == null || sortIdx == MangaSort.lastRead.index;
+      final onLastRead = sortIdx == null || sortIdx == MangaSort.lastRead.index;
       final savedDir = sharedPreferences.getBool('mangaSortDirection');
       if (onLastRead && savedDir != null) {
         await sharedPreferences.setBool('mangaSortDirection', !savedDir);
@@ -228,6 +228,12 @@ Future<void> _startApp() async {
     // by the last exit and previously-errored ones are retried, one at a time,
     // re-fetching only pages not already on disk. Fire-and-forget; native only.
     unawaited(Future(() async {
+      try {
+        await container.read(serverInstanceIdProvider.future);
+      } catch (_) {
+        return;
+      }
+      if (!container.read(offlineActiveProvider)) return;
       await pushPendingProgress(container);
       await reconcileAllAtLaunch(container);
       // One-time sweep of phantom (browsed-not-added) catalog entries.

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -112,6 +112,10 @@ enum DBKeys {
   // pause shouldn't silently resume on restart); read synchronously by the
   // download starters to gate every restart path.
   offlineDownloadsPaused(false),
+  offlineCatalogServerId(null),
+  offlineLastServerId(null),
+  offlineLastServerAddress(null),
+  offlineServerMismatchDismissedList(null),
   // ON-DEVICE delete-on-read settings (frees device space; the server copy is
   // untouched). Independent of the server's "Delete chapters" settings.
   // whileReading: 0 = off, 1 = the just-read chapter, 2..5 = the Nth behind it.

--- a/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
+++ b/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
@@ -6,7 +6,6 @@
 
 import 'dart:async';
 
-
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -23,11 +22,11 @@ part 'edit_category_controller.g.dart';
 class CategoryController extends _$CategoryController {
   @override
   Future<List<CategoryDto>?> build() async {
-    final offlineEnabled = ref.watch(offlineEnabledProvider);
+    final offlineDb = ref.watch(offlineReadDatabaseProvider);
     final result = await categoriesWithOfflineFallback(
       fetch: () => ref.watch(categoryRepositoryProvider).getCategoryList(),
-      db: offlineEnabled ? ref.watch(offlineDatabaseProvider) : null,
-      offlineEnabled: offlineEnabled,
+      db: offlineDb,
+      offlineEnabled: offlineDb != null,
     );
     final sync = ref.read(offlineSyncProvider);
     if (sync != null && result != null) {
@@ -116,8 +115,7 @@ AsyncValue<List<CategoryDto>?> nonZeroCategoryList(Ref ref) {
 @riverpod
 AsyncValue<List<CategoryDto>?> visibleCategoryList(Ref ref) {
   final categoryList = ref.watch(nonZeroCategoryListProvider);
-  final showHidden =
-      ref.watch(showHiddenCategoriesProvider).ifNull(false);
+  final showHidden = ref.watch(showHiddenCategoriesProvider).ifNull(false);
   return categoryList.copyWithData((_) => categoryList.valueOrNull
       ?.where((element) => showHidden || !element.isHidden)
       .toList());

--- a/lib/src/features/library/presentation/library/controller/library_manga_list.dart
+++ b/lib/src/features/library/presentation/library/controller/library_manga_list.dart
@@ -6,7 +6,6 @@
 
 import 'dart:async';
 
-
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -19,12 +18,12 @@ part 'library_manga_list.g.dart';
 
 @riverpod
 Future<List<MangaDto>?> libraryMangaList(Ref ref) async {
-  final offlineEnabled = ref.watch(offlineEnabledProvider);
+  final offlineDb = ref.watch(offlineReadDatabaseProvider);
   final list = await libraryWithOfflineFallback(
     fetch: () => ref.watch(categoryRepositoryProvider).getAllLibraryMangas(),
     // Only read the native-only DB when offline is available (never on web).
-    db: offlineEnabled ? ref.watch(offlineDatabaseProvider) : null,
-    offlineEnabled: offlineEnabled,
+    db: offlineDb,
+    offlineEnabled: offlineDb != null,
   );
   final sync = ref.read(offlineSyncProvider);
   if (sync != null && list != null) {

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -21,6 +21,7 @@ import '../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.d
 import '../../../../widgets/manga_cover/list/manga_cover_list_tile.dart';
 import '../../../../widgets/search_field.dart';
 import '../../../manga_book/widgets/update_status_popup_menu.dart';
+import '../../../offline/presentation/offline_server_mismatch_banner.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
 import '../../domain/category/category_model.dart';
 import '../../domain/library_group.dart';
@@ -31,6 +32,15 @@ import 'controller/library_grouping.dart';
 import 'controller/library_manga_list.dart';
 import 'widgets/library_manga_organizer.dart';
 
+/// Wraps a library Scaffold body so the offline server-mismatch banner sits
+/// below the app bar (inside the Scaffold), not floating over the status bar.
+Widget _libraryBody(Widget body) => Column(
+      children: [
+        const OfflineServerMismatchBanner(),
+        Expanded(child: body),
+      ],
+    );
+
 class LibraryScreen extends HookConsumerWidget {
   const LibraryScreen({super.key, required this.categoryId});
   final int categoryId;
@@ -40,11 +50,9 @@ class LibraryScreen extends HookConsumerWidget {
     final groupType =
         ref.watch(libraryGroupTypeProvider) ?? kDefaultLibraryGroupType;
 
-    if (groupType == LibraryGroup.byDefault) {
-      return _DefaultLibraryScreen(categoryId: categoryId);
-    }
-
-    return _GroupedLibraryScreen(groupType: groupType);
+    return groupType == LibraryGroup.byDefault
+        ? _DefaultLibraryScreen(categoryId: categoryId)
+        : _GroupedLibraryScreen(groupType: groupType);
   }
 }
 
@@ -125,9 +133,8 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
                         ref.watch(categoryTabsProvider).ifNull(true)
                     ? TabBar(
                         isScrollable: true,
-                        tabs: data
-                            .map((e) => _CategoryTab(category: e))
-                            .toList(),
+                        tabs:
+                            data.map((e) => _CategoryTab(category: e)).toList(),
                         dividerColor: Colors.transparent,
                       )
                     : null,
@@ -178,25 +185,28 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
                 shape: RoundedRectangleBorder(),
                 child: LibraryMangaOrganizer(),
               ),
-              body: data.isBlank
-                  ? Emoticons(
-                      title: context.l10n.noCategoriesFound,
-                      button: TextButton(
-                        onPressed: () =>
-                            ref.refresh(categoryControllerProvider.future),
-                        child: Text(context.l10n.refresh),
+              body: _libraryBody(
+                data.isBlank
+                    ? Emoticons(
+                        title: context.l10n.noCategoriesFound,
+                        button: TextButton(
+                          onPressed: () =>
+                              ref.refresh(categoryControllerProvider.future),
+                          child: Text(context.l10n.refresh),
+                        ),
+                      )
+                    : Padding(
+                        padding: KEdgeInsets.h8.size,
+                        child: TabBarView(
+                          children: data
+                              .map((e) => CategoryMangaList(
+                                    categoryId:
+                                        e.id.getValueOnNullOrNegative(),
+                                  ))
+                              .toList(),
+                        ),
                       ),
-                    )
-                  : Padding(
-                      padding: KEdgeInsets.h8.size,
-                      child: TabBarView(
-                        children: data
-                            .map((e) => CategoryMangaList(
-                                  categoryId: e.id.getValueOnNullOrNegative(),
-                                ))
-                            .toList(),
-                      ),
-                    ),
+              ),
             ),
           );
         }
@@ -206,7 +216,7 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
         appBar: AppBar(
           title: Text(context.l10n.library),
         ),
-        body: body,
+        body: _libraryBody(body),
       ),
     );
   }
@@ -241,8 +251,7 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
             body: Emoticons(
               title: context.l10n.noCategoriesFound,
               button: TextButton(
-                onPressed: () =>
-                    ref.refresh(libraryGroupedTabsProvider.future),
+                onPressed: () => ref.refresh(libraryGroupedTabsProvider.future),
                 child: Text(context.l10n.refresh),
               ),
             ),
@@ -317,12 +326,13 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
               shape: RoundedRectangleBorder(),
               child: LibraryMangaOrganizer(),
             ),
-            body: Padding(
-              padding: KEdgeInsets.h8.size,
-              child: TabBarView(
-                children: tabs
-                    .map((t) => _GroupedMangaList(tabId: t.id))
-                    .toList(),
+            body: _libraryBody(
+              Padding(
+                padding: KEdgeInsets.h8.size,
+                child: TabBarView(
+                  children:
+                      tabs.map((t) => _GroupedMangaList(tabId: t.id)).toList(),
+                ),
               ),
             ),
           ),
@@ -331,7 +341,7 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
       refresh: () => ref.refresh(libraryGroupedTabsProvider.future),
       wrapper: (body) => Scaffold(
         appBar: AppBar(title: Text(context.l10n.library)),
-        body: body,
+        body: _libraryBody(body),
       ),
     );
   }
@@ -351,8 +361,7 @@ class _CategoryTab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showCount =
-        ref.watch(categoryNumberOfItemsProvider).ifNull(false);
+    final showCount = ref.watch(categoryNumberOfItemsProvider).ifNull(false);
     if (!showCount) {
       return Tab(text: category.name);
     }
@@ -362,8 +371,7 @@ class _CategoryTab extends ConsumerWidget {
       ),
     );
     final count = mangaListAsync.valueOrNull?.length;
-    final label =
-        count != null ? '${category.name} ($count)' : category.name;
+    final label = count != null ? '${category.name} ($count)' : category.name;
     return Tab(text: label);
   }
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -33,10 +33,8 @@ class MangaWithId extends _$MangaWithId {
     final manga = await mangaWithOfflineFallback(
       fetch: () =>
           ref.watch(mangaBookRepositoryProvider).getManga(mangaId: mangaId),
-      db: ref.watch(offlineEnabledProvider)
-          ? ref.watch(offlineDatabaseProvider)
-          : null,
-      offlineEnabled: ref.watch(offlineEnabledProvider),
+      db: ref.watch(offlineReadDatabaseProvider),
+      offlineEnabled: ref.watch(offlineActiveProvider),
       mangaId: mangaId,
     );
     // Don't mirror browsed (non-library) manga into the offline catalog.
@@ -84,18 +82,15 @@ class MangaChapterList extends _$MangaChapterList {
         }
         return stored;
       },
-      db: ref.watch(offlineEnabledProvider)
-          ? ref.watch(offlineDatabaseProvider)
-          : null,
-      offlineEnabled: ref.watch(offlineEnabledProvider),
+      db: ref.watch(offlineReadDatabaseProvider),
+      offlineEnabled: ref.watch(offlineActiveProvider),
       mangaId: mangaId,
     );
     ref.keepAlive();
     if (result != null) {
-      unawaited(
-          (ref.read(offlineSyncProvider)?.syncChapters(result) ??
-                  Future.value())
-              .then((_) => reconcileManga(ref, mangaId)));
+      unawaited((ref.read(offlineSyncProvider)?.syncChapters(result) ??
+              Future.value())
+          .then((_) => reconcileManga(ref, mangaId)));
     }
     if (didSourceFetch) {
       // The source scrape above also populated this manga's description and
@@ -121,7 +116,7 @@ class MangaChapterList extends _$MangaChapterList {
     final refreshFromSource =
         onlineFetch || ref.read(refreshChaptersFromSourceProvider).ifNull();
     // offlineDatabaseProvider throws on web; only touch it when offline is on.
-    final offlineEnabled = ref.read(offlineEnabledProvider);
+    final offlineDb = ref.read(offlineReadDatabaseProvider);
     // Wrap in chaptersWithOfflineFallback like build() does, so an explicit
     // refresh while the device is offline serves the on-device catalog instead
     // of erroring/clearing the list.
@@ -139,8 +134,8 @@ class MangaChapterList extends _$MangaChapterList {
             }
             return stored;
           },
-          db: offlineEnabled ? ref.read(offlineDatabaseProvider) : null,
-          offlineEnabled: offlineEnabled,
+          db: offlineDb,
+          offlineEnabled: offlineDb != null,
           mangaId: mangaId,
         ));
     ref.keepAlive();
@@ -154,10 +149,9 @@ class MangaChapterList extends _$MangaChapterList {
         // server no longer lists) then reconcile to evict them — so a
         // server-side delete discovered via pull-to-refresh is cleaned up too,
         // not only on a cold provider rebuild.
-        unawaited(
-            (ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
-                    Future.value())
-                .then((_) => reconcileManga(ref, mangaId)));
+        unawaited((ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
+                Future.value())
+            .then((_) => reconcileManga(ref, mangaId)));
       }
     }
   }

--- a/lib/src/features/manga_book/presentation/reader/controller/reader_controller.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/reader_controller.dart
@@ -23,13 +23,12 @@ FutureOr<ChapterDto?> chapter(
     // Offline: a downloaded chapter must still open when the server is
     // unreachable, so fall back to the on-device catalog row.
     chapterMetaWithOfflineFallback(
-      fetch: () =>
-          ref.watch(mangaBookRepositoryProvider).getChapter(chapterId: chapterId),
+      fetch: () => ref
+          .watch(mangaBookRepositoryProvider)
+          .getChapter(chapterId: chapterId),
       // Only read the native-only DB when offline is available (never on web).
-      db: ref.watch(offlineEnabledProvider)
-          ? ref.watch(offlineDatabaseProvider)
-          : null,
-      offlineEnabled: ref.watch(offlineEnabledProvider),
+      db: ref.watch(offlineReadDatabaseProvider),
+      offlineEnabled: ref.watch(offlineActiveProvider),
       chapterId: chapterId,
     );
 
@@ -38,7 +37,7 @@ Future<ChapterPagesDto?> chapterPages(Ref ref, {required int chapterId}) async {
   // Offline: if this chapter is downloaded on-device, serve its pages from disk
   // (as file:// URIs that ServerImage renders locally) instead of the server.
   // Falls through to the network when not downloaded / offline is unavailable.
-  if (ref.watch(offlineEnabledProvider)) {
+  if (ref.watch(offlineReadDatabaseProvider) != null) {
     final local =
         await ref.watch(offlineRepositoryProvider).localChapterPages(chapterId);
     if (local != null && local.isNotEmpty) {

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -58,6 +58,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// Guards [ensureServiceRunning] against overlapping invocations (it does
   /// several awaited steps; concurrent enqueue + resume could double-start).
   bool _ensuring = false;
+  bool _suppressRestarts = false;
 
   OfflineDatabase get _db => _ref.read(offlineDatabaseProvider);
   OfflinePaths get _paths => _ref.read(offlinePathsProvider);
@@ -101,6 +102,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// active connection is metered, the service is not started.
   Future<void> ensureServiceRunning() async {
     if (!Platform.isAndroid) return;
+    if (_suppressRestarts) return;
     // PAUSE GATE — first line so EVERY restart path inherits it: the public
     // start, onEnqueued, replayOnResume, replayAtLaunchAndMaybeStart, _onDrained,
     // _onServiceStopped, and the connectivity-resume branch all funnel here.
@@ -191,6 +193,27 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// Resume on-device downloads (caller has cleared the persisted flag first).
   Future<void> resume() => ensureServiceRunning();
 
+  Future<void> stopAndClearWorkOrder() async {
+    if (!Platform.isAndroid) return;
+    _suppressRestarts = true;
+    await pause();
+    if (await FlutterForegroundTask.isRunningService) {
+      await FlutterForegroundTask.stopService();
+    }
+    for (var i = 0; i < 20; i++) {
+      if (!await FlutterForegroundTask.isRunningService) break;
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+    }
+    await FlutterForegroundTask.removeData(key: kWorkOrderKey);
+    await FlutterForegroundTask.removeData(key: kTokenRecordKey);
+    final log = _log;
+    if (await log.file.exists()) await log.file.delete();
+  }
+
+  void finishCatalogClear() {
+    _suppressRestarts = false;
+  }
+
   /// Tell the worker to drop a chapter (delete/cancel). The caller still does
   /// the actual drift/file delete; this only stops the in-flight download.
   Future<void> onRemoved(int chapterId) async {
@@ -264,6 +287,10 @@ class BackgroundDownloadController with WidgetsBindingObserver {
 
   void _onWorkerEvent(Object data) {
     if (data is! Map) return;
+    // During a catalog clear the worker is being torn down; a page/chapter event
+    // still in the SendPort queue would otherwise re-insert a row into the
+    // just-wiped catalog. Drop everything until the clear releases the flag.
+    if (_suppressRestarts) return;
     switch (data['kind']) {
       // Live foreground UI: mark the chapter downloading + accumulate page rows
       // as the worker reports them, so the per-chapter progress arc animates.

--- a/lib/src/features/offline/data/background/background_download_controller_stub.dart
+++ b/lib/src/features/offline/data/background/background_download_controller_stub.dart
@@ -26,6 +26,9 @@ class BackgroundDownloadController {
   Future<void> onWifiOnlyChanged(bool value) async {}
   Future<void> pause() async {}
   Future<void> resume() async {}
+
+  Future<void> stopAndClearWorkOrder() async {}
+  void finishCatalogClear() {}
   Future<void> replayAtLaunchAndMaybeStart() async {}
 }
 

--- a/lib/src/features/offline/data/graphql/server_identity.graphql
+++ b/lib/src/features/offline/data/graphql/server_identity.graphql
@@ -1,0 +1,17 @@
+query OfflineServerIdentity($key: String!) {
+  metas(condition: {key: $key}, first: 1) {
+    nodes {
+      key
+      value
+    }
+  }
+}
+
+mutation SetOfflineServerIdentity($key: String!, $value: String!) {
+  setGlobalMeta(input: {meta: {key: $key, value: $value}}) {
+    meta {
+      key
+      value
+    }
+  }
+}

--- a/lib/src/features/offline/data/offline_background_downloads.dart
+++ b/lib/src/features/offline/data/offline_background_downloads.dart
@@ -34,7 +34,7 @@ part 'offline_background_downloads.g.dart';
 /// Linux desktop build. Null on web / when offline storage is unavailable.
 @riverpod
 ChapterDownloadEngine? chapterDownloadEngine(Ref ref) {
-  if (!ref.watch(offlineEnabledProvider)) return null;
+  if (!ref.watch(offlineActiveProvider)) return null;
   // Page-level parallelism. One chapter downloads
   // at a time; this is how many of its pages are in flight at once.
   final parallel = (ref.watch(offlineDownloadConcurrencyProvider) ??
@@ -74,7 +74,7 @@ ChapterDownloadEngine? chapterDownloadEngine(Ref ref) {
 /// storage is unavailable.
 @riverpod
 OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
-  if (!ref.watch(offlineEnabledProvider)) return null;
+  if (!ref.watch(offlineActiveProvider)) return null;
   final engine = ref.watch(chapterDownloadEngineProvider);
   if (engine == null) return null;
   final repo = ref.watch(mangaBookRepositoryProvider);
@@ -87,8 +87,9 @@ OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
         const <String>[],
     measureChapterBytes: store.chapterBytes,
     persistedPaused: () =>
-        ref.read(sharedPreferencesProvider).getBool(
-            DBKeys.offlineDownloadsPaused.name) ??
+        ref
+            .read(sharedPreferencesProvider)
+            .getBool(DBKeys.offlineDownloadsPaused.name) ??
         false,
   );
 }
@@ -99,7 +100,7 @@ OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
 /// Chapters previously marked `error` get one fresh attempt — most past errors
 /// were the stale-token 401s the run-time-auth engine now avoids.
 Future<void> initOfflineDownloads(ProviderContainer container) async {
-  if (!container.read(offlineEnabledProvider)) return;
+  if (!container.read(offlineActiveProvider)) return;
   // On Android the foreground-service worker owns downloads (see the corruption
   // gate in pumpDownloads + BackgroundDownloadController); the launch path calls
   // the controller instead.

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -9,7 +9,14 @@ import 'package:drift/drift.dart';
 part 'offline_database.g.dart';
 
 /// On-device state of a chapter's bytes.
-enum OfflineDeviceState { none, queued, downloading, downloaded, error, orphaned }
+enum OfflineDeviceState {
+  none,
+  queued,
+  downloading,
+  downloaded,
+  error,
+  orphaned
+}
 
 /// How many of a series' chapters to keep on this device automatically.
 enum OfflineKeepRule { off, nUnread, allUnread, all }
@@ -22,8 +29,8 @@ class OfflineMangas extends Table {
   TextColumn get thumbnailUrl => text().nullable()();
   TextColumn get thumbnailRelPath => text().nullable()();
   DateTimeColumn get updatedAt => dateTime()();
-  TextColumn get keepRule =>
-      textEnum<OfflineKeepRule>().withDefault(Constant(OfflineKeepRule.off.name))();
+  TextColumn get keepRule => textEnum<OfflineKeepRule>()
+      .withDefault(Constant(OfflineKeepRule.off.name))();
   IntColumn get keepUnreadCount => integer().withDefault(const Constant(3))();
 
   // Server-sourced metadata for offline filters / sort / badges / grouping.
@@ -168,17 +175,27 @@ class OfflineDatabase extends _$OfflineDatabase {
           }
           if (from < 6) {
             await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceId);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceName);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceLang);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceIsNsfw);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.sourceName);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.sourceLang);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.sourceIsNsfw);
             await _addColumnIfMissing(m, offlineMangas, offlineMangas.status);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.unreadCount);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.downloadCount);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.bookmarkCount);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.inLibraryAt);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.latestFetchedAt);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.latestUploadedAt);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.totalChapters);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.unreadCount);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.downloadCount);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.bookmarkCount);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.inLibraryAt);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.latestFetchedAt);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.latestUploadedAt);
+            await _addColumnIfMissing(
+                m, offlineMangas, offlineMangas.totalChapters);
           }
         },
       );
@@ -223,9 +240,8 @@ class OfflineDatabase extends _$OfflineDatabase {
           id: Value(id),
           title: Value(title),
           updatedAt: Value(updatedAt),
-          thumbnailUrl: thumbnailUrl == null
-              ? const Value.absent()
-              : Value(thumbnailUrl),
+          thumbnailUrl:
+              thumbnailUrl == null ? const Value.absent() : Value(thumbnailUrl),
           // device-managed: thumbnailRelPath, keepRule, keepUnreadCount stay absent
           sourceId: Value(sourceId),
           sourceName: Value(sourceName),
@@ -428,8 +444,8 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// Chapters with any unpushed local change — read progress OR bookmark — for
   /// the up-sync to flush and the down-sync to preserve.
   Future<List<OfflineChapter>> dirtyChapters() => (select(offlineChapters)
-        ..where((t) =>
-            t.progressDirty.equals(true) | t.bookmarkDirty.equals(true)))
+        ..where(
+            (t) => t.progressDirty.equals(true) | t.bookmarkDirty.equals(true)))
       .get();
 
   // --- offline queries -------------------------------------------------------
@@ -442,9 +458,20 @@ class OfflineDatabase extends _$OfflineDatabase {
       (select(offlineChapters)..where((t) => t.id.equals(chapterId)))
           .getSingleOrNull();
 
-  Future<List<OfflineManga>> libraryManga() =>
-      (select(offlineMangas)..orderBy([(t) => OrderingTerm(expression: t.title)]))
-          .get();
+  Future<List<OfflineManga>> libraryManga() => (select(offlineMangas)
+        ..orderBy([(t) => OrderingTerm(expression: t.title)]))
+      .get();
+
+  Future<bool> hasCatalogData() async =>
+      (await (select(offlineMangas)..limit(1)).get()).isNotEmpty;
+
+  Future<void> clearAll() => transaction(() async {
+        await delete(offlinePages).go();
+        await delete(offlineMangaCategories).go();
+        await delete(offlineCategories).go();
+        await delete(offlineChapters).go();
+        await delete(offlineMangas).go();
+      });
 
   /// Sweep browsed-not-added manga a past bug wrote here: no library timestamp
   /// (null/'0') and nothing downloaded. Never touches downloads; a stray library
@@ -525,18 +552,20 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// Live stream of a manga's chapter rows — drives the series download
   /// progress UI (emits as device states change during a background download).
   Stream<List<OfflineChapter>> watchChaptersForManga(int mangaId) =>
-      (select(offlineChapters)..where((t) => t.mangaId.equals(mangaId))).watch();
+      (select(offlineChapters)..where((t) => t.mangaId.equals(mangaId)))
+          .watch();
 
   /// Live stream of every chapter that's downloaded OR actively
   /// downloading/queued on this device — drives the Downloads → Offline files
   /// tab (so it shows in-progress downloads, not just finished ones).
-  Stream<List<OfflineChapter>> watchOfflineChapters() => (select(offlineChapters)
-        ..where((t) => t.deviceState.isIn([
-              OfflineDeviceState.downloaded.name,
-              OfflineDeviceState.downloading.name,
-              OfflineDeviceState.queued.name,
-            ])))
-      .watch();
+  Stream<List<OfflineChapter>> watchOfflineChapters() =>
+      (select(offlineChapters)
+            ..where((t) => t.deviceState.isIn([
+                  OfflineDeviceState.downloaded.name,
+                  OfflineDeviceState.downloading.name,
+                  OfflineDeviceState.queued.name,
+                ])))
+          .watch();
 
   /// Live list of every series with an offline footprint on this device —
   /// either chapters present (downloaded / in-flight) OR an active keep-rule
@@ -548,18 +577,18 @@ class OfflineDatabase extends _$OfflineDatabase {
   Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
       watchOfflineSeries() {
     final downloaded = offlineChapters.id.count(
-        filter:
-            offlineChapters.deviceState.equalsValue(OfflineDeviceState.downloaded));
+        filter: offlineChapters.deviceState
+            .equalsValue(OfflineDeviceState.downloaded));
     final inFlight = offlineChapters.id.count(
         filter: offlineChapters.deviceState
                 .equalsValue(OfflineDeviceState.downloading) |
             offlineChapters.deviceState.equalsValue(OfflineDeviceState.queued));
     final byteSum = offlineChapters.bytes.sum(
-        filter:
-            offlineChapters.deviceState.equalsValue(OfflineDeviceState.downloaded));
+        filter: offlineChapters.deviceState
+            .equalsValue(OfflineDeviceState.downloaded));
     final query = select(offlineMangas).join([
-      leftOuterJoin(offlineChapters,
-          offlineChapters.mangaId.equalsExp(offlineMangas.id)),
+      leftOuterJoin(
+          offlineChapters, offlineChapters.mangaId.equalsExp(offlineMangas.id)),
     ])
       ..addColumns([downloaded, inFlight, byteSum])
       ..groupBy(

--- a/lib/src/features/offline/data/offline_download_coordinator.dart
+++ b/lib/src/features/offline/data/offline_download_coordinator.dart
@@ -83,6 +83,20 @@ class OfflineDownloadCoordinator {
     _cancelled.addAll(_active);
   }
 
+  /// Wait until nothing is actively downloading and the pump loop has exited, so
+  /// a catalog clear can be sure no `onPageStored` write lands after it wipes the
+  /// DB/files. Call after [pause]. Bounded so it can never hang the clear — the
+  /// clear proceeds even if a stubborn page fetch hasn't observed the cancel yet
+  /// (rare, and the worst case is one orphan row, which a later clear removes).
+  Future<void> awaitIdle(
+      {Duration timeout = const Duration(seconds: 3)}) async {
+    final deadline = DateTime.now().add(timeout);
+    while ((_active.isNotEmpty || _pumping) &&
+        DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+  }
+
   /// Resume on-device downloading and drain the backlog. Returns the drain
   /// future so callers can await it (the UI fires it and forgets).
   Future<void> resume() {

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -54,6 +54,7 @@ bool get _useBgService => isAndroidNative;
 /// ever again silently rely on the Android-disabled pump.
 final downloadStarterProvider = Provider<Future<void> Function()>((ref) {
   return () async {
+    if (!ref.read(offlineActiveProvider)) return;
     if (isAndroidNative) {
       await ref
           .read(backgroundDownloadControllerProvider)
@@ -88,12 +89,69 @@ Future<void> setOfflineDownloadsPaused(WidgetRef ref, bool paused) async {
   }
 }
 
+Future<void> clearOfflineCatalog(WidgetRef ref) async {
+  if (!ref.read(offlineEnabledProvider)) return;
+
+  final background = ref.read(backgroundDownloadControllerProvider);
+  await clearOfflineCatalogWithDependencies(
+    stopBackground: background.stopAndClearWorkOrder,
+    stopMainPump: () async {
+      final coordinator = ref.read(offlineDownloadCoordinatorProvider);
+      coordinator?.pause();
+      // Wait for the in-flight chapter to observe the cancel and unwind, so no
+      // page write lands after the wipe below.
+      await coordinator?.awaitIdle();
+    },
+    clearDatabase: ref.read(offlineDatabaseProvider).clearAll,
+    // Best-effort: a file-delete failure (a locked file, permissions) must not
+    // abort the clear before the identity stamp is reset — the DB is already
+    // wiped, and leftover bytes are only dead weight, not stale content.
+    clearFiles: () async {
+      try {
+        await ref.read(offlinePageStoreProvider).clearAll();
+      } catch (e) {
+        logger.e('Offline: clearing downloaded files failed: $e');
+      }
+    },
+    clearIdentity: () async {
+      final preferences = ref.read(sharedPreferencesProvider);
+      await preferences.remove(DBKeys.offlineCatalogServerId.name);
+      await preferences.remove(DBKeys.offlineServerMismatchDismissedList.name);
+    },
+    finish: background.finishCatalogClear,
+  );
+  ref.invalidate(offlineActiveProvider);
+  ref.invalidate(offlineReadDatabaseProvider);
+}
+
+Future<void> clearOfflineCatalogWithDependencies({
+  required Future<void> Function() stopBackground,
+  required Future<void> Function() stopMainPump,
+  required Future<void> Function() clearDatabase,
+  required Future<void> Function() clearFiles,
+  required Future<void> Function() clearIdentity,
+  required void Function() finish,
+}) async {
+  // stopBackground sets the restart-suppression flag; keep it INSIDE the try so
+  // finish() always clears it even if teardown throws — otherwise a leaked flag
+  // would silently drop every background-worker event for the rest of the session.
+  try {
+    await stopBackground();
+    await stopMainPump();
+    await clearDatabase();
+    await clearFiles();
+    await clearIdentity();
+  } finally {
+    finish();
+  }
+}
+
 /// True while any chapter is queued or downloading on this device — drives the
 /// On-device Pause/Resume control and the global paused badge. False when
 /// offline is unavailable.
 @riverpod
 Stream<bool> offlineHasPending(Ref ref) {
-  if (!ref.watch(offlineEnabledProvider)) return Stream.value(false);
+  if (!ref.watch(offlineActiveProvider)) return Stream.value(false);
   return ref.watch(offlineDatabaseProvider).watchOfflineChapters().map(
         (chapters) => chapters.any((c) =>
             c.deviceState == OfflineDeviceState.queued ||
@@ -105,7 +163,7 @@ Stream<bool> offlineHasPending(Ref ref) {
 /// downloaded / error). Always `none` when offline is unavailable.
 @riverpod
 Stream<OfflineDeviceState> offlineChapterState(Ref ref, int chapterId) {
-  if (!ref.watch(offlineEnabledProvider)) {
+  if (!ref.watch(offlineActiveProvider)) {
     return Stream.value(OfflineDeviceState.none);
   }
   return ref.watch(offlineRepositoryProvider).watchChapterState(chapterId);
@@ -116,7 +174,7 @@ Stream<OfflineDeviceState> offlineChapterState(Ref ref, int chapterId) {
 /// determinate progress arc on a downloading chapter.
 @riverpod
 Stream<double?> offlineChapterProgress(Ref ref, int chapterId) {
-  if (!ref.watch(offlineEnabledProvider)) {
+  if (!ref.watch(offlineActiveProvider)) {
     return Stream.value(null);
   }
   final repo = ref.watch(offlineRepositoryProvider);
@@ -181,7 +239,7 @@ Future<void> recordReadingProgress(
   required int lastPageRead,
   required bool isRead,
 }) async {
-  final offline = ref.read(offlineEnabledProvider);
+  final offline = ref.read(offlineActiveProvider);
   await recordReadingProgressWithDependencies(
     offlineEnabled: offline,
     offlineDatabase: offline ? ref.read(offlineDatabaseProvider) : null,
@@ -229,7 +287,7 @@ Future<void> recordBookmark(
   required int chapterId,
   required bool isBookmarked,
 }) async {
-  final offline = ref.read(offlineEnabledProvider);
+  final offline = ref.read(offlineActiveProvider);
   if (offline) {
     await ref
         .read(offlineDatabaseProvider)
@@ -292,7 +350,7 @@ Future<void> maybeDeleteOnReadLocal(
   required int mangaId,
   required int readChapterId,
 }) async {
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   final s = ref.read(localDeleteSettingsProvider);
   if (s.deleteWhileReading <= 0) return;
   final targetId =
@@ -306,7 +364,7 @@ Future<void> maybeDeleteOnManualLocal(
   WidgetRef ref, {
   required int chapterId,
 }) async {
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   final s = ref.read(localDeleteSettingsProvider);
   if (!s.deleteManuallyMarkedRead) return;
   await _deleteDeviceCopyIfDeletable(ref, chapterId, s.deleteWithBookmark);
@@ -386,7 +444,7 @@ Future<void> _deleteServerCopyIfDeletable(
     final c = chapters[idx];
     if (!c.isDownloaded) return;
     var isBookmarked = c.isBookmarked;
-    if (ref.read(offlineEnabledProvider)) {
+    if (ref.read(offlineActiveProvider)) {
       final row =
           await ref.read(offlineRepositoryProvider).chapterById(chapterId);
       if (row?.isBookmarked ?? false) isBookmarked = true;
@@ -408,7 +466,7 @@ Future<void> _deleteServerCopyIfDeletable(
 /// for any chapter that was marked read — so trackers stay in sync even when
 /// progress was recorded while the device was offline.
 Future<void> pushPendingProgress(ProviderContainer container) async {
-  if (!container.read(offlineEnabledProvider)) return;
+  if (!container.read(offlineActiveProvider)) return;
   final db = container.read(offlineDatabaseProvider);
   final repo = container.read(mangaBookRepositoryProvider);
 
@@ -516,7 +574,7 @@ Future<void> deleteChapterFromDevice(WidgetRef ref, int chapterId) async {
 /// left alone — it isn't tied to library membership (see #34, #36).
 Future<void> removeMangaFromLibraryAndPurge(WidgetRef ref, int mangaId) async {
   await ref.read(mangaBookRepositoryProvider).removeMangaFromLibrary(mangaId);
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   final db = ref.read(offlineDatabaseProvider);
   await db.setKeepRule(mangaId, OfflineKeepRule.off, 3);
   // Purge every chapter that has any on-device footprint — not just the fully
@@ -536,7 +594,7 @@ Future<void> removeMangaFromLibraryAndPurge(WidgetRef ref, int mangaId) async {
 /// can `ref.read(offlineDownloadManagerProvider)?.downloadChapter(c)`.
 @riverpod
 OfflineDownloadManager? offlineDownloadManager(Ref ref) {
-  if (!ref.watch(offlineEnabledProvider)) return null;
+  if (!ref.watch(offlineActiveProvider)) return null;
   final repo = ref.watch(mangaBookRepositoryProvider);
   return OfflineDownloadManager(
     db: ref.watch(offlineDatabaseProvider),
@@ -597,7 +655,7 @@ Future<PageBytes> fetchOfflinePageBytes(Ref ref, String pageUrl) async {
 /// unavailable so the filter is a no-op.
 @riverpod
 Future<Set<int>> offlineDeviceMangaIds(Ref ref) async {
-  if (!ref.watch(offlineEnabledProvider)) return const {};
+  if (!ref.watch(offlineActiveProvider)) return const {};
   return ref.watch(offlineRepositoryProvider).deviceDownloadedMangaIds();
 }
 
@@ -605,7 +663,7 @@ Future<Set<int>> offlineDeviceMangaIds(Ref ref) async {
 /// to show a checkmark on the active rule.
 @riverpod
 Future<OfflineKeepRule> mangaKeepRule(Ref ref, int mangaId) async {
-  if (!ref.watch(offlineEnabledProvider)) return OfflineKeepRule.off;
+  if (!ref.watch(offlineActiveProvider)) return OfflineKeepRule.off;
   return ref.watch(offlineRepositoryProvider).keepRuleFor(mangaId);
 }
 
@@ -614,7 +672,7 @@ Future<OfflineKeepRule> mangaKeepRule(Ref ref, int mangaId) async {
 @riverpod
 Future<({OfflineKeepRule rule, int count})> mangaKeepConfig(
     Ref ref, int mangaId) async {
-  if (!ref.watch(offlineEnabledProvider)) {
+  if (!ref.watch(offlineActiveProvider)) {
     return (rule: OfflineKeepRule.off, count: 5);
   }
   return ref.watch(offlineRepositoryProvider).keepConfigFor(mangaId);
@@ -624,7 +682,7 @@ Future<({OfflineKeepRule rule, int count})> mangaKeepConfig(
 /// series Download/On-device button label.
 @riverpod
 Future<int> mangaDownloadedCount(Ref ref, int mangaId) async {
-  if (!ref.watch(offlineEnabledProvider)) return 0;
+  if (!ref.watch(offlineActiveProvider)) return 0;
   return (await ref
           .watch(offlineDatabaseProvider)
           .downloadedChaptersForManga(mangaId))
@@ -636,7 +694,7 @@ Future<int> mangaDownloadedCount(Ref ref, int mangaId) async {
 @riverpod
 Stream<({int downloaded, int inFlight})> mangaOfflineProgress(
     Ref ref, int mangaId) {
-  if (!ref.watch(offlineEnabledProvider)) {
+  if (!ref.watch(offlineActiveProvider)) {
     return Stream.value((downloaded: 0, inFlight: 0));
   }
   return ref
@@ -665,7 +723,7 @@ Stream<({int downloaded, int inFlight})> mangaOfflineProgress(
 @riverpod
 Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
     offlineSeries(Ref ref) {
-  if (!ref.watch(offlineEnabledProvider)) return Stream.value(const []);
+  if (!ref.watch(offlineActiveProvider)) return Stream.value(const []);
   return ref.watch(offlineDatabaseProvider).watchOfflineSeries().map((rows) {
     final sorted = [...rows];
     sorted.sort((a, b) {
@@ -690,7 +748,7 @@ Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
 /// 3. Clear the rule (count is dormant while off; preserve it).
 /// 4. Reconcile — now eviction-safe: desired set = pinned = all downloaded.
 Future<void> detachKeepRule(WidgetRef ref, int mangaId) async {
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   final db = ref.read(offlineDatabaseProvider);
   for (final c in await db.chaptersForManga(mangaId)) {
     if (c.deviceState == OfflineDeviceState.queued ||
@@ -719,7 +777,7 @@ Future<void> detachKeepRule(WidgetRef ref, int mangaId) async {
 /// Stop keeping [mangaId] offline AND delete every on-device chapter (the
 /// server copy is untouched). Mirrors the per-series "remove" action.
 Future<void> removeKeepRuleAndDelete(WidgetRef ref, int mangaId) async {
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   final db = ref.read(offlineDatabaseProvider);
   final cfg = await ref.read(offlineRepositoryProvider).keepConfigFor(mangaId);
   await db.setKeepRule(mangaId, OfflineKeepRule.off, cfg.count);
@@ -733,7 +791,7 @@ Future<void> removeKeepRuleAndDelete(WidgetRef ref, int mangaId) async {
 /// Change the keep-rule for [mangaId] and reconcile (download/evict to match).
 Future<void> changeKeepRule(
     WidgetRef ref, int mangaId, OfflineKeepRule rule, int count) async {
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   await ref.read(offlineDatabaseProvider).setKeepRule(mangaId, rule, count);
   await reconcileMangaWidget(ref, mangaId);
 }
@@ -741,7 +799,7 @@ Future<void> changeKeepRule(
 /// Total bytes of on-device offline content — for the storage settings UI.
 @riverpod
 Future<int> offlineUsageBytes(Ref ref) async {
-  if (!ref.watch(offlineEnabledProvider)) return 0;
+  if (!ref.watch(offlineActiveProvider)) return 0;
   return ref.read(offlineRepositoryProvider).totalDownloadedBytes();
 }
 
@@ -804,7 +862,7 @@ Future<void> reconcileMangaCore({
 
 /// Controller / in-app entry point (generated Ref).
 Future<void> reconcileManga(Ref ref, int mangaId) async {
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   final manager = ref.read(offlineDownloadManagerProvider);
   final coordinator = ref.read(offlineDownloadCoordinatorProvider);
   if (manager == null || coordinator == null) return;
@@ -825,7 +883,7 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
 
 /// Widget entry point — same as [reconcileManga] but accepts a [WidgetRef].
 Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
-  if (!ref.read(offlineEnabledProvider)) return;
+  if (!ref.read(offlineActiveProvider)) return;
   final manager = ref.read(offlineDownloadManagerProvider);
   final coordinator = ref.read(offlineDownloadCoordinatorProvider);
   if (manager == null || coordinator == null) return;
@@ -847,7 +905,7 @@ Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
 
 /// Launch entry point (main.dart holds a ProviderContainer, not a Ref).
 Future<void> reconcileAllAtLaunch(ProviderContainer container) async {
-  if (!container.read(offlineEnabledProvider)) return;
+  if (!container.read(offlineActiveProvider)) return;
   final manager = container.read(offlineDownloadManagerProvider);
   final coordinator = container.read(offlineDownloadCoordinatorProvider);
   if (manager == null || coordinator == null) return;

--- a/lib/src/features/offline/data/offline_page_store.dart
+++ b/lib/src/features/offline/data/offline_page_store.dart
@@ -27,6 +27,8 @@ abstract class OfflinePageStore {
   /// Total bytes of a chapter's stored page files (for the catalog's byte
   /// count after a background download completes). 0 if nothing is stored.
   Future<int> chapterBytes(int mangaId, int chapterId);
+
+  Future<void> clearAll() => throw UnimplementedError();
 }
 
 /// Image bytes + file extension fetched for a single page.

--- a/lib/src/features/offline/data/offline_page_store_io.dart
+++ b/lib/src/features/offline/data/offline_page_store_io.dart
@@ -6,6 +6,8 @@
 
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+
 import 'offline_page_store.dart';
 import 'offline_paths.dart';
 
@@ -39,7 +41,8 @@ class IoOfflinePageStore implements OfflinePageStore {
 
   @override
   Future<void> deleteChapter(int mangaId, int chapterId) async {
-    final dir = Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
+    final dir =
+        Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
     if (await dir.exists()) {
       await dir.delete(recursive: true);
     }
@@ -47,12 +50,26 @@ class IoOfflinePageStore implements OfflinePageStore {
 
   @override
   Future<int> chapterBytes(int mangaId, int chapterId) async {
-    final dir = Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
+    final dir =
+        Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
     if (!await dir.exists()) return 0;
     var total = 0;
     await for (final e in dir.list()) {
       if (e is File) total += await e.length();
     }
     return total;
+  }
+
+  @override
+  Future<void> clearAll() async {
+    final dir = Directory(paths.baseDir);
+    if (!await dir.exists()) return;
+    await for (final entity in dir.list()) {
+      final name = p.basename(entity.path);
+      if (entity is Directory &&
+          (name == 'covers' || int.tryParse(name) != null)) {
+        await entity.delete(recursive: true);
+      }
+    }
   }
 }

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -8,9 +8,13 @@ import 'package:drift/drift.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../constants/db_keys.dart';
+import '../../../global_providers/global_providers.dart';
 import 'offline_database.dart';
 import 'offline_page_store.dart';
 import 'offline_paths.dart';
+import 'offline_server_identity.dart';
+import 'offline_server_identity_repository.dart';
 import 'offline_sync.dart';
 
 part 'offline_repository.g.dart';
@@ -75,14 +79,15 @@ class OfflineRepository {
   }
 
   /// Live device-download state for a chapter, so the UI reflects progress.
-  Stream<OfflineDeviceState> watchChapterState(int chapterId) =>
-      (db.select(db.offlineChapters)..where((t) => t.id.equals(chapterId)))
-          .watchSingleOrNull()
-          .map((c) => c?.deviceState ?? OfflineDeviceState.none)
-          // drift re-fires every per-chapter stream on ANY chapters-table write;
-          // distinct() stops a row from rebuilding unless ITS state changed
-          // (avoids a 98-row rebuild storm while a series downloads).
-          .distinct();
+  Stream<OfflineDeviceState> watchChapterState(int chapterId) => (db
+          .select(db.offlineChapters)
+        ..where((t) => t.id.equals(chapterId)))
+      .watchSingleOrNull()
+      .map((c) => c?.deviceState ?? OfflineDeviceState.none)
+      // drift re-fires every per-chapter stream on ANY chapters-table write;
+      // distinct() stops a row from rebuilding unless ITS state changed
+      // (avoids a 98-row rebuild storm while a series downloads).
+      .distinct();
 
   /// Live count of pages already on disk for a chapter — drives the per-chapter
   /// download progress arc. distinct() so a row only
@@ -100,7 +105,8 @@ class OfflineRepository {
   /// The per-series keep-offline rule (defaults to off if the manga isn't
   /// synced yet).
   Future<OfflineKeepRule> keepRuleFor(int mangaId) async {
-    final m = await (db.select(db.offlineMangas)..where((t) => t.id.equals(mangaId)))
+    final m = await (db.select(db.offlineMangas)
+          ..where((t) => t.id.equals(mangaId)))
         .getSingleOrNull();
     return m?.keepRule ?? OfflineKeepRule.off;
   }
@@ -108,14 +114,19 @@ class OfflineRepository {
   /// The per-series keep-offline rule AND its unread-buffer size — so the UI can
   /// tick the exact "Keep next N unread" preset that's active.
   Future<({OfflineKeepRule rule, int count})> keepConfigFor(int mangaId) async {
-    final m = await (db.select(db.offlineMangas)..where((t) => t.id.equals(mangaId)))
+    final m = await (db.select(db.offlineMangas)
+          ..where((t) => t.id.equals(mangaId)))
         .getSingleOrNull();
-    return (rule: m?.keepRule ?? OfflineKeepRule.off, count: m?.keepUnreadCount ?? 5);
+    return (
+      rule: m?.keepRule ?? OfflineKeepRule.off,
+      count: m?.keepUnreadCount ?? 5
+    );
   }
 
   /// Manga ids with at least one chapter downloaded to this device — for the
   /// "On device" library filter.
-  Future<Set<int>> deviceDownloadedMangaIds() => db.mangaIdsWithDeviceDownloads();
+  Future<Set<int>> deviceDownloadedMangaIds() =>
+      db.mangaIdsWithDeviceDownloads();
 
   /// Total bytes used by all downloaded chapters — for the storage settings UI.
   Future<int> totalDownloadedBytes() => db.totalDownloadedBytes();
@@ -149,11 +160,108 @@ OfflineRepository offlineRepository(Ref ref) => OfflineRepository(
 @riverpod
 bool offlineEnabled(Ref ref) => false;
 
+@riverpod
+bool offlineActive(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return false;
+  final stamp = ref.watch(sharedPreferencesProvider).getString(
+        DBKeys.offlineCatalogServerId.name,
+      );
+  final current = ref.watch(serverInstanceIdProvider).valueOrNull;
+  if (current == null) return false;
+  return isOfflineCatalogActive(
+    offlineEnabled: true,
+    catalogServer: stamp,
+    currentServer: current,
+  );
+}
+
+class OfflineServerMismatch {
+  const OfflineServerMismatch({
+    required this.catalogServer,
+    required this.currentServer,
+    required this.dismissed,
+  });
+
+  final String catalogServer;
+  final String currentServer;
+  final bool dismissed;
+}
+
+@riverpod
+Future<OfflineServerMismatch?> offlineServerMismatch(Ref ref) async {
+  if (!ref.watch(offlineEnabledProvider)) return null;
+  final preferences = ref.watch(sharedPreferencesProvider);
+  final stamp = preferences.getString(DBKeys.offlineCatalogServerId.name);
+  final current = await ref.watch(serverInstanceIdProvider.future);
+  if (stamp == null || stamp == current) return null;
+  if (!await ref.watch(offlineDatabaseProvider).hasCatalogData()) {
+    await preferences.setString(DBKeys.offlineCatalogServerId.name, current);
+    await preferences.remove(DBKeys.offlineServerMismatchDismissedList.name);
+    ref.invalidate(offlineActiveProvider);
+    return null;
+  }
+  final key = serverMismatchKey(stamp, current);
+  final dismissedKeys = preferences.getStringList(
+        DBKeys.offlineServerMismatchDismissedList.name,
+      ) ??
+      const <String>[];
+  return OfflineServerMismatch(
+    catalogServer: stamp,
+    currentServer: current,
+    dismissed: dismissedKeys.contains(key),
+  );
+}
+
+Future<void> dismissOfflineServerMismatch(
+  WidgetRef ref,
+  OfflineServerMismatch mismatch,
+) async {
+  final preferences = ref.read(sharedPreferencesProvider);
+  final key = serverMismatchKey(mismatch.catalogServer, mismatch.currentServer);
+  // Remember each dismissed (catalog, current) pair so switching among several
+  // servers doesn't un-dismiss a banner already dismissed.
+  final current = preferences.getStringList(
+        DBKeys.offlineServerMismatchDismissedList.name,
+      ) ??
+      const <String>[];
+  if (!current.contains(key)) {
+    await preferences.setStringList(
+      DBKeys.offlineServerMismatchDismissedList.name,
+      [...current, key],
+    );
+  }
+  ref.invalidate(offlineServerMismatchProvider);
+}
+
+@riverpod
+OfflineDatabase? offlineReadDatabase(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return null;
+  final stamp = ref.watch(sharedPreferencesProvider).getString(
+        DBKeys.offlineCatalogServerId.name,
+      );
+  if (stamp != null && !ref.watch(offlineActiveProvider)) return null;
+  return ref.watch(offlineDatabaseProvider);
+}
+
 /// The metadata down-sync, or null when offline storage is unavailable — so
 /// online controllers can call `ref.read(offlineSyncProvider)?.syncManga(m)`
 /// without caring about platform.
 @riverpod
 OfflineSync? offlineSync(Ref ref) {
-  if (!ref.watch(offlineEnabledProvider)) return null;
-  return OfflineSync(ref.watch(offlineDatabaseProvider));
+  if (!ref.watch(offlineActiveProvider)) return null;
+  final identity = ref.watch(serverInstanceIdProvider).valueOrNull;
+  if (identity == null) return null;
+  final preferences = ref.watch(sharedPreferencesProvider);
+  return OfflineSync(
+    ref.watch(offlineDatabaseProvider),
+    onSynced: () async {
+      if (preferences.getString(DBKeys.offlineCatalogServerId.name) == null) {
+        await preferences.setString(
+          DBKeys.offlineCatalogServerId.name,
+          identity,
+        );
+        ref.invalidate(offlineActiveProvider);
+      }
+    },
+  );
 }

--- a/lib/src/features/offline/data/offline_server_identity.dart
+++ b/lib/src/features/offline/data/offline_server_identity.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:math';
+
+import '../../../constants/db_keys.dart';
+import '../../../constants/endpoints.dart';
+
+const kTsumiruServerIdMetaKey = 'tsumiru_server_instance_id';
+
+String serverAddress({
+  required String? baseUrl,
+  required int? port,
+  required bool addPort,
+}) {
+  final raw = Endpoints.baseApi(
+    baseUrl: baseUrl ?? DBKeys.serverUrl.initial as String,
+    port: port,
+    addPort: addPort,
+    appendApiToUrl: false,
+  );
+  final uri = Uri.parse(raw);
+  final effectivePort = uri.hasPort
+      ? uri.port
+      : uri.scheme == 'https'
+          ? 443
+          : 80;
+  final host = uri.host.contains(':') ? '[${uri.host}]' : uri.host;
+  return '${uri.scheme.toLowerCase()}://$host:$effectivePort';
+}
+
+String serverMismatchKey(String catalogServer, String currentServer) =>
+    '$catalogServer\n$currentServer';
+
+String createServerInstanceId([Random? random]) {
+  final source = random ?? Random.secure();
+  final bytes = List<int>.generate(16, (_) => source.nextInt(256));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  final hex = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
+      '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
+      '${hex.substring(20)}';
+}
+
+bool isOfflineCatalogActive({
+  required bool offlineEnabled,
+  required String? catalogServer,
+  required String currentServer,
+}) =>
+    offlineEnabled && (catalogServer == null || catalogServer == currentServer);

--- a/lib/src/features/offline/data/offline_server_identity_repository.dart
+++ b/lib/src/features/offline/data/offline_server_identity_repository.dart
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/network/graphql_errors.dart';
+import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+import 'graphql/__generated__/server_identity.graphql.dart';
+import 'offline_server_identity.dart';
+
+part 'offline_server_identity_repository.g.dart';
+
+class OfflineServerIdentityRepository {
+  const OfflineServerIdentityRepository(this.client);
+
+  final GraphQLClient client;
+
+  Future<String?> read() => client
+      .query$OfflineServerIdentity(
+        Options$Query$OfflineServerIdentity(
+          variables: Variables$Query$OfflineServerIdentity(
+            key: kTsumiruServerIdMetaKey,
+          ),
+        ),
+      )
+      .getData((data) => data.metas.nodes.firstOrNull?.value);
+
+  Future<void> write(String value) => client
+      .mutate$SetOfflineServerIdentity(
+        Options$Mutation$SetOfflineServerIdentity(
+          variables: Variables$Mutation$SetOfflineServerIdentity(
+            key: kTsumiruServerIdMetaKey,
+            value: value,
+          ),
+        ),
+      )
+      .getData((data) => data.setGlobalMeta?.meta.value);
+
+  Future<String> resolve() => resolveServerInstanceId(
+        read: read,
+        write: write,
+        create: createServerInstanceId,
+      );
+}
+
+Future<String> resolveServerInstanceId({
+  required Future<String?> Function() read,
+  required Future<void> Function(String value) write,
+  required String Function() create,
+}) async {
+  final existing = await read();
+  if (existing != null && existing.isNotEmpty) return existing;
+  await write(create());
+  final stored = await read();
+  if (stored == null || stored.isEmpty) {
+    throw StateError('Server identity was not persisted');
+  }
+  return stored;
+}
+
+@riverpod
+OfflineServerIdentityRepository offlineServerIdentityRepository(Ref ref) =>
+    OfflineServerIdentityRepository(ref.watch(graphQlClientProvider));
+
+@riverpod
+String currentServerAddress(Ref ref) => serverAddress(
+      baseUrl: ref.watch(serverUrlProvider),
+      port: ref.watch(serverPortProvider),
+      addPort: ref.watch(serverPortToggleProvider).ifNull(),
+    );
+
+@riverpod
+Future<String> serverInstanceId(Ref ref) async {
+  final preferences = ref.watch(sharedPreferencesProvider);
+  final address = ref.watch(currentServerAddressProvider);
+  final cachedId = preferences.getString(DBKeys.offlineLastServerId.name);
+  final cachedAddress =
+      preferences.getString(DBKeys.offlineLastServerAddress.name);
+
+  // Offline-first: if we already know this address's id, return it immediately
+  // (no network wait, so the offline library opens instantly) and verify against
+  // the server in the background — a genuine switch is still caught a moment
+  // later, without blocking offline reads on a live round-trip.
+  if (cachedId != null && cachedId.isNotEmpty && cachedAddress == address) {
+    unawaited(_verifyServerInstanceId(ref, preferences, address, cachedId));
+    return cachedId;
+  }
+
+  // First time on this address: resolve online and cache it.
+  return _resolveAndCacheServerInstanceId(ref, preferences, address);
+}
+
+Future<void> _verifyServerInstanceId(
+  Ref ref,
+  SharedPreferences preferences,
+  String address,
+  String cachedId,
+) async {
+  try {
+    final live =
+        await ref.read(offlineServerIdentityRepositoryProvider).resolve();
+    if (live == cachedId) return;
+    // The address now points at a different server — record its id and
+    // re-evaluate so the mismatch guard/banner picks up the switch.
+    await preferences.setString(DBKeys.offlineLastServerId.name, live);
+    await preferences.setString(DBKeys.offlineLastServerAddress.name, address);
+    ref.invalidateSelf();
+  } catch (_) {
+    // Unreachable / server error → keep trusting the cached id (a token lapse
+    // or a 500 on the same address is not evidence of a server switch).
+  }
+}
+
+Future<String> _resolveAndCacheServerInstanceId(
+  Ref ref,
+  SharedPreferences preferences,
+  String address,
+) async {
+  try {
+    final id =
+        await ref.read(offlineServerIdentityRepositoryProvider).resolve();
+    await preferences.setString(DBKeys.offlineLastServerId.name, id);
+    await preferences.setString(DBKeys.offlineLastServerAddress.name, address);
+    return id;
+  } catch (error) {
+    final cachedAddress =
+        preferences.getString(DBKeys.offlineLastServerAddress.name);
+    final cachedId = preferences.getString(DBKeys.offlineLastServerId.name);
+    final fallback = cachedServerIdForFailure(
+      error: error,
+      currentAddress: address,
+      cachedAddress: cachedAddress,
+      cachedId: cachedId,
+    );
+    if (fallback != null) return fallback;
+    rethrow;
+  }
+}
+
+String? cachedServerIdForFailure({
+  required Object error,
+  required String currentAddress,
+  required String? cachedAddress,
+  required String? cachedId,
+}) {
+  final cause = error is OperationMessageException ? error.exception : error;
+  if (!isConnectionError(cause) ||
+      cachedAddress != currentAddress ||
+      cachedId == null ||
+      cachedId.isEmpty) {
+    return null;
+  }
+  return cachedId;
+}

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -16,31 +16,36 @@ import 'offline_database.dart';
 /// a re-sync never clobbers what the user has downloaded. Called online only;
 /// a no-op offline (the caller guards via [offlineSyncProvider] being null).
 class OfflineSync {
-  const OfflineSync(this._db);
+  const OfflineSync(this._db, {this.onSynced});
 
   final OfflineDatabase _db;
+  final Future<void> Function()? onSynced;
 
-  Future<void> syncManga(MangaDto manga) => _db.upsertMangaMetadata(
-        id: manga.id,
-        title: manga.title,
-        thumbnailUrl: manga.thumbnailUrl,
-        updatedAt: DateTime.now(),
-        sourceId: manga.source?.id,
-        sourceName: manga.source?.name,
-        sourceLang: manga.source?.lang,
-        sourceIsNsfw: manga.source?.isNsfw ?? false,
-        status: manga.status.name,
-        unreadCount: manga.unreadCount,
-        downloadCount: manga.downloadCount,
-        bookmarkCount: manga.bookmarkCount,
-        inLibraryAt: manga.inLibraryAt,
-        latestFetchedAt: manga.latestFetchedChapter?.fetchedAt,
-        latestUploadedAt: manga.latestUploadedChapter?.uploadDate,
-        totalChapters: manga.chapters.totalCount,
-      ).then((_) => _db.replaceMangaCategories(
-            manga.id,
-            manga.categories.nodes.map((c) => c.id).toList(),
-          ));
+  Future<void> syncManga(MangaDto manga) async {
+    await _db.upsertMangaMetadata(
+      id: manga.id,
+      title: manga.title,
+      thumbnailUrl: manga.thumbnailUrl,
+      updatedAt: DateTime.now(),
+      sourceId: manga.source?.id,
+      sourceName: manga.source?.name,
+      sourceLang: manga.source?.lang,
+      sourceIsNsfw: manga.source?.isNsfw ?? false,
+      status: manga.status.name,
+      unreadCount: manga.unreadCount,
+      downloadCount: manga.downloadCount,
+      bookmarkCount: manga.bookmarkCount,
+      inLibraryAt: manga.inLibraryAt,
+      latestFetchedAt: manga.latestFetchedChapter?.fetchedAt,
+      latestUploadedAt: manga.latestUploadedChapter?.uploadDate,
+      totalChapters: manga.chapters.totalCount,
+    );
+    await _db.replaceMangaCategories(
+      manga.id,
+      manga.categories.nodes.map((c) => c.id).toList(),
+    );
+    await onSynced?.call();
+  }
 
   Future<void> syncChapters(List<ChapterDto> chapters) async {
     final now = DateTime.now();
@@ -103,11 +108,13 @@ class OfflineSync {
       ];
       if (goneIds.isNotEmpty) await _db.markChaptersOrphaned(goneIds);
     }
+    await onSynced?.call();
   }
 
   Future<void> syncCategories(List<CategoryDto> categories) async {
     for (final cat in categories) {
       await _db.upsertCategory(cat.id, cat.name, cat.order);
     }
+    await onSynced?.call();
   }
 }

--- a/lib/src/features/offline/presentation/offline_server_mismatch_banner.dart
+++ b/lib/src/features/offline/presentation/offline_server_mismatch_banner.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../utils/extensions/custom_extensions.dart';
+import '../data/offline_download_providers.dart';
+import '../data/offline_repository.dart';
+
+class OfflineServerMismatchBanner extends ConsumerWidget {
+  const OfflineServerMismatchBanner({
+    super.key,
+    this.showAfterDismissal = false,
+  });
+
+  final bool showAfterDismissal;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mismatch = ref.watch(offlineServerMismatchProvider).valueOrNull;
+    if (mismatch == null || (mismatch.dismissed && !showAfterDismissal)) {
+      return const SizedBox.shrink();
+    }
+
+    return MaterialBanner(
+      content: Text(
+        mismatch.dismissed
+            ? context.l10n.offlineServerMismatchDisabled
+            : context.l10n.offlineServerMismatch,
+      ),
+      leading: const Icon(Icons.dns_rounded),
+      actions: [
+        if (!mismatch.dismissed)
+          TextButton(
+            onPressed: () => dismissOfflineServerMismatch(ref, mismatch),
+            child: Text(context.l10n.offlineServerMismatchDismiss),
+          ),
+        TextButton(
+          onPressed: () => _confirmClear(context, ref),
+          child: Text(
+            mismatch.dismissed
+                ? context.l10n.offlineServerMismatchClearAction
+                : context.l10n.offlineServerMismatchClear,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _confirmClear(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(context.l10n.offlineServerMismatchConfirmTitle),
+        content: Text(context.l10n.offlineServerMismatchConfirmBody),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: Text(context.l10n.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: Text(context.l10n.offlineServerMismatchClearAction),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !context.mounted) return;
+    await clearOfflineCatalog(ref);
+    ref.invalidate(offlineServerMismatchProvider);
+  }
+}

--- a/lib/src/features/offline/presentation/offline_settings_screen.dart
+++ b/lib/src/features/offline/presentation/offline_settings_screen.dart
@@ -14,6 +14,7 @@ import '../../../widgets/section_title.dart';
 import '../data/offline_download_providers.dart';
 import '../data/offline_repository.dart';
 import '../data/offline_settings_providers.dart';
+import 'offline_server_mismatch_banner.dart';
 import 'offline_settings_format.dart';
 
 /// The on-device (offline) download + storage settings, as a flat list of tiles
@@ -29,6 +30,7 @@ List<Widget> buildOnDeviceStorageTiles(BuildContext context, WidgetRef ref) {
     ];
   }
   return [
+    const OfflineServerMismatchBanner(showAfterDismissal: true),
     SectionTitle(title: context.l10n.offlineStorageSection),
     ListTile(
       title: Text(context.l10n.offlineStorageUsage),

--- a/lib/src/features/settings/presentation/connection/connection_screen.dart
+++ b/lib/src/features/settings/presentation/connection/connection_screen.dart
@@ -15,6 +15,7 @@ import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/launch_url_in_web.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/section_title.dart';
+import '../../../offline/presentation/offline_server_mismatch_banner.dart';
 import '../server/widget/client/server_port_tile/server_port_tile.dart';
 import '../server/widget/client/server_url_tile/server_url_tile.dart';
 import 'inline_auth_section.dart';
@@ -60,6 +61,10 @@ class ConnectionScreen extends HookConsumerWidget {
         ),
         child: ListView(
           children: [
+            // Surfaced here (where the server is changed) and kept visible even
+            // after dismissal, so it doubles as the "clear to re-enable offline"
+            // recovery affordance for this server.
+            const OfflineServerMismatchBanner(showAfterDismissal: true),
             SectionTitle(title: context.l10n.serverAddress),
             const ServerUrlTile(),
             const InlineAuthSection(),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2586,5 +2586,12 @@
     "zoomStartAutomatic": "Automatic",
     "zoomStartCenter": "Center",
     "zoomStartLeft": "Left",
-    "zoomStartRight": "Right"
+    "zoomStartRight": "Right",
+    "offlineServerMismatch": "Your offline downloads are from a different server.",
+    "offlineServerMismatchDisabled": "Offline is off here. Clear the other server's downloads to use it.",
+    "offlineServerMismatchClear": "Clear old downloads",
+    "offlineServerMismatchDismiss": "Dismiss",
+    "offlineServerMismatchConfirmTitle": "Clear offline data?",
+    "offlineServerMismatchConfirmBody": "This removes all on-device manga and queued downloads from the previous server.",
+    "offlineServerMismatchClearAction": "Clear offline data"
 }

--- a/test/offline/background/chapter_download_engine_offline_test.dart
+++ b/test/offline/background/chapter_download_engine_offline_test.dart
@@ -17,6 +17,8 @@ class _NoopStore implements OfflinePageStore {
   Future<void> deleteChapter(int m, int c) async {}
   @override
   Future<int> chapterBytes(int m, int c) async => 0;
+  @override
+  Future<void> clearAll() async {}
 }
 
 void main() {

--- a/test/offline/offline_catalog_clear_order_test.dart
+++ b/test/offline/offline_catalog_clear_order_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+
+void main() {
+  test('workers stop before catalog rows and files are cleared', () async {
+    final events = <String>[];
+
+    await clearOfflineCatalogWithDependencies(
+      stopBackground: () async => events.add('background'),
+      stopMainPump: () async => events.add('main'),
+      clearDatabase: () async => events.add('database'),
+      clearFiles: () async => events.add('files'),
+      clearIdentity: () async => events.add('identity'),
+      finish: () => events.add('finish'),
+    );
+
+    expect(
+      events,
+      ['background', 'main', 'database', 'files', 'identity', 'finish'],
+    );
+  });
+
+  test('restart suppression is released when a wipe fails', () async {
+    var finished = false;
+
+    await expectLater(
+      clearOfflineCatalogWithDependencies(
+        stopBackground: () async {},
+        stopMainPump: () async {},
+        clearDatabase: () async => throw StateError('wipe failed'),
+        clearFiles: () async {},
+        clearIdentity: () async {},
+        finish: () => finished = true,
+      ),
+      throwsStateError,
+    );
+    expect(finished, isTrue);
+  });
+}

--- a/test/offline/offline_page_store_clear_test.dart
+++ b/test/offline/offline_page_store_clear_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store_io.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+
+void main() {
+  test('clearAll deletes pages and covers but preserves the catalog', () async {
+    final temp = await Directory.systemTemp.createTemp('tsumiru-offline-');
+    addTearDown(() => temp.delete(recursive: true));
+    final paths = OfflinePaths(temp.path);
+    final store = IoOfflinePageStore(paths);
+    final catalog = File('${temp.path}/catalog.sqlite');
+    await catalog.writeAsString('catalog');
+    await store.writePage(12, 34, 0, [1, 2, 3], 'jpg');
+    final cover = File(paths.absolute('covers/12.jpg'));
+    await cover.parent.create(recursive: true);
+    await cover.writeAsBytes([1]);
+
+    await store.clearAll();
+
+    expect(await catalog.exists(), isTrue);
+    expect(await Directory(paths.absolute('12')).exists(), isFalse);
+    expect(await Directory(paths.absolute('covers')).exists(), isFalse);
+  });
+}

--- a/test/offline/offline_server_identity_repository_test.dart
+++ b/test/offline/offline_server_identity_repository_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_server_identity_repository.dart';
+
+void main() {
+  test('uses an existing server identity without writing', () async {
+    var writes = 0;
+
+    final result = await resolveServerInstanceId(
+      read: () async => 'existing-id',
+      write: (_) async => writes++,
+      create: () => 'new-id',
+    );
+
+    expect(result, 'existing-id');
+    expect(writes, 0);
+  });
+
+  test('creates missing identity and trusts the value read back', () async {
+    var reads = 0;
+    String? written;
+
+    final result = await resolveServerInstanceId(
+      read: () async => reads++ == 0 ? null : 'server-value',
+      write: (value) async => written = value,
+      create: () => 'candidate-value',
+    );
+
+    expect(written, 'candidate-value');
+    expect(result, 'server-value');
+  });
+
+  test('fails closed when the server does not persist the identity', () async {
+    await expectLater(
+      resolveServerInstanceId(
+        read: () async => null,
+        write: (_) async {},
+        create: () => 'candidate-value',
+      ),
+      throwsStateError,
+    );
+  });
+
+  test('uses a same-address cached identity only on connection loss', () {
+    expect(
+      cachedServerIdForFailure(
+        error: const SocketException('offline'),
+        currentAddress: 'https://reader.test:443',
+        cachedAddress: 'https://reader.test:443',
+        cachedId: 'cached-id',
+      ),
+      'cached-id',
+    );
+    expect(
+      cachedServerIdForFailure(
+        error: StateError('metadata write failed'),
+        currentAddress: 'https://reader.test:443',
+        cachedAddress: 'https://reader.test:443',
+        cachedId: 'cached-id',
+      ),
+      isNull,
+    );
+  });
+}

--- a/test/offline/offline_server_identity_test.dart
+++ b/test/offline/offline_server_identity_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_server_identity.dart';
+
+void main() {
+  group('serverIdentity', () {
+    test('normalizes trailing paths and the effective port', () {
+      expect(
+        serverAddress(
+          baseUrl: 'https://reader.example.test/path/',
+          port: 4567,
+          addPort: true,
+        ),
+        'https://reader.example.test:4567',
+      );
+    });
+
+    test('uses the URL port when the port toggle is off', () {
+      expect(
+        serverAddress(
+          baseUrl: 'http://reader.example.test:8080/',
+          port: 4567,
+          addPort: false,
+        ),
+        'http://reader.example.test:8080',
+      );
+    });
+
+    test('makes implicit and explicit default ports identical', () {
+      final implicit = serverAddress(
+        baseUrl: 'https://reader.example.test',
+        port: null,
+        addPort: false,
+      );
+      final explicit = serverAddress(
+        baseUrl: 'https://reader.example.test:443/',
+        port: null,
+        addPort: false,
+      );
+      expect(implicit, explicit);
+      expect(implicit, 'https://reader.example.test:443');
+    });
+  });
+
+  test('catalog is parked on another server and restored on return', () {
+    const serverA = 'https://a.example.test:443';
+    const serverB = 'https://b.example.test:443';
+
+    expect(
+      isOfflineCatalogActive(
+        offlineEnabled: true,
+        catalogServer: serverA,
+        currentServer: serverA,
+      ),
+      isTrue,
+    );
+    expect(
+      isOfflineCatalogActive(
+        offlineEnabled: true,
+        catalogServer: serverA,
+        currentServer: serverB,
+      ),
+      isFalse,
+    );
+    expect(
+      isOfflineCatalogActive(
+        offlineEnabled: true,
+        catalogServer: serverA,
+        currentServer: serverA,
+      ),
+      isTrue,
+    );
+  });
+
+  test('unstamped catalogs are trusted only when offline storage exists', () {
+    expect(
+      isOfflineCatalogActive(
+        offlineEnabled: true,
+        catalogServer: null,
+        currentServer: 'https://reader.example.test:443',
+      ),
+      isTrue,
+    );
+    expect(
+      isOfflineCatalogActive(
+        offlineEnabled: false,
+        catalogServer: null,
+        currentServer: 'https://reader.example.test:443',
+      ),
+      isFalse,
+    );
+  });
+
+  test('creates a UUID v4 server identifier', () {
+    final id = createServerInstanceId();
+    expect(
+      id,
+      matches(RegExp(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+      )),
+    );
+  });
+}

--- a/test/offline/offline_server_mismatch_banner_test.dart
+++ b/test/offline/offline_server_mismatch_banner_test.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/db_keys.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/features/offline/presentation/offline_server_mismatch_banner.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+/// Load the SDK's Roboto so captured screenshots have readable text (test hosts
+/// otherwise render the Ahem box font). Best-effort — falls through on CI.
+Future<void> _loadRoboto() async {
+  const candidates = [
+    '/var/home/valyth/development/flutter/bin/cache/artifacts/material_fonts/Roboto-Regular.ttf',
+  ];
+  for (final p in candidates) {
+    final f = File(p);
+    if (f.existsSync()) {
+      final loader = FontLoader('Roboto')
+        ..addFont(f.readAsBytes().then((b) => ByteData.view(b.buffer)));
+      await loader.load();
+      return;
+    }
+  }
+}
+
+Future<void> _capture(WidgetTester tester, Key rootKey, String name) async {
+  final dir = Directory('build/offline_banner_screenshots')
+    ..createSync(recursive: true);
+  await tester.runAsync(() async {
+    final boundary =
+        tester.renderObject<RenderRepaintBoundary>(find.byKey(rootKey));
+    final image = await boundary.toImage(pixelRatio: 2);
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    File('${dir.path}/$name.png').writeAsBytesSync(data!.buffer.asUint8List());
+  });
+}
+
+Widget _app(List<Override> overrides, Key rootKey, {String appBarTitle = 'Library'}) =>
+    ProviderScope(
+      overrides: overrides,
+      child: RepaintBoundary(
+        key: rootKey,
+        child: MaterialApp(
+          debugShowCheckedModeBanner: false,
+          theme: ThemeData(useMaterial3: true, fontFamily: 'Roboto'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            appBar: AppBar(title: Text(appBarTitle)),
+            body: const Column(
+              children: [
+                OfflineServerMismatchBanner(showAfterDismissal: true),
+                Expanded(child: Center(child: Text('library grid…'))),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  setUpAll(_loadRoboto);
+
+  testWidgets('active mismatch: banner shows message + Dismiss/Clear, and '
+      'Dismiss persists the pair', (tester) async {
+    tester.view.physicalSize = const Size(1080, 520);
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.reset);
+
+    SharedPreferences.setMockInitialValues(const {});
+    final prefs = await SharedPreferences.getInstance();
+    const mismatch = OfflineServerMismatch(
+        catalogServer: 'server-A', currentServer: 'server-B', dismissed: false);
+    final rootKey = GlobalKey();
+
+    await tester.pumpWidget(_app([
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      offlineServerMismatchProvider.overrideWith((ref) async => mismatch),
+    ], rootKey));
+    await tester.pumpAndSettle();
+
+    final l10n = AppLocalizations.of(
+        tester.element(find.byType(OfflineServerMismatchBanner)))!;
+    expect(find.byType(MaterialBanner), findsOneWidget);
+    expect(find.text(l10n.offlineServerMismatch), findsOneWidget);
+    expect(find.widgetWithText(TextButton, l10n.offlineServerMismatchDismiss),
+        findsOneWidget);
+    expect(find.widgetWithText(TextButton, l10n.offlineServerMismatchClear),
+        findsOneWidget);
+
+    await _capture(tester, rootKey, 'banner_active');
+
+    await tester.tap(
+        find.widgetWithText(TextButton, l10n.offlineServerMismatchDismiss));
+    await tester.pumpAndSettle();
+
+    expect(
+      prefs.getStringList(DBKeys.offlineServerMismatchDismissedList.name),
+      contains('server-A\nserver-B'),
+      reason: 'Dismiss persists the (catalog, current) pair',
+    );
+  });
+
+  testWidgets('dismissed mismatch: banner still shows the disabled state with '
+      'a clear-to-enable action', (tester) async {
+    tester.view.physicalSize = const Size(1080, 520);
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.reset);
+
+    SharedPreferences.setMockInitialValues(const {});
+    final prefs = await SharedPreferences.getInstance();
+    const mismatch = OfflineServerMismatch(
+        catalogServer: 'server-A', currentServer: 'server-B', dismissed: true);
+    final rootKey = GlobalKey();
+
+    await tester.pumpWidget(_app([
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      offlineServerMismatchProvider.overrideWith((ref) async => mismatch),
+    ], rootKey, appBarTitle: 'Connection'));
+    await tester.pumpAndSettle();
+
+    final l10n = AppLocalizations.of(
+        tester.element(find.byType(OfflineServerMismatchBanner)))!;
+    expect(find.text(l10n.offlineServerMismatchDisabled), findsOneWidget);
+    expect(
+        find.widgetWithText(
+            TextButton, l10n.offlineServerMismatchClearAction),
+        findsOneWidget);
+    // No Dismiss once already dismissed.
+    expect(find.widgetWithText(TextButton, l10n.offlineServerMismatchDismiss),
+        findsNothing);
+
+    await _capture(tester, rootKey, 'banner_dismissed');
+  });
+}

--- a/test/offline/server_instance_id_offline_first_test.dart
+++ b/test/offline/server_instance_id_offline_first_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/db_keys.dart';
+import 'package:tsumiru/src/features/offline/data/offline_server_identity_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+/// resolve() never completes until [completer] is fired — simulates a slow or
+/// unreachable network so the test can prove offline reads don't wait on it.
+class _HangingRepo extends OfflineServerIdentityRepository {
+  _HangingRepo() : super(_dummyClient());
+  final completer = Completer<String>();
+  int resolveCalls = 0;
+  @override
+  Future<String> resolve() {
+    resolveCalls++;
+    return completer.future;
+  }
+}
+
+class _FixedRepo extends OfflineServerIdentityRepository {
+  _FixedRepo(this._id) : super(_dummyClient());
+  final String _id;
+  @override
+  Future<String> resolve() async => _id;
+}
+
+void main() {
+  test(
+      'serverInstanceId returns the cached id instantly for a known address, '
+      'without waiting on the network (offline-first, #145 fix)', () async {
+    const address = 'http://host:4567';
+    SharedPreferences.setMockInitialValues({
+      DBKeys.offlineLastServerId.name: 'cached-id',
+      DBKeys.offlineLastServerAddress.name: address,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final repo = _HangingRepo();
+    final c = ProviderContainer(overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      currentServerAddressProvider.overrideWith((ref) => address),
+      offlineServerIdentityRepositoryProvider.overrideWithValue(repo),
+    ]);
+    addTearDown(() {
+      if (!repo.completer.isCompleted) repo.completer.complete('late');
+      c.dispose();
+    });
+
+    final id = await c
+        .read(serverInstanceIdProvider.future)
+        .timeout(const Duration(seconds: 2));
+
+    expect(id, 'cached-id',
+        reason: 'must resolve from cache even though the network hangs');
+    expect(repo.resolveCalls, 1,
+        reason: 'the online verify still fires in the background');
+  });
+
+  test('serverInstanceId resolves online and caches on a first-seen address',
+      () async {
+    const address = 'http://new-server:4567';
+    SharedPreferences.setMockInitialValues(const {});
+    final prefs = await SharedPreferences.getInstance();
+    final c = ProviderContainer(overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      currentServerAddressProvider.overrideWith((ref) => address),
+      offlineServerIdentityRepositoryProvider
+          .overrideWithValue(_FixedRepo('fresh-id')),
+    ]);
+    addTearDown(c.dispose);
+
+    final id = await c.read(serverInstanceIdProvider.future);
+
+    expect(id, 'fresh-id');
+    expect(prefs.getString(DBKeys.offlineLastServerId.name), 'fresh-id');
+    expect(prefs.getString(DBKeys.offlineLastServerAddress.name), address);
+  });
+}

--- a/test/src/features/offline/chapter_download_engine_test.dart
+++ b/test/src/features/offline/chapter_download_engine_test.dart
@@ -12,16 +12,21 @@ import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
 class _FakeStore implements OfflinePageStore {
   final written = <int, int>{}; // pageIndex -> bytes
   @override
-  Future<({String relPath, int bytes})> writePage(
-      int mangaId, int chapterId, int pageIndex, List<int> bytes, String ext) async {
+  Future<({String relPath, int bytes})> writePage(int mangaId, int chapterId,
+      int pageIndex, List<int> bytes, String ext) async {
     written[pageIndex] = bytes.length;
-    return (relPath: '$mangaId/$chapterId/$pageIndex.$ext', bytes: bytes.length);
+    return (
+      relPath: '$mangaId/$chapterId/$pageIndex.$ext',
+      bytes: bytes.length
+    );
   }
 
   @override
   Future<void> deleteChapter(int mangaId, int chapterId) async {}
   @override
   Future<int> chapterBytes(int mangaId, int chapterId) async => 0;
+  @override
+  Future<void> clearAll() async {}
 }
 
 List<PageRef> _pages(int n) =>
@@ -72,7 +77,7 @@ void main() {
       backoff: (_) => noBackoff,
     );
     final out = await engine.download(
-      mangaId: 1, chapterId: 1, pages: _pages(1), isCancelled: () => false);
+        mangaId: 1, chapterId: 1, pages: _pages(1), isCancelled: () => false);
     expect(out.succeeded, true);
     expect(refreshes, 1);
   });
@@ -85,7 +90,7 @@ void main() {
       backoff: (_) => noBackoff,
     );
     final out = await engine.download(
-      mangaId: 1, chapterId: 1, pages: _pages(3), isCancelled: () => false);
+        mangaId: 1, chapterId: 1, pages: _pages(3), isCancelled: () => false);
     expect(out.authFailed, true);
     expect(out.succeeded, false);
   });
@@ -103,7 +108,7 @@ void main() {
       backoff: (_) => noBackoff,
     );
     final out = await engine.download(
-      mangaId: 1, chapterId: 1, pages: _pages(1), isCancelled: () => false);
+        mangaId: 1, chapterId: 1, pages: _pages(1), isCancelled: () => false);
     expect(out.succeeded, false);
     expect(out.error, isNotNull);
     expect(calls, 3); // 3 attempts for the single page
@@ -126,7 +131,7 @@ void main() {
       backoff: (_) => noBackoff,
     );
     await engine.download(
-      mangaId: 1, chapterId: 1, pages: _pages(30), isCancelled: () => false);
+        mangaId: 1, chapterId: 1, pages: _pages(30), isCancelled: () => false);
     expect(peak, lessThanOrEqualTo(5));
     expect(peak, greaterThan(1)); // actually parallel
   });
@@ -146,7 +151,10 @@ void main() {
       backoff: (_) => noBackoff,
     );
     final out = await engine.download(
-      mangaId: 1, chapterId: 1, pages: _pages(100), isCancelled: () => cancel);
+        mangaId: 1,
+        chapterId: 1,
+        pages: _pages(100),
+        isCancelled: () => cancel);
     expect(out.cancelled, true);
     expect(fetched, lessThan(100));
   });

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -32,7 +32,8 @@ void main() {
     expect(rows.single.title, 'Solo Leveling');
   });
 
-  test('chapter deviceState defaults to none and round-trips an enum', () async {
+  test('chapter deviceState defaults to none and round-trips an enum',
+      () async {
     await db.into(db.offlineChapters).insert(
           OfflineChaptersCompanion.insert(
             id: const Value(2000),
@@ -68,5 +69,53 @@ void main() {
           ..where((t) => t.chapterId.equals(2000)))
         .get();
     expect(rows.single.relativePath, '552/2000/000.jpg');
+  });
+
+  test('clearAll removes the complete offline catalog', () async {
+    await db.into(db.offlineMangas).insert(
+          OfflineMangasCompanion.insert(
+            id: const Value(117),
+            title: 'Solo Leveling',
+            updatedAt: DateTime.utc(2026),
+          ),
+        );
+    await db.into(db.offlineChapters).insert(
+          OfflineChaptersCompanion.insert(
+            id: const Value(2000),
+            mangaId: 117,
+            name: 'Chapter 79',
+            chapterIndex: 79,
+            updatedAt: DateTime.utc(2026),
+          ),
+        );
+    await db.into(db.offlineCategories).insert(
+          const OfflineCategoriesCompanion(
+            id: Value(1),
+            name: Value('Reading'),
+            sortOrder: Value(0),
+          ),
+        );
+    await db.into(db.offlineMangaCategories).insert(
+          const OfflineMangaCategoriesCompanion(
+            mangaId: Value(117),
+            categoryId: Value(1),
+          ),
+        );
+    await db.into(db.offlinePages).insert(
+          OfflinePagesCompanion.insert(
+            chapterId: 2000,
+            pageIndex: 0,
+            relativePath: '117/2000/000.jpg',
+          ),
+        );
+
+    expect(await db.hasCatalogData(), isTrue);
+    await db.clearAll();
+
+    expect(await db.hasCatalogData(), isFalse);
+    expect(await db.select(db.offlineChapters).get(), isEmpty);
+    expect(await db.select(db.offlineCategories).get(), isEmpty);
+    expect(await db.select(db.offlineMangaCategories).get(), isEmpty);
+    expect(await db.select(db.offlinePages).get(), isEmpty);
   });
 }

--- a/test/src/features/offline/data/offline_download_coordinator_test.dart
+++ b/test/src/features/offline/data/offline_download_coordinator_test.dart
@@ -16,10 +16,13 @@ import '../../../../helpers/offline_test_db.dart';
 class _FakeStore implements OfflinePageStore {
   final pages = <String, int>{}; // '$chapter/$page' -> bytes
   @override
-  Future<({String relPath, int bytes})> writePage(
-      int mangaId, int chapterId, int pageIndex, List<int> bytes, String ext) async {
+  Future<({String relPath, int bytes})> writePage(int mangaId, int chapterId,
+      int pageIndex, List<int> bytes, String ext) async {
     pages['$chapterId/$pageIndex'] = bytes.length;
-    return (relPath: '$mangaId/$chapterId/$pageIndex.$ext', bytes: bytes.length);
+    return (
+      relPath: '$mangaId/$chapterId/$pageIndex.$ext',
+      bytes: bytes.length
+    );
   }
 
   @override
@@ -32,6 +35,9 @@ class _FakeStore implements OfflinePageStore {
     }
     return total;
   }
+
+  @override
+  Future<void> clearAll() async {}
 }
 
 void main() {
@@ -45,9 +51,15 @@ void main() {
 
   Future<void> seedChapter(int id, int mangaId, int pageCount) =>
       db.upsertChapterMetadata(
-          id: id, mangaId: mangaId, name: 'c$id', chapterIndex: 1,
-          isRead: false, lastPageRead: 0, isBookmarked: false,
-          serverIsDownloaded: true, pageCount: pageCount,
+          id: id,
+          mangaId: mangaId,
+          name: 'c$id',
+          chapterIndex: 1,
+          isRead: false,
+          lastPageRead: 0,
+          isBookmarked: false,
+          serverIsDownloaded: true,
+          pageCount: pageCount,
           updatedAt: DateTime(2026));
 
   /// Build a coordinator whose engine fetches with the given behaviour.
@@ -78,7 +90,8 @@ void main() {
     );
   }
 
-  test('downloads every page, stores rows, marks downloaded with bytes', () async {
+  test('downloads every page, stores rows, marks downloaded with bytes',
+      () async {
     await seedChapter(1, 7, 3);
     await coord().enqueueChapter((await db.chapterById(1))!);
     final c = await db.chapterById(1);
@@ -98,7 +111,8 @@ void main() {
     await db.into(db.offlinePages).insert(OfflinePagesCompanion.insert(
         chapterId: 1, pageIndex: 0, relativePath: '7/1/0.jpg'));
     await coord().enqueueChapter((await db.chapterById(1))!);
-    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
     expect(store.pages.keys.toSet(), {'1/1', '1/2'}); // only the 2 missing
   });
 
@@ -129,15 +143,18 @@ void main() {
     await c.queueChapter(1);
     await c.queueChapter(2);
     await c.pumpDownloads();
-    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
-    expect((await db.chapterById(2))!.deviceState, OfflineDeviceState.downloaded);
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+    expect(
+        (await db.chapterById(2))!.deviceState, OfflineDeviceState.downloaded);
   });
 
   test('pump resumes a chapter stranded as downloading', () async {
     await seedChapter(1, 7, 2);
     await db.setChapterDeviceState(1, OfflineDeviceState.downloading);
     await coord(pages: const ['/p/0', '/p/1']).pumpDownloads();
-    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
   });
 
   test('paused pump does not download queued chapters', () async {
@@ -158,8 +175,8 @@ void main() {
     c.pause();
     await c.enqueueChapter((await db.chapterById(1))!);
     // Left as-is (resumable), nothing written.
-    expect((await db.chapterById(1))!.deviceState,
-        OfflineDeviceState.downloading);
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloading);
     expect(store.pages, isEmpty);
   });
 
@@ -179,7 +196,8 @@ void main() {
       () async {
     await seedChapter(1, 7, 2);
     var paused = true; // simulates the saved flag after a restart
-    final c = coord(pages: const ['/p/0', '/p/1'], persistedPaused: () => paused);
+    final c =
+        coord(pages: const ['/p/0', '/p/1'], persistedPaused: () => paused);
     await c.queueChapter(1);
     await c.pumpDownloads();
     expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.queued);

--- a/test/src/features/offline/data/offline_download_manager_force_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_force_test.dart
@@ -20,6 +20,8 @@ class _FakeStore implements OfflinePageStore {
   Future<void> deleteChapter(int m, int c) async {}
   @override
   Future<int> chapterBytes(int m, int c) async => 0;
+  @override
+  Future<void> clearAll() async {}
 }
 
 void main() {
@@ -53,12 +55,14 @@ void main() {
         fetchBytes: (u) async => (bytes: [1, 2, 3], ext: 'jpg'),
       );
 
-  test('downloadChapter still refuses a not-server-downloaded chapter by default',
+  test(
+      'downloadChapter still refuses a not-server-downloaded chapter by default',
       () async {
     await expectLater(manager().downloadChapter(chap(false)), throwsStateError);
   });
 
-  test('downloadChapter(force: true) downloads despite serverIsDownloaded=false',
+  test(
+      'downloadChapter(force: true) downloads despite serverIsDownloaded=false',
       () async {
     await db.upsertChapterMetadata(
         id: 1,

--- a/test/src/features/offline/data/offline_download_manager_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_test.dart
@@ -17,9 +17,10 @@ class _FakeStore implements OfflinePageStore {
   final List<int> deletedChapters = [];
 
   @override
-  Future<({String relPath, int bytes})> writePage(
-      int mangaId, int chapterId, int pageIndex, List<int> bytes, String ext) async {
-    final rel = '$mangaId/$chapterId/${pageIndex.toString().padLeft(3, '0')}.$ext';
+  Future<({String relPath, int bytes})> writePage(int mangaId, int chapterId,
+      int pageIndex, List<int> bytes, String ext) async {
+    final rel =
+        '$mangaId/$chapterId/${pageIndex.toString().padLeft(3, '0')}.$ext';
     written[rel] = bytes.length;
     return (relPath: rel, bytes: bytes.length);
   }
@@ -34,6 +35,8 @@ class _FakeStore implements OfflinePageStore {
   Future<int> chapterBytes(int mangaId, int chapterId) async => written.entries
       .where((e) => e.key.startsWith('$mangaId/$chapterId/'))
       .fold<int>(0, (s, e) => s + e.value);
+  @override
+  Future<void> clearAll() async {}
 }
 
 void main() {
@@ -91,7 +94,8 @@ void main() {
     expect(c.bytes, 9); // 3 pages * 3 bytes
   });
 
-  test('downloadChapter refuses a chapter not downloaded server-side', () async {
+  test('downloadChapter refuses a chapter not downloaded server-side',
+      () async {
     final chapter = await seedChapter(serverDownloaded: false);
     expect(() => managerWith().downloadChapter(chapter), throwsStateError);
     final c = (await db.chaptersForManga(552)).single;
@@ -114,7 +118,8 @@ void main() {
           ..where((t) => t.chapterId.equals(2000)))
         .get();
     expect(pages, isEmpty, reason: 'partial page rows purged');
-    expect(store.deletedChapters, contains(2000), reason: 'partial files purged');
+    expect(store.deletedChapters, contains(2000),
+        reason: 'partial files purged');
   });
 
   test('deleteChapter removes files, page rows, and resets state', () async {

--- a/test/src/features/offline/data/offline_download_triggers_test.dart
+++ b/test/src/features/offline/data/offline_download_triggers_test.dart
@@ -35,6 +35,8 @@ class _FakeStore implements OfflinePageStore {
   Future<void> deleteChapter(int m, int c) async {}
   @override
   Future<int> chapterBytes(int m, int c) async => 0;
+  @override
+  Future<void> clearAll() async {}
 }
 
 void main() {
@@ -77,6 +79,7 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           offlineEnabledProvider.overrideWithValue(true),
+          offlineActiveProvider.overrideWithValue(true),
           offlineDatabaseProvider.overrideWithValue(db),
           offlinePathsProvider.overrideWithValue(const OfflinePaths('/tmp/x')),
           offlinePageStoreProvider.overrideWithValue(store),
@@ -105,12 +108,18 @@ void main() {
 
   testWidgets('saveChapterToDevice (single chapter) starts downloads',
       (tester) async {
-    await db.upsertMangaMetadata(
-        id: 7, title: 'M', updatedAt: DateTime(2026));
+    await db.upsertMangaMetadata(id: 7, title: 'M', updatedAt: DateTime(2026));
     await db.upsertChapterMetadata(
-        id: 1, mangaId: 7, name: 'c1', chapterIndex: 1, isRead: false,
-        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
-        pageCount: 1, updatedAt: DateTime(2026));
+        id: 1,
+        mangaId: 7,
+        name: 'c1',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 1,
+        updatedAt: DateTime(2026));
     final h = await harness(tester);
     await saveChapterToDevice(h.ref, 1);
     expect(h.starts(), 1,

--- a/test/src/features/offline/data/offline_screen_gates_test.dart
+++ b/test/src/features/offline/data/offline_screen_gates_test.dart
@@ -40,6 +40,7 @@ Future<ProviderContainer> _container(
     sharedPreferencesProvider.overrideWithValue(prefs),
     offlineDatabaseProvider.overrideWithValue(db),
     offlineEnabledProvider.overrideWithValue(true),
+    offlineActiveProvider.overrideWithValue(true),
     ...extra,
   ]);
   addTearDown(c.dispose);
@@ -63,9 +64,12 @@ void main() {
   group('categoriesWithOfflineFallback', () {
     Future<Never> boom() async => throw const SocketException('offline');
 
-    test('returns a single default category (count) when fetch throws', () async {
-      await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
-      await db.upsertMangaMetadata(id: 2, title: 'B', updatedAt: DateTime(2026));
+    test('returns a single default category (count) when fetch throws',
+        () async {
+      await db.upsertMangaMetadata(
+          id: 1, title: 'A', updatedAt: DateTime(2026));
+      await db.upsertMangaMetadata(
+          id: 2, title: 'B', updatedAt: DateTime(2026));
       final cats = await categoriesWithOfflineFallback(
           fetch: boom, db: db, offlineEnabled: true);
       expect(cats!.length, 1);
@@ -73,13 +77,18 @@ void main() {
     });
 
     test('rethrows when the catalog is empty', () async {
-      expect(categoriesWithOfflineFallback(fetch: boom, db: db, offlineEnabled: true),
+      expect(
+          categoriesWithOfflineFallback(
+              fetch: boom, db: db, offlineEnabled: true),
           throwsException);
     });
 
     test('rethrows when offline disabled', () async {
-      await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
-      expect(categoriesWithOfflineFallback(fetch: boom, db: db, offlineEnabled: false),
+      await db.upsertMangaMetadata(
+          id: 1, title: 'A', updatedAt: DateTime(2026));
+      expect(
+          categoriesWithOfflineFallback(
+              fetch: boom, db: db, offlineEnabled: false),
           throwsException);
     });
   });
@@ -89,9 +98,16 @@ void main() {
 
     test('falls back to the catalog chapter row on throw', () async {
       await db.upsertChapterMetadata(
-          id: 99, mangaId: 1, name: 'Ch99', chapterIndex: 5, isRead: false,
-          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
-          pageCount: 10, updatedAt: DateTime(2026));
+          id: 99,
+          mangaId: 1,
+          name: 'Ch99',
+          chapterIndex: 5,
+          isRead: false,
+          lastPageRead: 0,
+          isBookmarked: false,
+          serverIsDownloaded: true,
+          pageCount: 10,
+          updatedAt: DateTime(2026));
       final ch = await chapterMetaWithOfflineFallback(
           fetch: boom, db: db, offlineEnabled: true, chapterId: 99);
       expect(ch!.id, 99);
@@ -111,8 +127,10 @@ void main() {
   group('real gating providers offline', () {
     test('CategoryController returns a default category when the server fails',
         () async {
-      await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
-      await db.upsertMangaMetadata(id: 2, title: 'B', updatedAt: DateTime(2026));
+      await db.upsertMangaMetadata(
+          id: 1, title: 'A', updatedAt: DateTime(2026));
+      await db.upsertMangaMetadata(
+          id: 2, title: 'B', updatedAt: DateTime(2026));
       final c = await _container(db, [
         categoryRepositoryProvider.overrideWithValue(_ThrowingCategoryRepo()),
       ]);
@@ -121,11 +139,19 @@ void main() {
       expect(cats.single.mangas.totalCount, 2);
     });
 
-    test('reader chapter provider serves a downloaded chapter offline', () async {
+    test('reader chapter provider serves a downloaded chapter offline',
+        () async {
       await db.upsertChapterMetadata(
-          id: 99, mangaId: 1, name: 'Ch99', chapterIndex: 5, isRead: false,
-          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
-          pageCount: 10, updatedAt: DateTime(2026));
+          id: 99,
+          mangaId: 1,
+          name: 'Ch99',
+          chapterIndex: 5,
+          isRead: false,
+          lastPageRead: 0,
+          isBookmarked: false,
+          serverIsDownloaded: true,
+          pageCount: 10,
+          updatedAt: DateTime(2026));
       final c = await _container(db, [
         mangaBookRepositoryProvider.overrideWithValue(_ThrowingMangaBookRepo()),
       ]);
@@ -134,16 +160,32 @@ void main() {
       expect(ch.name, 'Ch99');
     });
 
-    test('mangaDownloadedCount counts only device-downloaded chapters', () async {
+    test('mangaDownloadedCount counts only device-downloaded chapters',
+        () async {
       await db.upsertChapterMetadata(
-          id: 1, mangaId: 7, name: 'a', chapterIndex: 1, isRead: false,
-          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
-          pageCount: 1, updatedAt: DateTime(2026));
+          id: 1,
+          mangaId: 7,
+          name: 'a',
+          chapterIndex: 1,
+          isRead: false,
+          lastPageRead: 0,
+          isBookmarked: false,
+          serverIsDownloaded: true,
+          pageCount: 1,
+          updatedAt: DateTime(2026));
       await db.upsertChapterMetadata(
-          id: 2, mangaId: 7, name: 'b', chapterIndex: 2, isRead: false,
-          lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
-          pageCount: 1, updatedAt: DateTime(2026));
-      await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 5);
+          id: 2,
+          mangaId: 7,
+          name: 'b',
+          chapterIndex: 2,
+          isRead: false,
+          lastPageRead: 0,
+          isBookmarked: false,
+          serverIsDownloaded: true,
+          pageCount: 1,
+          updatedAt: DateTime(2026));
+      await db.setChapterDeviceState(1, OfflineDeviceState.downloaded,
+          bytes: 5);
       final c = await _container(db, const []);
       expect(await c.read(mangaDownloadedCountProvider(7).future), 1);
     });

--- a/test/src/features/offline/data/offline_sync_test.dart
+++ b/test/src/features/offline/data/offline_sync_test.dart
@@ -6,7 +6,10 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/features/offline/data/offline_server_identity_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
 
 import '../../../../helpers/offline_test_db.dart';
 
@@ -17,16 +20,22 @@ void main() {
     expect(container.read(offlineSyncProvider), isNull);
   });
 
-  test('offlineSync is provided when offline is enabled', () {
+  test('offlineSync is provided when offline is enabled', () async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
     final db = testOfflineDatabase();
     final container = ProviderContainer(overrides: [
+      sharedPreferencesProvider.overrideWithValue(preferences),
       offlineEnabledProvider.overrideWithValue(true),
+      offlineActiveProvider.overrideWithValue(true),
+      serverInstanceIdProvider.overrideWith((ref) async => 'server-id'),
       offlineDatabaseProvider.overrideWithValue(db),
     ]);
     addTearDown(() {
       container.dispose();
       db.close();
     });
+    await container.read(serverInstanceIdProvider.future);
     expect(container.read(offlineSyncProvider), isNotNull);
   });
 }

--- a/test/src/features/offline/push_pending_progress_tracking_test.dart
+++ b/test/src/features/offline/push_pending_progress_tracking_test.dart
@@ -132,11 +132,12 @@ Fragment$TrackRecordDto _fakeRecord() => Fragment$TrackRecordDto(
       private: false,
     );
 
-Future<({
-  ProviderContainer container,
-  OfflineDatabase db,
-  _FakeTrackerRepository tracker,
-})> _build({
+Future<
+    ({
+      ProviderContainer container,
+      OfflineDatabase db,
+      _FakeTrackerRepository tracker,
+    })> _build({
   required List<int> mangaIds,
   int trackRecordCount = 1,
   bool toggleOn = true,
@@ -152,6 +153,7 @@ Future<({
   final overrides = <Override>[
     sharedPreferencesProvider.overrideWithValue(prefs),
     offlineEnabledProvider.overrideWithValue(true),
+    offlineActiveProvider.overrideWithValue(true),
     offlineDatabaseProvider.overrideWithValue(db),
     mangaBookRepositoryProvider.overrideWithValue(fakeMangaBook),
     trackerRepositoryProvider.overrideWithValue(fakeTracker),
@@ -173,8 +175,7 @@ Future<({
 
 void main() {
   group('pushPendingProgress → tracker push', () {
-    test(
-        'toggle ON + manga has track records → trackProgress called once',
+    test('toggle ON + manga has track records → trackProgress called once',
         () async {
       final (:container, :db, :tracker) = await _build(
         mangaIds: [1],
@@ -213,7 +214,8 @@ void main() {
           reason: 'toggle is off — no tracker push');
     });
 
-    test('failed push KEEPS the dirty flag (stays pending, server never got it)',
+    test(
+        'failed push KEEPS the dirty flag (stays pending, server never got it)',
         () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
@@ -222,6 +224,7 @@ void main() {
       final container = ProviderContainer(overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
         offlineEnabledProvider.overrideWithValue(true),
+        offlineActiveProvider.overrideWithValue(true),
         offlineDatabaseProvider.overrideWithValue(db),
         mangaBookRepositoryProvider
             .overrideWithValue(_FailingMangaBookRepository()),


### PR DESCRIPTION
Closes #145.

Fixes the bug where changing the server URL/port left the on-device offline library showing (and mixing in) the previous server's downloads.

## How
- **Stable server identity.** Each server gets a UUID stored in its own global meta (`setGlobalMeta`); the offline catalog is stamped with the id of the server it was built from. Same server at a new address keeps its id (not a switch); a different server has a different/absent id (a switch).
- **One guard at the offline-repository boundary.** When the current server's id doesn't match the catalog's stamp, offline reads and writes are both suppressed, so no screen (library, details, chapters, categories) can show or sync the foreign catalog.
- **Persistent banner** on the library and connection screens: clear the previous server's downloads, or dismiss. Clearing quiesces the background download engine first (so an in-flight page can't re-contaminate the wipe), then deletes the catalog rows and files.

## Offline-first is preserved
The server id resolves from a **local cache first** and verifies against the server in the background, so opening the app away from the server — or after a login lapse — never blocks the offline library on a network round-trip.

## Notes
- Client-side over the existing offline store; no new server behavior beyond one Tsumiru meta key.
- No unique-instance id exists server-side, so a genuinely different server reached at the *same* address while offline can't be distinguished until reconnect — the banner lets the user keep or clear, so no silent data loss.
- Covered by unit tests (identity resolution + offline-first, the guard, clear ordering, case) and a widget test that renders the banner and verifies Dismiss; verified live on-device.