### PR TITLE
Show an on-device badge on library covers

### DIFF
--- a/lib/src/widgets/manga_cover/widgets/manga_badges.dart
+++ b/lib/src/widgets/manga_cover/widgets/manga_badges.dart
@@ -9,7 +9,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../constants/app_sizes.dart';
 import '../../../features/manga_book/domain/manga/manga_model.dart';
+import '../../../features/offline/data/offline_download_providers.dart';
 import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/theme/brand.dart';
 import '../../server_image.dart';
 import '../providers/manga_cover_providers.dart';
 
@@ -37,13 +39,20 @@ class MangaBadgesRow extends ConsumerWidget {
     final localBadge = ref.watch(localBadgeProvider).ifNull(false);
     final sourceBadge = ref.watch(sourceBadgeProvider).ifNull(false);
 
+    // At least one chapter downloaded to THIS device — a subset of the server.
+    // Empty set when the offline feature is off, so the badge self-hides.
+    final onDevice = showCountBadges &&
+        (ref.watch(offlineDeviceMangaIdsProvider).valueOrNull ?? const <int>{})
+            .contains(manga.id);
+
     final source = manga.source;
     final isLocal = source?.lang == _kLocalSourceLang;
     final langCode = source?.lang;
     final hasLangBadge = languageBadge && langCode != null && !isLocal;
     final hasLocalBadge = localBadge && isLocal;
     final hasSourceBadge = sourceBadge && source != null && !isLocal;
-    final hasEndBadges = showCountBadges && (hasLangBadge || hasLocalBadge || hasSourceBadge);
+    final hasEndBadges = showCountBadges &&
+        (hasLangBadge || hasLocalBadge || hasSourceBadge || onDevice);
 
     // When we have end badges, expand the row to full width so the end cluster
     // sits at the top-right corner.
@@ -93,6 +102,7 @@ class MangaBadgesRow extends ConsumerWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (onDevice) const _OnDeviceBadge(),
           if (hasLangBadge && sourceNN != null && langCodeNN != null)
             useLangIcon
                 ? _SourceIconBadge(iconUrl: sourceNN.iconUrl)
@@ -130,6 +140,28 @@ class MangaBadgesRow extends ConsumerWidget {
                 if (showCountBadges && needSpacer) const Spacer(),
               ],
             ),
+    );
+  }
+}
+
+/// Passive "on device" badge — this series has at least one chapter downloaded
+/// to THIS device. Brand gradient + the app's downloaded pin so it reads as the
+/// downloaded motif, distinct from the flat server-download count badge.
+class _OnDeviceBadge extends StatelessWidget {
+  const _OnDeviceBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(gradient: brandGradient(context.theme.colorScheme)),
+      child: Padding(
+        padding: KEdgeInsets.a4.size,
+        child: const Icon(
+          Icons.offline_pin_rounded,
+          color: onBrandGradient,
+          size: 16,
+        ),
+      ),
     );
   }
 }

--- a/test/src/widgets/manga_cover/on_device_badge_test.dart
+++ b/test/src/widgets/manga_cover/on_device_badge_test.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/widgets/manga_cover/widgets/manga_badges.dart';
+
+MangaDto _manga(int id) => Fragment$MangaDto(
+      id: id,
+      title: 'M$id',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 0),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: const [],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 0,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/$id',
+    );
+
+Future<Widget> _harness(Set<int> deviceIds, MangaDto manga) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  return ProviderScope(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      offlineDeviceMangaIdsProvider.overrideWith((ref) async => deviceIds),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: MangaBadgesRow(manga: manga, showCountBadges: true),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows the on-device pin when the series is downloaded here',
+      (tester) async {
+    await tester.pumpWidget(await _harness({5}, _manga(5)));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.offline_pin_rounded), findsOneWidget);
+  });
+
+  testWidgets('no badge when the series has nothing on this device',
+      (tester) async {
+    await tester.pumpWidget(await _harness({7}, _manga(5)));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.offline_pin_rounded), findsNothing);
+  });
+}


### PR DESCRIPTION
Covers only ever showed the *server* download count, so there was no at-a-glance way to tell which series actually have chapters on this device (the device library is a subset of the server).

Adds a passive badge on covers when a series has at least one chapter downloaded locally. It reuses the app's existing downloaded pin on the brand gradient, so it recolors per theme and reads distinctly from the flat server-count badge. Driven by the existing `offlineDeviceMangaIds` provider (the signal behind the "On device" library filter), so it self-hides when offline is off.

Widget test covers show/hide.

Closes #119