### PR TITLE
Fix reading progress lost when closing from the reader

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -36,6 +36,7 @@ import '../manga_details/controller/manga_details_controller.dart';
 import 'controller/auto_webtoon.dart';
 import 'controller/display_cutout.dart';
 import 'controller/reader_controller.dart';
+import 'utils/flush_progress_on_lifecycle.dart';
 import 'widgets/chrome/reader_chrome.dart';
 import 'widgets/reader_mode/continuous_reader_mode.dart';
 import 'widgets/reader_mode/multichapter_paged_reader_mode.dart';
@@ -229,6 +230,15 @@ class ReaderScreen extends HookConsumerWidget {
         }
       };
     }, []);
+
+    // Desktop window-close fires neither the PopScope pop nor a reliable
+    // dispose, so also flush the buffered page on background/exit.
+    useFlushProgressOnAppLifecycle(() async {
+      debounce.value?.cancel();
+      if (latestPage.value >= 0) {
+        await updateRef.value(latestPage.value);
+      }
+    });
 
     useEffect(() {
       // Fullscreen OFF keeps the OS bars for the whole session (read once at

--- a/lib/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart
@@ -15,26 +15,28 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 ///
 /// The reader otherwise only flushes on a Flutter route-pop or widget dispose.
 /// Neither fires when a desktop window is closed straight from the reader, so
-/// the last buffered page was silently lost. `onPause` covers mobile
-/// backgrounding; `onExitRequested` covers a desktop window-close and fires
-/// while the tree is still mounted, so [flush] can safely use `ref`. On exit we
-/// await the write (bounded, so a slow server can't wedge the close) so the
-/// position reaches the server before the window goes away.
+/// the last buffered page was silently lost. `onHide` covers web tab-hide/close,
+/// desktop minimize, and mobile background (the `hidden` state precedes
+/// `paused`, so onPause would only double-fire). `onExitRequested` covers a
+/// desktop window-close; it fires while the tree is still mounted, so [flush]
+/// can safely use `ref`. Both go through [flush], which is bounded and swallows
+/// errors so a slow or failing write can neither wedge nor abort the close.
 void useFlushProgressOnAppLifecycle(Future<void> Function() flush) {
   final flushRef = useRef(flush);
   flushRef.value = flush;
   useEffect(() {
+    // A failed/slow write must not surface as an unhandled async error on
+    // background, nor abort the window close by erroring out of onExitRequested.
+    Future<void> safeFlush() async {
+      try {
+        await flushRef.value().timeout(const Duration(seconds: 3));
+      } catch (_) {}
+    }
+
     final listener = AppLifecycleListener(
-      // onPause: mobile background. onHide: web tab-hide/close and desktop
-      // minimize (web never reaches `paused` on a tab-hide, so onPause alone
-      // would miss it).
-      onPause: () => unawaited(flushRef.value()),
-      onHide: () => unawaited(flushRef.value()),
+      onHide: () => unawaited(safeFlush()),
       onExitRequested: () async {
-        await flushRef.value().timeout(
-              const Duration(seconds: 3),
-              onTimeout: () {},
-            );
+        await safeFlush();
         return AppExitResponse.exit;
       },
     );

--- a/lib/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+import 'dart:ui' show AppExitResponse;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+/// Flushes the reader's pending (debounced) progress on app background and on
+/// exit.
+///
+/// The reader otherwise only flushes on a Flutter route-pop or widget dispose.
+/// Neither fires when a desktop window is closed straight from the reader, so
+/// the last buffered page was silently lost. `onPause` covers mobile
+/// backgrounding; `onExitRequested` covers a desktop window-close and fires
+/// while the tree is still mounted, so [flush] can safely use `ref`. On exit we
+/// await the write (bounded, so a slow server can't wedge the close) so the
+/// position reaches the server before the window goes away.
+void useFlushProgressOnAppLifecycle(Future<void> Function() flush) {
+  final flushRef = useRef(flush);
+  flushRef.value = flush;
+  useEffect(() {
+    final listener = AppLifecycleListener(
+      onPause: () => unawaited(flushRef.value()),
+      onExitRequested: () async {
+        await flushRef.value().timeout(
+              const Duration(seconds: 3),
+              onTimeout: () {},
+            );
+        return AppExitResponse.exit;
+      },
+    );
+    return listener.dispose;
+  }, const []);
+}

--- a/lib/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart
@@ -25,7 +25,11 @@ void useFlushProgressOnAppLifecycle(Future<void> Function() flush) {
   flushRef.value = flush;
   useEffect(() {
     final listener = AppLifecycleListener(
+      // onPause: mobile background. onHide: web tab-hide/close and desktop
+      // minimize (web never reaches `paused` on a tab-hide, so onPause alone
+      // would miss it).
       onPause: () => unawaited(flushRef.value()),
+      onHide: () => unawaited(flushRef.value()),
       onExitRequested: () async {
         await flushRef.value().timeout(
               const Duration(seconds: 3),

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -33,6 +33,7 @@ import '../../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../../domain/manga/manga_model.dart';
 import '../../../../manga_details/controller/manga_details_controller.dart';
 import '../../../controller/reader_controller.dart';
+import '../../../utils/flush_progress_on_lifecycle.dart';
 import '../../../utils/reader_initial_page.dart';
 import '../../reader_wrapper.dart';
 import '../reader_zoom_view.dart';
@@ -291,6 +292,17 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
             .catchError((_) {}));
       };
     }, const []);
+
+    // Desktop window-close fires neither a route-pop nor a reliable dispose,
+    // and the teardown flush above is offline-only; flush the visible position
+    // to the server on background/exit too.
+    useFlushProgressOnAppLifecycle(() async {
+      progressDebounce.value?.cancel();
+      final p = latestProgress.value;
+      if (p == null) return;
+      if (completedChapterIds.value.contains(p.chapterId)) return;
+      await writeVisibleProgress(p.chapterId, p.rel);
+    });
 
     final bool isAnimationEnabled =
         ref.watch(readerScrollAnimationProvider).ifNull(true);

--- a/test/src/features/manga_book/reader/flush_progress_on_lifecycle_test.dart
+++ b/test/src/features/manga_book/reader/flush_progress_on_lifecycle_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart';
+
+void main() {
+  testWidgets('flushes pending progress when the app is backgrounded',
+      (tester) async {
+    var flushes = 0;
+    await tester.pumpWidget(
+      HookBuilder(
+        builder: (context) {
+          useFlushProgressOnAppLifecycle(() async => flushes++);
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+
+    // Drive resumed → … → paused, the sequence a mobile background produces;
+    // AppLifecycleListener.onPause fires on the transition into paused.
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+
+    expect(flushes, 1);
+  });
+}

--- a/test/src/features/manga_book/reader/flush_progress_on_lifecycle_test.dart
+++ b/test/src/features/manga_book/reader/flush_progress_on_lifecycle_test.dart
@@ -4,13 +4,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:ui' show AppExitResponse;
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/utils/flush_progress_on_lifecycle.dart';
 
 void main() {
-  testWidgets('flushes pending progress when the app is backgrounded',
+  testWidgets('flushes pending progress when the app is hidden',
       (tester) async {
     var flushes = 0;
     await tester.pumpWidget(
@@ -22,14 +24,34 @@ void main() {
       ),
     );
 
-    // Drive resumed → … → paused, the sequence a mobile background produces;
-    // AppLifecycleListener.onPause fires on the transition into paused.
+    // A web tab-hide/close (and desktop minimize) transitions to `hidden`;
+    // the fix must flush there — web never reaches `paused` on a tab-hide.
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
-    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
     await tester.pump();
 
     expect(flushes, 1);
+  });
+
+  testWidgets('flushes pending progress when the app is asked to exit',
+      (tester) async {
+    var flushes = 0;
+    await tester.pumpWidget(
+      HookBuilder(
+        builder: (context) {
+          useFlushProgressOnAppLifecycle(() async => flushes++);
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+
+    // A desktop window-close routes through an app-exit request; our handler
+    // must flush the pending position and then allow the exit.
+    final response = await tester.binding.handleRequestAppExit();
+    await tester.pump();
+
+    expect(flushes, 1);
+    expect(response, AppExitResponse.exit);
   });
 }

--- a/test/src/features/manga_book/reader/flush_progress_on_lifecycle_test.dart
+++ b/test/src/features/manga_book/reader/flush_progress_on_lifecycle_test.dart
@@ -24,11 +24,14 @@ void main() {
       ),
     );
 
-    // A web tab-hide/close (and desktop minimize) transitions to `hidden`;
-    // the fix must flush there — web never reaches `paused` on a tab-hide.
+    // Full mobile-background sequence: resumed → inactive → hidden → paused.
+    // The flush fires once (on `hidden`); driving on through `paused` must NOT
+    // fire a second time (we intentionally don't listen to onPause, so a
+    // background isn't double-flushed).
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
     await tester.pump();
 
     expect(flushes, 1);


### PR DESCRIPTION
Reading position was buffered for a couple of seconds and only saved on back-navigation or widget teardown. Closing the app straight from the reader — common on desktop, where you just close the window — never triggered either path, so the last position was dropped and the chapter resumed earlier than where you left off.

The reader now also flushes the pending position when the app is backgrounded, hidden, or asked to close, so it reaches the server before the window goes away. The write is bounded and swallows errors, so a slow or failing save can't hang or abort the window close.