### PR TITLE
Never un-read a chapter while reading forward

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -281,7 +281,9 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         final isCompletion = pageCount > 0 && p.rel >= pageCount - 1;
         unawaited(offlineDbForFlush
             .setChapterProgress(p.chapterId,
-                lastPageRead: isCompletion ? 0 : p.rel, isRead: isCompletion)
+                lastPageRead: isCompletion ? 0 : p.rel,
+                // Never un-read on a teardown flush: only a completion marks read.
+                isRead: isCompletion ? true : null)
             .catchError((_) {}));
       };
     }, const []);

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -383,12 +383,13 @@ class OfflineDatabase extends _$OfflineDatabase {
   Future<void> setChapterProgress(
     int chapterId, {
     required int lastPageRead,
-    required bool isRead,
+    bool? isRead,
   }) =>
       (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
         OfflineChaptersCompanion(
           lastPageRead: Value(lastPageRead),
-          isRead: Value(isRead),
+          // null → leave read-state untouched (a partial write must not un-read).
+          isRead: isRead == null ? const Value.absent() : Value(isRead),
           progressDirty: const Value(true),
         ),
       );
@@ -408,12 +409,14 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// clean and lost (the snapshot-then-clear race). A non-matching row keeps its
   /// flag and re-syncs on the next pass.
   Future<void> clearProgressDirtyIfUnchanged(int chapterId,
-          {required int lastPageRead, required bool isRead}) =>
+          {required int lastPageRead, bool? isRead}) =>
       (update(offlineChapters)
-            ..where((t) =>
-                t.id.equals(chapterId) &
-                t.lastPageRead.equals(lastPageRead) &
-                t.isRead.equals(isRead)))
+            ..where((t) {
+              final matches =
+                  t.id.equals(chapterId) & t.lastPageRead.equals(lastPageRead);
+              // isRead null → match on position alone (we never set it).
+              return isRead == null ? matches : matches & t.isRead.equals(isRead);
+            }))
           .write(const OfflineChaptersCompanion(progressDirty: Value(false)));
 
   /// Clear bookmarkDirty only if the bookmark still matches what was pushed —

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -258,23 +258,29 @@ Future<void> recordReadingProgressWithDependencies({
   required int lastPageRead,
   required bool isRead,
 }) async {
+  // Reading forward never un-reads: partial writes record position only (isRead
+  // omitted); only completion marks read. Mark-unread is a separate path.
+  final bool? markRead = isRead ? true : null;
   final db = offlineDatabase;
   if (offlineEnabled && db != null) {
     await db.setChapterProgress(
       chapterId,
       lastPageRead: lastPageRead,
-      isRead: isRead,
+      isRead: markRead,
     );
   }
   final result = await AsyncValue.guard(
     () => repository.putChapter(
       chapterId: chapterId,
-      patch: ChapterChange(lastPageRead: lastPageRead, isRead: isRead),
+      // Omit isRead (not null) when partial so the server keeps its read-state.
+      patch: markRead == null
+          ? ChapterChange(lastPageRead: lastPageRead)
+          : ChapterChange(lastPageRead: lastPageRead, isRead: markRead),
     ),
   );
   if (offlineEnabled && db != null && !result.hasError) {
     await db.clearProgressDirtyIfUnchanged(chapterId,
-        lastPageRead: lastPageRead, isRead: isRead);
+        lastPageRead: lastPageRead, isRead: markRead);
   }
 }
 

--- a/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
+++ b/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
@@ -262,8 +262,9 @@ void main() {
     await tester.pump(const Duration(seconds: 3));
 
     expect(
+      // Partial read: position is saved, read-state is omitted (never un-reads).
       repo.putChapterCalls.any((c) =>
-          c.chapterId == 1 && c.patch.lastPageRead == 1 && c.patch.isRead == false),
+          c.chapterId == 1 && c.patch.lastPageRead == 1 && c.patch.isRead == null),
       isTrue,
       reason: 'debounced progress for page 2 was not saved; ${repo.putChapterCalls}',
     );

--- a/test/src/features/manga_book/reader/reader_screen_test.dart
+++ b/test/src/features/manga_book/reader/reader_screen_test.dart
@@ -180,7 +180,9 @@ void main() {
     expect(repo.putChapterCalls, hasLength(1));
     expect(repo.putChapterCalls.single.chapterId, 1);
     expect(repo.putChapterCalls.single.patch.lastPageRead, 1);
-    expect(repo.putChapterCalls.single.patch.isRead, isFalse);
+    // A partial read records position but sends NO read-state — reading forward
+    // must never be able to un-read a chapter another client finished.
+    expect(repo.putChapterCalls.single.patch.isRead, isNull);
   });
 
   testWidgets('flushes debounced progress when the reader route pops',
@@ -245,7 +247,9 @@ void main() {
     expect(repo.putChapterCalls, hasLength(1));
     expect(repo.putChapterCalls.single.chapterId, 1);
     expect(repo.putChapterCalls.single.patch.lastPageRead, 1);
-    expect(repo.putChapterCalls.single.patch.isRead, isFalse);
+    // A partial read records position but sends NO read-state — reading forward
+    // must never be able to un-read a chapter another client finished.
+    expect(repo.putChapterCalls.single.patch.isRead, isNull);
   });
 
   testWidgets('opening at the end does not mark an unread chapter read',

--- a/test/src/features/offline/reading_never_unreads_test.dart
+++ b/test/src/features/offline/reading_never_unreads_test.dart
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+
+import '../../../helpers/offline_test_db.dart';
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+/// Captures the patch sent to the server so we can assert what reading writes.
+class _CapturingRepo extends MangaBookRepository {
+  _CapturingRepo() : super(_dummyClient());
+  ChapterChange? lastPatch;
+
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {
+    lastPatch = patch;
+  }
+}
+
+void main() {
+  group('reading forward never un-reads a chapter', () {
+    test('mid-chapter write OMITS isRead from the server patch', () async {
+      final repo = _CapturingRepo();
+      await recordReadingProgressWithDependencies(
+        offlineEnabled: false,
+        offlineDatabase: null,
+        repository: repo,
+        chapterId: 11,
+        lastPageRead: 38,
+        isRead: false, // not at the last page
+      );
+
+      final json = repo.lastPatch!.toJson();
+      expect(json.containsKey('isRead'), isFalse,
+          reason: 'a partial read must not send isRead at all — the server '
+              'keeps whatever it had, so a stale client cannot un-read it');
+      expect(json['lastPageRead'], 38);
+    });
+
+    test('completing a chapter DOES send isRead: true', () async {
+      final repo = _CapturingRepo();
+      await recordReadingProgressWithDependencies(
+        offlineEnabled: false,
+        offlineDatabase: null,
+        repository: repo,
+        chapterId: 11,
+        lastPageRead: 0,
+        isRead: true, // reached the last page
+      );
+
+      final json = repo.lastPatch!.toJson();
+      expect(json['isRead'], true);
+    });
+
+    test('offline: a partial read does NOT flip a read chapter to unread',
+        () async {
+      final db = testOfflineDatabase();
+      addTearDown(db.close);
+      await db.upsertChapterMetadata(
+        id: 11,
+        mangaId: 1,
+        name: 'c11',
+        chapterIndex: 11,
+        isRead: true, // already finished (e.g. on another device)
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 40,
+        updatedAt: DateTime(2026),
+      );
+
+      await recordReadingProgressWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: _CapturingRepo(),
+        chapterId: 11,
+        lastPageRead: 38,
+        isRead: false,
+      );
+
+      final row = await db.chapterById(11);
+      expect(row!.isRead, isTrue,
+          reason: 'the local cache must keep the chapter read; only position '
+              'updates on a partial read');
+      expect(row.lastPageRead, 38);
+    });
+  });
+}


### PR DESCRIPTION
## The bug

A chapter you'd finished could silently flip back to **unread** — reproducible when switching between two apps on the same server (e.g. the side-by-side dev build). Observed live: a chapter stuck unread at page 38 with the newest timestamp of its group.

## Root cause

Reading partway through a chapter wrote `isRead: false` to the server on every debounced progress save. A second app still holding a stale "unread, page N" view of a chapter the other app had **finished** would push that `false` and overwrite the server's "read." The reader's existing "already read → skip" guard couldn't catch it: it trusts the client's *own cached* read-state, which is exactly the stale bit.

## The fix

A reading-progress write records the **page position only** and never sends or persists `isRead: false`. Read-state is set exactly once — to `true` — when a chapter is completed. So reading forward can never regress a read chapter, regardless of stale caches.

- Centralized in `recordReadingProgressWithDependencies` (omits `isRead` from the patch unless completing), so it covers **every** reader mode — single, multichapter-paged, continuous — plus the offline cache write.
- Explicit "mark as unread" is a separate path and is unaffected.
- As a bonus, the offline path is improved: a partial read on a chapter finished elsewhere now preserves its `read` state instead of clobbering it locally.

## Testing

- New `reading_never_unreads_test.dart`: a partial read **omits** `isRead` from the server patch (proven via `!patch.toJson().containsKey('isRead')`), completion sends `isRead: true`, and the offline cache keeps a read chapter read on a partial write.
- Updated the two reader flush tests + the paged e2e test to pin the new behavior (position saved, read-state omitted).
- Full suite green; adversarially reviewed (offline dirty-sync integrity confirmed unaffected).