### PR TITLE
chore(deps): upgrade font_awesome_flutter to v11.0.0 and migrate widgets

### DIFF
--- a/lib/src/features/about/presentation/about/about_screen.dart
+++ b/lib/src/features/about/presentation/about/about_screen.dart
@@ -201,14 +201,14 @@ class AboutScreen extends HookConsumerWidget {
                 children: [
                   MediaLaunchButton(
                     title: "${context.l10n.gitHub} ",
-                    iconData: FontAwesomeIcons.github,
+                    icon: FaIcon(FontAwesomeIcons.github),
                     url: AppUrls.sorayomiGithubUrl.url,
                     toast: toast,
                   ),
                   if ((about?.discord).isNotBlank)
                     MediaLaunchButton(
                       title: context.l10n.discord,
-                      iconData: FontAwesomeIcons.discord,
+                      icon: FaIcon(FontAwesomeIcons.discord),
                       url: about!.discord,
                       toast: toast,
                     ),

--- a/lib/src/features/about/presentation/about/widget/app_update_dialog.dart
+++ b/lib/src/features/about/presentation/about/widget/app_update_dialog.dart
@@ -56,7 +56,7 @@ void appUpdateDialog({
                       url ?? AppUrls.sorayomiLatestReleaseUrl.url, toast);
                   Navigator.pop(context);
                 },
-                icon: const Icon(FontAwesomeIcons.github),
+                icon: const FaIcon(FontAwesomeIcons.github),
                 label: Text(context.l10n.gitHub),
               ),
             ],

--- a/lib/src/features/about/presentation/about/widget/media_launch_button.dart
+++ b/lib/src/features/about/presentation/about/widget/media_launch_button.dart
@@ -15,13 +15,13 @@ class MediaLaunchButton extends StatelessWidget {
     super.key,
     required this.toast,
     required this.title,
-    required this.iconData,
+    required this.icon,
     required this.url,
   });
 
   final Toast? toast;
   final String title;
-  final IconData iconData;
+  final Widget icon;
   final String url;
 
   @override
@@ -31,12 +31,12 @@ class MediaLaunchButton extends StatelessWidget {
             ? IconButton(
                 tooltip: title,
                 onPressed: () => launchUrlInWeb(context, url, toast),
-                icon: Icon(iconData),
+                icon: icon,
               )
             : TextButton.icon(
                 label: Text(title),
                 onPressed: () => launchUrlInWeb(context, url, toast),
-                icon: Icon(iconData),
+                icon: icon,
               )
         : const SizedBox.shrink();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -578,10 +578,10 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: b9011df3a1fa02993630b8fb83526368cf2206a711259830325bab2f1d2a4eb0
+      sha256: "09dcde8ab90ffae1a7d65ff2ef96fc62a17ad9d0ce7c127b317ded676b0d5935"
       url: "https://pub.dev"
     source: hosted
-    version: "10.12.0"
+    version: "11.0.0"
   freezed:
     dependency: "direct dev"
     description:
@@ -970,26 +970,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1600,10 +1600,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.11"
   timing:
     dependency: transitive
     description:
@@ -1797,5 +1797,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   flutter_markdown: ^0.7.1
   flutter_secure_storage: ^9.2.2
   fluttertoast: ^8.1.1
-  font_awesome_flutter: ^10.2.1
+  font_awesome_flutter: ^11.0.0
   freezed_annotation: ^2.2.0
   gap: ^3.0.1
   go_router: ^14.0.2


### PR DESCRIPTION
Resolves a compilation failure caused by an incompatibility between the Flutter SDK and font_awesome_flutter v10.2.1.

In recent Flutter versions, the framework's `IconData` class was marked as `final`. Because font_awesome_flutter v10.x attempts to extend `IconData`, the compiler threw the following error during build: "The class 'IconData' can't be extended outside of its library because it's a final class."

Upgrading font_awesome_flutter to v11.0.0 resolves this issue, but introduces a breaking change: the package now uses its own `FaIconData` type instead of inheriting from `IconData`.

To accommodate this change and resolve the resulting type mismatches:
- Modified `MediaLaunchButton` to accept a generic `Widget` instead of raw `IconData`.
- Updated usages in `about_screen.dart` to supply `FaIcon` widgets.
- Updated `app_update_dialog.dart` to use `FaIcon` instead of `Icon` for FontAwesome icons.