### PR TITLE
build(windows): fix MSVC compilation error for deprecated coroutines

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,9 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# Silence experimental coroutine deprecation warnings for legacy dependencies.
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
Recent updates to Visual Studio 2026 (MSVC 14.51+) deprecate the `/await` compiler option and the `<experimental/coroutine>` header, triggering the `STL1011` static assertion for projects that still rely on the experimental coroutine implementation.

This prevented Windows builds because third-party plugins (`permission_handler_windows` and `gal`) still depend on these legacy coroutine features.

Added `-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` to `windows/CMakeLists.txt` suppress the deprecation assertion and restore build compatibility.