### PR TITLE
Add a Migrate button to failed library updates

### DIFF
--- a/lib/src/features/manga_book/widgets/update_status_summary_sheet.dart
+++ b/lib/src/features/manga_book/widgets/update_status_summary_sheet.dart
@@ -7,9 +7,12 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../constants/app_sizes.dart';
 import '../../../routes/router_config.dart';
 import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/theme/brand.dart';
 import '../../../widgets/manga_cover/list/manga_cover_list_tile.dart';
+import '../../migration/domain/migration_models.dart';
 import '../data/updates/updates_repository.dart';
 import '../domain/manga/manga_model.dart';
 import '../domain/update_status/update_status_model.dart';
@@ -58,6 +61,9 @@ class UpdateStatusSummaryDialog extends ConsumerWidget {
                   mangas: data!.failedJobs.mangaList,
                   title: context.l10n.failed,
                   initiallyExpanded: true,
+                  onMigrate: (manga) => MigrationGlobalSearchRoute(
+                    $extra: MigrationRouteData(sourceManga: manga),
+                  ).push(context),
                 ),
             ],
           ),
@@ -74,12 +80,18 @@ class UpdateStatusExpansionTile extends StatelessWidget {
     required this.mangas,
     required this.title,
     this.initiallyExpanded = false,
+    this.onMigrate,
   });
   final List<MangaDto> mangas;
   final String title;
   final bool initiallyExpanded;
+
+  /// When set, each row shows a Migrate button that runs this with the row's
+  /// series — wired only for failed updates, whose source may have moved away.
+  final void Function(MangaDto manga)? onMigrate;
   @override
   Widget build(BuildContext context) {
+    final onMigrate = this.onMigrate;
     return ExpansionTile(
       title: Text("$title (${mangas.length.padLeft()})"),
       initiallyExpanded: initiallyExpanded,
@@ -91,8 +103,56 @@ class UpdateStatusExpansionTile extends StatelessWidget {
                 manga: e,
                 showCountBadges: true,
                 onPressed: () => MangaRoute(mangaId: e.id).push(context),
+                trailing: onMigrate != null
+                    ? _MigrateButton(onPressed: () => onMigrate(e))
+                    : null,
               ))
           .toList(),
+    );
+  }
+}
+
+/// A pill button that sends a series into the migration flow — shown on failed
+/// library-update rows so a dead source can be swapped without hunting for the
+/// entry.
+class _MigrateButton extends StatelessWidget {
+  const _MigrateButton({required this.onPressed});
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.theme.colorScheme;
+    final accent = brandBrightAccent(cs);
+    return Padding(
+      padding: KEdgeInsets.h8.size,
+      child: Material(
+        color: cs.primary.withValues(alpha: 0.14),
+        shape: StadiumBorder(
+          side: BorderSide(color: cs.primary.withValues(alpha: 0.5)),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onPressed,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.swap_horiz_rounded, size: 17, color: accent),
+                const SizedBox(width: 6),
+                Text(
+                  context.l10n.migrate,
+                  style: TextStyle(
+                    color: accent,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 12.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
+++ b/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
@@ -19,6 +19,7 @@ class MangaCoverListTile extends StatelessWidget {
     this.onPressed,
     this.onLongPress,
     this.onContinueReading,
+    this.trailing,
     this.showBadges = true,
     this.showCountBadges = false,
     this.selected = false,
@@ -30,6 +31,9 @@ class MangaCoverListTile extends StatelessWidget {
 
   /// When non-null, a play button at the row end opens the next unread chapter.
   final VoidCallback? onContinueReading;
+
+  /// An optional action widget pinned to the row end (e.g. a Migrate button).
+  final Widget? trailing;
   final bool showCountBadges;
   final bool showBadges;
   final bool selected;
@@ -74,6 +78,7 @@ class MangaCoverListTile extends StatelessWidget {
                   size: 28,
                 ),
               ),
+            if (trailing != null) trailing!,
           ],
         ),
       ),

--- a/test/src/features/manga_book/update_migrate_button_test.dart
+++ b/test/src/features/manga_book/update_migrate_button_test.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/widgets/update_status_summary_sheet.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+MangaDto _manga(int id) => Fragment$MangaDto(
+      id: id,
+      title: 'M$id',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 0),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: const [],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 0,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/$id',
+    );
+
+Future<Widget> _harness({
+  required void Function(MangaDto)? onMigrate,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  return ProviderScope(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      offlineDeviceMangaIdsProvider.overrideWith((ref) async => <int>{}),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: ListView(
+          children: [
+            UpdateStatusExpansionTile(
+              mangas: [_manga(7)],
+              title: 'Failed',
+              initiallyExpanded: true,
+              onMigrate: onMigrate,
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('tapping Migrate runs migration for that exact series',
+      (tester) async {
+    MangaDto? migrated;
+    await tester.pumpWidget(await _harness(onMigrate: (m) => migrated = m));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.swap_horiz_rounded), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.swap_horiz_rounded));
+    await tester.pump();
+
+    expect(migrated?.id, 7); // the row's own series, not some other
+  });
+
+  testWidgets('no Migrate button when migration is not offered',
+      (tester) async {
+    await tester.pumpWidget(await _harness(onMigrate: null));
+    await tester.pump();
+    expect(find.byIcon(Icons.swap_horiz_rounded), findsNothing);
+  });
+}


### PR DESCRIPTION
When a library update fails for a series (its source moved, went away, or errored), the entry appeared in the Failed list but there was no quick way to act on it.

Adds a Migrate button on each failed row that opens the migration flow for that series, so a dead source can be swapped without hunting the entry down in the library. The button shows only on failed rows.

A widget test covers the behaviour without needing a real failed update: the button appears only when migration is offered, and tapping it runs migration for that exact series.

Closes #126