### PR TITLE
Surface extension-repo management on the Extensions tab

### DIFF
--- a/lib/src/features/browse_center/presentation/browse/browse_screen.dart
+++ b/lib/src/features/browse_center/presentation/browse/browse_screen.dart
@@ -56,6 +56,11 @@ class BrowseScreen extends HookConsumerWidget {
               icon: const Icon(Icons.travel_explore_rounded),
             ),
           if (tabController.index == 1) ...[
+            IconButton(
+              tooltip: context.l10n.extensionRepository,
+              onPressed: () => const ExtensionRepositoryRoute().push(context),
+              icon: const Icon(Icons.dns_rounded),
+            ),
             const InstallExtensionFile(),
           ],
           IconButton(

--- a/test/src/features/browse_center/extension_repo_affordance_test.dart
+++ b/test/src/features/browse_center/extension_repo_affordance_test.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/browse/browse_screen.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+Widget _harness(int currentIndex) => ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BrowseScreen(
+          currentIndex: currentIndex,
+          onDestinationSelected: (_) {},
+          children: const [
+            Center(child: Text('sources')),
+            Center(child: Text('extensions')),
+          ],
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('repo affordance shows on the Extensions tab', (tester) async {
+    await tester.pumpWidget(_harness(1));
+    await tester.pump();
+    expect(find.byTooltip('Extension Repository'), findsOneWidget);
+  });
+
+  testWidgets('repo affordance is absent on the Sources tab', (tester) async {
+    await tester.pumpWidget(_harness(0));
+    await tester.pump();
+    expect(find.byTooltip('Extension Repository'), findsNothing);
+  });
+}


### PR DESCRIPTION
Adding a source repo was buried under Settings > Browse > Extension Repos, two levels from where the intent lives.

Adds a button to the Browse top bar (Extensions tab) that opens the Extension Repository manager directly. The existing Settings entry stays.

Widget test confirms the button appears on the Extensions tab and not on Sources.

Closes #120