### PR TITLE
Simplify the reader auto-scroll bar

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_utils_bar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_utils_bar.dart
@@ -42,13 +42,12 @@ class ReaderUtilsBar extends ConsumerWidget {
     final cs = context.theme.colorScheme;
     final active = ref.watch(autoScrollActiveProvider);
 
-    // Vertical glide vs page-flip: same toggle, but different label, a
-    // different stored interval, and no smooth option when turning pages.
+    // Vertical glide vs page-flip: same toggle, different label and a different
+    // stored interval. Smooth-vs-jump is a set-once preference and lives in
+    // reader settings only, never here.
     final isScrollMode = readerMode == ReaderMode.webtoon ||
         readerMode == ReaderMode.continuousVertical;
 
-    final smooth = ref.watch(smoothAutoScrollProvider) ??
-        DBKeys.smoothAutoScroll.initial as bool;
     final int interval;
     if (isScrollMode) {
       interval = ref.watch(autoScrollIntervalSecondsProvider) ??
@@ -68,8 +67,8 @@ class ReaderUtilsBar extends ConsumerWidget {
     }
 
     final label = isScrollMode
-        ? context.l10n.autoScrollInterval
-        : context.l10n.autoAdvanceInterval;
+        ? context.l10n.autoScroll
+        : context.l10n.autoAdvance;
 
     return Material(
       color: readerNavSurface(cs),
@@ -117,29 +116,6 @@ class ReaderUtilsBar extends ConsumerWidget {
                             icon: Icon(Icons.add, color: cs.onSurface),
                             onPressed: () => setInterval(interval + 1),
                           ),
-                          // Smooth/jump only matters while gliding; page-flip
-                          // is always a discrete turn.
-                          if (isScrollMode) ...[
-                            const SizedBox(width: 8),
-                            Tooltip(
-                              message: context.l10n.smoothAutoScroll,
-                              child: Switch(
-                                value: smooth,
-                                activeThumbColor: cs.primary,
-                                thumbIcon: WidgetStateProperty.resolveWith(
-                                  (states) => Icon(
-                                    states.contains(WidgetState.selected)
-                                        ? Icons.waves_rounded
-                                        : Icons.arrow_downward_rounded,
-                                    size: 16,
-                                  ),
-                                ),
-                                onChanged: (value) => ref
-                                    .read(smoothAutoScrollProvider.notifier)
-                                    .update(value),
-                              ),
-                            ),
-                          ],
                         ],
                       ),
                     ),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1464,6 +1464,14 @@
     "scrollAmountSmall": "Small",
     "scrollAmountMedium": "Medium",
     "scrollAmountLarge": "Large",
+    "autoScroll": "Auto scroll",
+    "@autoScroll": {
+        "description": "Reader utils bar: auto-scroll toggle label (webtoon)"
+    },
+    "autoAdvance": "Auto advance",
+    "@autoAdvance": {
+        "description": "Reader utils bar: auto-advance toggle label (paged)"
+    },
     "autoScrollInterval": "Auto scroll interval",
     "@autoScrollInterval": {
         "description": "Long-strip auto-scroll: seconds per advance"

--- a/test/src/features/manga_book/reader/reader_utils_bar_test.dart
+++ b/test/src/features/manga_book/reader/reader_utils_bar_test.dart
@@ -67,8 +67,10 @@ void main() {
     final container = await _pumpBar(tester, expanded);
 
     expect(container.read(autoScrollActiveProvider), false);
-    // Auto-scroll switch is the first of the two switches (auto-scroll, smooth).
-    await tester.tap(find.byType(Switch).first);
+    // One switch only — smooth/jump is a settings-only preference, never here.
+    expect(find.byType(Switch), findsOneWidget);
+    expect(find.text('Auto scroll'), findsOneWidget);
+    await tester.tap(find.byType(Switch));
     await tester.pumpAndSettle();
 
     expect(container.read(autoScrollActiveProvider), true);
@@ -94,8 +96,7 @@ void main() {
     expect(container.read(autoScrollIntervalSecondsProvider), 12);
   });
 
-  testWidgets(
-      'paged mode surfaces Auto advance: its own interval, no smooth switch',
+  testWidgets('paged mode surfaces Auto advance with its own interval',
       (tester) async {
     final expanded = ValueNotifier(true);
     addTearDown(expanded.dispose);
@@ -105,12 +106,11 @@ void main() {
       readerMode: ReaderMode.continuousHorizontalLTR,
     );
 
-    // "Auto advance interval" label, not "Auto scroll interval".
-    expect(find.text('Auto advance interval'), findsOneWidget);
-    expect(find.text('Auto scroll interval'), findsNothing);
+    // "Auto advance" label, not "Auto scroll".
+    expect(find.text('Auto advance'), findsOneWidget);
+    expect(find.text('Auto scroll'), findsNothing);
 
-    // Smooth/jump is meaningless when turning pages, so only the toggle switch
-    // is present.
+    // Only the on/off toggle — no smooth switch anywhere.
     expect(find.byType(Switch), findsOneWidget);
 
     // The stepper drives the separate auto-advance interval (default 5).


### PR DESCRIPTION
The pull-down auto-scroll bar had two unlabeled switches side by side — the on/off toggle and a smooth-vs-jump toggle — which read as ambiguous checkboxes.

Smooth-vs-jump is a set-once preference and already lives in the reader's Reading-mode settings (matching Komikku, which keeps it there and not in the bar). Removed it from the bar, leaving one clear row:

`[on/off]  Auto scroll  −  3 seconds  +`

Also shortened the label ("Auto scroll" / "Auto advance") so it no longer truncates.