### PR TITLE
Fix reader & details lifecycle crashes

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -64,6 +64,8 @@ class MangaDetailsScreen extends HookConsumerWidget {
     // Refresh manga
     final mangaRefresh = useCallback(([bool onlineFetch = false]) async {
       await ref.read(mangaProvider.notifier).refresh();
+      // Screen may be disposed during the refresh → don't invalidate a dead ref.
+      if (!context.mounted) return;
       ref.invalidate(categoryControllerProvider);
     }, [mangaProvider]);
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_settings_dialog.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_settings_dialog.dart
@@ -96,14 +96,18 @@ Future<void> showReaderSettingsSheet({
     if (dismissed) return;
     dismissed = true;
     subscription.close();
-    // Flush any live slider draft the dismissal interrupted mid-drag (§2.4).
-    final model = ref.read(readerSettingsModelProvider(mangaId).notifier);
+    // Clear the app-global preview drafts first, even if disposed, so they
+    // don't bleed into the next reader's sliders.
     final brightnessDraft = readerBrightnessPreview.value;
-    if (brightnessDraft != null) model.setCustomBrightnessValue(brightnessDraft);
     final colorDraft = readerColorFilterPreview.value;
-    if (colorDraft != null) model.setColorFilterValue(colorDraft);
     readerBrightnessPreview.value = null;
     readerColorFilterPreview.value = null;
+    // Reader gone (e.g. volume-key chapter change) → ref is dead.
+    if (!context.mounted) return;
+    // Flush any live slider draft the dismissal interrupted mid-drag (§2.4).
+    final model = ref.read(readerSettingsModelProvider(mangaId).notifier);
+    if (brightnessDraft != null) model.setCustomBrightnessValue(brightnessDraft);
+    if (colorDraft != null) model.setColorFilterValue(colorDraft);
     visibility.value = wasVisible;
     ref.invalidate(readerSettingsPreviewProvider);
   }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -192,6 +192,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     }
 
     Future<void> writeVisibleProgress(int chapterId, int rel) async {
+      // Debounce can fire after the reader's gone.
+      if (!context.mounted) return;
       if (ref.read(incognitoModeProvider)) return;
       // We've already moved past this chapter — a late debounced partial must
       // not revert what the boundary mark-read recorded for it. Let that path
@@ -219,6 +221,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         lastPageRead: completed ? 0 : rel,
         isRead: completed,
       );
+      // Disposed during the await → the ref calls below would throw.
+      if (!context.mounted) return;
       if (completed && !completedChapterIds.value.contains(chapterId)) {
         completedChapterIds.value = {...completedChapterIds.value, chapterId};
         unawaited(maybeTrackProgressOnReadFetch(ref,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -287,7 +287,11 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     _displayIndex =
         target >= 0 ? target : _clampDisplay(widget.initialDisplayIndex);
     _dragOffset = 0;
-    _emitRawPage();
+    // Runs inside didUpdateWidget; a sync emit would setState an ancestor
+    // mid-build. Defer (like commitPendingIfAny).
+    Future.microtask(() {
+      if (mounted) _emitRawPage();
+    });
   }
 
   void jumpToRaw(int rawIndex) {

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -950,9 +950,13 @@ class ReaderView extends HookConsumerWidget {
 
     void handleLongPressCancel() {
       if (readWithLongTap) {
+        // Flag-first + canPop so this and the sheet's own dismissal can't
+        // double-pop (which trips the scope assertion) or pop the reader itself.
         if (pageActionsOpen.value &&
             context.mounted &&
-            ModalRoute.of(context)?.isCurrent == false) {
+            ModalRoute.of(context)?.isCurrent == false &&
+            Navigator.of(context).canPop()) {
+          pageActionsOpen.value = false;
           unawaited(Navigator.of(context).maybePop());
         }
         return;


### PR DESCRIPTION
Guards for five ref-after-dispose / setState-during-build races surfaced by real device crash logs. All are **caught-and-recovered today** (one is debug-only), so this is quieter logs, not a behavior change for release users.

- **Reader settings sheet** — dismissing after the reader was disposed (a volume-key chapter change with the sheet open) read a dead `ref`. Guard on `context.mounted`; clear the app-global slider-preview drafts first so a mid-drag draft can't bleed into the next reader.
- **Paged viewport re-anchor** — after a window swap, `_reanchor` emitted the new page index to an ancestor synchronously inside `didUpdateWidget` (setState-during-build). Defer the emit to a microtask (mirrors the host's `commitPendingIfAny`).
- **Long-press page actions** — releasing could fire a second `Navigator` pop racing the sheet's own dismissal, tripping a debug-only `scope != null` assertion. Clear the open flag before popping and gate on `canPop` so neither path double-pops.
- **Webtoon `writeVisibleProgress`** — the 2s debounce firing post-dispose, or a dispose during the progress await, threw on the tracker push / `ref.invalidate`. Guard `context.mounted` before and after the await. (Recurring in the wild — the most-read mode.)
- **Manga details `mangaRefresh`** — `ref.invalidate` ran after the refresh await with no mount check, crashing when a download-preset tap popped the screen. Guard it.

Deliberately **not** fixed: a `zoom_view` null-check crash deep in Flutter's scroll-momentum during a pinch/pan — framework-internal, a single occurrence, too risky to touch for the gain.

Stacked on #174 (read-status fix); will retarget to `main` once that merges. Adversarially reviewed (SHIP); full suite green; tested on-device.