### PR TITLE
Fix two paged-reader glitches

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -135,10 +135,16 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
 
     final isHorizontal = scrollDirection == Axis.horizontal;
     final isLandscape = context.width > context.height;
+    // An explicit page-layout choice (the bottom-bar toggle) always wins.
+    // "Dual page spread in landscape" only augments Automatic, and respects
+    // landscape — otherwise it forced dual everywhere and made the toggle a
+    // no-op.
     final wantDouble = isHorizontal &&
-        (settings.pageLayout == PageLayout.doublePages ||
-            (settings.pageLayout == PageLayout.automatic && isLandscape) ||
-            settings.trueDualPageSpread);
+        switch (settings.pageLayout) {
+          PageLayout.doublePages => true,
+          PageLayout.singlePage => false,
+          PageLayout.automatic => isLandscape || settings.trueDualPageSpread,
+        };
     final splitWide = settings.dualPageSplitPaged && isHorizontal;
     final splitInvert = settings.dualPageInvertPaged;
     final reversePair = settings.invertDoublePages != reverse;

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -986,7 +986,10 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
                     _PositionedDisplayEntry(
                       axis: widget.axis,
                       offset: _entryOffset(index),
-                      child: _buildDisplayEntry(index),
+                      child: _buildDisplayEntry(
+                        index,
+                        active: index == _displayIndex,
+                      ),
                     ),
                 ],
               ),
@@ -1006,7 +1009,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   double _entryOffset(int index) =>
       (index - _displayIndex) * _axisExtent * _axisSign + _dragOffset;
 
-  Widget _buildDisplayEntry(int index) {
+  Widget _buildDisplayEntry(int index, {required bool active}) {
     final item = widget.window.items[index];
     if (item is TransitionDisplay) {
       return widget.transitionBuilder(item);
@@ -1014,6 +1017,10 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     final spread = item as SpreadDisplay;
     return _ZoomedDisplayEntry(
       controller: _zoomControllerFor(index),
+      // Only the focused page applies its zoom/pan transform. A neighbor still
+      // carries whatever zoom/pan it was left with; applying that off-screen
+      // drags it partly back into view, overlapping the current page.
+      active: active,
       child: DoublePageView(
         entry: spread.entry,
         pages: widget.window.pagesAt(index)!,
@@ -1053,14 +1060,20 @@ class _PositionedDisplayEntry extends StatelessWidget {
 class _ZoomedDisplayEntry extends StatelessWidget {
   const _ZoomedDisplayEntry({
     required this.controller,
+    required this.active,
     required this.child,
   });
 
   final _PageZoomController controller;
+
+  /// True only for the focused page. A neighbor renders at base fit so its
+  /// retained zoom/pan can't displace it into the viewport.
+  final bool active;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
+    if (!active) return child;
     return AnimatedBuilder(
       animation: controller,
       builder: (context, child) {


### PR DESCRIPTION
Two fixes in the paged (left/right) reader.

**Overlapping pages after zoom-panning.** Each page's zoom/pan state persists across turns, and the viewport applied every entry's zoom/pan transform — including the off-screen neighbors. So a page you zoomed and panned, then turned away from, kept its 2D pan offset as a neighbor and rendered displaced over the current page (a diagonal double-page glitch, mid-chapter). Only the focused page now applies its transform; neighbors render at base fit.

**Single/double toggle did nothing.** The bottom-bar page-layout toggle was a no-op whenever "Dual page spread in landscape" was on, because that setting forced dual-page regardless of the layout choice (and ignored its own "in landscape" scope, forcing dual in portrait too). An explicit toggle choice now always wins, and the landscape-dual setting only augments Automatic mode.