### PR TITLE
Add a library update progress banner (+ update on pull-to-refresh)

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -77,6 +77,9 @@ enum DBKeys {
   volumeTapInvert(false),
   keepScreenOn(true),
   hideEmptyCategory(false),
+  // Ambient "Updating library (NN%)" strip shown app-root while a global/
+  // category update is running. On by default, matching Komikku's pref.
+  showUpdateProgressBanner(true),
   // When false (default), opening an entry shows the chapters the
   // server already has, without re-scraping the source. When true, also refresh
   // from the source on open.

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -21,8 +21,10 @@ import '../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.d
 import '../../../../widgets/manga_cover/list/manga_cover_list_tile.dart';
 import '../../../../widgets/manga_cover/providers/manga_cover_providers.dart';
 import '../../../../widgets/selection_action_bar.dart';
+import '../../../../widgets/shell/update_banner_state.dart';
 import '../../../manga_book/data/downloads/downloads_repository.dart';
 import '../../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../../manga_book/data/updates/updates_repository.dart';
 import '../../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../../manga_book/domain/manga/manga_model.dart';
 import '../../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
@@ -33,6 +35,7 @@ import '../../../offline/presentation/keep_rule_picker.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
 import '../../../tracking/domain/track_progress_gate.dart';
 import 'controller/library_controller.dart';
+import 'controller/library_manga_list.dart';
 
 class CategoryMangaList extends HookConsumerWidget {
   const CategoryMangaList({super.key, required this.categoryId});
@@ -222,7 +225,20 @@ class CategoryMangaList extends HookConsumerWidget {
         };
 
         final list = RefreshIndicator(
-          onRefresh: () async => refresh(),
+          // Pull = "check this category for new chapters, and pull down the
+          // latest" (Mihon/Komikku parity). The source-check runs server-side
+          // and the progress banner reflects it, so the spinner only waits on
+          // the immediate re-read, not the whole update. The standing rule in
+          // LibraryScreen re-reads again when the update finishes.
+          onRefresh: () async {
+            ref.read(updateOptimisticProvider.notifier).arm();
+            unawaited(ref
+                .read(updatesRepositoryProvider)
+                .fetchUpdates(categoryId: categoryId)
+                .catchError((Object _) {}));
+            ref.invalidate(libraryMangaListProvider);
+            await ref.read(libraryMangaListProvider.future);
+          },
           child: grid,
         );
 

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
@@ -20,6 +21,8 @@ import '../../../../widgets/manga_cover/grid/manga_cover_grid_tile.dart';
 import '../../../../widgets/manga_cover/list/manga_cover_descriptive_list_tile.dart';
 import '../../../../widgets/manga_cover/list/manga_cover_list_tile.dart';
 import '../../../../widgets/search_field.dart';
+import '../../../../widgets/shell/update_banner_state.dart';
+import '../../../manga_book/data/updates/updates_repository.dart';
 import '../../../manga_book/widgets/update_status_popup_menu.dart';
 import '../../../offline/presentation/offline_server_mismatch_banner.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
@@ -49,6 +52,21 @@ class LibraryScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final groupType =
         ref.watch(libraryGroupTypeProvider) ?? kDefaultLibraryGroupType;
+
+    // Standing rule: whenever ANY library update finishes (pull-triggered,
+    // menu-triggered, or server-scheduled), re-read the library so the new
+    // chapters it found appear without a manual refresh. Tracks the last
+    // known running state and fires on the running→idle edge, ignoring the
+    // transient null frames a socket reconnect emits.
+    final lastRunning = useRef<bool>(false);
+    ref.listen(updateRunningSocketProvider, (_, next) {
+      final running = next.valueOrNull;
+      if (running == null) return;
+      if (lastRunning.value && !running) {
+        ref.invalidate(libraryMangaListProvider);
+      }
+      lastRunning.value = running;
+    });
 
     return groupType == LibraryGroup.byDefault
         ? _DefaultLibraryScreen(categoryId: categoryId)
@@ -412,7 +430,19 @@ class _GroupedMangaList extends ConsumerWidget {
         }
         final items = data;
         return RefreshIndicator(
-          onRefresh: () async => ref.refresh(libraryMangaListProvider),
+          // Grouped views (by source/status/ungrouped) have no single category
+          // to update, so pull triggers a whole-library source-check (matches
+          // Komikku's non-BY_DEFAULT rule). The banner shows its progress; the
+          // spinner only waits on the immediate server re-read.
+          onRefresh: () async {
+            ref.read(updateOptimisticProvider.notifier).arm();
+            unawaited(ref
+                .read(updatesRepositoryProvider)
+                .fetchUpdates()
+                .catchError((Object _) {}));
+            ref.invalidate(libraryMangaListProvider);
+            await ref.read(libraryMangaListProvider.future);
+          },
           child: switch (displayMode) {
             DisplayMode.list || null => ListView.builder(
                 itemExtent: 96,

--- a/lib/src/features/manga_book/data/updates/graphql/query.graphql
+++ b/lib/src/features/manga_book/data/updates/graphql/query.graphql
@@ -42,6 +42,16 @@ query UpdateStatusDto {
   }
 }
 
+# Lightweight running-only status. The full UpdateStatusDto drags every
+# manga in every job list, which the server can't resolve promptly during a
+# large library update — so the banner's "is it running" signal must come
+# from this cheap shape, not the heavy one.
+query UpdateRunningStatus {
+  updateStatus {
+    ...UpdateStatusBaseDto
+  }
+}
+
 query LastUpdateTimestamp {
   lastUpdateTimestamp {
     timestamp
@@ -51,6 +61,12 @@ query LastUpdateTimestamp {
 subscription UpdateStatusChange {
   updateStatusChanged {
     ...UpdateStatusDto
+  }
+}
+
+subscription UpdateRunningChange {
+  updateStatusChanged {
+    ...UpdateStatusBaseDto
   }
 }
 

--- a/lib/src/features/manga_book/data/updates/updates_repository.dart
+++ b/lib/src/features/manga_book/data/updates/updates_repository.dart
@@ -86,6 +86,12 @@ class UpdatesRepository {
       .query$UpdateStatusDto(Options$Query$UpdateStatusDto())
       .getData((data) => data.updateStatus);
 
+  /// Cheap "is a run in progress" read, decoupled from the heavy job lists
+  /// (see [updateRunningSubscription]).
+  Future<bool?> runningSummary() async => client
+      .query$UpdateRunningStatus(Options$Query$UpdateRunningStatus())
+      .getData((data) => data.updateStatus.isRunning);
+
   /// Epoch-millis (as a string) of the last global library update, or null.
   Future<String?> lastUpdateTimestamp() async => client
       .query$LastUpdateTimestamp(Options$Query$LastUpdateTimestamp())
@@ -94,6 +100,14 @@ class UpdatesRepository {
   Stream<UpdateStatusDto?> updateStatusSubscription() => subscriptionClient
       .subscribe$UpdateStatusChange(Options$Subscription$UpdateStatusChange())
       .getData((data) => data.updateStatusChanged);
+
+  /// Running-only live signal. Requesting just `isRunning` keeps each pushed
+  /// frame tiny, so it arrives promptly even mid-update when the full-status
+  /// feed ([updateStatusSubscription]) stalls on the server's job-list
+  /// resolvers. The banner's visibility rides on this, not the heavy feed.
+  Stream<bool?> updateRunningSubscription() => subscriptionClient
+      .subscribe$UpdateRunningChange(Options$Subscription$UpdateRunningChange())
+      .getData((data) => data.updateStatusChanged.isRunning);
 }
 
 @riverpod
@@ -112,3 +126,11 @@ Future<String?> libraryLastUpdated(Ref ref) =>
 @riverpod
 Stream<UpdateStatusDto?> updatesSocket(Ref ref) =>
     ref.watch(updatesRepositoryProvider).updateStatusSubscription();
+
+@riverpod
+Future<bool?> updateRunningSummary(Ref ref) =>
+    ref.watch(updatesRepositoryProvider).runningSummary();
+
+@riverpod
+Stream<bool?> updateRunningSocket(Ref ref) =>
+    ref.watch(updatesRepositoryProvider).updateRunningSubscription();

--- a/lib/src/features/manga_book/widgets/update_status_fab.dart
+++ b/lib/src/features/manga_book/widgets/update_status_fab.dart
@@ -10,6 +10,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../routes/router_config.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../../utils/theme/brand.dart';
+import '../../../widgets/shell/update_banner_state.dart';
 import '../data/updates/updates_repository.dart';
 import '../domain/update_status/update_status_model.dart';
 
@@ -22,9 +23,14 @@ class UpdateStatusFab extends ConsumerWidget {
     final showStatus = (updateStatus.valueOrNull?.isUpdateChecking).ifNull();
     return BrandFab(
       icon: showStatus ? null : const Icon(Icons.refresh_rounded),
-      onPressed: () => showStatus
-          ? const UpdateStatusRoute().push(context)
-          : ref.read(updatesRepositoryProvider).fetchUpdates(),
+      onPressed: () {
+        if (showStatus) {
+          const UpdateStatusRoute().push(context);
+        } else {
+          ref.read(updateOptimisticProvider.notifier).arm();
+          ref.read(updatesRepositoryProvider).fetchUpdates();
+        }
+      },
       label: showStatus
           ? Text("${updateStatus.valueOrNull?.updateChecked.padLeft()}"
               "/${updateStatus.valueOrNull?.total.padLeft()}")

--- a/lib/src/features/manga_book/widgets/update_status_popup_menu.dart
+++ b/lib/src/features/manga_book/widgets/update_status_popup_menu.dart
@@ -10,6 +10,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../constants/app_sizes.dart';
 import '../../../routes/router_config.dart';
 import '../../../utils/extensions/custom_extensions.dart';
+import '../../../widgets/shell/update_banner_state.dart';
 import '../../library/domain/category/category_model.dart';
 import '../data/updates/updates_repository.dart';
 
@@ -32,12 +33,18 @@ class UpdateStatusPopupMenu extends ConsumerWidget {
           if (category != null && category.id != 0)
             PopupMenuItem(
               child: Text(context.l10n.categoryUpdate),
-              onTap: () => ref
-                  .read(updatesRepositoryProvider)
-                  .fetchUpdates(categoryId: category.id),
+              onTap: () {
+                ref.read(updateOptimisticProvider.notifier).arm();
+                ref
+                    .read(updatesRepositoryProvider)
+                    .fetchUpdates(categoryId: category.id);
+              },
             ),
           PopupMenuItem(
-            onTap: () => ref.read(updatesRepositoryProvider).fetchUpdates(),
+            onTap: () {
+              ref.read(updateOptimisticProvider.notifier).arm();
+              ref.read(updatesRepositoryProvider).fetchUpdates();
+            },
             child: Text(context.l10n.globalUpdate),
           ),
           if (showSummaryButton)

--- a/lib/src/features/settings/presentation/library/library_settings_screen.dart
+++ b/lib/src/features/settings/presentation/library/library_settings_screen.dart
@@ -24,6 +24,7 @@ import '../../controller/server_controller.dart';
 import '../../domain/settings/settings.dart';
 import 'data/library_settings_repository.dart';
 import 'widgets/refresh_chapters_from_source_tile/refresh_chapters_from_source_tile.dart';
+import 'widgets/show_update_progress_banner/show_update_progress_banner.dart';
 import 'widgets/skip_updating_entries_popup.dart';
 import 'widgets/update_categories_dialog.dart';
 
@@ -118,6 +119,7 @@ class LibrarySettingsScreen extends ConsumerWidget {
                   // HideEmptyCategoryTile(),
                   const RefreshChaptersFromSourceTile(),
                   SectionTitle(title: context.l10n.globalUpdate),
+                  const ShowUpdateProgressBannerTile(),
                   SettingsPropTile(
                     leading: const Icon(Icons.autorenew_rounded),
                     title: context.l10n.automaticUpdate,

--- a/lib/src/features/settings/presentation/library/widgets/show_update_progress_banner/show_update_progress_banner.dart
+++ b/lib/src/features/settings/presentation/library/widgets/show_update_progress_banner/show_update_progress_banner.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'show_update_progress_banner.g.dart';
+
+@riverpod
+class ShowUpdateProgressBanner extends _$ShowUpdateProgressBanner
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.showUpdateProgressBanner);
+}
+
+class ShowUpdateProgressBannerTile extends HookConsumerWidget {
+  const ShowUpdateProgressBannerTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.sync_rounded),
+      title: Text(context.l10n.showUpdateProgressBanner),
+      onChanged: ref.read(showUpdateProgressBannerProvider.notifier).update,
+      value: ref.watch(showUpdateProgressBannerProvider).ifNull(true),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1656,6 +1656,7 @@
     "editCategory": "Edit Category",
     "hideCategory": "Hide category",
     "showCategory": "Show category",
+    "showUpdateProgressBanner": "Show update progress banner",
     "incognitoMode": "Incognito mode",
     "incognitoModeDescription": "Pauses reading history",
     "emptyCategory": "Category name can't be Empty",
@@ -2129,6 +2130,25 @@
     "updates": "Updates",
     "updatesSummary": "Updates Summary",
     "updating": "Updating",
+    "updatingLibrary": "Updating library…",
+    "updatingLibraryProgress": "Updating library ({percent}% · {checked}/{total})",
+    "@updatingLibraryProgress": {
+        "description": "App-root banner text while a library update is running, once the job total is known. Percent alongside the raw checked/total counts (locked in the design spec: Komikku's banner is percent-only, ours adds counts since the data is already available).",
+        "placeholders": {
+            "percent": {
+                "example": "37",
+                "type": "int"
+            },
+            "checked": {
+                "example": "44",
+                "type": "int"
+            },
+            "total": {
+                "example": "120",
+                "type": "int"
+            }
+        }
+    },
     "userName": "User Name",
     "validating": "Validating",
     "versionAvailable": "Version {version} available for {app}!!",

--- a/lib/src/widgets/shell/navigation_shell_screen.dart
+++ b/lib/src/widgets/shell/navigation_shell_screen.dart
@@ -18,6 +18,8 @@ import '../../utils/misc/toast/toast.dart';
 import 'big_screen_navigation_bar.dart';
 import 'incognito_banner.dart';
 import 'small_screen_navigation_bar.dart';
+import 'update_banner_state.dart';
+import 'update_progress_banner.dart';
 
 class NavigationShellScreen extends HookConsumerWidget {
   const NavigationShellScreen({
@@ -119,6 +121,18 @@ class NavigationShellScreen extends HookConsumerWidget {
       child.goBranch(target, initialLocation: target == child.currentIndex);
     }
 
+    // While the update banner occupies the top (incl. the status-bar strip),
+    // drop the redundant status-bar inset on the content below so the pushed-
+    // down screen's own app bar doesn't reserve it a second time (dead gap).
+    final bannerVisible = ref.watch(updateBannerVisibleProvider);
+    final content = bannerVisible
+        ? MediaQuery.removePadding(
+            context: context,
+            removeTop: true,
+            child: child,
+          )
+        : child;
+
     final Widget scaffold;
     if (context.isTablet) {
       scaffold = Scaffold(
@@ -135,7 +149,8 @@ class NavigationShellScreen extends HookConsumerWidget {
               Expanded(
                 child: Column(
                   children: [
-                    Expanded(child: child),
+                    const UpdateProgressBanner(),
+                    Expanded(child: content),
                     const IncognitoBanner(),
                   ],
                 ),
@@ -148,7 +163,8 @@ class NavigationShellScreen extends HookConsumerWidget {
       scaffold = Scaffold(
         body: Column(
           children: [
-            Expanded(child: child),
+            const UpdateProgressBanner(),
+            Expanded(child: content),
             const IncognitoBanner(),
           ],
         ),

--- a/lib/src/widgets/shell/update_banner_state.dart
+++ b/lib/src/widgets/shell/update_banner_state.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../features/manga_book/data/updates/updates_repository.dart';
+
+part 'update_banner_state.g.dart';
+
+/// Optimistic "an update was just requested" flag.
+///
+/// A user-triggered update (pull-to-refresh, the overflow menu, the Updates
+/// FAB) takes ~1.5s before the server reports it as running, and the banner
+/// then adds its own 1s appear-debounce on top — so without this the banner
+/// sat blank for a couple of seconds after a pull and the action felt dead.
+///
+/// Callers [arm] this the instant they fire an update, which shows the banner
+/// immediately (bypassing the debounce). It then hands back to the real
+/// running signal: [onRealRunning] releases the optimistic hold once the
+/// genuine run has been seen to start and then end, and a safety timeout
+/// releases it for updates that never register as running (nothing to check /
+/// failed to start).
+@Riverpod(keepAlive: true)
+class UpdateOptimistic extends _$UpdateOptimistic {
+  Timer? _safety;
+  bool _sawRealRunning = false;
+
+  @override
+  bool build() {
+    ref.onDispose(() => _safety?.cancel());
+    return false;
+  }
+
+  void arm() {
+    // Seed from the current run state: if an update is ALREADY running (a
+    // second pull mid-run), treat it as already-seen so the next idle edge
+    // releases the hold — otherwise the change-only running stream never
+    // re-delivers `true` and only the safety timeout would clear it.
+    _sawRealRunning = ref.read(updateRunningSocketProvider).valueOrNull ?? false;
+    _safety?.cancel();
+    _safety = Timer(const Duration(seconds: 12), _clear);
+    state = true;
+  }
+
+  /// Feed the real server running state so the optimistic hold releases once
+  /// the genuine run has started and then ended.
+  void onRealRunning(bool running) {
+    if (!state) return;
+    if (running) {
+      _sawRealRunning = true;
+    } else if (_sawRealRunning) {
+      _clear();
+    }
+  }
+
+  void _clear() {
+    _safety?.cancel();
+    _sawRealRunning = false;
+    state = false;
+  }
+}
+
+/// Whether the update banner is currently on screen. Published by the banner,
+/// read by the app shell to drop the now-redundant status-bar inset on the
+/// content below — the banner occupies that space while it's shown, and
+/// without this the pushed-down screen's own app bar reserves the status-bar
+/// strip a second time, leaving a dead gap under the banner.
+@Riverpod(keepAlive: true)
+class UpdateBannerVisible extends _$UpdateBannerVisible {
+  @override
+  bool build() => false;
+
+  void set(bool value) {
+    if (state != value) state = value;
+  }
+}

--- a/lib/src/widgets/shell/update_progress_banner.dart
+++ b/lib/src/widgets/shell/update_progress_banner.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../features/manga_book/data/updates/updates_repository.dart';
+import '../../features/manga_book/domain/update_status/update_status_model.dart';
+import '../../features/settings/presentation/library/widgets/show_update_progress_banner/show_update_progress_banner.dart';
+import '../../routes/router_config.dart';
+import '../../utils/extensions/custom_extensions.dart';
+import 'update_banner_state.dart';
+
+/// App-root "Updating library…" strip, shown while a global/category update
+/// runs. Mirrors Komikku's `AppStateBanners` "updating" strip
+/// (`eu.kanade.presentation.components.Banners.kt`, `IndexingDownloadBanner`)
+/// and reuses [IncognitoBanner]'s placement convention.
+///
+/// **Visibility rides on a running-only signal, NOT the full status feed.**
+/// The full `updateStatusChanged` feed carries every manga in every job list;
+/// the server can't resolve those job-list fields promptly during a large
+/// library update, so that feed goes silent mid-run. If the banner learned
+/// "is it running" from there, it would show nothing during exactly the
+/// updates it exists for. So on/off comes from the cheap
+/// [updateRunningSocketProvider] (just `isRunning`), and the percentage is a
+/// best-effort enrichment layered on top — present on small/fast updates,
+/// gracefully absent (plain "Updating library…") when the heavy feed stalls.
+///
+/// `isRunning` is debounced 1000ms **symmetrically** (both edges), matching
+/// Komikku's `Flow<Boolean>.debounce(1000L)` in `BannerProgressStatus.kt` —
+/// a run that finishes inside that window never flashes the banner at all.
+class UpdateProgressBanner extends HookConsumerWidget {
+  const UpdateProgressBanner({super.key});
+
+  static const _debounce = Duration(milliseconds: 1000);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final showPref =
+        ref.watch(showUpdateProgressBannerProvider).ifNull(true);
+
+    final runSocket = ref.watch(updateRunningSocketProvider);
+    final runFallback = ref.watch(updateRunningSummaryProvider);
+    // Never trust a frozen frame from before a socket error — once the
+    // stream errors, prefer a fresh one-shot read until it recovers.
+    final effectiveRun = runSocket.hasError ? runFallback : runSocket;
+
+    ref.listen(updateRunningSocketProvider, (previous, next) {
+      if (next.hasError && !(previous?.hasError ?? false)) {
+        ref.invalidate(updateRunningSummaryProvider);
+      }
+      // Hand the optimistic hold back to the real running signal.
+      final running = next.valueOrNull;
+      if (running != null) {
+        ref.read(updateOptimisticProvider.notifier).onRealRunning(running);
+      }
+    });
+    // Re-query the one-shot fallback on resume, so a running-state fetched
+    // while backgrounded (or long before a socket error) isn't shown stale.
+    useOnAppLifecycleStateChange((previous, current) {
+      if (current == AppLifecycleState.resumed) {
+        ref.invalidate(updateRunningSummaryProvider);
+      }
+    });
+
+    final rawRunning = effectiveRun.valueOrNull ?? false;
+
+    final debouncedRunning = useState(false);
+    final timer = useRef<Timer?>(null);
+    useEffect(() {
+      timer.value?.cancel();
+      // Cancel the local `t`, not `timer.value` — by the time this dispose
+      // runs (after the *next* effect body already reassigned timer.value),
+      // reading timer.value here would cancel the wrong (new) timer.
+      final t = Timer(_debounce, () {
+        debouncedRunning.value = rawRunning;
+      });
+      timer.value = t;
+      return t.cancel;
+    }, [rawRunning]);
+
+    // Optimistic hold shows the banner the instant an update is triggered,
+    // before the server confirms it's running and before the appear-debounce.
+    // The user's "hide the banner" preference folds in here (not an early
+    // return) so that toggling it off mid-update publishes visible=false and
+    // the shell restores the status-bar inset it dropped.
+    final armed = ref.watch(updateOptimisticProvider);
+    final visible = showPref && (debouncedRunning.value || armed);
+
+    // Publish visibility so the shell can drop the redundant status-bar inset
+    // on the content below while the banner occupies that space. Deferred to a
+    // post-frame callback — writing a provider during build is disallowed.
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+        ref.read(updateBannerVisibleProvider.notifier).set(visible);
+      });
+      return null;
+    }, [visible]);
+
+    // Only subscribe to the heavy status feed while the bar is actually shown
+    // AND the real run is confirmed (not merely armed) — during the optimistic
+    // window there are no counts yet, so the banner shows the indeterminate
+    // "Updating library…".
+    UpdateStatusDto? status;
+    if (visible && debouncedRunning.value) {
+      final heavySocket = ref.watch(updatesSocketProvider);
+      final heavyFallback = ref.watch(updateSummaryProvider);
+      status = (heavySocket.valueOrNull?.total.isGreaterThan(0)).ifNull()
+          ? heavySocket.valueOrNull
+          : heavyFallback.valueOrNull;
+    }
+
+    // The colour fills up behind the status bar and the content pads below it
+    // (Komikku's `windowInsetsPadding(statusBars)`). On phone the banner draws
+    // into the status bar, so take the top inset from the raw window (shell-nav
+    // descendants read MediaQuery insets as 0 — see project_shell_nav_bottom_
+    // inset). On tablet the shell already wraps everything in a SafeArea, so
+    // the banner is below the status bar and must add no inset of its own.
+    final topInset = context.isTablet
+        ? 0.0
+        : View.of(context).viewPadding.top / View.of(context).devicePixelRatio;
+
+    final scheme = context.theme.colorScheme;
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      alignment: Alignment.topCenter,
+      child: !visible
+          ? const SizedBox.shrink()
+          : Material(
+              color: scheme.secondary,
+              child: InkWell(
+                onTap: () => const UpdateStatusRoute().push(context),
+                child: Padding(
+                  padding: EdgeInsets.only(top: topInset) +
+                      const EdgeInsets.symmetric(vertical: 6, horizontal: 16),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: scheme.onSecondary,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        _label(context, status),
+                        style: TextStyle(
+                          color: scheme.onSecondary,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+    );
+  }
+
+  String _label(BuildContext context, UpdateStatusDto? status) {
+    final total = status?.total ?? 0;
+    if (total <= 0) return context.l10n.updatingLibrary;
+    final checked = status?.updateChecked ?? 0;
+    final percent = (checked / total * 100).floor().clamp(0, 100);
+    return context.l10n.updatingLibraryProgress(percent, checked, total);
+  }
+}

--- a/test/settings/show_update_progress_banner_test.dart
+++ b/test/settings/show_update_progress_banner_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/settings/presentation/library/widgets/show_update_progress_banner/show_update_progress_banner.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+void main() {
+  group('showUpdateProgressBannerProvider', () {
+    test('defaults to on', () async {
+      SharedPreferences.setMockInitialValues(const {});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(showUpdateProgressBannerProvider), isTrue);
+    });
+
+    test('update persists the flag', () async {
+      SharedPreferences.setMockInitialValues(const {});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(container.dispose);
+
+      container.read(showUpdateProgressBannerProvider.notifier).update(false);
+      expect(container.read(showUpdateProgressBannerProvider), isFalse);
+      expect(prefs.getBool('showUpdateProgressBanner'), isFalse);
+    });
+  });
+}

--- a/test/src/widgets/shell/update_banner_state_test.dart
+++ b/test/src/widgets/shell/update_banner_state_test.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/data/updates/updates_repository.dart';
+import 'package:tsumiru/src/widgets/shell/update_banner_state.dart';
+
+ProviderContainer _container({bool runningNow = false}) {
+  final container = ProviderContainer(
+    overrides: [
+      // arm() reads this to seed whether a run is already in flight.
+      updateRunningSocketProvider
+          .overrideWith((ref) => Stream.value(runningNow)),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('UpdateOptimistic', () {
+    test('defaults to off', () {
+      final c = _container();
+      expect(c.read(updateOptimisticProvider), isFalse);
+    });
+
+    test('arm() shows the banner immediately', () {
+      final c = _container();
+      c.read(updateOptimisticProvider.notifier).arm();
+      expect(c.read(updateOptimisticProvider), isTrue);
+    });
+
+    test('hands back once a real run is seen to start then end', () async {
+      final c = _container();
+      // Resolve the seed read to "not running" before arming.
+      await c.read(updateRunningSocketProvider.future);
+      final notifier = c.read(updateOptimisticProvider.notifier);
+      notifier.arm();
+
+      // Server confirms running, then finishes.
+      notifier.onRealRunning(true);
+      expect(c.read(updateOptimisticProvider), isTrue,
+          reason: 'still held while the real run is in progress');
+      notifier.onRealRunning(false);
+      expect(c.read(updateOptimisticProvider), isFalse,
+          reason: 'released on the running→idle edge');
+    });
+
+    test('a second arm mid-run releases on the next idle edge, not 12s later',
+        () async {
+      final c = _container(runningNow: true);
+      // Seed read resolves to "already running".
+      await c.read(updateRunningSocketProvider.future);
+      final notifier = c.read(updateOptimisticProvider.notifier);
+      notifier.arm();
+      expect(c.read(updateOptimisticProvider), isTrue);
+
+      // The change-only stream never re-delivers `true`; the idle edge alone
+      // must release the hold because arm() seeded "already seen running".
+      notifier.onRealRunning(false);
+      expect(c.read(updateOptimisticProvider), isFalse);
+    });
+
+    test('does not release on idle frames before the real run starts',
+        () async {
+      final c = _container();
+      await c.read(updateRunningSocketProvider.future);
+      final notifier = c.read(updateOptimisticProvider.notifier);
+      notifier.arm();
+
+      // Pre-start idle frames must NOT clear the optimistic hold.
+      notifier.onRealRunning(false);
+      expect(c.read(updateOptimisticProvider), isTrue);
+    });
+
+    test('onRealRunning before arm is a no-op', () {
+      final c = _container();
+      c.read(updateOptimisticProvider.notifier).onRealRunning(false);
+      expect(c.read(updateOptimisticProvider), isFalse);
+      c.read(updateOptimisticProvider.notifier).onRealRunning(true);
+      expect(c.read(updateOptimisticProvider), isFalse);
+    });
+
+    test('safety timeout releases the hold after 12s if no run registers', () {
+      fakeAsync((async) {
+        final container = ProviderContainer(
+          overrides: [
+            updateRunningSocketProvider
+                .overrideWith((ref) => const Stream.empty()),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        container.read(updateOptimisticProvider.notifier).arm();
+        expect(container.read(updateOptimisticProvider), isTrue);
+
+        async.elapse(const Duration(seconds: 12));
+        expect(container.read(updateOptimisticProvider), isFalse);
+      });
+    });
+  });
+
+  group('UpdateBannerVisible', () {
+    test('defaults to false and set() flips it', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(updateBannerVisibleProvider), isFalse);
+      container.read(updateBannerVisibleProvider.notifier).set(true);
+      expect(container.read(updateBannerVisibleProvider), isTrue);
+    });
+  });
+}

--- a/test/src/widgets/shell/update_progress_banner_test.dart
+++ b/test/src/widgets/shell/update_progress_banner_test.dart
@@ -1,0 +1,219 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/browse_center/domain/manga_page/graphql/__generated__/fragment.graphql.dart'
+    show Fragment$MangaPageDto;
+import 'package:tsumiru/src/features/library/domain/category/graphql/__generated__/fragment.graphql.dart'
+    show Fragment$CategoryPageDto;
+import 'package:tsumiru/src/features/manga_book/data/updates/updates_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/update_status/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/fragments.graphql.dart'
+    show Fragment$PageInfoDto;
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/widgets/shell/update_banner_state.dart';
+import 'package:tsumiru/src/widgets/shell/update_progress_banner.dart';
+
+Fragment$PageInfoDto _emptyPage() =>
+    Fragment$PageInfoDto(hasNextPage: false, hasPreviousPage: false);
+
+Fragment$UpdateStatusJobDto _jobs(int count) => Fragment$UpdateStatusJobDto(
+      mangas: Fragment$MangaPageDto(
+        nodes: const [],
+        pageInfo: _emptyPage(),
+        totalCount: count,
+      ),
+    );
+
+Fragment$UpdateStatusDto$skippedCategories _emptyCategoryPage() =>
+    Fragment$UpdateStatusDto$skippedCategories(
+      categories: Fragment$CategoryPageDto(
+        nodes: const [],
+        pageInfo: _emptyPage(),
+        totalCount: 0,
+      ),
+    );
+
+Fragment$UpdateStatusDto _status({
+  required bool isRunning,
+  int pending = 0,
+  int running = 0,
+  int complete = 0,
+  int failed = 0,
+}) =>
+    Fragment$UpdateStatusDto(
+      isRunning: isRunning,
+      pendingJobs: _jobs(pending),
+      runningJobs: _jobs(running),
+      completeJobs: _jobs(complete),
+      failedJobs: _jobs(failed),
+      skippedJobs: _jobs(0),
+      skippedCategories: _emptyCategoryPage(),
+      updatingCategories: Fragment$UpdateStatusDto$updatingCategories(
+        categories: Fragment$CategoryPageDto(
+          nodes: const [],
+          pageInfo: _emptyPage(),
+          totalCount: 0,
+        ),
+      ),
+    );
+
+/// A stream that never emits and never closes — models the heavy status feed
+/// stalling mid-update (the server can't resolve the job-list fields), so the
+/// StreamProvider stays in loading and `valueOrNull` is null throughout.
+Stream<T> _stalled<T>() => Stream<T>.fromFuture(Completer<T>().future);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  // Visibility source (cheap running-only signal).
+  Stream<bool?>? running,
+  Future<bool?>? runningFallback,
+  // Label source (heavy status feed; percent enrichment).
+  Stream<Fragment$UpdateStatusDto?>? heavy,
+  Future<Fragment$UpdateStatusDto?>? heavyFallback,
+  bool prefOn = true,
+}) async {
+  SharedPreferences.setMockInitialValues(
+    {'showUpdateProgressBanner': prefOn},
+  );
+  final prefs = await SharedPreferences.getInstance();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        updateRunningSocketProvider
+            .overrideWith((ref) => running ?? Stream.value(false)),
+        updateRunningSummaryProvider
+            .overrideWith((ref) => runningFallback ?? Future.value(null)),
+        updatesSocketProvider
+            .overrideWith((ref) => heavy ?? _stalled()),
+        updateSummaryProvider
+            .overrideWith((ref) => heavyFallback ?? Future.value(null)),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: UpdateProgressBanner()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('hidden while idle', (tester) async {
+    await _pump(tester, running: Stream.value(false));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1000));
+
+    expect(find.byType(UpdateProgressBanner), findsOneWidget);
+    expect(find.textContaining('Updating library'), findsNothing);
+  });
+
+  testWidgets('appears after the 1000ms debounce once running', (tester) async {
+    await _pump(tester, running: Stream.value(true));
+    await tester.pump();
+
+    // Before the debounce fires, the banner must not have appeared yet.
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.textContaining('Updating library'), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(find.text('Updating library…'), findsOneWidget);
+  });
+
+  testWidgets('optimistic arm shows the banner immediately, before the debounce',
+      (tester) async {
+    // Server still reports idle — but the user just triggered an update. The
+    // banner must appear at once (bypassing the appear-debounce), so a pull
+    // doesn't feel dead for the ~1.5s before the server confirms it's running.
+    await _pump(tester, running: Stream.value(false));
+    await tester.pump();
+    expect(find.textContaining('Updating library'), findsNothing);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(UpdateProgressBanner)),
+    );
+    container.read(updateOptimisticProvider.notifier).arm();
+    await tester.pump(); // no debounce wait
+
+    expect(find.text('Updating library…'), findsOneWidget);
+
+    // Drain the arm's safety timeout so no timer outlives the test.
+    await tester.pump(const Duration(seconds: 13));
+  });
+
+  testWidgets(
+      'shows the running bar with indeterminate text when the heavy feed '
+      'stalls (the bug this fix addresses)', (tester) async {
+    // Running signal says "yes", but the heavy status feed never delivers —
+    // exactly the large-update case where the server stalls on job lists.
+    // The bar must still appear, showing "Updating library…", not nothing.
+    await _pump(
+      tester,
+      running: Stream.value(true),
+      heavy: _stalled(),
+      heavyFallback: Completer<Fragment$UpdateStatusDto?>().future,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1000));
+
+    expect(find.text('Updating library…'), findsOneWidget);
+  });
+
+  testWidgets('enriches to floor-rounded percent when the heavy feed resolves',
+      (tester) async {
+    await _pump(
+      tester,
+      running: Stream.value(true),
+      heavy: Stream.value(_status(isRunning: true, complete: 37, pending: 63)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1000));
+    // The heavy feed is only subscribed once the bar is visible, so it first
+    // shows "Updating library…" then enriches to the percent a frame later.
+    await tester.pump();
+
+    expect(find.text('Updating library (37% · 37/100)'), findsOneWidget);
+  });
+
+  testWidgets('hidden when the preference is off', (tester) async {
+    await _pump(
+      tester,
+      running: Stream.value(true),
+      heavy: Stream.value(_status(isRunning: true, complete: 1, pending: 1)),
+      prefOn: false,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1000));
+
+    expect(find.textContaining('Updating library'), findsNothing);
+  });
+
+  testWidgets(
+      'visibility falls back to the one-shot running query when the running '
+      'socket errors', (tester) async {
+    await _pump(
+      tester,
+      running: Stream<bool?>.error(Exception('ws down')),
+      runningFallback: Future.value(true),
+    );
+    await tester.pump();
+    // The error->invalidate round trip only lands on the frame the first
+    // (stale "not running") debounce timer fires, which then starts a
+    // second full 1000ms debounce for the freshly-discovered "running"
+    // state — so settling takes ~2000ms here, not one debounce window.
+    await tester.pump(const Duration(milliseconds: 1000));
+    await tester.pump(const Duration(milliseconds: 1100));
+
+    expect(find.text('Updating library…'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

A slim **"Updating library…"** strip at the top of the app whenever a global or category update is running, visible from any screen. Previously the only live signal was the counter on the Updates screen; from anywhere else there was no indication an update was happening. Addresses Discord feedback asking for a visible indicator of the background update.

Also makes Library **pull-to-refresh trigger a real update**, which brings it in line with every other Suwayomi/Mihon-family client (where a refresh means "check for new chapters" — ours previously just re-read the list).

## How it works

**Banner visibility rides on a cheap running-only signal, not the full update feed.** The full `updateStatusChanged` feed carries every manga in every job list; on a large library the server can't resolve those job-list fields promptly during a run, so the feed goes silent mid-update. Learning "is it running?" from there would show nothing during exactly the updates the banner exists for. So a new lightweight `isRunning`-only query + subscription drives on/off, and the percentage is best-effort enrichment from the heavy feed — shown when the counts resolve quickly, degrading to the indeterminate label otherwise.

**Optimistic feedback.** A user-triggered update (pull, overflow menu, Updates FAB) shows the banner the instant it's triggered, then hands back to the real running signal once the server confirms (~1.5s later), so the action never feels dead. A safety timeout releases the hold if a run never registers.

**Disconnect handling.** On a socket error the one-shot fallback is re-queried (and on app resume) rather than trusting the last streamed frame.

**Layout.** The strip fills behind the status bar; the shell drops the now-redundant status-bar inset on the content below while it's shown. Tablet-aware (only the phone shell draws into the status bar).

**Pull-to-refresh + refresh-on-completion.** Pull triggers a category update in the by-category view, or a whole-library update in grouped views; the spinner only waits on the immediate re-read, not the whole update. A standing listener refreshes the library when *any* update finishes, so new chapters appear without a manual refresh.

A Library setting hides the banner (default on).

## Testing

- Unit tests for the optimistic state machine (arm, real-signal handoff, mid-run re-arm, pre-start idle, safety timeout).
- Widget tests for the banner: debounce timing, the stalled-heavy-feed indeterminate case, percent enrichment, pref-off, and the socket-error→fallback path.
- Verified on-device against a real server: the banner shows during a real large-library update (where the naive full-feed approach showed nothing) and clears when it ends.
- Full suite passes; no server changes.

## Follow-ups (not in this PR)

- A failed pull currently swallows the error silently (matches the existing fire-and-forget trigger pattern) — worth surfacing.
- Completion + live-progress **notifications** are tracked separately (#137).