### PR TITLE
Add reader auto-scroll and auto-advance

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -210,6 +210,9 @@ enum DBKeys {
   cropBordersWebtoon(false),
   cropBordersGaps(false),
   smoothAutoScroll(true),
+  readerScrollAmount(ReaderScrollAmount.large),
+  autoScrollIntervalSeconds(3),
+  autoAdvanceIntervalSeconds(5),
   dualPageSplitWebtoon(false),
   dualPageInvertWebtoon(false),
   // Reader General tab (all global).

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -240,6 +240,25 @@ enum FlashColor {
       };
 }
 
+/// Fraction of the viewport advanced per keyboard/manual scroll step.
+enum ReaderScrollAmount {
+  tiny(0.10),
+  small(0.25),
+  medium(0.75),
+  large(0.95);
+
+  const ReaderScrollAmount(this.fraction);
+
+  final double fraction;
+
+  String toLocale(BuildContext context) => switch (this) {
+        ReaderScrollAmount.tiny => context.l10n.scrollAmountTiny,
+        ReaderScrollAmount.small => context.l10n.scrollAmountSmall,
+        ReaderScrollAmount.medium => context.l10n.scrollAmountMedium,
+        ReaderScrollAmount.large => context.l10n.scrollAmountLarge,
+      };
+}
+
 /// Custom color-filter blend (order 0-5). Native Android
 /// gates the last three behind API level P+; Flutter's BlendMode supports all
 /// six everywhere, so no gate. "Multiply" is Compose Modulate (src×dst).

--- a/lib/src/constants/reader_keyboard_shortcuts.dart
+++ b/lib/src/constants/reader_keyboard_shortcuts.dart
@@ -21,13 +21,37 @@ class ViewportScrollForwardIntent extends Intent {}
 
 class ViewportScrollBackwardIntent extends Intent {}
 
+class AutoScrollToggleIntent extends Intent {}
+
+class AutoScrollFasterIntent extends Intent {}
+
+class AutoScrollSlowerIntent extends Intent {}
+
 ShortcutManager readerShortcutManager(Axis scrollDirection,
-        {bool isRtl = false}) =>
+        {bool isRtl = false, bool autoScrollSupported = false}) =>
     ShortcutManager(
       shortcuts: {
-        const SingleActivator(LogicalKeyboardKey.space): NextScrollIntent(),
+        // Space toggles auto-scroll only in vertical modes that actually mount
+        // an auto-scroll engine; elsewhere it stays page-advance (and
+        // Shift+Space page-back), so keyboard paging never goes dead.
+        const SingleActivator(LogicalKeyboardKey.space):
+            scrollDirection == Axis.vertical && autoScrollSupported
+                ? AutoScrollToggleIntent()
+                : NextScrollIntent(),
         const SingleActivator(LogicalKeyboardKey.space, shift: true):
-            PreviousScrollIntent(),
+            scrollDirection == Axis.vertical && autoScrollSupported
+                ? AutoScrollToggleIntent()
+                : PreviousScrollIntent(),
+        if (scrollDirection == Axis.vertical && autoScrollSupported) ...{
+          const SingleActivator(LogicalKeyboardKey.equal):
+              AutoScrollFasterIntent(),
+          const SingleActivator(LogicalKeyboardKey.numpadAdd):
+              AutoScrollFasterIntent(),
+          const SingleActivator(LogicalKeyboardKey.minus):
+              AutoScrollSlowerIntent(),
+          const SingleActivator(LogicalKeyboardKey.numpadSubtract):
+              AutoScrollSlowerIntent(),
+        },
         // RTL manga reads right→left, so the physical left key advances.
         const SingleActivator(LogicalKeyboardKey.arrowLeft):
             isRtl ? NextScrollIntent() : PreviousScrollIntent(),

--- a/lib/src/features/manga_book/presentation/reader/controller/auto_scroll_controller.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/auto_scroll_controller.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_scroll_controller.g.dart';
+
+/// Whether hands-free auto-scroll is currently running in the reader.
+///
+/// Session-scoped (autoDispose): resets to off each time the reader is
+/// opened. Flipped by the keyboard trigger and the on-screen utils bar;
+/// watched by the reader-mode ticker to drive the scroll loop.
+@riverpod
+class AutoScrollActive extends _$AutoScrollActive {
+  @override
+  bool build() => false;
+
+  void toggle() => state = !state;
+
+  void start() => state = true;
+
+  void stop() => state = false;
+}

--- a/lib/src/features/manga_book/presentation/reader/controller/reader_settings_model.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/reader_settings_model.dart
@@ -226,6 +226,24 @@ abstract final class ReaderSettings {
     fallback: DBKeys.smoothAutoScroll.initial as bool,
   );
 
+  static final readerScrollAmount = ReaderSetting<ReaderScrollAmount>(
+    scope: ReaderSettingScope.global,
+    global: readerScrollAmountKeyProvider,
+    fallback: DBKeys.readerScrollAmount.initial as ReaderScrollAmount,
+  );
+
+  static final autoScrollIntervalSeconds = ReaderSetting<int>(
+    scope: ReaderSettingScope.global,
+    global: autoScrollIntervalSecondsProvider,
+    fallback: DBKeys.autoScrollIntervalSeconds.initial as int,
+  );
+
+  static final autoAdvanceIntervalSeconds = ReaderSetting<int>(
+    scope: ReaderSettingScope.global,
+    global: autoAdvanceIntervalSecondsProvider,
+    fallback: DBKeys.autoAdvanceIntervalSeconds.initial as int,
+  );
+
   static final dualPageSplitWebtoon = ReaderSetting<bool>(
     scope: ReaderSettingScope.global,
     global: dualPageSplitWebtoonProvider,
@@ -382,6 +400,9 @@ class ReaderSettingsState with _$ReaderSettingsState {
     required bool cropBordersWebtoon,
     required bool cropBordersGaps,
     required bool smoothAutoScroll,
+    required ReaderScrollAmount readerScrollAmount,
+    required int autoScrollIntervalSeconds,
+    required int autoAdvanceIntervalSeconds,
     required bool dualPageSplitWebtoon,
     required bool dualPageInvertWebtoon,
     required ReaderBackgroundColor backgroundColor,
@@ -434,6 +455,9 @@ class ReaderSettingsModel extends _$ReaderSettingsModel {
   late CropBordersWebtoon _cropBordersWebtoon;
   late CropBordersGaps _cropBordersGaps;
   late SmoothAutoScroll _smoothAutoScroll;
+  late ReaderScrollAmountKey _readerScrollAmount;
+  late AutoScrollIntervalSeconds _autoScrollIntervalSeconds;
+  late AutoAdvanceIntervalSeconds _autoAdvanceIntervalSeconds;
   late DualPageSplitWebtoon _dualPageSplitWebtoon;
   late DualPageInvertWebtoon _dualPageInvertWebtoon;
   late ReaderBackgroundColorKey _backgroundColor;
@@ -487,6 +511,11 @@ class ReaderSettingsModel extends _$ReaderSettingsModel {
     _cropBordersWebtoon = ref.read(cropBordersWebtoonProvider.notifier);
     _cropBordersGaps = ref.read(cropBordersGapsProvider.notifier);
     _smoothAutoScroll = ref.read(smoothAutoScrollProvider.notifier);
+    _readerScrollAmount = ref.read(readerScrollAmountKeyProvider.notifier);
+    _autoScrollIntervalSeconds =
+        ref.read(autoScrollIntervalSecondsProvider.notifier);
+    _autoAdvanceIntervalSeconds =
+        ref.read(autoAdvanceIntervalSecondsProvider.notifier);
     _dualPageSplitWebtoon = ref.read(dualPageSplitWebtoonProvider.notifier);
     _dualPageInvertWebtoon = ref.read(dualPageInvertWebtoonProvider.notifier);
     _backgroundColor = ref.read(readerBackgroundColorKeyProvider.notifier);
@@ -559,6 +588,12 @@ class ReaderSettingsModel extends _$ReaderSettingsModel {
           ReaderSettings.cropBordersWebtoon.resolveWith(ref, null),
       cropBordersGaps: ReaderSettings.cropBordersGaps.resolveWith(ref, null),
       smoothAutoScroll: ReaderSettings.smoothAutoScroll.resolveWith(ref, null),
+      readerScrollAmount:
+          ReaderSettings.readerScrollAmount.resolveWith(ref, null),
+      autoScrollIntervalSeconds:
+          ReaderSettings.autoScrollIntervalSeconds.resolveWith(ref, null),
+      autoAdvanceIntervalSeconds:
+          ReaderSettings.autoAdvanceIntervalSeconds.resolveWith(ref, null),
       dualPageSplitWebtoon:
           ReaderSettings.dualPageSplitWebtoon.resolveWith(ref, null),
       dualPageInvertWebtoon:
@@ -631,6 +666,15 @@ class ReaderSettingsModel extends _$ReaderSettingsModel {
   void setCropBordersGaps(bool value) => _cropBordersGaps.update(value);
 
   void setSmoothAutoScroll(bool value) => _smoothAutoScroll.update(value);
+
+  void setReaderScrollAmount(ReaderScrollAmount value) =>
+      _readerScrollAmount.update(value);
+
+  void setAutoScrollIntervalSeconds(int value) =>
+      _autoScrollIntervalSeconds.update(value);
+
+  void setAutoAdvanceIntervalSeconds(int value) =>
+      _autoAdvanceIntervalSeconds.update(value);
 
   void setDualPageSplitPaged(bool value) => _dualPageSplitPaged.update(value);
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
@@ -20,12 +20,14 @@ import '../../../../../settings/presentation/reader/widgets/reader_left_handed_s
 import '../../../../domain/chapter/chapter_model.dart';
 import '../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../domain/manga/manga_model.dart';
+import '../reader_mode/infinity_continuous/measure_size.dart';
 import 'chrome_extents.dart';
 import 'reader_bottom_controls.dart';
 import 'reader_color_overlays.dart';
 import 'reader_flash_overlay.dart';
 import 'reader_side_seekbar.dart';
 import 'reader_top_bar.dart';
+import 'reader_utils_bar.dart';
 
 /// UI mode while the chrome is hidden: fullscreen hides the OS bars; with
 /// fullscreen OFF they stay visible (edgeToEdge) even when the chrome goes.
@@ -60,11 +62,13 @@ class ReaderChrome extends HookConsumerWidget {
     required this.currentIndex,
     required this.totalPageCount,
     required this.visibility,
+    required this.utilsBarExpanded,
     required this.useBottomSeekBar,
     required this.showSideSeekBar,
     required this.scrollDirection,
     required this.nextPrevChapterPair,
     required this.resolvedReaderMode,
+    required this.autoScrollSupported,
     required this.reverseSeekBar,
     required this.onChanged,
     required this.onOpenSettings,
@@ -83,6 +87,10 @@ class ReaderChrome extends HookConsumerWidget {
   /// The controller tracks this notifier; [visibility] is never written here.
   final ValueNotifier<bool> visibility;
 
+  /// Owned by [ReaderWrapper]; toggled by [ReaderTopBar]'s tune button.
+  /// Expands [ReaderUtilsBar] beneath the top bar.
+  final ValueNotifier<bool> utilsBarExpanded;
+
   /// True when the horizontal bottom seek bar should be shown (paged / landscape).
   final bool useBottomSeekBar;
 
@@ -93,6 +101,11 @@ class ReaderChrome extends HookConsumerWidget {
   final Axis scrollDirection;
   final ({ChapterDto? first, ChapterDto? second})? nextPrevChapterPair;
   final ReaderMode resolvedReaderMode;
+
+  /// True only in modes that actually mount an auto-scroll/auto-advance engine.
+  /// The utils bar (and its toggle) is hidden otherwise, so it's never a dead
+  /// control.
+  final bool autoScrollSupported;
   final bool reverseSeekBar;
   final ValueChanged<int> onChanged;
   final VoidCallback onOpenSettings;
@@ -271,10 +284,20 @@ class ReaderChrome extends HookConsumerWidget {
                 ),
               ),
 
-            // ── Top bar ───────────────────────────────────────────────────────
+            // ── Top bar + utils bar ──────────────────────────────────────────
             // SlideTransition from Offset(0, -1) (fully above viewport) → zero.
             // FadeTransition from 0 → 1, driven by the same curved animation.
             // IgnorePointer when dismissed so the hidden bar doesn't eat taps.
+            //
+            // ReaderUtilsBar rides in the same Column as the top bar so it
+            // slides/fades as one rigid unit with it — its own expand/collapse
+            // is a separate, local AnimatedSize.
+            //
+            // MeasureSize now wraps BOTH bars (moved down from ReaderTopBar
+            // alone) so chromeExtentsNotifierProvider's topInset covers the
+            // utils bar's height too when it's expanded — otherwise the side
+            // seekbar's `top` offset would sit above the top bar only and
+            // overlap the expanded utils bar.
             Positioned(
               top: 0,
               left: 0,
@@ -288,10 +311,38 @@ class ReaderChrome extends HookConsumerWidget {
                       begin: const Offset(0, -1),
                       end: Offset.zero,
                     ).animate(slide),
-                    child: ReaderTopBar(
-                      manga: manga,
-                      chapter: chapter,
-                      onBack: () => context.pop(),
+                    child: MeasureSize(
+                      onChange: (size) {
+                        // Fires from a post-frame callback; the reader may have
+                        // unmounted by then, so never touch ref after dispose.
+                        if (!context.mounted) return;
+                        final current = ref.read(chromeExtentsNotifierProvider);
+                        final next = ChromeExtents(
+                          topInset: size.height,
+                          bottomInset: current.bottomInset,
+                        );
+                        ref
+                            .read(chromeExtentsNotifierProvider.notifier)
+                            .update(next);
+                      },
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ReaderTopBar(
+                            manga: manga,
+                            chapter: chapter,
+                            onBack: () => context.pop(),
+                          ),
+                          // Komikku-style pulldown, shown only where an
+                          // auto-scroll/advance engine is actually mounted so
+                          // the toggle is never a dead control.
+                          if (autoScrollSupported)
+                            ReaderUtilsBar(
+                              expanded: utilsBarExpanded,
+                              readerMode: resolvedReaderMode,
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_top_bar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_top_bar.dart
@@ -13,8 +13,6 @@ import '../../../../../../utils/misc/toast/toast.dart';
 import '../../../../../../utils/theme/brand.dart';
 import '../../../../domain/chapter/chapter_model.dart';
 import '../../../../domain/manga/manga_model.dart';
-import '../reader_mode/infinity_continuous/measure_size.dart';
-import 'chrome_extents.dart';
 import 'reader_bookmark_button.dart';
 
 /// The reader's top chrome bar — mirrors the content that was previously in
@@ -23,6 +21,11 @@ import 'reader_bookmark_button.dart';
 /// This is a plain [Material]+[Row] widget, NOT a [Scaffold.appBar], so it can
 /// live in the body [Stack] and be driven by a shared animation controller.
 /// Visual output is byte-identical to the old AppBar.
+///
+/// Height measurement ([MeasureSize] → `chromeExtentsNotifierProvider`) lives
+/// one level up in `ReaderChrome`, wrapping this bar together with
+/// [ReaderUtilsBar] — so the reported inset covers both, and the side
+/// seekbar clears the utils bar when it's expanded.
 class ReaderTopBar extends ConsumerWidget {
   const ReaderTopBar({
     super.key,
@@ -41,77 +44,55 @@ class ReaderTopBar extends ConsumerWidget {
     final view = View.of(context);
     final systemTopInset = view.viewPadding.top / view.devicePixelRatio;
 
-    // Wrap the bar in MeasureSize so its resting laid-out height is reported to
-    // chromeExtentsNotifierProvider.  MeasureSize already defers via
-    // addPostFrameCallback, so we are safely outside the build phase when
-    // the provider.update() call runs. The SlideTransition that animates this
-    // bar uses a Transform (no relayout), so MeasureSize always sees the
-    // resting height — never a mid-animation partial height.
-    return MeasureSize(
-      onChange: (size) {
-        final current = ref.read(chromeExtentsNotifierProvider);
-        // size.height is the full Material height: it already includes the
-        // status-bar padding baked in via Padding(top: systemTopInset) below.
-        // Adding systemTopInset again would double-count it, pushing the side
-        // seekbar ~44 dp too low on notch devices.  Mirror the bottom bar:
-        //   its onChange uses `bottomInset: size.height` for
-        //   the same reason — the nav-bar Padding is inside the measured subtree.
-        final next = ChromeExtents(
-          topInset: size.height,
-          bottomInset: current.bottomInset,
-        );
-        ref.read(chromeExtentsNotifierProvider.notifier).update(next);
-      },
-      child: Material(
-        // Shared chrome surface; the Material fills behind the status bar.
-        color: readerNavSurface(context.theme.colorScheme),
-        elevation: 0,
-        child: Padding(
-          padding: EdgeInsets.only(top: systemTopInset),
-          child: Row(
-            children: [
-              // Back button (mirrors AppBar's leading).
-              IconButton(
-                onPressed: onBack,
-                icon: const BackButtonIcon(),
+    return Material(
+      // Shared chrome surface; the Material fills behind the status bar.
+      color: readerNavSurface(context.theme.colorScheme),
+      elevation: 0,
+      child: Padding(
+        padding: EdgeInsets.only(top: systemTopInset),
+        child: Row(
+          children: [
+            // Back button (mirrors AppBar's leading).
+            IconButton(
+              onPressed: onBack,
+              icon: const BackButtonIcon(),
+            ),
+            // Title + subtitle (mirrors AppBar's title ListTile).
+            Expanded(
+              child: ListTile(
+                title: (manga.title).isNotBlank
+                    ? Text(
+                        manga.title,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : null,
+                subtitle: (chapter.name).isNotBlank
+                    ? Text(
+                        chapter.name,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    : null,
+                contentPadding: EdgeInsets.zero,
               ),
-              // Title + subtitle (mirrors AppBar's title ListTile).
-              Expanded(
-                child: ListTile(
-                  title: (manga.title).isNotBlank
-                      ? Text(
-                          manga.title,
-                          overflow: TextOverflow.ellipsis,
-                        )
-                      : null,
-                  subtitle: (chapter.name).isNotBlank
-                      ? Text(
-                          chapter.name,
-                          overflow: TextOverflow.ellipsis,
-                        )
-                      : null,
-                  contentPadding: EdgeInsets.zero,
-                ),
-              ),
-              // Actions (mirrors AppBar.actions).
-              ReaderBookmarkButton(
-                chapterId: chapter.id,
-                fallbackIsBookmarked: chapter.isBookmarked,
-              ),
-              chapter.realUrl.isBlank
-                  ? const SizedBox.shrink()
-                  : IconButton(
-                      onPressed: () async {
-                        launchUrlInWeb(
-                          context,
-                          (chapter.realUrl ?? ""),
-                          ref.read(toastProvider),
-                        );
-                      },
-                      icon: const Icon(Icons.public_rounded),
-                    ),
-            ],
-          ),
+            ),
+            // Actions (mirrors AppBar.actions).
+            ReaderBookmarkButton(
+              chapterId: chapter.id,
+              fallbackIsBookmarked: chapter.isBookmarked,
+            ),
+            chapter.realUrl.isBlank
+                ? const SizedBox.shrink()
+                : IconButton(
+                    onPressed: () async {
+                      launchUrlInWeb(
+                        context,
+                        (chapter.realUrl ?? ""),
+                        ref.read(toastProvider),
+                      );
+                    },
+                    icon: const Icon(Icons.public_rounded),
+                  ),
+          ],
         ),
       ),
     );

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_utils_bar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_utils_bar.dart
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../constants/enum.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/theme/brand.dart';
+import '../../../../../settings/presentation/reader/widgets/reader_webtoon_prefs/reader_webtoon_prefs.dart';
+import '../../controller/auto_scroll_controller.dart';
+
+/// Komikku-style collapsible utils bar (`ExhUtils.kt` parity): an always-visible
+/// centered pull-down chevron sits under [ReaderTopBar]; tapping it expands the
+/// on-screen auto-motion controls for touch users. Seeded without Komikku's
+/// Retry-All/Boost-Page grab-bag.
+///
+/// The one toggle adapts to the reading mode: in the vertical glide modes it's
+/// "Auto scroll" (with a smooth/jump option), in the page-flip modes it's
+/// "Auto advance" and turns a page per interval. Each keeps its own stored
+/// interval so a page-flip pace can differ from a scroll pace.
+class ReaderUtilsBar extends ConsumerWidget {
+  const ReaderUtilsBar({
+    super.key,
+    required this.expanded,
+    required this.readerMode,
+  });
+
+  /// Owned by [ReaderWrapper]; flipped by this bar's own chevron handle.
+  final ValueNotifier<bool> expanded;
+
+  /// Resolved reading mode, used to pick scroll-vs-advance wording, interval,
+  /// and whether the smooth/jump option is meaningful.
+  final ReaderMode readerMode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cs = context.theme.colorScheme;
+    final active = ref.watch(autoScrollActiveProvider);
+
+    // Vertical glide vs page-flip: same toggle, but different label, a
+    // different stored interval, and no smooth option when turning pages.
+    final isScrollMode = readerMode == ReaderMode.webtoon ||
+        readerMode == ReaderMode.continuousVertical;
+
+    final smooth = ref.watch(smoothAutoScrollProvider) ??
+        DBKeys.smoothAutoScroll.initial as bool;
+    final int interval;
+    if (isScrollMode) {
+      interval = ref.watch(autoScrollIntervalSecondsProvider) ??
+          DBKeys.autoScrollIntervalSeconds.initial as int;
+    } else {
+      interval = ref.watch(autoAdvanceIntervalSecondsProvider) ??
+          DBKeys.autoAdvanceIntervalSeconds.initial as int;
+    }
+
+    void setInterval(int value) {
+      final clamped = value.clamp(1, 30);
+      if (isScrollMode) {
+        ref.read(autoScrollIntervalSecondsProvider.notifier).update(clamped);
+      } else {
+        ref.read(autoAdvanceIntervalSecondsProvider.notifier).update(clamped);
+      }
+    }
+
+    final label = isScrollMode
+        ? context.l10n.autoScrollInterval
+        : context.l10n.autoAdvanceInterval;
+
+    return Material(
+      color: readerNavSurface(cs),
+      child: ValueListenableBuilder<bool>(
+        valueListenable: expanded,
+        builder: (context, isOpen, _) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Controls slide in above the handle.
+            AnimatedSize(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.fastOutSlowIn,
+              alignment: Alignment.topCenter,
+              child: !isOpen
+                  ? const SizedBox(width: double.infinity, height: 0)
+                  : Padding(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                      child: Row(
+                        children: [
+                          Switch(
+                            value: active,
+                            activeThumbColor: cs.primary,
+                            onChanged: (_) => ref
+                                .read(autoScrollActiveProvider.notifier)
+                                .toggle(),
+                          ),
+                          Expanded(
+                            child: Text(
+                              label,
+                              style: TextStyle(color: cs.onSurface),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          // Faster = shorter interval, so "-" lowers seconds.
+                          IconButton(
+                            icon: Icon(Icons.remove, color: cs.onSurface),
+                            onPressed: () => setInterval(interval - 1),
+                          ),
+                          Text(
+                            context.l10n.autoScrollSeconds(interval),
+                            style: TextStyle(color: cs.onSurface),
+                          ),
+                          IconButton(
+                            icon: Icon(Icons.add, color: cs.onSurface),
+                            onPressed: () => setInterval(interval + 1),
+                          ),
+                          // Smooth/jump only matters while gliding; page-flip
+                          // is always a discrete turn.
+                          if (isScrollMode) ...[
+                            const SizedBox(width: 8),
+                            Tooltip(
+                              message: context.l10n.smoothAutoScroll,
+                              child: Switch(
+                                value: smooth,
+                                activeThumbColor: cs.primary,
+                                thumbIcon: WidgetStateProperty.resolveWith(
+                                  (states) => Icon(
+                                    states.contains(WidgetState.selected)
+                                        ? Icons.waves_rounded
+                                        : Icons.arrow_downward_rounded,
+                                    size: 16,
+                                  ),
+                                ),
+                                onChanged: (value) => ref
+                                    .read(smoothAutoScrollProvider.notifier)
+                                    .update(value),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+            ),
+            // Always-visible centered pull-down handle (Komikku's chevron).
+            // Komikku lets the IconButton keep its natural size so the arrow
+            // gets even room above and below; a little bottom padding keeps it
+            // off the seekbar that sits just under this bar.
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: SizedBox(
+                height: 30,
+                child: IconButton(
+                  padding: EdgeInsets.zero,
+                  iconSize: 26,
+                  visualDensity: VisualDensity.compact,
+                  tooltip: label,
+                  onPressed: () => expanded.value = !expanded.value,
+                  icon: Icon(
+                    isOpen
+                        ? Icons.keyboard_arrow_up_rounded
+                        : Icons.keyboard_arrow_down_rounded,
+                    color: cs.onSurface,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/general_tab.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/general_tab.dart
@@ -15,6 +15,7 @@ import '../../../../../../settings/presentation/reader/widgets/reader_general_pr
 import '../../../../../../settings/presentation/reader/widgets/reader_keep_screen_on_tile/reader_keep_screen_on_tile.dart';
 import '../../../../../../settings/presentation/reader/widgets/reader_left_handed_seekbar_tile/reader_left_handed_seekbar_tile.dart';
 import '../../../controller/reader_settings_model.dart';
+import 'int_slider_tile.dart';
 
 /// General tab: background color,
 /// page number, seekbar chain, fullscreen, keep-screen-on, long-tap actions,
@@ -120,7 +121,7 @@ class GeneralTab extends ConsumerWidget {
           onChanged: model.setFlashOnPageChange,
         ),
         if (settings.flashOnPageChange) ...[
-          _IntSliderTile(
+          IntSliderTile(
             title: context.l10n.flashDuration,
             valueLabel: context.l10n.flashDurationMs(
               settings.flashDuration * kFlashMsPerTick,
@@ -130,9 +131,10 @@ class GeneralTab extends ConsumerWidget {
             max: 15,
             onChanged: model.setFlashDuration,
           ),
-          _IntSliderTile(
+          IntSliderTile(
             title: context.l10n.flashEvery,
-            valueLabel: context.l10n.flashEveryPages(settings.flashPageInterval),
+            valueLabel:
+                context.l10n.flashEveryPages(settings.flashPageInterval),
             value: settings.flashPageInterval,
             min: 1,
             max: 10,
@@ -159,47 +161,6 @@ class GeneralTab extends ConsumerWidget {
           onChanged: ref.read(autoWebtoonModeProvider.notifier).update,
         ),
       ],
-    );
-  }
-}
-
-/// Discrete int slider with a trailing value readout.
-class _IntSliderTile extends StatelessWidget {
-  const _IntSliderTile({
-    required this.title,
-    required this.valueLabel,
-    required this.value,
-    required this.min,
-    required this.max,
-    required this.onChanged,
-  });
-
-  final String title;
-  final String valueLabel;
-  final int value;
-  final int min;
-  final int max;
-  final ValueChanged<int> onChanged;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      title: Text(title),
-      subtitle: Row(
-        children: [
-          Expanded(
-            child: Slider(
-              value: value.toDouble(),
-              min: min.toDouble(),
-              max: max.toDouble(),
-              divisions: max - min,
-              label: valueLabel,
-              onChanged: (v) => onChanged(v.round()),
-            ),
-          ),
-          Text(valueLabel),
-        ],
-      ),
     );
   }
 }

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/int_slider_tile.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/int_slider_tile.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+/// Discrete int slider with a trailing value readout.
+class IntSliderTile extends StatelessWidget {
+  const IntSliderTile({
+    super.key,
+    required this.title,
+    required this.valueLabel,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String valueLabel;
+  final int value;
+  final int min;
+  final int max;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title),
+      subtitle: Row(
+        children: [
+          Expanded(
+            child: Slider(
+              value: value.toDouble(),
+              min: min.toDouble(),
+              max: max.toDouble(),
+              divisions: max - min,
+              label: valueLabel,
+              onChanged: (v) => onChanged(v.round()),
+            ),
+          ),
+          Text(valueLabel),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/reading_mode_tab.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/reading_mode_tab.dart
@@ -15,6 +15,7 @@ import '../../../../../../settings/presentation/reader/widgets/reader_navigation
 import '../../../../../../settings/presentation/reader/widgets/reader_padding_slider/reader_padding_slider.dart';
 import '../../../controller/reader_mode_adapter.dart';
 import '../../../controller/reader_settings_model.dart';
+import 'int_slider_tile.dart';
 
 /// Reading-mode tab: chip rows for the common settings,
 /// then a paged / long-strip section swapped on the resolved mode.
@@ -226,6 +227,15 @@ class _PagedSection extends ConsumerWidget {
               ),
           ],
         ),
+        IntSliderTile(
+          title: context.l10n.autoAdvanceInterval,
+          valueLabel: context.l10n
+              .autoScrollSeconds(settings.autoAdvanceIntervalSeconds),
+          value: settings.autoAdvanceIntervalSeconds,
+          min: 1,
+          max: 30,
+          onChanged: model.setAutoAdvanceIntervalSeconds,
+        ),
         SwitchListTile(
           controlAffinity: ListTileControlAffinity.trailing,
           title: Text(context.l10n.smallerTapZones),
@@ -354,8 +364,33 @@ class _LongStripSection extends ConsumerWidget {
           value: settings.cropBordersWebtoon,
           onChanged: model.setCropBordersWebtoon,
         ),
-        // smoothAutoScroll hidden: no auto-scroll driver exists yet (a webtoon
-        // auto-advance feature); see docs/architecture/reader.md.
+        SwitchListTile(
+          controlAffinity: ListTileControlAffinity.trailing,
+          title: Text(context.l10n.smoothAutoScroll),
+          value: settings.smoothAutoScroll,
+          onChanged: model.setSmoothAutoScroll,
+        ),
+        IntSliderTile(
+          title: context.l10n.autoScrollInterval,
+          valueLabel: context.l10n
+              .autoScrollSeconds(settings.autoScrollIntervalSeconds),
+          value: settings.autoScrollIntervalSeconds,
+          min: 1,
+          max: 30,
+          onChanged: model.setAutoScrollIntervalSeconds,
+        ),
+        _SectionLabel(context.l10n.scrollAmount),
+        _ChipRow(
+          children: [
+            for (final amount in ReaderScrollAmount.values)
+              FilterChip(
+                selected: settings.readerScrollAmount == amount,
+                showCheckmark: false,
+                label: Text(amount.toLocale(context)),
+                onSelected: (_) => model.setReaderScrollAmount(amount),
+              ),
+          ],
+        ),
         SwitchListTile(
           controlAffinity: ListTileControlAffinity.trailing,
           title: Text(context.l10n.animatePageTransitions),

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
@@ -14,6 +14,7 @@ import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
+import '../../../../../../constants/db_keys.dart';
 import '../../../../../../constants/enum.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../utils/misc/app_utils.dart';
@@ -33,8 +34,6 @@ import '../chapter_separator.dart';
 import '../reader_wrapper.dart';
 import 'infinity_continuous_reader_mode.dart';
 import 'reader_zoom_view.dart';
-
-const double _kViewportScrollFraction = 0.9; // ~one screen, small overlap
 
 class _ScrollConfig {
   const _ScrollConfig._();
@@ -189,6 +188,9 @@ class ContinuousReaderMode extends HookConsumerWidget {
         : context.width;
     // Auto-crop solid borders in the long-strip.
     final bool cropBorders = ref.watch(cropBordersWebtoonProvider).ifNull();
+    final ReaderScrollAmount scrollAmount =
+        ref.watch(readerScrollAmountKeyProvider) ??
+            DBKeys.readerScrollAmount.initial as ReaderScrollAmount;
     final wrapperReaderMode = effectiveReaderMode ??
         _continuousReaderMode(
           scrollDirection: scrollDirection,
@@ -203,7 +205,7 @@ class ContinuousReaderMode extends HookConsumerWidget {
         final double viewport = pos.viewportDimension;
         final double sign = (forward ? 1.0 : -1.0) * (reverse ? -1.0 : 1.0);
         scrollOffsetController.animateScroll(
-          offset: viewport * _kViewportScrollFraction * sign,
+          offset: viewport * scrollAmount.fraction * sign,
           duration: const Duration(milliseconds: 200),
           curve: Curves.easeOut,
         );

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -9,10 +9,12 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
+import '../../../../../../../constants/db_keys.dart';
 import '../../../../../../../constants/enum.dart';
 import '../../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../../utils/misc/app_utils.dart';
@@ -32,6 +34,7 @@ import '../../../../../domain/chapter/chapter_model.dart';
 import '../../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../../domain/manga/manga_model.dart';
 import '../../../../manga_details/controller/manga_details_controller.dart';
+import '../../../controller/auto_scroll_controller.dart';
 import '../../../controller/reader_controller.dart';
 import '../../../utils/flush_progress_on_lifecycle.dart';
 import '../../../utils/reader_initial_page.dart';
@@ -42,13 +45,24 @@ import 'infinity_continuous_feedback.dart';
 import 'infinity_continuous_utils.dart';
 import 'measure_size.dart';
 
+/// Pixels to advance this auto-scroll frame. [intervalSeconds] is the pace
+/// setting (seconds to glide one full viewport); [dtMs] is elapsed time since
+/// the previous tick.
+double autoScrollDelta({
+  required double viewport,
+  required int intervalSeconds,
+  required int dtMs,
+}) {
+  if (intervalSeconds <= 0) return 0;
+  final pxPerMs = viewport / (intervalSeconds * 1000);
+  return pxPerMs * dtMs;
+}
+
 typedef _LoadedChapter = ({
   ChapterPagesDto pages,
   ChapterDto chapter,
   int chapterId,
 });
-
-const double _kViewportScrollFraction = 0.9; // ~one screen, small overlap
 
 /// Multi-chapter webtoon reader built on ``ScrollablePositionedList``.
 ///
@@ -318,6 +332,21 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // below, which still reserves placeholderHeight and measures the cropped
     // strip — the scroll/height math is untouched.
     final bool cropBorders = ref.watch(cropBordersWebtoonProvider).ifNull();
+    final ReaderScrollAmount scrollAmount =
+        ref.watch(readerScrollAmountKeyProvider) ??
+            DBKeys.readerScrollAmount.initial as ReaderScrollAmount;
+
+    final bool autoScrollActive = ref.watch(autoScrollActiveProvider);
+    final bool smoothAutoScroll = ref.watch(smoothAutoScrollProvider) ??
+        DBKeys.smoothAutoScroll.initial as bool;
+    final int autoScrollIntervalSeconds =
+        ref.watch(autoScrollIntervalSecondsProvider) ??
+            DBKeys.autoScrollIntervalSeconds.initial as int;
+    // Set around every auto-scroll-driven jump so the manual-scroll listener
+    // (below) doesn't mistake the engine's own motion for the user grabbing
+    // the strip and stop itself.
+    final programmaticScroll = useRef<bool>(false);
+    final lastAutoScrollTick = useRef<Duration>(Duration.zero);
 
     // Decode a page's image off-screen AND record its true rendered height from
     // the decoded aspect ratio. Caching the height
@@ -699,7 +728,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // reverse:true flips the visual direction of the list.
         final double sign = (forward ? 1.0 : -1.0) * (reverse ? -1.0 : 1.0);
         scrollOffsetController.animateScroll(
-          offset: viewport * _kViewportScrollFraction * sign,
+          offset: viewport * scrollAmount.fraction * sign,
           duration: const Duration(milliseconds: 200),
           curve: Curves.easeOut,
         );
@@ -707,6 +736,106 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // Attached but not laid out yet (no ScrollPosition) — skip this press.
       }
     }
+
+    // --- auto-scroll engine -----------------------------------------------
+    //
+    // Smooth mode drives per-frame pixel deltas straight on the
+    // ScrollPosition; jump mode reuses handlePageNavigation on a periodic
+    // timer (Komikku's scrollDown() analog). Both stop themselves at the end
+    // of the last loaded chapter, and are stopped externally by the manual-
+    // scroll listener and the app-lifecycle listener below.
+
+    bool atLastLoadedPage() =>
+        hasReachedEnd.value &&
+        currentGlobalIndex() >=
+            InfinityContinuousUtils.getTotalPages(loadedChapters.value) - 1;
+
+    void onAutoScrollTick(Duration elapsed) {
+      if (!itemScrollController.isAttached) return;
+      final dtMs = (elapsed - lastAutoScrollTick.value).inMilliseconds;
+      lastAutoScrollTick.value = elapsed;
+      if (dtMs <= 0) return;
+      try {
+        final pos = scrollOffsetController.position;
+        final interval = ref.read(autoScrollIntervalSecondsProvider) ??
+            DBKeys.autoScrollIntervalSeconds.initial as int;
+        final delta = autoScrollDelta(
+          viewport: pos.viewportDimension,
+          intervalSeconds: interval,
+          dtMs: dtMs,
+        );
+        final target = pos.pixels + (reverse ? -delta : delta);
+        if (target >= pos.maxScrollExtent && hasReachedEnd.value) {
+          ref.read(autoScrollActiveProvider.notifier).stop();
+          return;
+        }
+        programmaticScroll.value = true;
+        pos.jumpTo(target.clamp(pos.minScrollExtent, pos.maxScrollExtent));
+        programmaticScroll.value = false;
+      } catch (_) {
+        // Attached but not laid out yet (no ScrollPosition) — skip this tick.
+      }
+    }
+
+    // useSingleTickerProvider's TickerProvider only permits ONE createTicker
+    // call per hook instance (a second call asserts) — so the Ticker itself
+    // is built exactly once via useMemoized and then just started/stopped as
+    // the active/smooth state changes, never recreated.
+    final autoScrollTickerProvider = useSingleTickerProvider();
+    final autoScrollTicker = useMemoized(
+      () => autoScrollTickerProvider.createTicker(onAutoScrollTick),
+      const [],
+    );
+
+    useEffect(() {
+      if (autoScrollActive && smoothAutoScroll) {
+        lastAutoScrollTick.value = Duration.zero;
+        if (!autoScrollTicker.isActive) autoScrollTicker.start();
+      } else if (autoScrollTicker.isActive) {
+        autoScrollTicker.stop();
+      }
+      return null;
+    }, [autoScrollActive, smoothAutoScroll]);
+
+    // Jump mode (smoothAutoScroll off): periodic page-advance instead of a
+    // per-frame glide.
+    useEffect(() {
+      Timer? timer;
+      if (autoScrollActive && !smoothAutoScroll) {
+        timer = Timer.periodic(
+          Duration(seconds: autoScrollIntervalSeconds),
+          (_) {
+            if (atLastLoadedPage()) {
+              ref.read(autoScrollActiveProvider.notifier).stop();
+              return;
+            }
+            programmaticScroll.value = true;
+            handlePageNavigation(isNext: true);
+            programmaticScroll.value = false;
+          },
+        );
+      }
+      return () => timer?.cancel();
+    }, [autoScrollActive, smoothAutoScroll, autoScrollIntervalSeconds]);
+
+    // The ticker outlives both effects above (it's created once); stop and
+    // dispose it only on the widget's own teardown.
+    useEffect(() {
+      return () {
+        if (autoScrollTicker.isActive) autoScrollTicker.stop();
+        autoScrollTicker.dispose();
+      };
+    }, const []);
+
+    // Backgrounding the app mid-glide would otherwise leave auto-scroll
+    // running (and writing progress) while the user isn't looking.
+    useEffect(() {
+      final listener = AppLifecycleListener(
+        onHide: () => ref.read(autoScrollActiveProvider.notifier).stop(),
+        onPause: () => ref.read(autoScrollActiveProvider.notifier).stop(),
+      );
+      return listener.dispose;
+    }, const []);
 
     // --- build -----------------------------------------------------------
 
@@ -820,6 +949,20 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       separatorBuilder: buildSeparator,
     );
 
+    // A real user drag/fling stops auto-scroll immediately; the engine's own
+    // jumps are excluded via the programmaticScroll guard set around them.
+    final autoScrollAwareList = NotificationListener<UserScrollNotification>(
+      onNotification: (notification) {
+        if (!programmaticScroll.value &&
+            notification.direction != ScrollDirection.idle &&
+            ref.read(autoScrollActiveProvider)) {
+          ref.read(autoScrollActiveProvider.notifier).stop();
+        }
+        return false;
+      },
+      child: positionedList,
+    );
+
     final child = AppUtils.wrapOn(
       !kIsWeb &&
               (Platform.isAndroid || Platform.isIOS) &&
@@ -835,7 +978,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
                 child: child,
               )
           : null,
-      positionedList,
+      autoScrollAwareList,
     );
 
     return ReaderWrapper(
@@ -852,6 +995,22 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       onNext: () => handlePageNavigation(isNext: true),
       onViewportScrollForward: () => handleViewportScroll(forward: true),
       onViewportScrollBackward: () => handleViewportScroll(forward: false),
+      onToggleAutoScroll: () =>
+          ref.read(autoScrollActiveProvider.notifier).toggle(),
+      onAutoScrollFaster: () {
+        final cur = ref.read(autoScrollIntervalSecondsProvider) ??
+            DBKeys.autoScrollIntervalSeconds.initial as int;
+        ref
+            .read(autoScrollIntervalSecondsProvider.notifier)
+            .update((cur - 1).clamp(1, 30));
+      },
+      onAutoScrollSlower: () {
+        final cur = ref.read(autoScrollIntervalSecondsProvider) ??
+            DBKeys.autoScrollIntervalSeconds.initial as int;
+        ref
+            .read(autoScrollIntervalSecondsProvider.notifier)
+            .update((cur + 1).clamp(1, 30));
+      },
       child: child,
     );
   }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous_reader_mode.dart
@@ -12,6 +12,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
+import '../../../../../../constants/db_keys.dart';
 import '../../../../../../constants/enum.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../utils/misc/app_utils.dart';
@@ -32,8 +33,6 @@ import 'infinity_continuous/infinity_continuous_navigation.dart';
 import 'infinity_continuous/infinity_continuous_utils.dart';
 import 'infinity_continuous/multichapter_continuous_reader_mode.dart';
 import 'reader_zoom_view.dart';
-
-const double _kViewportScrollFraction = 0.9; // ~one screen, small overlap
 
 /// Continuous reader mode entry point.
 ///
@@ -152,6 +151,9 @@ class InfinityContinuousReaderMode extends HookConsumerWidget {
         ref.watch(doubleTapToZoomProvider).ifNull(true);
     final bool isZoomOutDisabled = ref.watch(disableZoomOutProvider).ifNull();
     final bool cropBorders = ref.watch(cropBordersWebtoonProvider).ifNull();
+    final ReaderScrollAmount scrollAmount =
+        ref.watch(readerScrollAmountKeyProvider) ??
+            DBKeys.readerScrollAmount.initial as ReaderScrollAmount;
 
     void handleViewportScroll({required bool forward}) {
       if (!scrollController.isAttached) return;
@@ -160,7 +162,7 @@ class InfinityContinuousReaderMode extends HookConsumerWidget {
         final double viewport = pos.viewportDimension;
         final double sign = (forward ? 1.0 : -1.0) * (reverse ? -1.0 : 1.0);
         scrollOffsetController.animateScroll(
-          offset: viewport * _kViewportScrollFraction * sign,
+          offset: viewport * scrollAmount.fraction * sign,
           duration: const Duration(milliseconds: 200),
           curve: Curves.easeOut,
         );

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../../../constants/db_keys.dart';
 import '../../../../../../constants/enum.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../history/presentation/history_controller.dart';
@@ -17,12 +18,14 @@ import '../../../../../offline/data/offline_download_providers.dart';
 import '../../../../../offline/data/offline_repository.dart';
 import '../../../../../settings/presentation/incognito/incognito_mode.dart';
 import '../../../../../settings/presentation/reader/widgets/reader_feedback_toasts_tile/reader_feedback_toasts_tile.dart';
+import '../../../../../settings/presentation/reader/widgets/reader_webtoon_prefs/reader_webtoon_prefs.dart';
 import '../../../../../tracking/domain/track_progress_gate.dart';
 import '../../../../data/manga_book/manga_book_repository.dart';
 import '../../../../domain/chapter/chapter_model.dart';
 import '../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../domain/manga/manga_model.dart';
 import '../../../manga_details/controller/manga_details_controller.dart';
+import '../../controller/auto_scroll_controller.dart';
 import '../../controller/reader_controller.dart';
 import '../../controller/reader_settings_model.dart';
 import '../../utils/reader_initial_page.dart';
@@ -96,6 +99,39 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
 
     final controller = useMemoized(() => PagedReaderController());
     final settings = ref.watch(readerEffectiveSettingsProvider(manga.id));
+
+    // Komikku parity (ExhUtils / ReaderActivity autoscroll loop): in paged
+    // modes the shared auto-scroll toggle turns one page per interval
+    // (moveToNext), with no smooth glide — that's webtoon-only. It reads its
+    // own "auto advance" interval, which defaults slower than webtoon scroll,
+    // and stops once the last page is reached.
+    final autoAdvanceActive = ref.watch(autoScrollActiveProvider);
+    final autoAdvanceInterval = ref.watch(autoAdvanceIntervalSecondsProvider) ??
+        DBKeys.autoAdvanceIntervalSeconds.initial as int;
+    useEffect(() {
+      if (!autoAdvanceActive) return null;
+      final timer = Timer.periodic(
+        Duration(seconds: autoAdvanceInterval),
+        (_) {
+          if (controller.isAtLast) {
+            ref.read(autoScrollActiveProvider.notifier).stop();
+            return;
+          }
+          controller.next();
+        },
+      );
+      return timer.cancel;
+    }, [autoAdvanceActive, autoAdvanceInterval]);
+
+    // Backgrounding the app would otherwise keep turning pages (and writing
+    // progress) while the user isn't looking — mirror the continuous engine.
+    useEffect(() {
+      final listener = AppLifecycleListener(
+        onHide: () => ref.read(autoScrollActiveProvider.notifier).stop(),
+        onPause: () => ref.read(autoScrollActiveProvider.notifier).stop(),
+      );
+      return listener.dispose;
+    }, const []);
 
     final isHorizontal = scrollDirection == Axis.horizontal;
     final isLandscape = context.width > context.height;
@@ -544,6 +580,25 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       showReaderLayoutAnimation: showReaderLayoutAnimation,
       onPrevious: controller.previous,
       onNext: controller.next,
+      // Same auto-motion toggle as webtoon, but here it drives auto-advance;
+      // in vertical paged this makes Space toggle it, in horizontal the utils
+      // bar switch does. Speed keys tune the separate auto-advance interval.
+      onToggleAutoScroll: () =>
+          ref.read(autoScrollActiveProvider.notifier).toggle(),
+      onAutoScrollFaster: () {
+        final cur = ref.read(autoAdvanceIntervalSecondsProvider) ??
+            DBKeys.autoAdvanceIntervalSeconds.initial as int;
+        ref
+            .read(autoAdvanceIntervalSecondsProvider.notifier)
+            .update((cur - 1).clamp(1, 30));
+      },
+      onAutoScrollSlower: () {
+        final cur = ref.read(autoAdvanceIntervalSecondsProvider) ??
+            DBKeys.autoAdvanceIntervalSeconds.initial as int;
+        ref
+            .read(autoAdvanceIntervalSecondsProvider.notifier)
+            .update((cur + 1).clamp(1, 30));
+      },
       childHandlesGestures: true,
       handlesOwnChapterNavigation: true,
       isAtFirstBoundary: () => controller.isAtFirst,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -132,6 +132,9 @@ class ReaderWrapper extends HookConsumerWidget {
     required this.onPrevious,
     this.onViewportScrollForward,
     this.onViewportScrollBackward,
+    this.onToggleAutoScroll,
+    this.onAutoScrollFaster,
+    this.onAutoScrollSlower,
     required this.scrollDirection,
     this.showReaderLayoutAnimation = false,
     required this.chapterPages,
@@ -152,6 +155,9 @@ class ReaderWrapper extends HookConsumerWidget {
   final VoidCallback onNext;
   final VoidCallback? onViewportScrollForward;
   final VoidCallback? onViewportScrollBackward;
+  final VoidCallback? onToggleAutoScroll;
+  final VoidCallback? onAutoScrollFaster;
+  final VoidCallback? onAutoScrollSlower;
   final int currentIndex;
   final Axis scrollDirection;
   final bool showReaderLayoutAnimation;
@@ -253,6 +259,9 @@ class ReaderWrapper extends HookConsumerWidget {
     final visibility = useState(
       sessionVisibility ?? ref.read(readerInitialOverlayProvider).ifNull(),
     );
+    // Komikku-style utils bar (auto-scroll control): starts collapsed each
+    // reader open, unlike chrome visibility which persists across chapters.
+    final utilsBarExpanded = useState(false);
     final mangaReaderPadding =
         useState(manga.metaData.readerPadding ?? localMangaReaderPadding);
     final mangaReaderMagnifierSize = useState(
@@ -536,7 +545,8 @@ class ReaderWrapper extends HookConsumerWidget {
             Positioned.fill(
               child: Shortcuts.manager(
                 manager: readerShortcutManager(scrollDirection,
-                    isRtl: _isRTLReaderMode(resolvedReaderMode)),
+                    isRtl: _isRTLReaderMode(resolvedReaderMode),
+                    autoScrollSupported: onToggleAutoScroll != null),
                 child: Actions(
                   actions: {
                     PreviousScrollIntent: CallbackAction<PreviousScrollIntent>(
@@ -580,6 +590,29 @@ class ReaderWrapper extends HookConsumerWidget {
                         CallbackAction<ViewportScrollBackwardIntent>(
                       onInvoke: (intent) {
                         (onViewportScrollBackward ?? onReaderPrevious)();
+                        return null;
+                      },
+                    ),
+                    // Nullable callbacks: any non-continuous vertical mode
+                    // that doesn't supply these is a safe no-op.
+                    AutoScrollToggleIntent:
+                        CallbackAction<AutoScrollToggleIntent>(
+                      onInvoke: (intent) {
+                        onToggleAutoScroll?.call();
+                        return null;
+                      },
+                    ),
+                    AutoScrollFasterIntent:
+                        CallbackAction<AutoScrollFasterIntent>(
+                      onInvoke: (intent) {
+                        onAutoScrollFaster?.call();
+                        return null;
+                      },
+                    ),
+                    AutoScrollSlowerIntent:
+                        CallbackAction<AutoScrollSlowerIntent>(
+                      onInvoke: (intent) {
+                        onAutoScrollSlower?.call();
                         return null;
                       },
                     ),
@@ -648,11 +681,13 @@ class ReaderWrapper extends HookConsumerWidget {
                 currentIndex: currentIndex,
                 totalPageCount: totalPageCount,
                 visibility: visibility,
+                utilsBarExpanded: utilsBarExpanded,
                 useBottomSeekBar: useBottomSeekBar,
                 showSideSeekBar: showSideSeekBar,
                 scrollDirection: scrollDirection,
                 nextPrevChapterPair: nextPrevChapterPair,
                 resolvedReaderMode: resolvedReaderMode,
+                autoScrollSupported: onToggleAutoScroll != null,
                 reverseSeekBar: _isRTLReaderMode(resolvedReaderMode),
                 onChanged: onChanged,
                 onOpenSettings: () async {

--- a/lib/src/features/settings/presentation/reader/widgets/reader_webtoon_prefs/reader_webtoon_prefs.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_webtoon_prefs/reader_webtoon_prefs.dart
@@ -46,6 +46,30 @@ class SmoothAutoScroll extends _$SmoothAutoScroll
   bool? build() => initialize(DBKeys.smoothAutoScroll);
 }
 
+@riverpod
+class ReaderScrollAmountKey extends _$ReaderScrollAmountKey
+    with SharedPreferenceEnumClientMixin<ReaderScrollAmount> {
+  @override
+  ReaderScrollAmount? build() => initialize(
+        DBKeys.readerScrollAmount,
+        enumList: ReaderScrollAmount.values,
+      );
+}
+
+@riverpod
+class AutoScrollIntervalSeconds extends _$AutoScrollIntervalSeconds
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.autoScrollIntervalSeconds);
+}
+
+@riverpod
+class AutoAdvanceIntervalSeconds extends _$AutoAdvanceIntervalSeconds
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.autoAdvanceIntervalSeconds);
+}
+
 // Webtoon wide-page split (+invert): persists for a later engine PR — the
 // frozen webtoon engine can't remap 1 page → 2 entries yet.
 

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1456,6 +1456,30 @@
     },
     "smallerTapZones": "Smaller tap zones",
     "smoothAutoScroll": "Smooth Auto Scroll",
+    "scrollAmount": "Keyboard scroll distance",
+    "@scrollAmount": {
+        "description": "Keyboard scroll step, fraction of the screen"
+    },
+    "scrollAmountTiny": "Tiny",
+    "scrollAmountSmall": "Small",
+    "scrollAmountMedium": "Medium",
+    "scrollAmountLarge": "Large",
+    "autoScrollInterval": "Auto scroll interval",
+    "@autoScrollInterval": {
+        "description": "Long-strip auto-scroll: seconds per advance"
+    },
+    "autoAdvanceInterval": "Auto advance interval",
+    "@autoAdvanceInterval": {
+        "description": "Paged reader auto-advance: seconds per page turn"
+    },
+    "autoScrollSeconds": "{count, plural, =1{1 second} other{{count} seconds}}",
+    "@autoScrollSeconds": {
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
     "tabs": "Tabs",
     "@tabs": {
         "description": "Library Display sheet section heading for tab-related toggles"

--- a/test/src/constants/reader_keyboard_shortcuts_test.dart
+++ b/test/src/constants/reader_keyboard_shortcuts_test.dart
@@ -35,6 +35,38 @@ void main() {
         isA<NextChapterIntent>());
   });
 
+  test('vertical mode with auto-scroll support maps space to toggle and +/-',
+      () {
+    final m = readerShortcutManager(Axis.vertical, autoScrollSupported: true);
+    expect(m.shortcuts[const SingleActivator(LogicalKeyboardKey.space)],
+        isA<AutoScrollToggleIntent>());
+    expect(m.shortcuts[const SingleActivator(LogicalKeyboardKey.equal)],
+        isA<AutoScrollFasterIntent>());
+    expect(m.shortcuts[const SingleActivator(LogicalKeyboardKey.minus)],
+        isA<AutoScrollSlowerIntent>());
+  });
+
+  test('vertical mode WITHOUT auto-scroll support keeps space as page-advance',
+      () {
+    // The engine isn't mounted (e.g. continuous-vertical), so space must stay
+    // page navigation instead of going dead.
+    final m = readerShortcutManager(Axis.vertical);
+    expect(m.shortcuts[const SingleActivator(LogicalKeyboardKey.space)],
+        isA<NextScrollIntent>());
+    expect(
+        m.shortcuts[const SingleActivator(LogicalKeyboardKey.space,
+            shift: true)],
+        isA<PreviousScrollIntent>());
+    expect(m.shortcuts[const SingleActivator(LogicalKeyboardKey.equal)],
+        isNull);
+  });
+
+  test('horizontal (paged) mode keeps space as next-page', () {
+    final m = readerShortcutManager(Axis.horizontal);
+    expect(m.shortcuts[const SingleActivator(LogicalKeyboardKey.space)],
+        isA<NextScrollIntent>());
+  });
+
   test('RTL flips left/right: left advances, right goes back', () {
     final m = readerShortcutManager(Axis.horizontal, isRtl: true);
     expect(m.shortcuts[const SingleActivator(LogicalKeyboardKey.arrowLeft)],

--- a/test/src/constants/reader_scroll_amount_test.dart
+++ b/test/src/constants/reader_scroll_amount_test.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+
+void main() {
+  test('ReaderScrollAmount fractions match the manual-scroll step spec', () {
+    expect(ReaderScrollAmount.tiny.fraction, 0.10);
+    expect(ReaderScrollAmount.small.fraction, 0.25);
+    expect(ReaderScrollAmount.medium.fraction, 0.75);
+    expect(ReaderScrollAmount.large.fraction, 0.95);
+  });
+}

--- a/test/src/features/manga_book/reader/auto_scroll_controller_test.dart
+++ b/test/src/features/manga_book/reader/auto_scroll_controller_test.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/auto_scroll_controller.dart';
+
+void main() {
+  group('AutoScrollActive', () {
+    test('defaults to off', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(autoScrollActiveProvider), isFalse);
+    });
+
+    test('start() turns it on', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.read(autoScrollActiveProvider.notifier).start();
+      expect(container.read(autoScrollActiveProvider), isTrue);
+    });
+
+    test('stop() turns it off again', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(autoScrollActiveProvider.notifier);
+      notifier.start();
+      notifier.stop();
+      expect(container.read(autoScrollActiveProvider), isFalse);
+    });
+
+    test('toggle() flips the state each call', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(autoScrollActiveProvider.notifier);
+      notifier.toggle();
+      expect(container.read(autoScrollActiveProvider), isTrue);
+      notifier.toggle();
+      expect(container.read(autoScrollActiveProvider), isFalse);
+    });
+  });
+}

--- a/test/src/features/manga_book/reader/auto_scroll_delta_test.dart
+++ b/test/src/features/manga_book/reader/auto_scroll_delta_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart';
+
+void main() {
+  group('autoScrollDelta', () {
+    test('advances one viewport over the interval', () {
+      final d = autoScrollDelta(viewport: 1000, intervalSeconds: 5, dtMs: 5000);
+      expect(d, closeTo(1000, 0.001));
+    });
+
+    test('scales linearly with elapsed frame time', () {
+      final full =
+          autoScrollDelta(viewport: 1000, intervalSeconds: 5, dtMs: 5000);
+      final quarter =
+          autoScrollDelta(viewport: 1000, intervalSeconds: 5, dtMs: 1250);
+      expect(quarter, closeTo(full / 4, 0.001));
+    });
+
+    test('a shorter interval means a bigger per-frame delta', () {
+      final slow =
+          autoScrollDelta(viewport: 1000, intervalSeconds: 10, dtMs: 16);
+      final fast =
+          autoScrollDelta(viewport: 1000, intervalSeconds: 5, dtMs: 16);
+      expect(fast, greaterThan(slow));
+    });
+
+    test('zero or negative interval means no motion', () {
+      expect(
+        autoScrollDelta(viewport: 1000, intervalSeconds: 0, dtMs: 16),
+        0,
+      );
+      expect(
+        autoScrollDelta(viewport: 1000, intervalSeconds: -1, dtMs: 16),
+        0,
+      );
+    });
+
+    test('zero elapsed time means no motion', () {
+      expect(
+        autoScrollDelta(viewport: 1000, intervalSeconds: 5, dtMs: 0),
+        0,
+      );
+    });
+  });
+}

--- a/test/src/features/manga_book/reader/page_number_indicator_test.dart
+++ b/test/src/features/manga_book/reader/page_number_indicator_test.dart
@@ -80,6 +80,8 @@ Future<void> _pumpChrome(
   final prefs = await SharedPreferences.getInstance();
   final visibility = ValueNotifier(visible);
   addTearDown(visibility.dispose);
+  final utilsBarExpanded = ValueNotifier(false);
+  addTearDown(utilsBarExpanded.dispose);
 
   await tester.pumpWidget(
     ProviderScope(
@@ -101,6 +103,7 @@ Future<void> _pumpChrome(
             currentIndex: currentIndex,
             totalPageCount: null,
             visibility: visibility,
+            utilsBarExpanded: utilsBarExpanded,
             useBottomSeekBar: true,
             showSideSeekBar: false,
             scrollDirection: Axis.horizontal,
@@ -108,6 +111,7 @@ Future<void> _pumpChrome(
             resolvedReaderMode: reverseSeekBar
                 ? ReaderMode.singleHorizontalRTL
                 : ReaderMode.singleHorizontalLTR,
+            autoScrollSupported: false,
             reverseSeekBar: reverseSeekBar,
             onChanged: (_) {},
             onOpenSettings: () {},

--- a/test/src/features/manga_book/reader/reader_color_overlays_test.dart
+++ b/test/src/features/manga_book/reader/reader_color_overlays_test.dart
@@ -301,6 +301,8 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final visibility = ValueNotifier(true);
       addTearDown(visibility.dispose);
+      final utilsBarExpanded = ValueNotifier(false);
+      addTearDown(utilsBarExpanded.dispose);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -322,11 +324,13 @@ void main() {
                 currentIndex: 0,
                 totalPageCount: null,
                 visibility: visibility,
+                utilsBarExpanded: utilsBarExpanded,
                 useBottomSeekBar: true,
                 showSideSeekBar: false,
                 scrollDirection: Axis.horizontal,
                 nextPrevChapterPair: null,
                 resolvedReaderMode: ReaderMode.singleHorizontalLTR,
+                autoScrollSupported: false,
                 reverseSeekBar: false,
                 onChanged: (_) {},
                 onOpenSettings: () {},

--- a/test/src/features/manga_book/reader/reader_settings_model_test.dart
+++ b/test/src/features/manga_book/reader/reader_settings_model_test.dart
@@ -228,6 +228,16 @@ void main() {
       expect(state.disableZoomIn, false);
     });
 
+    test('scroll amount and auto-scroll interval seed from DBKeys defaults',
+        () async {
+      final container = await _container(_manga());
+
+      final state = await _resolvedState(container);
+      expect(state.readerScrollAmount, ReaderScrollAmount.large);
+      expect(state.autoScrollIntervalSeconds, 3);
+      expect(state.autoAdvanceIntervalSeconds, 5);
+    });
+
     test('zoom toggles resolve the live global providers', () async {
       final container = await _container(_manga());
       container.read(pinchToZoomProvider.notifier).update(false);

--- a/test/src/features/manga_book/reader/reader_utils_bar_test.dart
+++ b/test/src/features/manga_book/reader/reader_utils_bar_test.dart
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Komikku-style collapsible utils bar: collapsed renders nothing tappable;
+// expanded surfaces the auto-scroll toggle + interval stepper and writes
+// through to the shared providers.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/auto_scroll_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/chrome/reader_utils_bar.dart';
+import 'package:tsumiru/src/features/settings/presentation/reader/widgets/reader_webtoon_prefs/reader_webtoon_prefs.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+Future<ProviderContainer> _pumpBar(
+  WidgetTester tester,
+  ValueNotifier<bool> expanded, {
+  ReaderMode readerMode = ReaderMode.webtoon,
+}) async {
+  SharedPreferences.setMockInitialValues(const {});
+  final prefs = await SharedPreferences.getInstance();
+  late ProviderContainer container;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      child: Builder(
+        builder: (context) {
+          container = ProviderScope.containerOf(context);
+          return MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: ReaderUtilsBar(
+                expanded: expanded,
+                readerMode: readerMode,
+              ),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+void main() {
+  testWidgets('collapsed renders no controls', (tester) async {
+    final expanded = ValueNotifier(false);
+    addTearDown(expanded.dispose);
+    await _pumpBar(tester, expanded);
+
+    expect(find.byType(Switch), findsNothing);
+  });
+
+  testWidgets('expanded shows the auto-scroll switch and toggles it',
+      (tester) async {
+    final expanded = ValueNotifier(true);
+    addTearDown(expanded.dispose);
+    final container = await _pumpBar(tester, expanded);
+
+    expect(container.read(autoScrollActiveProvider), false);
+    // Auto-scroll switch is the first of the two switches (auto-scroll, smooth).
+    await tester.tap(find.byType(Switch).first);
+    await tester.pumpAndSettle();
+
+    expect(container.read(autoScrollActiveProvider), true);
+  });
+
+  testWidgets('interval stepper clamps to 1..30', (tester) async {
+    final expanded = ValueNotifier(true);
+    addTearDown(expanded.dispose);
+    final container = await _pumpBar(tester, expanded);
+
+    // Default is 3 (DBKeys.autoScrollIntervalSeconds initial).
+    expect(container.read(autoScrollIntervalSecondsProvider), 3);
+
+    await tester.tap(find.byIcon(Icons.remove));
+    await tester.pumpAndSettle();
+    // 3 (fallback) - 1 = 2.
+    expect(container.read(autoScrollIntervalSecondsProvider), 2);
+
+    for (var i = 0; i < 10; i++) {
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+    }
+    expect(container.read(autoScrollIntervalSecondsProvider), 12);
+  });
+
+  testWidgets(
+      'paged mode surfaces Auto advance: its own interval, no smooth switch',
+      (tester) async {
+    final expanded = ValueNotifier(true);
+    addTearDown(expanded.dispose);
+    final container = await _pumpBar(
+      tester,
+      expanded,
+      readerMode: ReaderMode.continuousHorizontalLTR,
+    );
+
+    // "Auto advance interval" label, not "Auto scroll interval".
+    expect(find.text('Auto advance interval'), findsOneWidget);
+    expect(find.text('Auto scroll interval'), findsNothing);
+
+    // Smooth/jump is meaningless when turning pages, so only the toggle switch
+    // is present.
+    expect(find.byType(Switch), findsOneWidget);
+
+    // The stepper drives the separate auto-advance interval (default 5).
+    expect(container.read(autoAdvanceIntervalSecondsProvider), 5);
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+    expect(container.read(autoAdvanceIntervalSecondsProvider), 6);
+    // The webtoon scroll interval is untouched at its own default.
+    expect(container.read(autoScrollIntervalSecondsProvider), 3);
+  });
+}

--- a/test/src/features/manga_book/reader/reading_mode_tab_test.dart
+++ b/test/src/features/manga_book/reader/reading_mode_tab_test.dart
@@ -12,12 +12,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
 import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
 import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
 import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/chrome/tabs/reading_mode_tab.dart';
 import 'package:tsumiru/src/features/settings/presentation/reader/widgets/reader_paged_prefs/reader_paged_prefs.dart';
+import 'package:tsumiru/src/features/settings/presentation/reader/widgets/reader_webtoon_prefs/reader_webtoon_prefs.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
 import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
 import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
@@ -237,6 +239,51 @@ void main() {
     expect(find.text('Crop borders'), findsOneWidget);
   });
 
+  testWidgets(
+      'long strip auto-scroll tiles: toggle, interval slider, and scroll '
+      'amount chips all write their providers', (tester) async {
+    await pumpTab(tester, meta: {'flutter_readerMode': 'webtoon'});
+
+    await tester.scrollUntilVisible(
+      find.text('Smooth Auto Scroll'),
+      200,
+      scrollable: tabScrollable(),
+    );
+    expect(find.text('Smooth Auto Scroll'), findsOneWidget);
+    // Defaults ON (DBKeys.smoothAutoScroll(true)), so a tap flips it OFF.
+    await tester.tap(find.text('Smooth Auto Scroll'));
+    await tester.pumpAndSettle();
+    expect(container(tester).read(smoothAutoScrollProvider), isFalse);
+
+    await tester.scrollUntilVisible(
+      find.text('Auto scroll interval'),
+      200,
+      scrollable: tabScrollable(),
+    );
+    expect(find.text('Auto scroll interval'), findsOneWidget);
+    final slider = find.descendant(
+      of: find.widgetWithText(ListTile, 'Auto scroll interval'),
+      matching: find.byType(Slider),
+    );
+    tester.widget<Slider>(slider).onChanged!(20);
+    await tester.pumpAndSettle();
+    expect(container(tester).read(autoScrollIntervalSecondsProvider), 20);
+
+    await tester.scrollUntilVisible(
+      find.text('Keyboard scroll distance'),
+      200,
+      scrollable: tabScrollable(),
+    );
+    expect(find.text('Keyboard scroll distance'), findsOneWidget);
+    expect(find.widgetWithText(FilterChip, 'Large'), findsOneWidget);
+    await tester.tap(find.widgetWithText(FilterChip, 'Tiny'));
+    await tester.pumpAndSettle();
+    expect(
+      container(tester).read(readerScrollAmountKeyProvider),
+      ReaderScrollAmount.tiny,
+    );
+  });
+
   testWidgets('long strip with gaps adds the gaps-scoped crop borders',
       (tester) async {
     await pumpTab(tester, meta: {'flutter_readerMode': 'continuousVertical'});
@@ -354,6 +401,8 @@ void main() {
       200,
       scrollable: tabScrollable(),
     );
+    await tester.ensureVisible(find.text('Dual page spread in landscape'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Dual page spread in landscape'));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## What

Hands-free reading for long manga:

- **Webtoon / vertical-continuous** get **auto-scroll** — a smooth per-frame glide, or a page-at-a-time jump.
- **Paged modes** (left/right and single-page) get **auto-advance** — one page turned on a timer.

Both share one toggle (space bar, or the pull-down bar's switch) but keep **separate stored intervals**, since a comfortable page-turn pace (5s/page) is slower than a scroll pace (3s/screen). Speed is adjustable live with the on-screen stepper or the `+`/`-` keys.

## UX

- The pull-down bar mirrors Komikku's chevron affordance and adapts its label ("Auto scroll" vs "Auto advance") and controls to the current mode.
- It only appears where an engine is actually mounted, so the toggle is never a dead control, and the space bar falls back to page navigation wherever auto-scroll isn't available.
- Arrow-key scroll distance is now a setting.
- Auto-motion stops when the app is backgrounded, so it never scrolls or turns pages unwatched.

## Notes

- New settings persist by key name (no ordinal coupling); no non-reader code paths are touched.
- 243 reader/constants tests, incl. coverage for the mode-adaptive bar and the keyboard fallback.