### PR TITLE
Desktop input and app-wide keyboard shortcuts

### DIFF
--- a/lib/src/constants/reader_keyboard_shortcuts.dart
+++ b/lib/src/constants/reader_keyboard_shortcuts.dart
@@ -27,6 +27,10 @@ class AutoScrollFasterIntent extends Intent {}
 
 class AutoScrollSlowerIntent extends Intent {}
 
+class FirstPageIntent extends Intent {}
+
+class LastPageIntent extends Intent {}
+
 ShortcutManager readerShortcutManager(Axis scrollDirection,
         {bool isRtl = false, bool autoScrollSupported = false}) =>
     ShortcutManager(
@@ -84,6 +88,8 @@ ShortcutManager readerShortcutManager(Axis scrollDirection,
             ViewportScrollBackwardIntent(),
         const SingleActivator(LogicalKeyboardKey.pageDown):
             ViewportScrollForwardIntent(),
+        const SingleActivator(LogicalKeyboardKey.home): FirstPageIntent(),
+        const SingleActivator(LogicalKeyboardKey.end): LastPageIntent(),
         const SingleActivator(LogicalKeyboardKey.escape): HideQuickOpenIntent(),
       },
     );

--- a/lib/src/features/hotkeys/data/hotkey_binding.dart
+++ b/lib/src/features/hotkeys/data/hotkey_binding.dart
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../../l10n/generated/app_localizations.dart';
+import '../../../utils/platform/platform_runtime.dart';
+
+class GoBackIntent extends Intent {
+  const GoBackIntent();
+}
+
+/// Esc. Closes the quick-open overlay if it's showing, else goes back. Bound
+/// directly in the host's Shortcuts (not via the framework DismissIntent,
+/// which pushed routes like the manga details screen don't propagate up to
+/// the host) so it fires reliably on every screen.
+class EscapeIntent extends Intent {
+  const EscapeIntent();
+}
+
+class OpenLibraryIntent extends Intent {
+  const OpenLibraryIntent();
+}
+
+class OpenDownloadsIntent extends Intent {
+  const OpenDownloadsIntent();
+}
+
+class OpenSearchIntent extends Intent {
+  const OpenSearchIntent();
+}
+
+/// Sentinel for rows documented on the page but NOT bound via a keyboard
+/// Shortcut: Esc (routed through DismissIntent) and the mouse back-button
+/// (handled by a Listener); excluded from the Shortcuts map via
+/// [GlobalHotkey.hasKeyboardActivator].
+class _NoActivator extends ShortcutActivator {
+  const _NoActivator();
+  @override
+  Iterable<LogicalKeyboardKey>? get triggers => const [];
+  @override
+  bool accepts(KeyEvent event, HardwareKeyboard state) => false;
+  @override
+  String debugDescribeKeys() => '';
+}
+
+const ShortcutActivator noActivator = _NoActivator();
+
+class GlobalHotkey {
+  const GlobalHotkey({
+    required this.activator,
+    required this.intent,
+    required this.label,
+    required this.displayKeys,
+    this.desktopOnly = false,
+  });
+
+  final ShortcutActivator activator;
+  final Intent intent;
+  final String Function(AppLocalizations) label;
+  final List<String> displayKeys;
+  final bool desktopOnly;
+
+  bool get hasKeyboardActivator => activator is! _NoActivator;
+}
+
+String _backLabel(AppLocalizations l) => l.hotkeyGoBack;
+String _searchLabel(AppLocalizations l) => l.hotkeyOpenSearch;
+String _libraryLabel(AppLocalizations l) => l.hotkeyOpenLibrary;
+String _downloadsLabel(AppLocalizations l) => l.hotkeyOpenDownloads;
+
+// Entries sharing a label render as one grouped row on the Hotkeys page
+// (e.g. all three "Go back" bindings on a single line). Order here is the
+// page order.
+const List<GlobalHotkey> globalHotkeys = [
+  GlobalHotkey(
+    activator: SingleActivator(LogicalKeyboardKey.escape),
+    intent: EscapeIntent(),
+    label: _backLabel,
+    displayKeys: ['Esc'],
+  ),
+  GlobalHotkey(
+    activator: SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true),
+    intent: GoBackIntent(),
+    label: _backLabel,
+    displayKeys: ['Alt', '←'],
+  ),
+  GlobalHotkey(
+    activator: noActivator, // mouse button 4, handled by Listener
+    intent: GoBackIntent(),
+    label: _backLabel,
+    displayKeys: ['Mouse', 'Back'],
+  ),
+  GlobalHotkey(
+    activator: SingleActivator(LogicalKeyboardKey.keyF, control: true),
+    intent: OpenSearchIntent(),
+    label: _searchLabel,
+    displayKeys: ['Ctrl', 'F'],
+  ),
+  GlobalHotkey(
+    activator: SingleActivator(LogicalKeyboardKey.keyP, control: true),
+    intent: OpenSearchIntent(),
+    label: _searchLabel,
+    displayKeys: ['Ctrl', 'P'],
+  ),
+  GlobalHotkey(
+    activator: SingleActivator(LogicalKeyboardKey.keyL, control: true),
+    intent: OpenLibraryIntent(),
+    label: _libraryLabel,
+    displayKeys: ['Ctrl', 'L'],
+    desktopOnly: true,
+  ),
+  GlobalHotkey(
+    activator: SingleActivator(LogicalKeyboardKey.keyJ, control: true),
+    intent: OpenDownloadsIntent(),
+    label: _downloadsLabel,
+    displayKeys: ['Ctrl', 'J'],
+    desktopOnly: true,
+  ),
+];
+
+List<GlobalHotkey> activeGlobalHotkeys() =>
+    globalHotkeys.where((h) => !h.desktopOnly || isDesktopPlatform).toList();
+
+class HotkeyDisplay {
+  const HotkeyDisplay({required this.label, required this.displayKeys});
+  final String Function(AppLocalizations) label;
+  final List<String> displayKeys;
+}
+
+String _rPrevPage(AppLocalizations l) => l.hotkeyReaderPrevPage;
+String _rNextPage(AppLocalizations l) => l.hotkeyReaderNextPage;
+String _rFirstPage(AppLocalizations l) => l.hotkeyReaderFirstPage;
+String _rLastPage(AppLocalizations l) => l.hotkeyReaderLastPage;
+String _rPrevChapter(AppLocalizations l) => l.hotkeyReaderPrevChapter;
+String _rNextChapter(AppLocalizations l) => l.hotkeyReaderNextChapter;
+String _rToggleMenu(AppLocalizations l) => l.hotkeyReaderToggleMenu;
+
+const List<HotkeyDisplay> readerHotkeyDisplays = [
+  HotkeyDisplay(label: _rPrevPage, displayKeys: ['←', 'A']),
+  HotkeyDisplay(label: _rNextPage, displayKeys: ['→', 'D']),
+  HotkeyDisplay(label: _rFirstPage, displayKeys: ['Home']),
+  HotkeyDisplay(label: _rLastPage, displayKeys: ['End']),
+  HotkeyDisplay(label: _rPrevChapter, displayKeys: [',']),
+  HotkeyDisplay(label: _rNextChapter, displayKeys: ['.']),
+  HotkeyDisplay(label: _rToggleMenu, displayKeys: ['Esc']),
+];

--- a/lib/src/features/hotkeys/presentation/global_shortcut_host.dart
+++ b/lib/src/features/hotkeys/presentation/global_shortcut_host.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../routes/router_config.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../quick_open/presentation/search_stack/search_stack_screen.dart';
+import '../../settings/presentation/general/quick_search_toggle/quick_search_toggle_tile.dart';
+import '../data/hotkey_binding.dart';
+
+/// App-wide keyboard + mouse navigation, mounted as the OUTERMOST wrapper
+/// around the shell. Owns every global shortcut (back, search, library,
+/// downloads) so there is a single `Shortcuts` layer that reliably receives
+/// keys — the FocusScope below keeps a focused node under it at all times,
+/// which a bare `Shortcuts` needs to fire. Esc is routed via Flutter's
+/// built-in [DismissIntent] so dialogs/menus dismiss first and this is the
+/// last resort.
+class GlobalShortcutHost extends ConsumerWidget {
+  const GlobalShortcutHost({super.key, required this.child});
+
+  final Widget child;
+
+  void _back(BuildContext context) {
+    if (GoRouter.of(context).canPop()) context.pop();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    void openSearch() {
+      if (ref.read(quickSearchToggleProvider).ifNull()) {
+        ref.read(quickOpenVisibleProvider.notifier).state = true;
+      }
+    }
+
+    return Shortcuts(
+      shortcuts: {
+        for (final h in activeGlobalHotkeys())
+          if (h.hasKeyboardActivator) h.activator: h.intent,
+      },
+      child: Actions(
+        actions: {
+          // Esc: close the quick-open overlay if it's showing, else go back.
+          EscapeIntent: CallbackAction<EscapeIntent>(
+            onInvoke: (_) {
+              if (ref.read(quickOpenVisibleProvider)) {
+                ref.read(quickOpenVisibleProvider.notifier).state = false;
+              } else {
+                _back(context);
+              }
+              return null;
+            },
+          ),
+          GoBackIntent: CallbackAction<GoBackIntent>(
+            onInvoke: (_) {
+              _back(context);
+              return null;
+            },
+          ),
+          OpenSearchIntent: CallbackAction<OpenSearchIntent>(
+            onInvoke: (_) {
+              openSearch();
+              return null;
+            },
+          ),
+          OpenLibraryIntent: CallbackAction<OpenLibraryIntent>(
+            onInvoke: (_) {
+              const LibraryRoute(categoryId: 0).go(context);
+              return null;
+            },
+          ),
+          OpenDownloadsIntent: CallbackAction<OpenDownloadsIntent>(
+            onInvoke: (_) {
+              const DownloadsRoute().go(context);
+              return null;
+            },
+          ),
+        },
+        // A `Shortcuts` widget only receives key events when a focused widget
+        // lives below it. The app shell never autofocuses anything, so without
+        // this the whole global keymap is dead. FocusScope(autofocus) keeps a
+        // focused node under the host at all times (yielding to any inner
+        // widget — text field, reader — that requests focus).
+        child: FocusScope(
+          autofocus: true,
+          child: Builder(
+            builder: (context) => Listener(
+              // buttons is a bitmask — test the bit, not equality, so a chorded
+              // press (e.g. left held + back) still triggers.
+              onPointerDown: (event) {
+                if (event.buttons & kBackMouseButton != 0) {
+                  Actions.maybeInvoke(context, const GoBackIntent());
+                }
+              },
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/hotkeys/presentation/hotkeys_settings_screen.dart
+++ b/lib/src/features/hotkeys/presentation/hotkeys_settings_screen.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../../l10n/generated/app_localizations.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../data/hotkey_binding.dart';
+
+class HotkeysSettingsScreen extends StatelessWidget {
+  const HotkeysSettingsScreen({super.key});
+
+  // Collapse registry entries that share a label into one row, each entry's
+  // keys shown as a separate chord (e.g. Go back → Esc · Alt+← · Mouse Back).
+  List<_Row> _globalRows(AppLocalizations l) {
+    final rows = <_Row>[];
+    for (final h in activeGlobalHotkeys()) {
+      final label = h.label(l);
+      final existing = rows.where((r) => r.label == label);
+      if (existing.isEmpty) {
+        rows.add(_Row(label, [h.displayKeys]));
+      } else {
+        existing.first.chords.add(h.displayKeys);
+      }
+    }
+    return rows;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = context.l10n;
+    final rows = [
+      _SectionHeader(l.hotkeysGlobalSection),
+      for (final r in _globalRows(l)) _HotkeyRow(label: r.label, chords: r.chords),
+      _SectionHeader(l.hotkeysReaderSection),
+      for (final h in readerHotkeyDisplays)
+        _HotkeyRow(label: h.label(l), chords: [h.displayKeys]),
+    ];
+    return Scaffold(
+      appBar: AppBar(title: Text(l.keyboardShortcuts)),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 640),
+          child: ListView(padding: const EdgeInsets.only(bottom: 24), children: rows),
+        ),
+      ),
+    );
+  }
+}
+
+class _Row {
+  _Row(this.label, this.chords);
+  final String label;
+  final List<List<String>> chords;
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.text);
+  final String text;
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+        child: Text(text,
+            style: context.textTheme.titleSmall
+                ?.copyWith(color: context.colorScheme.primary)),
+      );
+}
+
+class _HotkeyRow extends StatelessWidget {
+  const _HotkeyRow({required this.label, required this.chords});
+  final String label;
+  final List<List<String>> chords;
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(child: Text(label, style: context.textTheme.bodyLarge)),
+            const SizedBox(width: 16),
+            Flexible(
+              child: Wrap(
+                alignment: WrapAlignment.end,
+                spacing: 12,
+                runSpacing: 6,
+                children: [for (final chord in chords) _Chord(chord)],
+              ),
+            ),
+          ],
+        ),
+      );
+}
+
+// One key combination, e.g. Alt+← rendered as two adjacent caps.
+class _Chord extends StatelessWidget {
+  const _Chord(this.keys);
+  final List<String> keys;
+  @override
+  Widget build(BuildContext context) => Wrap(
+        spacing: 4,
+        children: [for (final k in keys) _KeyCap(k)],
+      );
+}
+
+class _KeyCap extends StatelessWidget {
+  const _KeyCap(this.label);
+  final String label;
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: context.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: context.colorScheme.outlineVariant),
+        ),
+        child: Text(label, style: context.textTheme.labelMedium),
+      );
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
@@ -246,6 +246,9 @@ class ContinuousReaderMode extends HookConsumerWidget {
       ),
       onViewportScrollForward: () => handleViewportScroll(forward: true),
       onViewportScrollBackward: () => handleViewportScroll(forward: false),
+      onJumpToFirst: () => scrollController.jumpTo(index: 0),
+      onJumpToLast: () =>
+          scrollController.jumpTo(index: chapterPages.pages.length - 1),
       child: AppUtils.wrapOn(
         !kIsWeb &&
                 (Platform.isAndroid || Platform.isIOS) &&

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -995,6 +995,14 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       onNext: () => handlePageNavigation(isNext: true),
       onViewportScrollForward: () => handleViewportScroll(forward: true),
       onViewportScrollBackward: () => handleViewportScroll(forward: false),
+      // Reuse the slider-jump primitive (chapter-relative index -> global) so
+      // currentChapterPageIndex/prefetch/scroll-adjust guard stay in sync,
+      // rather than calling itemScrollController.jumpTo directly.
+      onJumpToFirst: () => jumpToChapterRelative(0),
+      onJumpToLast: () => jumpToChapterRelative(
+          (loadedById(currentVisibleChapter.value.id)?.pages.pages.length ??
+                  chapterPages.pages.length) -
+              1),
       onToggleAutoScroll: () =>
           ref.read(autoScrollActiveProvider.notifier).toggle(),
       onAutoScrollFaster: () {

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous_reader_mode.dart
@@ -197,6 +197,9 @@ class InfinityContinuousReaderMode extends HookConsumerWidget {
       ),
       onViewportScrollForward: () => handleViewportScroll(forward: true),
       onViewportScrollBackward: () => handleViewportScroll(forward: false),
+      onJumpToFirst: () => scrollController.jumpTo(index: 0),
+      onJumpToLast: () =>
+          scrollController.jumpTo(index: chapterPages.pages.length - 1),
       child: AppUtils.wrapOn(
         !kIsWeb &&
                 (Platform.isAndroid || Platform.isIOS) &&

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -609,6 +609,12 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       handlesOwnChapterNavigation: true,
       isAtFirstBoundary: () => controller.isAtFirst,
       isAtLastBoundary: () => controller.isAtLast,
+      // jumpToRaw is scoped to the currently DISPLAYED chapter internally, so
+      // the last-page bound must come from visibleChapterPages, not the
+      // originally-opened chapterPages param.
+      onJumpToFirst: () => controller.jumpToRaw(0),
+      onJumpToLast: () =>
+          controller.jumpToRaw(visibleChapterPages.pages.length - 1),
       spreadPageIndexes: spreadPageIndexes,
       effectiveReaderMode: wrapperReaderMode,
       child: PagedReaderViewport(

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
@@ -177,6 +177,8 @@ class SinglePageReaderMode extends HookConsumerWidget {
       childHandlesGestures: true,
       isAtFirstBoundary: () => controller.isAtFirst,
       isAtLastBoundary: () => controller.isAtLast,
+      onJumpToFirst: () => controller.jumpToRaw(0),
+      onJumpToLast: () => controller.jumpToRaw(chapterPages.pages.length - 1),
       spreadPageIndexes: spreadPageIndexes,
       effectiveReaderMode: wrapperReaderMode,
       child: PagedReaderViewport(

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -135,6 +135,8 @@ class ReaderWrapper extends HookConsumerWidget {
     this.onToggleAutoScroll,
     this.onAutoScrollFaster,
     this.onAutoScrollSlower,
+    this.onJumpToFirst,
+    this.onJumpToLast,
     required this.scrollDirection,
     this.showReaderLayoutAnimation = false,
     required this.chapterPages,
@@ -158,6 +160,8 @@ class ReaderWrapper extends HookConsumerWidget {
   final VoidCallback? onToggleAutoScroll;
   final VoidCallback? onAutoScrollFaster;
   final VoidCallback? onAutoScrollSlower;
+  final VoidCallback? onJumpToFirst;
+  final VoidCallback? onJumpToLast;
   final int currentIndex;
   final Axis scrollDirection;
   final bool showReaderLayoutAnimation;
@@ -613,6 +617,18 @@ class ReaderWrapper extends HookConsumerWidget {
                         CallbackAction<AutoScrollSlowerIntent>(
                       onInvoke: (intent) {
                         onAutoScrollSlower?.call();
+                        return null;
+                      },
+                    ),
+                    FirstPageIntent: CallbackAction<FirstPageIntent>(
+                      onInvoke: (intent) {
+                        onJumpToFirst?.call();
+                        return null;
+                      },
+                    ),
+                    LastPageIntent: CallbackAction<LastPageIntent>(
+                      onInvoke: (intent) {
+                        onJumpToLast?.call();
                         return null;
                       },
                     ),

--- a/lib/src/features/quick_open/presentation/search_stack/search_stack_screen.dart
+++ b/lib/src/features/quick_open/presentation/search_stack/search_stack_screen.dart
@@ -4,97 +4,49 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import 'dart:io';
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../settings/presentation/general/quick_search_toggle/quick_search_toggle_tile.dart';
 import '../quick_search/quick_search_screen.dart';
 
-class ShowQuickOpenIntent extends Intent {}
+/// Whether the quick-open overlay is showing. The keyboard shortcuts that
+/// open it live in the app-wide GlobalShortcutHost (which holds focus, unlike
+/// this deep-in-the-tree widget), so they toggle this provider rather than a
+/// local state.
+final quickOpenVisibleProvider = StateProvider<bool>((ref) => false);
 
-class HideQuickOpenIntent extends Intent {}
-
-class SearchStackScreen extends HookConsumerWidget {
+class SearchStackScreen extends ConsumerWidget {
   const SearchStackScreen({super.key, this.child});
   final Widget? child;
+
   @override
-  Widget build(context, ref) {
-    final visible = useState(false);
+  Widget build(BuildContext context, WidgetRef ref) {
     final isQuickSearchEnabled = ref.watch(quickSearchToggleProvider).ifNull();
     if (!isQuickSearchEnabled) return child!;
-    return QuickSearchShortcutWrapper(
-      visible: visible,
-      child: Stack(
-        children: [
-          if (child != null) child!,
-          if (visible.value)
-            GestureDetector(
-              onTap: () => visible.value = (false),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-                child: Container(
-                  constraints: const BoxConstraints.expand(),
-                  decoration: BoxDecoration(
-                    color: context.theme.canvasColor.withValues(alpha: .1),
-                  ),
-                  child: QuickSearchScreen(
-                    afterClick: () => visible.value = (false),
-                  ),
+    final visible = ref.watch(quickOpenVisibleProvider);
+    void hide() => ref.read(quickOpenVisibleProvider.notifier).state = false;
+    return Stack(
+      children: [
+        if (child != null) child!,
+        if (visible)
+          GestureDetector(
+            onTap: hide,
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+              child: Container(
+                constraints: const BoxConstraints.expand(),
+                decoration: BoxDecoration(
+                  color: context.theme.canvasColor.withValues(alpha: .1),
                 ),
+                child: QuickSearchScreen(afterClick: hide),
               ),
             ),
-        ],
-      ),
-    );
-  }
-}
-
-class QuickSearchShortcutWrapper extends StatelessWidget {
-  const QuickSearchShortcutWrapper({
-    super.key,
-    required this.child,
-    required this.visible,
-  });
-  final Widget child;
-  final ValueNotifier<bool> visible;
-  @override
-  Widget build(BuildContext context) {
-    return Shortcuts(
-      shortcuts: {
-        SingleActivator(
-          LogicalKeyboardKey.keyP,
-          control: kIsWeb || !Platform.isMacOS,
-          meta: kIsWeb ? false : Platform.isMacOS,
-        ): ShowQuickOpenIntent(),
-        const SingleActivator(LogicalKeyboardKey.escape): HideQuickOpenIntent(),
-      },
-      child: Actions(
-        actions: {
-          ShowQuickOpenIntent: CallbackAction<ShowQuickOpenIntent>(
-            onInvoke: (ShowQuickOpenIntent intent) {
-              visible.value = (true);
-              return null;
-            },
           ),
-          HideQuickOpenIntent: CallbackAction<HideQuickOpenIntent>(
-            onInvoke: (HideQuickOpenIntent intent) {
-              visible.value = (false);
-              return null;
-            },
-          ),
-        },
-        child: GestureDetector(
-          onLongPress: () => visible.value = (true),
-          child: child,
-        ),
-      ),
+      ],
     );
   }
 }

--- a/lib/src/features/settings/presentation/settings/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings/settings_screen.dart
@@ -12,6 +12,7 @@ import '../../../../routes/router_config.dart';
 import '../../../../utils/crash/crash_log.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
+import '../../../../utils/platform/platform_runtime.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -51,6 +52,12 @@ class SettingsScreen extends StatelessWidget {
             leading: const Icon(Icons.chrome_reader_mode_rounded),
             onTap: () => const ReaderSettingsRoute().go(context),
           ),
+          if (isKeyboardRuntime)
+            ListTile(
+              title: Text(context.l10n.keyboardShortcuts),
+              leading: const Icon(Icons.keyboard_rounded),
+              onTap: () => const HotkeysSettingsRoute().go(context),
+            ),
           ListTile(
             title: Text(context.l10n.browse),
             leading: const Icon(Icons.explore_rounded),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2670,5 +2670,61 @@
     "offlineServerMismatchDismiss": "Dismiss",
     "offlineServerMismatchConfirmTitle": "Clear offline data?",
     "offlineServerMismatchConfirmBody": "This removes all on-device manga and queued downloads from the previous server.",
-    "offlineServerMismatchClearAction": "Clear offline data"
+    "offlineServerMismatchClearAction": "Clear offline data",
+    "keyboardShortcuts": "Keyboard shortcuts",
+    "@keyboardShortcuts": {
+        "description": "Settings tile + Hotkeys page title"
+    },
+    "hotkeysGlobalSection": "Global",
+    "@hotkeysGlobalSection": {
+        "description": "Hotkeys page section header"
+    },
+    "hotkeysReaderSection": "Reader",
+    "@hotkeysReaderSection": {
+        "description": "Hotkeys page section header"
+    },
+    "hotkeyGoBack": "Go back",
+    "@hotkeyGoBack": {
+        "description": "Hotkey action"
+    },
+    "hotkeyOpenLibrary": "Open library",
+    "@hotkeyOpenLibrary": {
+        "description": "Hotkey action"
+    },
+    "hotkeyOpenDownloads": "Open downloads",
+    "@hotkeyOpenDownloads": {
+        "description": "Hotkey action"
+    },
+    "hotkeyOpenSearch": "Search",
+    "@hotkeyOpenSearch": {
+        "description": "Hotkey action"
+    },
+    "hotkeyReaderPrevPage": "Previous page",
+    "@hotkeyReaderPrevPage": {
+        "description": "Reader hotkey action"
+    },
+    "hotkeyReaderNextPage": "Next page",
+    "@hotkeyReaderNextPage": {
+        "description": "Reader hotkey action"
+    },
+    "hotkeyReaderFirstPage": "First page",
+    "@hotkeyReaderFirstPage": {
+        "description": "Reader hotkey action"
+    },
+    "hotkeyReaderLastPage": "Last page",
+    "@hotkeyReaderLastPage": {
+        "description": "Reader hotkey action"
+    },
+    "hotkeyReaderPrevChapter": "Previous chapter",
+    "@hotkeyReaderPrevChapter": {
+        "description": "Reader hotkey action"
+    },
+    "hotkeyReaderNextChapter": "Next chapter",
+    "@hotkeyReaderNextChapter": {
+        "description": "Reader hotkey action"
+    },
+    "hotkeyReaderToggleMenu": "Toggle menu",
+    "@hotkeyReaderToggleMenu": {
+        "description": "Reader hotkey action"
+    }
 }

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -15,6 +15,8 @@ import '../features/browse_center/presentation/source/source_screen.dart';
 import '../features/browse_center/presentation/source_manga_list/source_manga_list_screen.dart';
 import '../features/browse_center/presentation/source_preference/source_preference_screen.dart';
 import '../features/history/presentation/history_screen.dart';
+import '../features/hotkeys/presentation/global_shortcut_host.dart';
+import '../features/hotkeys/presentation/hotkeys_settings_screen.dart';
 import '../features/library/presentation/category/edit_category_screen.dart';
 import '../features/library/presentation/library/library_screen.dart';
 import '../features/manga_book/presentation/downloads/downloads_screen.dart';
@@ -101,6 +103,7 @@ abstract class Routes {
   static const offlineSettings = 'offline';
   static const connection = 'connection';
   static const trackingSettings = 'tracking';
+  static const hotkeysSettings = 'hotkeys';
 
   // Commons
   static const mangaRoute = '/manga/:mangaId';
@@ -231,6 +234,8 @@ GoRouter routerConfig(ref) {
                         path: Routes.offlineSettings),
                     TypedGoRoute<TrackingSettingsRoute>(
                         path: Routes.trackingSettings),
+                    TypedGoRoute<HotkeysSettingsRoute>(
+                        path: Routes.hotkeysSettings),
                   ],
                 ),
               ],
@@ -274,7 +279,9 @@ class QuickSearchRoute extends ShellRouteData {
                   : Brightness.dark,
           systemNavigationBarDividerColor: Colors.transparent,
         ),
-        child: SearchStackScreen(child: navigator),
+        child: GlobalShortcutHost(
+          child: SearchStackScreen(child: navigator),
+        ),
       );
 }
 

--- a/lib/src/routes/sub_routes/more_routes.dart
+++ b/lib/src/routes/sub_routes/more_routes.dart
@@ -114,3 +114,10 @@ class TrackingSettingsRoute extends GoRouteData {
   @override
   Widget build(context, state) => const TrackingSettingsScreen();
 }
+
+class HotkeysSettingsRoute extends GoRouteData {
+  const HotkeysSettingsRoute();
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const HotkeysSettingsScreen();
+}

--- a/lib/src/utils/platform/platform_runtime.dart
+++ b/lib/src/utils/platform/platform_runtime.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+/// Native desktop OS (not web, not mobile). `!kIsWeb` must be first — dart:io
+/// `Platform` throws on web.
+bool get isDesktopPlatform =>
+    !kIsWeb && (Platform.isLinux || Platform.isWindows || Platform.isMacOS);
+
+/// Runtimes where a physical keyboard is expected: native desktop or web.
+bool get isKeyboardRuntime => kIsWeb || isDesktopPlatform;

--- a/test/hotkeys/global_shortcut_host_test.dart
+++ b/test/hotkeys/global_shortcut_host_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/hotkeys/presentation/global_shortcut_host.dart';
+import 'package:tsumiru/src/features/quick_open/presentation/search_stack/search_stack_screen.dart';
+import 'package:tsumiru/src/features/settings/presentation/general/quick_search_toggle/quick_search_toggle_tile.dart';
+
+// Faithful reproduction: the host wraps a router shell and NOTHING is given
+// focus (exactly like the real app at the library screen). A `Shortcuts`
+// widget only receives key events when a focused widget lives below it, so
+// these must pass without any test-side autofocus. The previous test cheated
+// with `Focus(autofocus: true)`, which hid the real bug — every app-wide
+// shortcut was dead because nothing ever holds focus.
+//
+// The host navigates via the app's typed LibraryRoute (`/library/0`) and
+// DownloadsRoute (`/downloads`); this test router provides plain routes at
+// those exact locations so Ctrl+L / Ctrl+J are exercised for real.
+
+// Force quick-search on so OpenSearch takes effect (the real provider is
+// SharedPreferences-backed and would be null/off in a test).
+class _ToggleOn extends QuickSearchToggle {
+  @override
+  bool? build() => true;
+}
+
+GoRouter _router() => GoRouter(
+      initialLocation: '/',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) => GlobalShortcutHost(child: child),
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => context.push('/b'),
+                    child: const Text('to B'),
+                  ),
+                ),
+              ),
+            ),
+            GoRoute(
+              path: '/b',
+              builder: (context, state) =>
+                  const Scaffold(body: Center(child: Text('PAGE B'))),
+            ),
+            GoRoute(
+              path: '/library/:categoryId',
+              builder: (context, state) =>
+                  const Scaffold(body: Center(child: Text('LIBRARY'))),
+            ),
+            GoRoute(
+              path: '/downloads',
+              builder: (context, state) =>
+                  const Scaffold(body: Center(child: Text('DOWNLOADS'))),
+            ),
+          ],
+        ),
+      ],
+    );
+
+Future<void> _defocus(WidgetTester tester) async {
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump();
+}
+
+Future<void> _pumpRouter(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(child: MaterialApp.router(routerConfig: _router())),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('Esc pops the route with nothing pre-focused', (tester) async {
+    await _pumpRouter(tester);
+    await tester.tap(find.text('to B'));
+    await tester.pumpAndSettle();
+    expect(find.text('PAGE B'), findsOneWidget);
+    await _defocus(tester);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.text('PAGE B'), findsNothing, reason: 'Esc should go back');
+    expect(find.text('to B'), findsOneWidget);
+  });
+
+  testWidgets('Alt+Left pops the route with nothing pre-focused',
+      (tester) async {
+    await _pumpRouter(tester);
+    await tester.tap(find.text('to B'));
+    await tester.pumpAndSettle();
+    await _defocus(tester);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.altLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
+    await tester.pumpAndSettle();
+
+    expect(find.text('PAGE B'), findsNothing, reason: 'Alt+Left should go back');
+  });
+
+  testWidgets('mouse back-button pops the route with nothing pre-focused',
+      (tester) async {
+    await _pumpRouter(tester);
+    await tester.tap(find.text('to B'));
+    await tester.pumpAndSettle();
+    await _defocus(tester);
+
+    final center = tester.getCenter(find.text('PAGE B'));
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester
+        .sendEventToBinding(pointer.down(center, buttons: kBackMouseButton));
+    await tester.pumpAndSettle();
+    await tester.sendEventToBinding(pointer.up());
+
+    expect(find.text('PAGE B'), findsNothing,
+        reason: 'mouse back-button should go back');
+  });
+
+  testWidgets('Ctrl+L opens the library with nothing pre-focused',
+      (tester) async {
+    await _pumpRouter(tester);
+    await _defocus(tester);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyL);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    expect(find.text('LIBRARY'), findsOneWidget, reason: 'Ctrl+L → library');
+  });
+
+  testWidgets('Ctrl+J opens downloads with nothing pre-focused',
+      (tester) async {
+    await _pumpRouter(tester);
+    await _defocus(tester);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyJ);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pumpAndSettle();
+
+    expect(find.text('DOWNLOADS'), findsOneWidget, reason: 'Ctrl+J → downloads');
+  });
+
+  testWidgets('Ctrl+F opens quick search with nothing pre-focused',
+      (tester) async {
+    final container = ProviderContainer(
+      overrides: [quickSearchToggleProvider.overrideWith(_ToggleOn.new)],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(
+        home: GlobalShortcutHost(
+          child: Scaffold(body: Center(child: Text('home'))),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(container.read(quickOpenVisibleProvider), isFalse);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyF);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    expect(container.read(quickOpenVisibleProvider), isTrue,
+        reason: 'Ctrl+F opens search');
+  });
+
+  testWidgets('Esc closes the quick-open overlay instead of going back',
+      (tester) async {
+    final container = ProviderContainer(
+      overrides: [quickSearchToggleProvider.overrideWith(_ToggleOn.new)],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(
+        home: GlobalShortcutHost(
+          child: Scaffold(body: Center(child: Text('home'))),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    container.read(quickOpenVisibleProvider.notifier).state = true;
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(container.read(quickOpenVisibleProvider), isFalse,
+        reason: 'Esc closes the overlay');
+  });
+}

--- a/test/hotkeys/hotkey_binding_test.dart
+++ b/test/hotkeys/hotkey_binding_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/hotkeys/data/hotkey_binding.dart';
+
+void main() {
+  test('every global hotkey has display keys', () {
+    for (final h in globalHotkeys) {
+      expect(h.displayKeys, isNotEmpty);
+    }
+  });
+
+  test('library and downloads are desktop-only; back is not', () {
+    final byKeys = {for (final h in globalHotkeys) h.displayKeys.join('+'): h};
+    expect(byKeys['Ctrl+L']!.desktopOnly, isTrue);
+    expect(byKeys['Ctrl+J']!.desktopOnly, isTrue);
+    expect(byKeys['Esc']!.desktopOnly, isFalse);
+  });
+
+  test('no forward row exists', () {
+    expect(globalHotkeys.any((h) => h.displayKeys.contains('Forward')), isFalse);
+  });
+
+  test('activeGlobalHotkeys on desktop includes desktop-only binds', () {
+    final active = activeGlobalHotkeys().map((h) => h.displayKeys.join('+'));
+    expect(active, containsAll(<String>['Esc', 'Ctrl+L', 'Ctrl+J']));
+  });
+
+  test('mouse-back is display-only; Esc and Alt+Left are real keybinds', () {
+    final byKeys = {for (final h in globalHotkeys) h.displayKeys.join('+'): h};
+    // Mouse back is handled by a Listener, so it has no keyboard activator.
+    expect(byKeys['Mouse+Back']!.hasKeyboardActivator, isFalse);
+    // Esc is bound directly in the host Shortcuts (not via DismissIntent).
+    expect(byKeys['Esc']!.hasKeyboardActivator, isTrue);
+    expect(byKeys['Alt+←']!.hasKeyboardActivator, isTrue);
+  });
+}

--- a/test/hotkeys/hotkeys_settings_screen_test.dart
+++ b/test/hotkeys/hotkeys_settings_screen_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/hotkeys/presentation/hotkeys_settings_screen.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+void main() {
+  testWidgets('lists Global and Reader sections', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const HotkeysSettingsScreen(),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Global'), findsOneWidget);
+    expect(find.text('Reader'), findsOneWidget);
+    expect(find.text('Go back'), findsWidgets);
+    expect(find.text('Open library'), findsOneWidget); // host is desktop
+  });
+}

--- a/test/hotkeys/platform_runtime_test.dart
+++ b/test/hotkeys/platform_runtime_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/utils/platform/platform_runtime.dart';
+
+void main() {
+  test('desktop implies keyboard runtime', () {
+    expect(isKeyboardRuntime || !isDesktopPlatform, isTrue);
+    expect(isDesktopPlatform, isTrue); // flutter_test host is desktop
+  });
+}

--- a/test/src/features/manga_book/reader/reader_wrapper_test.dart
+++ b/test/src/features/manga_book/reader/reader_wrapper_test.dart
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -118,5 +119,62 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(chapterFetches, 1);
     expect(pageFetches, 1);
+  });
+
+  testWidgets('Home/End dispatch onJumpToFirst/onJumpToLast', (tester) async {
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    SharedPreferences.setMockInitialValues(const {});
+    final prefs = await SharedPreferences.getInstance();
+    var firstInvoked = false;
+    var lastInvoked = false;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+              .overrideWithValue(null),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ReaderWrapper(
+            manga: testManga(),
+            chapter: testChapter(),
+            chapterPages: ChapterPagesDto(
+              chapter: ChapterPagesChapterDto(id: 1, pageCount: 3),
+              pages: const ['a', 'b', 'c'],
+            ),
+            currentIndex: 1,
+            onChanged: (_) {},
+            onNext: () {},
+            onPrevious: () {},
+            onJumpToFirst: () => firstInvoked = true,
+            onJumpToLast: () => lastInvoked = true,
+            scrollDirection: Axis.horizontal,
+            effectiveReaderMode: ReaderMode.singleHorizontalLTR,
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    // Focus lands on the reader's own FocusNode via a post-frame callback.
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.home);
+    await tester.pump();
+    expect(firstInvoked, isTrue);
+    expect(lastInvoked, isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.end);
+    await tester.pump();
+    expect(lastInvoked, isTrue);
+
+    expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
Adds keyboard and desktop-input shortcuts across the app, plus a settings page that lists them. Closes #109.

## App-wide

- **Esc** goes back, or closes the quick-search overlay if it's open
- **Alt+Left** and the **mouse back button** go back
- **Ctrl+F** / **Ctrl+P** open quick search
- **Ctrl+L** (library) and **Ctrl+J** (downloads) on desktop

## Reader

- **Home** / **End** jump to the first and last page, in every reading mode
- Alongside the existing prev/next page, prev/next chapter, and toggle-menu keys

## Settings

A new **Keyboard shortcuts** page under settings lists every binding, and only shows the ones that apply where you're running — so the browser build doesn't advertise desktop-only keys like Ctrl+L.
