### PR TITLE
Add status, source, tracked, and OR-groups to library search

### DIFF
--- a/lib/src/features/library/domain/library_search_query.dart
+++ b/lib/src/features/library/domain/library_search_query.dart
@@ -16,8 +16,14 @@
 /// Supported keys: `tag:` (exact match on a source genre OR a custom tag,
 /// case-insensitive), `genre:` (source genre, substring), `author:`, `artist:`,
 /// `title:` (substring), `unread:`/`downloaded:` (bool), `rating:` (int with
-/// optional `>=`/`<=`/`>`/`<`/`=`). An unrecognized key is treated as plain
-/// text, so titles like `Re:Zero` still search normally.
+/// optional `>=`/`<=`/`>`/`<`/`=`), `status:` (ongoing/completed/hiatus/…),
+/// `source:` (source name, substring), and `tracked:` (bool, or a service name
+/// like `tracked:anilist`). An unrecognized key is treated as plain text, so
+/// titles like `Re:Zero` still search normally.
+///
+/// `{a|b}` groups alternatives: the group matches if ANY term inside it matches,
+/// so `{genre:action|genre:romance}` finds either. A leading `-` negates a whole
+/// group.
 library;
 
 /// Flat, GraphQL-free view of the fields the DSL can match against. Keeps the
@@ -32,6 +38,9 @@ class LibraryFilterFields {
     this.downloadCount = 0,
     this.rating,
     this.userTags = const [],
+    this.status,
+    this.sourceName,
+    this.trackers = const {},
   });
 
   final String title;
@@ -42,9 +51,30 @@ class LibraryFilterFields {
   final int downloadCount;
   final int? rating;
   final List<String> userTags;
+
+  /// The manga's publication status, as the enum name (e.g. `COMPLETED`).
+  final String? status;
+
+  /// The source's display name.
+  final String? sourceName;
+
+  /// Lowercased names of the tracker services this manga is bound to.
+  final Set<String> trackers;
 }
 
-enum _Field { tag, genre, author, artist, title, unread, downloaded, rating }
+enum _Field {
+  tag,
+  genre,
+  author,
+  artist,
+  title,
+  unread,
+  downloaded,
+  rating,
+  status,
+  source,
+  tracked,
+}
 
 /// Recognized metatag keys, in display order. Exported so the search field's
 /// syntax highlighter colors exactly the keys the parser understands.
@@ -57,6 +87,9 @@ const List<String> librarySearchMetatagKeys = [
   'unread',
   'downloaded',
   'rating',
+  'status',
+  'source',
+  'tracked',
 ];
 
 _Field? _fieldFor(String key) => switch (key) {
@@ -68,6 +101,9 @@ _Field? _fieldFor(String key) => switch (key) {
       'unread' => _Field.unread,
       'downloaded' => _Field.downloaded,
       'rating' => _Field.rating,
+      'status' => _Field.status,
+      'source' => _Field.source,
+      'tracked' => _Field.tracked,
       _ => null,
     };
 
@@ -90,20 +126,26 @@ class LibrarySearchQuery {
     return LibrarySearchQuery(terms);
   }
 
-  /// Splits on spaces/commas, keeping double-quoted spans intact. Quote chars
-  /// are consumed, so `tag:"slice of life"` becomes the single token
-  /// `tag:slice of life`.
+  /// Splits on spaces/commas, keeping double-quoted spans and `{…}` groups
+  /// intact. Quote chars are consumed, so `tag:"slice of life"` becomes the
+  /// single token `tag:slice of life`; a `{a|b}` group stays one token so its
+  /// inner spaces don't split it.
   static List<String> _tokenize(String raw) {
     final tokens = <String>[];
     final buf = StringBuffer();
     var inQuotes = false;
+    var braceDepth = 0;
     for (var i = 0; i < raw.length; i++) {
       final ch = raw[i];
       if (ch == '"') {
         inQuotes = !inQuotes;
         continue;
       }
-      if (!inQuotes && (ch == ' ' || ch == ',')) {
+      if (!inQuotes) {
+        if (ch == '{') braceDepth++;
+        if (ch == '}' && braceDepth > 0) braceDepth--;
+      }
+      if (!inQuotes && braceDepth == 0 && (ch == ' ' || ch == ',')) {
         if (buf.isNotEmpty) {
           tokens.add(buf.toString());
           buf.clear();
@@ -125,6 +167,18 @@ class LibrarySearchQuery {
     }
     if (t.isEmpty) return null;
 
+    // `{a|b|c}` — matches if any inner alternative matches.
+    if (t.length > 1 && t.startsWith('{') && t.endsWith('}')) {
+      final alts = <SearchTerm>[];
+      for (final part in t.substring(1, t.length - 1).split('|')) {
+        final sub = _parseToken(part.trim());
+        if (sub != null) alts.add(sub);
+      }
+      // An empty/half-typed group imposes no constraint rather than hiding all.
+      if (alts.isEmpty) return null;
+      return SearchTerm._group(alts, negated);
+    }
+
     final colon = t.indexOf(':');
     if (colon > 0) {
       final field = _fieldFor(t.substring(0, colon).toLowerCase());
@@ -145,7 +199,9 @@ class SearchTerm {
     this.text,
     _Field? field,
     this.value,
-  }) : _field = field;
+    List<SearchTerm>? alternatives,
+  })  : _field = field,
+        _alternatives = alternatives;
 
   factory SearchTerm._text(String text, bool negated) =>
       SearchTerm._(negated: negated, text: text.toLowerCase());
@@ -153,10 +209,14 @@ class SearchTerm {
   factory SearchTerm._field(_Field field, String value, bool negated) =>
       SearchTerm._(negated: negated, field: field, value: value);
 
+  factory SearchTerm._group(List<SearchTerm> alternatives, bool negated) =>
+      SearchTerm._(negated: negated, alternatives: alternatives);
+
   final bool negated;
   final String? text;
   final _Field? _field;
   final String? value;
+  final List<SearchTerm>? _alternatives;
 
   bool matches(LibraryFilterFields f) {
     final res = _rawMatch(f);
@@ -167,6 +227,8 @@ class SearchTerm {
   }
 
   bool? _rawMatch(LibraryFilterFields f) {
+    final alts = _alternatives;
+    if (alts != null) return alts.any((a) => a.matches(f));
     final t = text;
     if (t != null) {
       return f.title.toLowerCase().contains(t) ||
@@ -198,6 +260,23 @@ class SearchTerm {
         return want == null ? null : (f.downloadCount > 0) == want;
       case _Field.rating:
         return _matchRating(f.rating ?? 0, v);
+      case _Field.status:
+        final s = f.status;
+        if (s == null) return null;
+        final ns = s.toLowerCase();
+        final lv = v.toLowerCase();
+        // Match the exact enum name, or a partial like `hiatus` → `on_hiatus`
+        // and `finished` → `publishing_finished`.
+        return ns == lv || ns.replaceAll('_', ' ').contains(lv) || ns.contains(lv);
+      case _Field.source:
+        return f.sourceName?.toLowerCase().contains(v.toLowerCase());
+      case _Field.tracked:
+        final want = _parseBool(v);
+        // `tracked:true`/`false` = has any tracker; otherwise match a service
+        // name, e.g. `tracked:anilist`.
+        if (want != null) return f.trackers.isNotEmpty == want;
+        final lv = v.toLowerCase();
+        return f.trackers.any((name) => name.contains(lv));
     }
   }
 

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -66,6 +66,7 @@ List<MangaDto> applyLibraryFilterSort(
   int seed = 0,
   Map<int, double> trackerScales = const {},
   Map<int, bool?> trackerFilters = const {},
+  Map<int, String> trackerNames = const {},
 }) {
   final searchQuery = LibrarySearchQuery.parse(query);
   // Tags match case-insensitively (aligning with the `tag:` search operator),
@@ -107,7 +108,7 @@ List<MangaDto> applyLibraryFilterSort(
     }
     // Meta-derived fields (rating, tags) plus the DSL-searchable fields, built
     // once and reused by the rating filter, tags filter, and search below.
-    final fields = manga.filterFields;
+    final fields = manga.filterFields(trackerNames);
     if (mangaFilterMinRating > 0 &&
         (fields.rating ?? 0) < mangaFilterMinRating) {
       return false;
@@ -306,6 +307,7 @@ class CategoryMangaListWithQueryAndFilter
               seed: seed,
               trackerScales: ref.watch(libraryTrackerScalesProvider),
               trackerFilters: ref.watch(libraryTrackerFiltersProvider),
+              trackerNames: ref.watch(libraryTrackerNamesProvider),
             )),
       error: (e) => e,
       loading: (e) => e,
@@ -538,6 +540,15 @@ Map<int, double> libraryTrackerScales(Ref ref) {
   };
 }
 
+/// Map of tracker id → display name, resolving the `tracked:<service>` search
+/// metatag (e.g. `tracked:anilist`). Uses all known trackers, not just
+/// logged-in ones, so a bound record still resolves after a logout.
+@riverpod
+Map<int, String> libraryTrackerNames(Ref ref) {
+  final all = ref.watch(trackersProvider).valueOrNull ?? const [];
+  return {for (final t in all) t.id: t.name};
+}
+
 @riverpod
 class LibraryDisplayMode extends _$LibraryDisplayMode
     with SharedPreferenceEnumClientMixin<DisplayMode> {
@@ -668,6 +679,7 @@ class GroupedMangaListWithQueryAndFilter
               seed: seed,
               trackerScales: ref.watch(libraryTrackerScalesProvider),
               trackerFilters: ref.watch(libraryTrackerFiltersProvider),
+              trackerNames: ref.watch(libraryTrackerNamesProvider),
             )),
       error: (e) => e,
       loading: (e) => e,

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -526,7 +526,12 @@ void showSearchTips(BuildContext context) {
     context: context,
     builder: (context) => AlertDialog(
       title: Text(context.l10n.searchTips),
-      content: Text(context.l10n.searchTipsBody),
+      // The `{a|b}` OR-group example lives here rather than in the l10n string
+      // because ICU message syntax reserves curly braces for placeholders.
+      content: Text(
+        '${context.l10n.searchTipsBody}'
+        '\nMatch any of these: {genre:action|genre:romance}',
+      ),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),

--- a/lib/src/features/manga_book/domain/manga/manga_model.dart
+++ b/lib/src/features/manga_book/domain/manga/manga_model.dart
@@ -27,12 +27,14 @@ extension MangaExtensions on MangaDto {
   /// quick-search; the library list parses the query once instead (see
   /// applyLibraryFilterSort).
   bool query([String? query]) =>
-      LibrarySearchQuery.parse(query).matches(filterFields);
+      LibrarySearchQuery.parse(query).matches(filterFields());
 
   /// Flattened field view used by the library search DSL (see
   /// [LibrarySearchQuery]). Resolves meta once so rating/tags come from the same
-  /// build as the rest of the fields.
-  LibraryFilterFields get filterFields {
+  /// build as the rest of the fields. [trackerNames] maps tracker id → service
+  /// name so the `tracked:<service>` metatag can resolve; pass it empty (the
+  /// default) when only the bool `tracked:` form is needed.
+  LibraryFilterFields filterFields([Map<int, String> trackerNames = const {}]) {
     final m = metaData;
     return LibraryFilterFields(
       title: title,
@@ -43,6 +45,12 @@ extension MangaExtensions on MangaDto {
       downloadCount: downloadCount,
       rating: m.rating,
       userTags: m.userTags ?? const [],
+      status: status.name,
+      sourceName: source?.displayName ?? source?.name,
+      trackers: {
+        for (final r in trackRecords.nodes)
+          if (trackerNames[r.trackerId] case final name?) name.toLowerCase(),
+      },
     );
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2429,7 +2429,7 @@
     "copyToClipboard": "Copy to clipboard",
     "copiedToClipboard": "Copied to clipboard",
     "searchTips": "Search tips",
-    "searchTipsBody": "Filter by field with key:value.\n\ntag:seinen (source tags or your own)\ngenre:action (source genres)\nauthor:oda\nrating:>=4 (your rating)\nunread:true, downloaded:true\n\nQuote multi-word values: tag:\"slice of life\"\nExclude with a minus sign: -tag:dropped",
+    "searchTipsBody": "Filter by field with key:value.\n\ntag:seinen (source tags or your own)\ngenre:action (source genres)\nauthor:oda\nstatus:ongoing (also completed, hiatus, cancelled)\nsource:mangadex\ntracked:true, tracked:anilist\nrating:>=4 (your rating)\nunread:true, downloaded:true\n\nQuote multi-word values: tag:\"slice of life\"\nExclude with a minus sign: -tag:dropped",
     "@tracking": {
         "description": "Settings entry and screen title for the Tracking screen"
     },

--- a/test/src/features/library/library_search_query_test.dart
+++ b/test/src/features/library/library_search_query_test.dart
@@ -16,6 +16,9 @@ LibraryFilterFields _manga({
   int downloadCount = 0,
   int? rating,
   List<String> userTags = const [],
+  String? status = 'ONGOING',
+  String? sourceName = 'MangaDex',
+  Set<String> trackers = const {},
 }) =>
     LibraryFilterFields(
       title: title,
@@ -26,6 +29,9 @@ LibraryFilterFields _manga({
       downloadCount: downloadCount,
       rating: rating,
       userTags: userTags,
+      status: status,
+      sourceName: sourceName,
+      trackers: trackers,
     );
 
 bool _matches(String query, LibraryFilterFields f) =>
@@ -163,6 +169,73 @@ void main() {
       final m = _manga(userTags: ['Reread'], rating: 5);
       expect(_matches('tag:reread rating:>=4 piece', m), isTrue);
       expect(_matches('tag:reread rating:>=4 naruto', m), isFalse);
+    });
+  });
+
+  group('status:', () {
+    test('exact enum name matches', () {
+      expect(_matches('status:ongoing', _manga(status: 'ONGOING')), isTrue);
+      expect(_matches('status:completed', _manga(status: 'ONGOING')), isFalse);
+    });
+    test('partial matches a multi-word enum', () {
+      expect(_matches('status:hiatus', _manga(status: 'ON_HIATUS')), isTrue);
+      expect(
+          _matches('status:finished', _manga(status: 'PUBLISHING_FINISHED')),
+          isTrue);
+    });
+    test('null status is a no-op, not a hide-all', () {
+      expect(_matches('status:completed', _manga(status: null)), isTrue);
+    });
+    test('negation works', () {
+      expect(_matches('-status:completed', _manga(status: 'ONGOING')), isTrue);
+    });
+  });
+
+  group('source:', () {
+    test('substring match on source name, case-insensitive', () {
+      expect(_matches('source:mangadex', _manga(sourceName: 'MangaDex')), isTrue);
+      expect(_matches('source:dex', _manga(sourceName: 'MangaDex')), isTrue);
+      expect(
+          _matches('source:comick', _manga(sourceName: 'MangaDex')), isFalse);
+    });
+  });
+
+  group('tracked:', () {
+    test('bool form checks for any tracker', () {
+      expect(_matches('tracked:true', _manga(trackers: {'anilist'})), isTrue);
+      expect(_matches('tracked:true', _manga(trackers: {})), isFalse);
+      expect(_matches('tracked:false', _manga(trackers: {})), isTrue);
+    });
+    test('service name matches a bound tracker', () {
+      final m = _manga(trackers: {'anilist', 'myanimelist'});
+      expect(_matches('tracked:anilist', m), isTrue);
+      expect(_matches('tracked:kitsu', m), isFalse);
+    });
+  });
+
+  group('{a|b} OR groups', () {
+    test('matches when any alternative matches', () {
+      final m = _manga(genres: ['Romance']);
+      expect(_matches('{genre:action|genre:romance}', m), isTrue);
+      expect(_matches('{genre:action|genre:horror}', m), isFalse);
+    });
+    test('keeps quoted multi-word alternatives intact', () {
+      final m = _manga(genres: ['Slice of Life']);
+      expect(_matches('{tag:"slice of life"|genre:action}', m), isTrue);
+    });
+    test('AND-s with terms outside the group', () {
+      final m = _manga(title: 'One Piece', genres: ['Adventure']);
+      expect(_matches('piece {genre:action|genre:adventure}', m), isTrue);
+      expect(_matches('naruto {genre:action|genre:adventure}', m), isFalse);
+    });
+    test('a negated group excludes any match', () {
+      final m = _manga(genres: ['Action']);
+      expect(_matches('-{genre:action|genre:romance}', m), isFalse);
+      expect(_matches('-{genre:horror|genre:romance}', m), isTrue);
+    });
+    test('empty group is a no-op', () {
+      expect(_matches('{}', _manga()), isTrue);
+      expect(_matches('{|}', _manga()), isTrue);
     });
   });
 }


### PR DESCRIPTION
The library search DSL could filter by tag, genre, author, rating, and read/download state, but not by publication status, source, or tracking, and had no way to express "either of these".

Adds four capabilities:
- `status:` — e.g. `status:ongoing`, `status:completed`, `status:hiatus` (partial match on the status name)
- `source:` — source name, substring
- `tracked:` — bool (`tracked:true`/`false`) or a service name (`tracked:anilist`)
- `{a|b}` OR-groups that match if any alternative matches, negatable as `-{a|b}`

Tracker names resolve off the existing trackers list, so `tracked:` needs no extra fetches. The in-app search cheat-sheet lists the new keys.

Covered by 12 new parser tests plus the existing library suite.

Closes #135