### PR TITLE
Add self-hosted Renovate for dependency automation

### DIFF
--- a/.github/renovate-global.js
+++ b/.github/renovate-global.js
@@ -1,0 +1,11 @@
+// Global (self-hosted admin) config for the Renovate workflow. Repo-level rules
+// live in renovate.json. `binarySource: 'install'` lets Renovate's containerbase
+// install Dart/Flutter on demand so it can resolve pubspec.lock.
+module.exports = {
+  platform: "github",
+  onboarding: false,
+  requireConfig: "optional",
+  branchPrefix: "renovate/",
+  repositories: ["Suwayomi/Suwayomi-Tsumiru"],
+  binarySource: "install",
+};

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,35 @@
+# Self-hosted dependency updater. Runs weekly (and on demand), opens small,
+# CI-gated PRs to keep dependencies current. Authenticated with a fine-grained
+# PAT in the RENOVATE_TOKEN secret — NOT the default GITHUB_TOKEN, whose PRs
+# wouldn't trigger the PR checks.
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Renovate log level
+        default: info
+        type: choice
+        options: [debug, info, warn, error]
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: renovatebot/github-action@v46.1.19
+        with:
+          configurationFile: .github/renovate-global.js
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "enabledManagers": ["fvm", "pub", "github-actions", "gradle", "cocoapods", "custom.regex"],
+  "constraints": {
+    "flutter": "3.44.6"
+  },
+  "rangeStrategy": "update-lockfile",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "branchConcurrentLimit": 5,
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Major bumps wait on the dashboard so they land one at a time, reviewed",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Riverpod moves as one migration",
+      "matchManagers": ["pub"],
+      "matchPackageNames": ["hooks_riverpod", "riverpod_annotation", "riverpod_generator", "flutter_riverpod", "riverpod"],
+      "groupName": "riverpod"
+    },
+    {
+      "description": "go_router runtime and builder move together",
+      "matchManagers": ["pub"],
+      "matchPackageNames": ["go_router", "go_router_builder"],
+      "groupName": "go_router"
+    },
+    {
+      "description": "freezed runtime and annotation move together",
+      "matchManagers": ["pub"],
+      "matchPackageNames": ["freezed", "freezed_annotation"],
+      "groupName": "freezed"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["ghcr\\.io/andyholmes/flatter/freedesktop:(?<currentValue>[0-9]+\\.[0-9]+)"],
+      "depNameTemplate": "ghcr.io/andyholmes/flatter/freedesktop",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ]
+}


### PR DESCRIPTION
Stands up self-hosted Renovate (running in our own Actions, not the org-level Mend app) to keep dependencies current with small, CI-gated PRs. This is the automation half of the toolchain-currency effort; it also organizes and clears the ~24-major backlog left after the Flutter 3.44.6 bump.

## What it adds

- `.github/workflows/renovate.yml` — runs weekly (and on demand), authenticated by a `RENOVATE_TOKEN` secret (a PAT, so its PRs actually trigger the `verify` check; the default token would not).
- `.github/renovate-global.js` — global settings; `binarySource: install` lets Renovate install Dart/Flutter to resolve `pubspec.lock`.
- `renovate.json` — the update rules across every ecosystem: `pub`, `fvm`, `github-actions`, `gradle`, `cocoapods`, plus a custom manager for the date-tagged flatpak container.

## Conservative first rollout

- **No auto-merge** — every update is a PR you review.
- **Major bumps wait on the Dependency Dashboard** — the backlog shows up as a checklist you tick one at a time, rather than opening two dozen PRs at once.
- **Coupled packages move as one PR**: the Riverpod trio, go_router + its builder, and freezed + its annotation — so those migrations arrive whole, not in conflicting pieces.
- **Flood limits** (a few PRs at a time) and `update-lockfile` keep `pubspec.lock` coherent.

## One setup step (yours)

The bot can't run until its token exists. Create a token on an account with write access to the repo and add it as the repo secret `RENOVATE_TOKEN`:
- Fine-grained PAT scoped to this repo — permissions: Contents RW, Pull requests RW, Workflows RW, Issues RW, Checks read; or
- Classic PAT with `repo` + `workflow` scopes.

Then trigger the first run from the Actions tab (Renovate → Run workflow), or wait for Monday.

Note: `constraints.flutter` in `renovate.json` is pinned to 3.44.6 and should be bumped alongside `.fvmrc` when the SDK moves (Renovate can't read `.fvmrc` for the toolchain it resolves with).
