### PR TITLE
Bulk-edit categories from a library multi-selection

### DIFF
--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -36,6 +36,7 @@ import '../../../settings/presentation/appearance/widgets/grid_cover_width_slide
 import '../../../tracking/domain/track_progress_gate.dart';
 import 'controller/library_controller.dart';
 import 'controller/library_manga_list.dart';
+import 'widgets/edit_mangas_category_dialog.dart';
 
 class CategoryMangaList extends HookConsumerWidget {
   const CategoryMangaList({super.key, required this.categoryId});
@@ -318,21 +319,23 @@ class CategoryMangaList extends HookConsumerWidget {
                       }
                     },
                     onEditCategories: () async {
-                      // Single-manga category dialog when exactly one is picked;
-                      // multi-manga category editing is a follow-up.
-                      if (selection.value.length == 1) {
-                        final id = selection.value.first;
-                        final manga = items.firstWhere((m) => m.id == id);
-                        selection.value = const {};
-                        await showDialog(
-                          context: context,
-                          builder: (context) => EditMangaCategoryDialog(
-                            mangaId: id,
-                            title: manga.title,
-                          ),
-                        );
-                        refresh();
-                      }
+                      final selected = items
+                          .where((m) => selection.value.contains(m.id))
+                          .toList();
+                      if (selected.isEmpty) return;
+                      selection.value = const {};
+                      // One series → the per-series toggle dialog; many → the
+                      // bulk tri-state dialog.
+                      await showDialog<void>(
+                        context: context,
+                        builder: (context) => selected.length == 1
+                            ? EditMangaCategoryDialog(
+                                mangaId: selected.first.id,
+                                title: selected.first.title,
+                              )
+                            : EditMangasCategoryDialog(mangas: selected),
+                      );
+                      refresh();
                     },
                   ),
                 ),
@@ -345,9 +348,8 @@ class CategoryMangaList extends HookConsumerWidget {
   }
 }
 
-/// Bottom action bar shown while library manga are multi-selected. Scoped to
-/// the actions we can wire to existing APIs (sync offline / download to
-/// server). Mark-read and multi-manga category edits are a follow-up.
+/// Bottom action bar shown while library manga are multi-selected: mark
+/// read/unread, edit categories (bulk), keep offline, and download to server.
 class _SelectionBar extends StatelessWidget {
   const _SelectionBar({
     required this.count,
@@ -386,12 +388,11 @@ class _SelectionBar extends StatelessWidget {
           icon: const Icon(Icons.select_all_rounded),
           onPressed: onSelectAll,
         ),
-        if (count == 1)
-          IconButton(
-            tooltip: 'Edit categories',
-            icon: const Icon(Icons.label_outline_rounded),
-            onPressed: onEditCategories,
-          ),
+        IconButton(
+          tooltip: 'Edit categories',
+          icon: const Icon(Icons.label_outline_rounded),
+          onPressed: onEditCategories,
+        ),
         IconButton(
           tooltip: 'Mark read',
           icon: const Icon(Icons.done_all_rounded),

--- a/lib/src/features/library/presentation/library/widgets/edit_mangas_category_dialog.dart
+++ b/lib/src/features/library/presentation/library/widgets/edit_mangas_category_dialog.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../constants/app_sizes.dart';
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/misc/toast/toast.dart';
+import '../../../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../../../manga_book/domain/manga/manga_model.dart';
+import '../../category/controller/edit_category_controller.dart';
+import '../controller/library_manga_list.dart';
+
+/// Bulk "edit categories" for a multi-selection. Each category is tri-state
+/// against the selection: checked = all selected series are in it, unchecked =
+/// none are, dash = some are (mixed). Tapping resolves toward "add all"; only
+/// categories the user actually changes are written, so a mixed category left
+/// untouched keeps each series' membership. Applied in one bulk request.
+class EditMangasCategoryDialog extends HookConsumerWidget {
+  const EditMangasCategoryDialog({super.key, required this.mangas});
+  final List<MangaDto> mangas;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categories =
+        (ref.watch(categoryControllerProvider).valueOrNull ?? const [])
+            .where((c) => c.id != 0)
+            .toList();
+
+    // Initial tri-state per category, from the selection's current membership.
+    final memberIds = [
+      for (final m in mangas) {for (final n in m.categories.nodes) n.id},
+    ];
+    final initial = useMemoized<Map<int, bool?>>(
+      () => {
+        for (final c in categories)
+          c.id: categoryMembership(memberIds, c.id),
+      },
+      [categories.map((c) => c.id).join(','), mangas.length],
+    );
+    // Seed from `initial` so the first frame is correct (no all-dash flash);
+    // the effect keeps it in sync if the category set loads/changes later.
+    final current = useState<Map<int, bool?>>({...initial});
+    useEffect(() {
+      current.value = {...initial};
+      return null;
+    }, [initial]);
+
+    Future<void> apply() async {
+      final addTo = <int>[];
+      final removeFrom = <int>[];
+      for (final c in categories) {
+        final now = current.value[c.id];
+        if (now == initial[c.id]) continue; // untouched → leave as-is
+        if (now == true) {
+          addTo.add(c.id);
+        } else if (now == false) {
+          removeFrom.add(c.id);
+        }
+      }
+      if (addTo.isEmpty && removeFrom.isEmpty) {
+        if (context.mounted) Navigator.pop(context);
+        return;
+      }
+      final toast = ref.read(toastProvider);
+      try {
+        await ref.read(mangaBookRepositoryProvider).updateMangasCategories(
+              [for (final m in mangas) m.id],
+              addTo: addTo,
+              removeFrom: removeFrom,
+            );
+      } catch (e) {
+        toast?.showError(e.toString());
+        return; // keep the dialog open so the user can retry
+      }
+      ref.invalidate(libraryMangaListProvider);
+      ref.invalidate(categoryControllerProvider);
+      if (context.mounted) Navigator.pop(context);
+    }
+
+    return AlertDialog(
+      title: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(context.l10n.editCategory),
+          Text(
+            '${mangas.length} series',
+            style: context.textTheme.bodySmall,
+          ),
+        ],
+      ),
+      contentPadding: KEdgeInsets.h8v16.size,
+      content: categories.isEmpty
+          ? Padding(
+              padding: KEdgeInsets.h16.size,
+              child: Text(context.l10n.noCategoriesFoundAlt),
+            )
+          : ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: context.height * .6),
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (final c in categories)
+                      CheckboxListTile(
+                        tristate: true,
+                        value: current.value[c.id],
+                        title: Text(c.name),
+                        onChanged: (_) {
+                          // Tap always resolves to a definite decision: add
+                          // all, unless already all-in → then remove all.
+                          current.value = {
+                            ...current.value,
+                            c.id: current.value[c.id] == true ? false : true,
+                          };
+                        },
+                      ),
+                  ],
+                ),
+              ),
+            ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(context.l10n.cancel),
+        ),
+        TextButton(
+          onPressed: categories.isEmpty ? null : apply,
+          child: Text(context.l10n.save),
+        ),
+      ],
+    );
+  }
+}
+
+/// A category's tri-state against a multi-selection, from each series' set of
+/// category ids: all series in it → true, none → false, some → null (mixed).
+bool? categoryMembership(List<Set<int>> perMangaCategoryIds, int categoryId) {
+  if (perMangaCategoryIds.isEmpty) return false;
+  final inCount =
+      perMangaCategoryIds.where((ids) => ids.contains(categoryId)).length;
+  if (inCount == 0) return false;
+  if (inCount == perMangaCategoryIds.length) return true;
+  return null;
+}

--- a/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
+++ b/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
@@ -121,6 +121,29 @@ class MangaBookRepository {
       )
       .getData((data) => null);
 
+  /// Bulk category edit across many series in one request: add [addTo] and
+  /// remove [removeFrom] on every id in [mangaIds]. Empty lists are no-ops.
+  Future<void> updateMangasCategories(
+    List<int> mangaIds, {
+    List<int> addTo = const [],
+    List<int> removeFrom = const [],
+  }) =>
+      client
+          .mutate$UpdateMangasCategories(
+            Options$Mutation$UpdateMangasCategories(
+              variables: Variables$Mutation$UpdateMangasCategories(
+                input: Input$UpdateMangasCategoriesInput(
+                  ids: mangaIds,
+                  patch: Input$UpdateMangaCategoriesPatchInput(
+                    addToCategories: addTo,
+                    removeFromCategories: removeFrom,
+                  ),
+                ),
+              ),
+            ),
+          )
+          .getData((data) => null);
+
   // Chapters
 
   Future<ChapterDto?> getChapter({

--- a/lib/src/features/manga_book/data/manga_book/query.graphql
+++ b/lib/src/features/manga_book/data/manga_book/query.graphql
@@ -32,6 +32,14 @@ mutation UpdateMangaCategories($updateCategoryInput: UpdateMangaCategoriesInput!
   }
 }
 
+mutation UpdateMangasCategories($input: UpdateMangasCategoriesInput!) {
+  updateMangasCategories(input: $input) {
+    mangas {
+      id
+    }
+  }
+}
+
 query GetChapter($id: Int!) {
   chapter(id: $id) {
     ...ChapterDto

--- a/test/library/category_membership_test.dart
+++ b/test/library/category_membership_test.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/library/presentation/library/widgets/edit_mangas_category_dialog.dart';
+
+void main() {
+  group('categoryMembership (bulk category tri-state)', () {
+    test('all selected series in the category → true', () {
+      expect(
+        categoryMembership([
+          {1, 2},
+          {1, 3},
+          {1},
+        ], 1),
+        isTrue,
+      );
+    });
+
+    test('no selected series in the category → false', () {
+      expect(
+        categoryMembership([
+          {2, 3},
+          {4},
+        ], 1),
+        isFalse,
+      );
+    });
+
+    test('some in, some out → null (mixed)', () {
+      expect(
+        categoryMembership([
+          {1, 2},
+          {3},
+          {1},
+        ], 1),
+        isNull,
+      );
+    });
+
+    test('single series → true/false, never mixed', () {
+      expect(categoryMembership([{5}], 5), isTrue);
+      expect(categoryMembership([{5}], 6), isFalse);
+    });
+
+    test('empty selection → false (nothing is "in")', () {
+      expect(categoryMembership(const [], 1), isFalse);
+    });
+
+    test('series with no categories count as "out"', () {
+      expect(
+        categoryMembership([
+          {1},
+          <int>{},
+        ], 1),
+        isNull, // one in, one out → mixed
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

The library selection bar's **edit-categories** action only appeared when exactly one series was selected — so there was no way to change categories for several series at once. Now it shows for any selection, and a multi-selection opens a bulk dialog.

## How

Each category is **tri-state** against the selection:
- **checked** — all selected series are in it
- **dash** — some are (mixed)
- **unchecked** — none are

Tapping resolves toward "add all" (or removes all if it was all-in). **Only the categories you actually change are written** — a mixed category you leave alone keeps each series' own membership, so nothing is silently clobbered. Everything applies in **one** `updateMangasCategories` request (the server fans out across the ids), on Save.

Membership is computed from data already loaded (each `MangaDto` carries its `categories { nodes { id } }`), so no extra fetches.

## Testing

- Pure `categoryMembership` helper unit-tested (all → checked, none → unchecked, some → mixed, empty, single).
- On-device verified against a real library, including selecting series that are in different categories (tri-state shows correctly).
- Adversarially reviewed for the data-integrity risk (a series gaining/losing a category it shouldn't) — none found; full suite green.

## Known limitation (separate follow-up)

Multi-select only works in the **default (by-category) grouping** today — the by-source/status/ungrouped list never wired up long-press selection. That's a pre-existing gap tracked as its own change; this PR is the bulk-edit dialog it feeds.