### PR TITLE
Comfortable grid library display mode

### DIFF
--- a/lib/src/constants/app_sizes.dart
+++ b/lib/src/constants/app_sizes.dart
@@ -95,10 +95,15 @@ enum KRadius {
   final Radius radius;
 }
 
-SliverGridDelegateWithMaxCrossAxisExtent mangaCoverGridDelegate(double? size) =>
+/// [titleBelow] (comfortable grid) stretches the cell to leave room for the
+/// two-line title block under the cover.
+SliverGridDelegateWithMaxCrossAxisExtent mangaCoverGridDelegate(
+  double? size, {
+  bool titleBelow = false,
+}) =>
     SliverGridDelegateWithMaxCrossAxisExtent(
       maxCrossAxisExtent: size ?? DBKeys.gridMangaCoverWidth.initial,
       crossAxisSpacing: 2.0,
       mainAxisSpacing: 2.0,
-      childAspectRatio: 0.75,
+      childAspectRatio: titleBelow ? 0.62 : 0.75,
     );

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -351,11 +351,23 @@ enum DisplayMode {
   list(Icons.view_list_rounded),
   descriptiveList(Icons.view_list_rounded),
   coverOnly(Icons.view_comfy_rounded),
+  // Appended last: saved prefs store the index into [values].
+  comfortableGrid(Icons.view_module_rounded),
   ;
 
   static const List<DisplayMode> sourceDisplayList = [
     DisplayMode.grid,
     DisplayMode.list
+  ];
+
+  /// Menu order for the library display tab (differs from declaration order,
+  /// which is frozen by persisted indexes).
+  static const List<DisplayMode> libraryDisplayList = [
+    DisplayMode.grid,
+    DisplayMode.comfortableGrid,
+    DisplayMode.list,
+    DisplayMode.descriptiveList,
+    DisplayMode.coverOnly,
   ];
 
   final IconData icon;
@@ -366,6 +378,7 @@ enum DisplayMode {
         DisplayMode.list => context.l10n.displayModeList,
         DisplayMode.descriptiveList => context.l10n.displayModeDescriptiveList,
         DisplayMode.coverOnly => context.l10n.displayModeCoverOnly,
+        DisplayMode.comfortableGrid => context.l10n.displayModeComfortableGrid,
       };
 }
 

--- a/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_display_view.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_display_view.dart
@@ -85,7 +85,11 @@ class SourceMangaDisplayView extends ConsumerWidget {
           source: source,
           toggleFavorite: toggleFavorite,
         ),
-      DisplayMode.coverOnly => SourceMangaGridView(
+      // comfortableGrid isn't offered in the source display picker; map it to
+      // the grid so the exhaustive switch stays safe.
+      DisplayMode.coverOnly ||
+      DisplayMode.comfortableGrid =>
+        SourceMangaGridView(
           sourceId: sourceId,
           sourceType: sourceType,
           controller: controller,

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -50,14 +50,15 @@ class CategoryMangaList extends HookConsumerWidget {
     final landscapeCols = ref.watch(libraryLandscapeColumnsProvider) ?? 0;
     final fixedCols = isLandscape ? landscapeCols : portraitCols;
     // gridDelegate: fixed count when the user set cols > 0, else Auto (width-based).
-    SliverGridDelegate libraryGridDelegate() => fixedCols > 0
-        ? SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: fixedCols,
-            crossAxisSpacing: 2.0,
-            mainAxisSpacing: 2.0,
-            childAspectRatio: 0.75,
-          )
-        : mangaCoverGridDelegate(gridWidth);
+    SliverGridDelegate libraryGridDelegate({bool titleBelow = false}) =>
+        fixedCols > 0
+            ? SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: fixedCols,
+                crossAxisSpacing: 2.0,
+                mainAxisSpacing: 2.0,
+                childAspectRatio: titleBelow ? 0.62 : 0.75,
+              )
+            : mangaCoverGridDelegate(gridWidth, titleBelow: titleBelow);
     refresh() => ref.invalidate(categoryMangaListProvider(categoryId));
     useEffect(() {
       if (mangaList.isNotLoading) refresh();
@@ -175,6 +176,20 @@ class CategoryMangaList extends HookConsumerWidget {
                 onPressed: () => open(items[index]),
                 onContinueReading: continueReadingFor(items[index]),
                 showCountBadges: true,
+                showDarkOverlay: false,
+              ),
+            ),
+          DisplayMode.comfortableGrid => GridView.builder(
+              gridDelegate: libraryGridDelegate(titleBelow: true),
+              itemCount: items.length,
+              itemBuilder: (context, index) => MangaCoverGridTile(
+                manga: items[index],
+                selected: selection.value.contains(items[index].id),
+                onLongPress: () => toggle(items[index].id),
+                onPressed: () => open(items[index]),
+                onContinueReading: continueReadingFor(items[index]),
+                showCountBadges: true,
+                titleBelow: true,
                 showDarkOverlay: false,
               ),
             ),

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -395,14 +395,14 @@ class _GroupedMangaList extends ConsumerWidget {
     final landscapeCols = ref.watch(libraryLandscapeColumnsProvider) ?? 0;
     final fixedCols = isLandscape ? landscapeCols : portraitCols;
 
-    SliverGridDelegate gridDelegate() => fixedCols > 0
+    SliverGridDelegate gridDelegate({bool titleBelow = false}) => fixedCols > 0
         ? SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: fixedCols,
             crossAxisSpacing: 2.0,
             mainAxisSpacing: 2.0,
-            childAspectRatio: 0.75,
+            childAspectRatio: titleBelow ? 0.62 : 0.75,
           )
-        : mangaCoverGridDelegate(gridWidth);
+        : mangaCoverGridDelegate(gridWidth, titleBelow: titleBelow);
 
     return mangaListAsync.showUiWhenData(
       context,
@@ -436,6 +436,20 @@ class _GroupedMangaList extends ConsumerWidget {
                   onPressed: () =>
                       MangaRoute(mangaId: items[index].id).push(context),
                   showCountBadges: true,
+                  showDarkOverlay: false,
+                ),
+              ),
+            DisplayMode.comfortableGrid => GridView.builder(
+                gridDelegate: gridDelegate(titleBelow: true),
+                itemCount: items.length,
+                itemBuilder: (context, index) => MangaCoverGridTile(
+                  manga: items[index],
+                  selected: false,
+                  onLongPress: () {},
+                  onPressed: () =>
+                      MangaRoute(mangaId: items[index].id).push(context),
+                  showCountBadges: true,
+                  titleBelow: true,
                   showDarkOverlay: false,
                 ),
               ),

--- a/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
@@ -46,7 +46,7 @@ class LibraryMangaDisplay extends ConsumerWidget {
             spacing: 8,
             runSpacing: 4,
             children: [
-              for (final mode in DisplayMode.values)
+              for (final mode in DisplayMode.libraryDisplayList)
                 FilterChip(
                   selected: selectedMode == mode,
                   showCheckmark: false,

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1619,6 +1619,7 @@
     "discord": "Discord",
     "display": "Display",
     "displayMode": "Display Mode",
+    "displayModeComfortableGrid": "Comfortable grid",
     "displayModeCoverOnly": "Cover-only grid",
     "displayModeDescriptiveList": "Descriptive List",
     "displayModeGrid": "Grid",

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -25,6 +25,7 @@ class MangaCoverGridTile extends StatelessWidget {
     this.onLongPress,
     this.onContinueReading,
     this.showTitle = true,
+    this.titleBelow = false,
     this.showBadges = true,
     this.showCountBadges = false,
     this.showDarkOverlay = true,
@@ -40,12 +41,19 @@ class MangaCoverGridTile extends StatelessWidget {
   final VoidCallback? onContinueReading;
   final bool showCountBadges;
   final bool showTitle;
+
+  /// Comfortable grid: the title renders under the cover on the theme surface
+  /// instead of overlaid on the art ([showTitle] is ignored for the overlay).
+  final bool titleBelow;
   final bool showBadges;
   final bool showDarkOverlay;
 
   /// Multi-select highlight: a primary-tinted border + check on the
   /// library selection.
   final bool selected;
+
+  bool get _overlayTitle => showTitle && !titleBelow;
+
   @override
   Widget build(BuildContext context) {
     return InkResponse(
@@ -78,46 +86,69 @@ class MangaCoverGridTile extends StatelessWidget {
                 ),
               ),
       onLongPress: onLongPress,
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        shape: RoundedRectangleBorder(
-          borderRadius: KBorderRadius.r12.radius,
-          side: selected
-              ? BorderSide(color: context.theme.colorScheme.primary, width: 3)
-              : BorderSide.none,
-        ),
-        child: Stack(
-          fit: StackFit.passthrough,
-          children: [
-            _selectableChild(context),
-            if (selected)
-              Positioned(
-                top: 4,
-                right: 4,
-                child: Icon(
-                  Icons.check_circle_rounded,
-                  color: context.theme.colorScheme.primary,
-                  shadows: const [Shadow(blurRadius: 4)],
+      child: titleBelow
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(child: _card(context)),
+                // Komikku's comfortable-grid title: 4dp padding, 12sp over an
+                // 18px line, two lines ellipsized, on the theme surface.
+                Padding(
+                  padding: const EdgeInsets.all(4),
+                  child: Text(
+                    manga.title,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 2,
+                    style: const TextStyle(fontSize: 12, height: 1.5),
+                  ),
                 ),
+              ],
+            )
+          : _card(context),
+    );
+  }
+
+  Widget _card(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(
+        borderRadius: KBorderRadius.r12.radius,
+        side: selected
+            ? BorderSide(color: context.theme.colorScheme.primary, width: 3)
+            : BorderSide.none,
+      ),
+      child: Stack(
+        fit: StackFit.passthrough,
+        children: [
+          _selectableChild(context),
+          if (selected)
+            Positioned(
+              top: 4,
+              right: 4,
+              child: Icon(
+                Icons.check_circle_rounded,
+                color: context.theme.colorScheme.primary,
+                shadows: const [Shadow(blurRadius: 4)],
               ),
-            // No title to flow beside (cover-only / descriptive-list cover):
-            // overlay the button on the cover corner. With a title, the button
-            // lives in the footer row instead so it can't cover the text.
-            if (onContinueReading != null && !selected && !showTitle)
-              Positioned(
-                right: 6,
-                bottom: 6,
-                child: ContinueReadingButton(onPressed: onContinueReading!),
-              ),
-            if (showBadges)
-              Positioned(
-                left: 0,
-                right: 0,
-                bottom: 0,
-                child: _CoverReadProgressBar(manga: manga),
-              ),
-          ],
-        ),
+            ),
+          // No title to flow beside (cover-only, title-below, or the
+          // descriptive-list cover): overlay the button on the cover corner.
+          // With an overlaid title, the button lives in the footer row
+          // instead so it can't cover the text.
+          if (onContinueReading != null && !selected && !_overlayTitle)
+            Positioned(
+              right: 6,
+              bottom: 6,
+              child: ContinueReadingButton(onPressed: onContinueReading!),
+            ),
+          if (showBadges)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: _CoverReadProgressBar(manga: manga),
+            ),
+        ],
       ),
     );
   }
@@ -127,7 +158,7 @@ class MangaCoverGridTile extends StatelessWidget {
           header: showBadges
               ? MangaBadgesRow(manga: manga, showCountBadges: showCountBadges)
               : null,
-          footer: showTitle
+          footer: _overlayTitle
               ? ListTile(
                   contentPadding: const EdgeInsets.symmetric(horizontal: 8),
                   dense: true,
@@ -174,7 +205,7 @@ class MangaCoverGridTile extends StatelessWidget {
                     // Theme-independent scrim (Komikku: transparent → 67%
                     // black over the bottom third) — the title always reads
                     // white-on-dark in both light and dark mode.
-                    gradient: showTitle
+                    gradient: _overlayTitle
                         ? const LinearGradient(
                             begin: Alignment(0, 1 / 3),
                             end: Alignment.bottomCenter,

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -92,14 +92,20 @@ class MangaCoverGridTile extends StatelessWidget {
               children: [
                 Expanded(child: _card(context)),
                 // Komikku's comfortable-grid title: 4dp padding, 12sp over an
-                // 18px line, two lines ellipsized, on the theme surface.
-                Padding(
-                  padding: const EdgeInsets.all(4),
-                  child: Text(
-                    manga.title,
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 2,
-                    style: const TextStyle(fontSize: 12, height: 1.5),
+                // 18px line, two lines ellipsized, on the theme surface. The
+                // block height is FIXED (two lines reserved, minLines-style)
+                // so one-line titles don't let their covers grow taller than
+                // the rest of the row.
+                SizedBox(
+                  height: 44,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Text(
+                      manga.title,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 2,
+                      style: const TextStyle(fontSize: 12, height: 1.5),
+                    ),
                   ),
                 ),
               ],


### PR DESCRIPTION
Adds a Komikku-style **Comfortable grid** display option to the library: the title renders under the cover on the theme surface instead of overlaid on the art. Suggested by a user on Discord.

- New `DisplayMode.comfortableGrid`, appended last so persisted display-mode indexes stay stable; the display tab's chip order comes from a separate `libraryDisplayList` (Grid, Comfortable grid, List, Descriptive List, Cover-only grid).
- `MangaCoverGridTile` gains `titleBelow`: cover card (badges, read-progress bar, continue-reading button unchanged) over a fixed two-line title block, so covers stay uniform whether a title wraps or not (matches Komikku's minLines=2).
- Grid cells stretch (aspect 0.62 vs 0.75) to fit the title block, in both the width-based and fixed-column delegates, and in the grouped library view.
- Library only; the source browse picker keeps its existing modes (exhaustive switch maps the new value to the plain grid defensively).

Verified on-device: uniform cells, correct badges/progress, both category tabs and grouped views.