### PR TITLE
Handle an unreachable server gracefully

### DIFF
--- a/lib/src/features/library/presentation/library/controller/library_manga_list.dart
+++ b/lib/src/features/library/presentation/library/controller/library_manga_list.dart
@@ -11,6 +11,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../../features/offline/data/offline_read_fallback.dart';
 import '../../../../../features/offline/data/offline_repository.dart';
+import '../../../../../features/offline/data/server_reachability.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
 import '../../../data/category_repository.dart';
 
@@ -19,11 +20,21 @@ part 'library_manga_list.g.dart';
 @riverpod
 Future<List<MangaDto>?> libraryMangaList(Ref ref) async {
   final offlineDb = ref.watch(offlineReadDatabaseProvider);
+  // Captured before the await; the keepAlive notifier outlives this provider.
+  final reachability = ref.read(serverUnreachableProvider.notifier);
   final list = await libraryWithOfflineFallback(
     fetch: () => ref.watch(categoryRepositoryProvider).getAllLibraryMangas(),
     // Only read the native-only DB when offline is available (never on web).
     db: offlineDb,
     offlineEnabled: offlineDb != null,
+    // Riverpod forbids modifying another provider while this one is building,
+    // so defer the flip to a later tick (past the build) and ignore it if the
+    // container is already gone.
+    onReachability: (reachable) => Future(() {
+      try {
+        reachability.set(!reachable);
+      } catch (_) {}
+    }),
   );
   final sync = ref.read(offlineSyncProvider);
   if (sync != null && list != null) {

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -25,6 +25,7 @@ import '../../../../widgets/shell/update_banner_state.dart';
 import '../../../manga_book/data/updates/updates_repository.dart';
 import '../../../manga_book/widgets/update_status_popup_menu.dart';
 import '../../../offline/presentation/offline_server_mismatch_banner.dart';
+import '../../../offline/presentation/server_unreachable_banner.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
 import '../../domain/category/category_model.dart';
 import '../../domain/library_group.dart';
@@ -39,6 +40,7 @@ import 'widgets/library_manga_organizer.dart';
 /// below the app bar (inside the Scaffold), not floating over the status bar.
 Widget _libraryBody(Widget body) => Column(
       children: [
+        const ServerUnreachableBanner(),
         const OfflineServerMismatchBanner(),
         Expanded(child: body),
       ],

--- a/lib/src/features/offline/data/offline_read_fallback.dart
+++ b/lib/src/features/offline/data/offline_read_fallback.dart
@@ -26,11 +26,18 @@ Future<List<MangaDto>?> libraryWithOfflineFallback({
   required Future<List<MangaDto>?> Function() fetch,
   required OfflineDatabase? db,
   required bool offlineEnabled,
+  void Function(bool reachable)? onReachability,
 }) async {
   try {
-    return await fetch();
+    final result = await fetch();
+    onReachability?.call(true);
+    return result;
   } catch (e) {
-    if (!offlineEnabled || !_shouldFallBack(e)) rethrow;
+    // Report unreachability even when we go on to serve cache below, so the
+    // outage isn't hidden from an app-wide "offline" indicator.
+    final connectionLost = _shouldFallBack(e);
+    onReachability?.call(!connectionLost);
+    if (!offlineEnabled || !connectionLost) rethrow;
     final rows = await db!.libraryManga();
     if (rows.isEmpty) rethrow;
     final lastReadByManga = await db.lastReadAtByManga();

--- a/lib/src/features/offline/data/server_reachability.dart
+++ b/lib/src/features/offline/data/server_reachability.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'server_reachability.g.dart';
+
+/// Whether the last server request failed to connect — a wrong URL, a server
+/// that's down, or no network — as opposed to reaching a server that answered.
+///
+/// Set by the offline-fallback read path: `true` when a fetch hits a connection
+/// error (even when cached data is then served, which would otherwise hide the
+/// outage from the UI), `false` on any successful fetch. Watched by
+/// `ServerUnreachableBannerHost` to surface an app-wide banner, so a user
+/// browsing stale cached data still knows they're offline.
+@Riverpod(keepAlive: true)
+class ServerUnreachable extends _$ServerUnreachable {
+  @override
+  bool build() => false;
+
+  void set(bool value) {
+    if (state != value) state = value;
+  }
+}

--- a/lib/src/features/offline/presentation/server_unreachable_banner.dart
+++ b/lib/src/features/offline/presentation/server_unreachable_banner.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../routes/router_config.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../data/server_reachability.dart';
+
+/// Inline banner shown in the library while the server can't be reached.
+///
+/// It lives on the library because that's where the reachability signal is
+/// detected, and where the case it exists for happens: browsing a stale cached
+/// library without realising you're offline. It sits inline (not via
+/// `ScaffoldMessenger`) so it never contends with the app-wide re-auth banner
+/// for the shared banner slot.
+class ServerUnreachableBanner extends ConsumerWidget {
+  const ServerUnreachableBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(serverUnreachableProvider)) return const SizedBox.shrink();
+
+    return MaterialBanner(
+      content: Text(context.l10n.serverUnreachableTitle),
+      leading: const Icon(Icons.cloud_off_rounded),
+      actions: [
+        TextButton(
+          onPressed: () => const ConnectionRoute().go(context),
+          child: Text(context.l10n.serverUnreachableAction),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/server/server_screen.dart
+++ b/lib/src/features/settings/presentation/server/server_screen.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../utils/network/graphql_errors.dart';
+import '../../../../widgets/server_unreachable_view.dart';
 import '../../controller/server_controller.dart';
 import 'widget/cloud_flare/cloud_flare_section.dart';
 import 'widget/misc_settings/misc_settings_section.dart';
@@ -46,6 +48,26 @@ class ServerScreen extends ConsumerWidget {
                   padding: EdgeInsets.all(24),
                   child: Center(child: CircularProgressIndicator()),
                 ),
+              // On error these settings can't load (they live on the server).
+              // A connection failure gets the "can't reach server" view with a
+              // path to Connection settings, instead of a blank page.
+              if (serverSettings.hasError && !serverSettings.hasValue)
+                Builder(builder: (context) {
+                  final error = serverSettings.error!;
+                  final unwrapped = error is OperationMessageException
+                      ? error.exception
+                      : error;
+                  if (isConnectionError(unwrapped)) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 40),
+                      child: ServerUnreachableView(onRetry: onRefresh),
+                    );
+                  }
+                  return Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Center(child: Text(error.toString())),
+                  );
+                }),
               if (serverSettings.valueOrNull != null) ...[
                 ServerBindingSection(serverBindingDto: serverSettings.value!),
                 SocksProxySection(socksProxyDto: serverSettings.value!),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2117,6 +2117,18 @@
     "serverPort": "Server Port",
     "serverPortHintText": "Server port",
     "serverSettingsSubtitle": "Configure the Suwayomi server itself.",
+    "serverUnreachableTitle": "Can't reach your server",
+    "@serverUnreachableTitle": {
+        "description": "Shown when the app cannot connect to the Suwayomi server"
+    },
+    "serverUnreachableSubtitle": "Make sure it's running, then check your connection settings.",
+    "@serverUnreachableSubtitle": {
+        "description": "Guidance under the server-unreachable message"
+    },
+    "serverUnreachableAction": "Connection settings",
+    "@serverUnreachableAction": {
+        "description": "Button that opens the connection settings screen"
+    },
     "clearCrashLog": "Clear crash log",
     "copyCrashLog": "Copy crash log",
     "copyCrashLogSubtitle": "For bug reports — copies the latest error log to the clipboard",

--- a/lib/src/utils/extensions/custom_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions.dart
@@ -18,10 +18,12 @@ import '../../abstracts/locale_enum.dart';
 import '../../l10n/generated/app_localizations.dart';
 import '../../widgets/custom_circular_progress_indicator.dart';
 import '../../widgets/emoticons.dart';
+import '../../widgets/server_unreachable_view.dart';
 import '../callbacks.dart';
 import '../logger/logger.dart';
 import '../misc/app_utils.dart';
 import '../misc/toast/toast.dart';
+import '../network/graphql_errors.dart';
 
 part 'custom_extensions/async_value_extensions.dart';
 part 'custom_extensions/bool_extensions.dart';

--- a/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
@@ -46,19 +46,30 @@ extension AsyncValueExtensions<T> on AsyncValue<T> {
     return when(
       data: data,
       skipError: true,
-      error: (error, trace) => AppUtils.wrapOn(
-          wrapper,
-          Emoticons(
-            title: showGenericError
-                ? context.l10n.errorSomethingWentWrong
-                : error.toString(),
-            button: refresh != null
-                ? TextButton(
-                    onPressed: refresh,
-                    child: Text(context.l10n.refresh),
-                  )
-                : null,
-          )),
+      error: (error, trace) {
+        // A genuine "can't reach the server" failure gets a dedicated view
+        // that points at Connection settings, instead of a blank/opaque error
+        // (the connection exception's own message is empty).
+        final unwrapped =
+            error is OperationMessageException ? error.exception : error;
+        if (isConnectionError(unwrapped)) {
+          return AppUtils.wrapOn(
+              wrapper, ServerUnreachableView(onRetry: refresh));
+        }
+        return AppUtils.wrapOn(
+            wrapper,
+            Emoticons(
+              title: showGenericError
+                  ? context.l10n.errorSomethingWentWrong
+                  : error.toString(),
+              button: refresh != null
+                  ? TextButton(
+                      onPressed: refresh,
+                      child: Text(context.l10n.refresh),
+                    )
+                  : null,
+            ));
+      },
       loading: () =>
           AppUtils.wrapOn(wrapper, const CenterSorayomiShimmerIndicator()),
     );

--- a/lib/src/widgets/server_unreachable_view.dart
+++ b/lib/src/widgets/server_unreachable_view.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../routes/router_config.dart';
+import '../utils/extensions/custom_extensions.dart';
+import 'emoticons.dart';
+
+/// Shown when a request failed because the server couldn't be reached (wrong
+/// URL, server down, no network) — as opposed to an auth or server-side error.
+///
+/// It points straight at Connection settings, the one screen where a wrong
+/// server URL is fixed, so a disconnected user is never stranded on a blank
+/// screen with no way forward.
+class ServerUnreachableView extends StatelessWidget {
+  const ServerUnreachableView({super.key, this.onRetry});
+
+  /// Optional retry (re-runs the failed query). Omitted where there's nothing
+  /// to re-fetch.
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Emoticons(
+      iconData: Icons.cloud_off_rounded,
+      title: context.l10n.serverUnreachableTitle,
+      subTitle: context.l10n.serverUnreachableSubtitle,
+      button: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FilledButton.tonalIcon(
+            onPressed: () => const ConnectionRoute().go(context),
+            icon: const Icon(Icons.settings_ethernet_rounded),
+            label: Text(context.l10n.serverUnreachableAction),
+          ),
+          if (onRetry != null)
+            TextButton(
+              onPressed: onRetry,
+              child: Text(context.l10n.refresh),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/src/features/offline/data/offline_read_fallback_test.dart
+++ b/test/src/features/offline/data/offline_read_fallback_test.dart
@@ -101,4 +101,50 @@ void main() {
             fetch: serverError, db: db, offlineEnabled: true),
         throwsA(predicate((e) => e.toString().contains('HTTP 500'))));
   });
+
+  test('reachability: reports reachable on a successful fetch', () async {
+    final calls = <bool>[];
+    await libraryWithOfflineFallback(
+        fetch: () async => null,
+        db: db,
+        offlineEnabled: true,
+        onReachability: calls.add);
+    expect(calls, [true]);
+  });
+
+  test('reachability: reports unreachable on a connection error, even while '
+      'serving cache', () async {
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    final calls = <bool>[];
+    await libraryWithOfflineFallback(
+        fetch: boom, db: db, offlineEnabled: true, onReachability: calls.add);
+    expect(calls, [false]);
+  });
+
+  test('reachability: reports unreachable on a connection error with no cache',
+      () async {
+    final calls = <bool>[];
+    await expectLater(
+        libraryWithOfflineFallback(
+            fetch: boom,
+            db: db,
+            offlineEnabled: true,
+            onReachability: calls.add),
+        throwsException);
+    expect(calls, [false]);
+  });
+
+  test('reachability: reports reachable on a server error (server answered)',
+      () async {
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    final calls = <bool>[];
+    await expectLater(
+        libraryWithOfflineFallback(
+            fetch: serverError,
+            db: db,
+            offlineEnabled: true,
+            onReachability: calls.add),
+        throwsA(predicate((e) => e.toString().contains('HTTP 500'))));
+    expect(calls, [true]);
+  });
 }

--- a/test/src/features/offline/presentation/server_unreachable_banner_test.dart
+++ b/test/src/features/offline/presentation/server_unreachable_banner_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/server_reachability.dart';
+import 'package:tsumiru/src/features/offline/presentation/server_unreachable_banner.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+void main() {
+  testWidgets('shows a banner only while the server is unreachable',
+      (tester) async {
+    late ProviderContainer container;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: Builder(
+          builder: (context) {
+            container = ProviderScope.containerOf(context);
+            return MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: const Scaffold(body: ServerUnreachableBanner()),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Reachable by default → nothing shown.
+    expect(find.byType(MaterialBanner), findsNothing);
+
+    container.read(serverUnreachableProvider.notifier).set(true);
+    await tester.pumpAndSettle();
+    expect(find.byType(MaterialBanner), findsOneWidget);
+    expect(find.text("Can't reach your server"), findsOneWidget);
+    expect(find.text('Connection settings'), findsOneWidget);
+
+    // Recovering hides it again.
+    container.read(serverUnreachableProvider.notifier).set(false);
+    await tester.pumpAndSettle();
+    expect(find.byType(MaterialBanner), findsNothing);
+  });
+}

--- a/test/src/utils/async_value_connection_error_test.dart
+++ b/test/src/utils/async_value_connection_error_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/utils/extensions/custom_extensions.dart';
+import 'package:tsumiru/src/widgets/server_unreachable_view.dart';
+
+Widget _host(AsyncValue<int> async, {VoidCallback? refresh}) => MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) =>
+              async.showUiWhenData(context, (d) => Text('data $d'),
+                  refresh: refresh),
+        ),
+      ),
+    );
+
+// A genuine unreachable-server failure as it arrives in the app: the GraphQL
+// wrapper around a ServerException whose cause is a socket error.
+OperationMessageException _connectionError() => OperationMessageException(
+      OperationException(
+        linkException: ServerException(
+          parsedResponse: null,
+          originalException: const SocketException('unreachable'),
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('a connection failure shows the server-unreachable view',
+      (tester) async {
+    await tester.pumpWidget(
+      _host(AsyncError(_connectionError(), StackTrace.current), refresh: () {}),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ServerUnreachableView), findsOneWidget);
+    expect(find.text("Can't reach your server"), findsOneWidget);
+  });
+
+  testWidgets('an ordinary error still shows the generic error, not that view',
+      (tester) async {
+    await tester.pumpWidget(
+      _host(AsyncError<int>('boom', StackTrace.current)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ServerUnreachableView), findsNothing);
+    expect(find.text('boom'), findsOneWidget);
+  });
+}

--- a/test/src/widgets/server_unreachable_view_test.dart
+++ b/test/src/widgets/server_unreachable_view_test.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/widgets/server_unreachable_view.dart';
+
+Future<void> _pump(WidgetTester tester, {VoidCallback? onRetry}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: ServerUnreachableView(onRetry: onRetry)),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('shows the unreachable message and a Connection settings action',
+      (tester) async {
+    await _pump(tester);
+
+    expect(find.text("Can't reach your server"), findsOneWidget);
+    expect(find.text('Connection settings'), findsOneWidget);
+  });
+
+  testWidgets('retry button is shown only when a retry is provided',
+      (tester) async {
+    await _pump(tester);
+    expect(find.text('Refresh'), findsNothing);
+
+    var retried = 0;
+    await _pump(tester, onRetry: () => retried++);
+    expect(find.text('Refresh'), findsOneWidget);
+
+    await tester.tap(find.text('Refresh'));
+    await tester.pumpAndSettle();
+    expect(retried, 1);
+  });
+}


### PR DESCRIPTION
## What

When the app can't reach the Suwayomi server (wrong URL, server down, no network) it previously showed **blank screens with no guidance** — a blank library and a blank Server settings page. This adds a proper disconnected experience.

- **Shared "Can't reach your server" state** — names the problem and links straight to Connection settings. Shown by every screen that loads data through the shared loader when a *connection* failure occurs (distinguished from auth/server errors), and by the Server settings screen (which previously rendered nothing on error).
- **Inline library banner** — the offline layer serves cached data on a connection loss, so a user browsing a stale library wouldn't otherwise know they're offline. A reachability signal is tracked from that read path (reported unreachable even when cache is served) and surfaced as an inline banner with a Connection-settings shortcut.

## Notes

- Connection-vs-other-error classification reuses the existing `isConnectionError`.
- The reachability flag flip is deferred out of the provider build to respect Riverpod's build-time constraints.
- The banner is inline (not app-wide via `ScaffoldMessenger`) so it never contends with the re-auth banner for the shared banner slot.
- Coverage is honest: the banner is library-scoped (where the signal is detected); other screens surface their own error state.
- Tests: shared view, connection-classification wiring, reachability semantics (incl. the serve-cache-while-unreachable path), and the banner show/hide. Full suite green.