### PR TITLE
Restore global search and match Komikku's Browse search layout

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -67,6 +67,7 @@ enum DBKeys {
   chapterSortDirection(false), // asc=true, dsc=false
   libraryDisplayMode(DisplayMode.grid),
   sourceDisplayMode(DisplayMode.grid),
+  globalSearchSourceFilter(GlobalSearchSourceFilter.pinned),
   gridMangaCoverWidth(192.0),
   readerOverlay(true),
   // Show the continuous-reader feedback snackbars ("loading next chapter",

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -415,3 +415,6 @@ enum IncludeOrExclude implements ValueEnum {
   @override
   final String value;
 }
+
+/// Global-search source scope: search only pinned sources, or all of them.
+enum GlobalSearchSourceFilter { pinned, all }

--- a/lib/src/features/browse_center/presentation/browse/browse_screen.dart
+++ b/lib/src/features/browse_center/presentation/browse/browse_screen.dart
@@ -8,14 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../../../constants/app_sizes.dart';
+import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
-import '../../../../widgets/search_field.dart';
-import '../extension/controller/extension_controller.dart';
 import '../extension/widgets/extension_language_filter_dialog.dart';
 import '../extension/widgets/install_extension_file.dart';
-import '../source/controller/source_controller.dart'
-    show sourceSearchQueryProvider;
 import '../source/widgets/source_language_filter.dart';
 
 class BrowseScreen extends HookConsumerWidget {
@@ -49,15 +45,16 @@ class BrowseScreen extends HookConsumerWidget {
     }, [tabController.index]);
     useListenable(tabController);
 
-    final showSearch = useState(false);
     return Scaffold(
       appBar: AppBar(
         title: Text(context.l10n.browse),
         actions: [
-          IconButton(
-            onPressed: () => showSearch.value = (true),
-            icon: const Icon(Icons.search_rounded),
-          ),
+          if (tabController.index == 0)
+            IconButton(
+              tooltip: context.l10n.globalSearch,
+              onPressed: () => const GlobalSearchRoute().push(context),
+              icon: const Icon(Icons.travel_explore_rounded),
+            ),
           if (tabController.index == 1) ...[
             const InstallExtensionFile(),
           ],
@@ -71,47 +68,14 @@ class BrowseScreen extends HookConsumerWidget {
             icon: const Icon(Icons.translate_rounded),
           ),
         ],
-        bottom: PreferredSize(
-          preferredSize: kCalculateAppBarBottomSize([true, showSearch.value]),
-          child: Column(
-            children: [
-              TabBar(
-                dividerColor: Colors.transparent,
-                isScrollable: context.isTablet,
-                controller: tabController,
-                tabs: [
-                  Tab(text: context.l10n.sources),
-                  Tab(text: context.l10n.extensions),
-                ],
-              ),
-              if (showSearch.value)
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: tabController.index == 0
-                      ? SearchField(
-                          key: const ValueKey(0),
-                          initialText: ref.read(sourceSearchQueryProvider),
-                          onChanged: (val) => ref
-                              .read(sourceSearchQueryProvider.notifier)
-                              .update(val),
-                          onClose: () {
-                            ref
-                                .read(sourceSearchQueryProvider.notifier)
-                                .update(null);
-                            showSearch.value = (false);
-                          },
-                        )
-                      : SearchField(
-                          key: const ValueKey(1),
-                          initialText: ref.read(extensionQueryProvider),
-                          onChanged: (val) => ref
-                              .read(extensionQueryProvider.notifier)
-                              .update(val),
-                          onClose: () => showSearch.value = (false),
-                        ),
-                ),
-            ],
-          ),
+        bottom: TabBar(
+          dividerColor: Colors.transparent,
+          isScrollable: context.isTablet,
+          controller: tabController,
+          tabs: [
+            Tab(text: context.l10n.sources),
+            Tab(text: context.l10n.extensions),
+          ],
         ),
       ),
       body: TabBarView(controller: tabController, children: children),

--- a/lib/src/features/browse_center/presentation/extension/extension_screen.dart
+++ b/lib/src/features/browse_center/presentation/extension/extension_screen.dart
@@ -13,6 +13,7 @@ import '../../../../constants/language_list.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/emoticons.dart';
+import '../../../../widgets/search_field.dart';
 import '../../domain/extension/extension_model.dart';
 import 'controller/extension_controller.dart';
 import 'widgets/extension_list_tile.dart';
@@ -74,7 +75,7 @@ class ExtensionScreen extends HookConsumerWidget {
       return;
     }, [extensionMapData.valueOrNull]);
 
-    return extensionMapData.showUiWhenData(
+    final body = extensionMapData.showUiWhenData(
       context,
       (data) => (extensionMap.isEmpty &&
               installed.isBlank &&
@@ -123,6 +124,19 @@ class ExtensionScreen extends HookConsumerWidget {
               ),
             ),
       refresh: refresh,
+    );
+
+    return Column(
+      children: [
+        SearchField(
+          autofocus: false,
+          hintText: context.l10n.searchForExtensions,
+          initialText: ref.watch(extensionQueryProvider),
+          onChanged: (val) =>
+              ref.read(extensionQueryProvider.notifier).update(val),
+        ),
+        Expanded(child: body),
+      ],
     );
   }
 }

--- a/lib/src/features/browse_center/presentation/global_search/controller/source_quick_search_controller.dart
+++ b/lib/src/features/browse_center/presentation/global_search/controller/source_quick_search_controller.dart
@@ -7,24 +7,72 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../../../constants/db_keys.dart';
+import '../../../../../constants/enum.dart';
 import '../../../../../global_providers/global_providers.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
+import '../../../../settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
 import '../../../data/source_repository/source_repository.dart';
 import '../../../domain/source/source_model.dart';
 import '../../source/controller/source_controller.dart';
 
 part 'source_quick_search_controller.g.dart';
 
-/// Global-search source scope: search only pinned sources, or
-/// all of them.
-enum GlobalSearchSourceFilter { pinned, all }
+/// Tsumiru-only server global-meta key so the scope follows the user across
+/// devices. Stores the enum name ('pinned' / 'all').
+const kGlobalSearchScopeMetaKey = 'tsumiru_global_search_scope';
 
-/// Search scope for global search. Defaults to pinned; the
-/// search falls back to "all" when there are no pinned sources.
-final globalSearchSourceFilterProvider =
-    StateProvider<GlobalSearchSourceFilter>(
-        (ref) => GlobalSearchSourceFilter.pinned);
+/// Search scope for global search, remembered across launches. Local prefs
+/// answer instantly (and offline); the server's global meta is the shared
+/// copy — adopted on open when reachable, pushed on every change.
+@riverpod
+class GlobalSearchScope extends _$GlobalSearchScope
+    with SharedPreferenceEnumClientMixin<GlobalSearchSourceFilter> {
+  @override
+  GlobalSearchSourceFilter? build() {
+    final local = initialize(
+      DBKeys.globalSearchSourceFilter,
+      enumList: GlobalSearchSourceFilter.values,
+    );
+    _adoptServerValue();
+    return local;
+  }
+
+  Future<void> _adoptServerValue() async {
+    try {
+      final before = state;
+      final metas = await ref
+          .read(deleteChaptersSettingsRepositoryProvider)
+          .getGlobalMetas();
+      String? raw;
+      for (final m in metas ?? const []) {
+        if (m.key == kGlobalSearchScopeMetaKey) raw = m.value;
+      }
+      final server = GlobalSearchSourceFilter.values
+          .where((e) => e.name == raw)
+          .firstOrNull;
+      // Only adopt if the user didn't change the scope while we were fetching.
+      if (server != null && server != state && state == before) {
+        super.update(server);
+      }
+    } catch (_) {
+      // Offline or unreachable: the local value stands.
+    }
+  }
+
+  @override
+  void update(GlobalSearchSourceFilter? value) {
+    super.update(value);
+    if (value == null) return;
+    // Best-effort cross-device sync; local prefs stay authoritative offline.
+    ref
+        .read(deleteChaptersSettingsRepositoryProvider)
+        .setGlobalMeta(kGlobalSearchScopeMetaKey, value.name)
+        .catchError((_) {});
+  }
+}
 
 /// When true, only sources that returned results are shown (hide empty/loading).
 final globalSearchOnlyHasResultsProvider = StateProvider<bool>((ref) => false);
@@ -58,7 +106,7 @@ AsyncValue<List<QuickSearchResults>> quickSearchResults(Ref ref,
   // excluded from the grouped map and would never be searched). The Pinned/All
   // chip narrows it to just the pinned ones; with no pinned, it's always "all".
   final sourcesData = ref.watch(searchableSourcesProvider);
-  final scope = ref.watch(globalSearchSourceFilterProvider);
+  final scope = ref.watch(globalSearchScopeProvider);
   final pinned = ref.watch(pinnedSourcesProvider);
   final allSources = sourcesData.valueOrNull ?? const <SourceDto>[];
   final sourceList =

--- a/lib/src/features/browse_center/presentation/global_search/global_search_screen.dart
+++ b/lib/src/features/browse_center/presentation/global_search/global_search_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../constants/app_sizes.dart';
+import '../../../../constants/enum.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../widgets/emoticons.dart';
 import '../../../../widgets/search_field.dart';
@@ -24,7 +25,7 @@ class GlobalSearchScreen extends HookConsumerWidget {
     final query = useState(initialQuery);
     final quickSearchResult =
         ref.watch(quickSearchResultsProvider(query: query.value));
-    final scope = ref.watch(globalSearchSourceFilterProvider);
+    final scope = ref.watch(globalSearchScopeProvider);
     final onlyHasResults = ref.watch(globalSearchOnlyHasResultsProvider);
     final hasPinned = ref.watch(pinnedSourcesProvider).isNotEmpty;
     return Scaffold(
@@ -59,9 +60,9 @@ class GlobalSearchScreen extends HookConsumerWidget {
                     avatar: const Icon(Icons.push_pin_outlined, size: 18),
                     label: Text(context.l10n.pinnedSources),
                     selected: scope == GlobalSearchSourceFilter.pinned,
-                    onSelected: (_) =>
-                        ref.read(globalSearchSourceFilterProvider.notifier).state =
-                            GlobalSearchSourceFilter.pinned,
+                    onSelected: (_) => ref
+                        .read(globalSearchScopeProvider.notifier)
+                        .update(GlobalSearchSourceFilter.pinned),
                   ),
                   const SizedBox(width: 8),
                 ],
@@ -70,9 +71,9 @@ class GlobalSearchScreen extends HookConsumerWidget {
                   avatar: const Icon(Icons.done_all_rounded, size: 18),
                   label: Text(context.l10n.all),
                   selected: !hasPinned || scope == GlobalSearchSourceFilter.all,
-                  onSelected: (_) =>
-                      ref.read(globalSearchSourceFilterProvider.notifier).state =
-                          GlobalSearchSourceFilter.all,
+                  onSelected: (_) => ref
+                      .read(globalSearchScopeProvider.notifier)
+                      .update(GlobalSearchSourceFilter.all),
                 ),
                 const SizedBox(width: 12),
                 FilterChip(

--- a/lib/src/features/browse_center/presentation/source/source_screen.dart
+++ b/lib/src/features/browse_center/presentation/source/source_screen.dart
@@ -12,6 +12,7 @@ import '../../../../constants/language_list.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/emoticons.dart';
+import '../../../../widgets/search_field.dart';
 import 'controller/source_controller.dart';
 import 'widgets/source_list_tile.dart';
 
@@ -46,7 +47,7 @@ class SourceScreen extends HookConsumerWidget {
       return;
     }, [sourceMapData.valueOrNull]);
 
-    return sourceMapData.showUiWhenData(
+    final body = sourceMapData.showUiWhenData(
       context,
       (data) {
         if ((sourceMap.isEmpty &&
@@ -134,6 +135,19 @@ class SourceScreen extends HookConsumerWidget {
         );
       },
       refresh: refresh,
+    );
+
+    return Column(
+      children: [
+        SearchField(
+          autofocus: false,
+          hintText: context.l10n.searchForSources,
+          initialText: query,
+          onChanged: (val) =>
+              ref.read(sourceSearchQueryProvider.notifier).update(val),
+        ),
+        Expanded(child: body),
+      ],
     );
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2354,6 +2354,8 @@
     "yourRating": "Your rating",
     "addTag": "Add tag",
     "tags": "Tags",
+    "searchForSources": "Search for sources",
+    "searchForExtensions": "Search for extensions",
     "noTagsYet": "No tags in your library yet",
     "copyToClipboard": "Copy to clipboard",
     "copiedToClipboard": "Copied to clipboard",


### PR DESCRIPTION
Follow-up to #152, which wired the Sources tab search to the new name filter but removed the Browse screen's entry point to global search — the primary way to find a manga across sources.

## Browse search layout (matches Komikku)
- The app bar keeps a single search action: the globe on the Sources tab, which opens Global Search directly.
- The source-name filter is now an always-visible field above the sources list ("Search for sources"), filtering live as you type.
- The Extensions tab gets the same always-visible field ("Search for extensions"), replacing the app-bar toggle search on both tabs.

## Global search scope is remembered, synced via server meta
The Pinned/All chip reset to Pinned on every launch. It now persists in local prefs (instant, offline-safe) and mirrors to the server's global meta under `tsumiru_global_search_scope`, so the choice follows the user across devices: adopted on open when the server is reachable, pushed on every change, local value stands when offline.

## Verification
- `setGlobalMeta`/read-back verified against a live Suwayomi server.
- Full test suite green (798 tests), analyzer clean.
- Verified on-device: globe opens Global Search, both filters work, scope adoption from server meta and persistence across restarts confirmed.