### PR TITLE
Migrate the codegen stack: Riverpod 3, freezed 3, graphql_codegen 3, go_router 17

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,12 @@
+# riverpod_generator 4.x resolves provider signature types for real, so the
+# GraphQL types our DTOs alias must exist in its build phase. Without this,
+# build_runner phases riverpod_generator first (reverse-alphabetical tiebreak)
+# and every provider touching a Fragment$* type dies with InvalidTypeException.
+global_options:
+  graphql_codegen:graphql_codegen:
+    runs_before:
+      - riverpod_generator:riverpod_generator
+
 targets:
   $default:
     builders:

--- a/lib/src/features/about/data/about_repository.dart
+++ b/lib/src/features/about/data/about_repository.dart
@@ -66,7 +66,7 @@ class AboutRepository {
 }
 
 @riverpod
-AboutRepository aboutRepository(ref) => AboutRepository(
+AboutRepository aboutRepository(Ref ref) => AboutRepository(
       client: ref.watch(graphQlClientProvider),
       packageInfo: ref.watch(packageInfoProvider),
     );

--- a/lib/src/features/about/domain/server_update/server_update.dart
+++ b/lib/src/features/about/domain/server_update/server_update.dart
@@ -11,7 +11,7 @@ import 'graphql/__generated__/fragment.graphql.dart';
 part 'server_update.freezed.dart';
 
 @freezed
-class ServerUpdate with _$ServerUpdate {
+abstract class ServerUpdate with _$ServerUpdate {
   factory ServerUpdate({
     String? channel,
     String? tag,

--- a/lib/src/features/about/presentation/about/about_screen.dart
+++ b/lib/src/features/about/presentation/about/about_screen.dart
@@ -114,7 +114,7 @@ class AboutScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final toast = ref.watch(toastProvider);
     final aboutAsync = ref.watch(aboutProvider);
-    final about = aboutAsync.valueOrNull;
+    final about = aboutAsync.value;
     final serverVer = about?.buildType == "Stable"
         ? about?.version
         : "${about?.version}-${about?.revision}";
@@ -125,7 +125,7 @@ class AboutScreen extends HookConsumerWidget {
         aboutAsync.showToastOnError(toast, withMicrotask: true);
       }
       return;
-    }, [aboutAsync.valueOrNull]);
+    }, [aboutAsync.value]);
 
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.about)),

--- a/lib/src/features/about/presentation/about/controllers/about_controller.dart
+++ b/lib/src/features/about/presentation/about/controllers/about_controller.dart
@@ -20,4 +20,4 @@ Future<AboutDto?> about(Ref ref) =>
     ref.watch(aboutRepositoryProvider).getAbout();
 
 @riverpod
-PackageInfo packageInfo(ref) => throw UnimplementedError();
+PackageInfo packageInfo(Ref ref) => throw UnimplementedError();

--- a/lib/src/features/auth/data/auth_coordinator.dart
+++ b/lib/src/features/auth/data/auth_coordinator.dart
@@ -192,7 +192,7 @@ class AuthCoordinator extends _$AuthCoordinator {
     ref.listen<AsyncValue<AuthCredentialsState>>(
       authCredentialsStoreProvider,
       (prev, next) {
-        final state = next.valueOrNull;
+        final state = next.value;
         if (state == null) return;
         if (state.uiAccessToken == null ||
             state.uiAccessTokenExpiresAt == null) {
@@ -202,7 +202,7 @@ class AuthCoordinator extends _$AuthCoordinator {
         // Re-schedule only when the expiry actually changed (e.g.
         // post-refresh, post-login, post-bootstrap). Cheap idempotent
         // reschedule is also fine — we cancel any existing Timer first.
-        final prevExpiry = prev?.valueOrNull?.uiAccessTokenExpiresAt;
+        final prevExpiry = prev?.value?.uiAccessTokenExpiresAt;
         if (prevExpiry == state.uiAccessTokenExpiresAt &&
             _proactiveRefreshTimer != null) {
           return;
@@ -223,7 +223,7 @@ class AuthCoordinator extends _$AuthCoordinator {
 
     final expiresAt = ref
         .read(authCredentialsStoreProvider)
-        .valueOrNull
+        .value
         ?.uiAccessTokenExpiresAt;
     if (expiresAt == null) return;
 
@@ -531,7 +531,7 @@ class AuthCoordinator extends _$AuthCoordinator {
     }
     final expiresAt = ref
         .read(authCredentialsStoreProvider)
-        .valueOrNull
+        .value
         ?.uiAccessTokenExpiresAt;
     if (expiresAt == null) return null;
     final remaining = expiresAt.difference(DateTime.now().toUtc());

--- a/lib/src/features/auth/data/auth_credentials_store.dart
+++ b/lib/src/features/auth/data/auth_credentials_store.dart
@@ -20,7 +20,7 @@ class UiLoginTokens {
 
 /// In-memory snapshot of every credential the app holds. This is the
 /// `state` of [AuthCredentialsStore] — synchronously readable via
-/// `ref.watch(authCredentialsStoreProvider).valueOrNull` so widgets like
+/// `ref.watch(authCredentialsStoreProvider).value` so widgets like
 /// `server_image` can authenticate on the first frame without an
 /// `AsyncLoading` flash that would otherwise cache a 401.
 ///
@@ -145,7 +145,7 @@ class AuthCredentialsStore extends _$AuthCredentialsStore {
   /// hasn't completed yet. Used internally by mutators that need to
   /// apply `copyWith` even before the initial load finishes.
   AuthCredentialsState get _current =>
-      state.valueOrNull ?? const AuthCredentialsState.empty();
+      state.value ?? const AuthCredentialsState.empty();
 
   // ---------- Password ----------
 

--- a/lib/src/features/browse_center/data/source_repository/source_repository.dart
+++ b/lib/src/features/browse_center/data/source_repository/source_repository.dart
@@ -101,5 +101,5 @@ class SourceRepository {
 }
 
 @riverpod
-SourceRepository sourceRepository(ref) =>
+SourceRepository sourceRepository(Ref ref) =>
     SourceRepository(ref.watch(graphQlClientProvider));

--- a/lib/src/features/browse_center/domain/language/language_model.dart
+++ b/lib/src/features/browse_center/domain/language/language_model.dart
@@ -10,7 +10,7 @@ part 'language_model.freezed.dart';
 part 'language_model.g.dart';
 
 @freezed
-class Language with _$Language {
+abstract class Language with _$Language {
   Language._();
   factory Language({
     String? code,

--- a/lib/src/features/browse_center/presentation/extension/controller/extension_controller.dart
+++ b/lib/src/features/browse_center/presentation/extension/controller/extension_controller.dart
@@ -29,7 +29,7 @@ Future<List<Extension>?> extension(Ref ref) {
 AsyncValue<Map<String, List<Extension>>> extensionMap(Ref ref) {
   final extensionMap = <String, List<Extension>>{};
   final extensionListData = ref.watch(extensionProvider);
-  final extensionList = [...?extensionListData.valueOrNull];
+  final extensionList = [...?extensionListData.value];
   final showNsfw = ref.watch(showNSFWProvider).ifNull(true);
   for (final e in extensionList) {
     if (!showNsfw && (e.isNsfw.ifNull())) continue;
@@ -67,7 +67,7 @@ AsyncValue<Map<String, List<Extension>>> extensionMap(Ref ref) {
 
 @riverpod
 List<String> extensionFilterLangList(Ref ref) {
-  final extensionMap = {...?ref.watch(extensionMapProvider).valueOrNull};
+  final extensionMap = {...?ref.watch(extensionMapProvider).value};
   extensionMap.remove("installed");
   extensionMap.remove("update");
   return [...extensionMap.keys]..sort();
@@ -84,7 +84,7 @@ class ExtensionLanguageFilter extends _$ExtensionLanguageFilter
 AsyncValue<Map<String, List<Extension>>> extensionMapFiltered(Ref ref) {
   final extensionMapFiltered = <String, List<Extension>>{};
   final extensionMapData = ref.watch(extensionMapProvider);
-  final extensionMap = {...?extensionMapData.valueOrNull};
+  final extensionMap = {...?extensionMapData.value};
   final enabledLangList = [...?ref.watch(extensionLanguageFilterProvider)];
   for (final e in enabledLangList) {
     if (extensionMap.containsKey(e)) extensionMapFiltered[e] = extensionMap[e]!;
@@ -97,7 +97,7 @@ AsyncValue<Map<String, List<Extension>>> extensionMapFilteredAndQueried(
   Ref ref,
 ) {
   final extensionMapData = ref.watch(extensionMapFilteredProvider);
-  final extensionMap = {...?extensionMapData.valueOrNull};
+  final extensionMap = {...?extensionMapData.value};
   final query = ref.watch(extensionQueryProvider);
   if (query.isBlank) return extensionMapData;
   return extensionMapData.copyWithData(

--- a/lib/src/features/browse_center/presentation/extension/extension_screen.dart
+++ b/lib/src/features/browse_center/presentation/extension/extension_screen.dart
@@ -52,7 +52,7 @@ class ExtensionScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final extensionMapData = ref.watch(extensionMapFilteredAndQueriedProvider);
 
-    final extensionMap = {...?extensionMapData.valueOrNull};
+    final extensionMap = {...?extensionMapData.value};
     final installed = extensionMap.remove("installed");
     final update = extensionMap.remove("update");
     final all = extensionMap.remove("all");
@@ -73,7 +73,7 @@ class ExtensionScreen extends HookConsumerWidget {
         );
       }
       return;
-    }, [extensionMapData.valueOrNull]);
+    }, [extensionMapData.value]);
 
     final body = extensionMapData.showUiWhenData(
       context,

--- a/lib/src/features/browse_center/presentation/global_search/controller/source_quick_search_controller.dart
+++ b/lib/src/features/browse_center/presentation/global_search/controller/source_quick_search_controller.dart
@@ -6,6 +6,7 @@
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:hooks_riverpod/legacy.dart';
 
 import '../../../../../constants/db_keys.dart';
 import '../../../../../constants/enum.dart';
@@ -75,7 +76,7 @@ class GlobalSearchScope extends _$GlobalSearchScope
 }
 
 /// When true, only sources that returned results are shown (hide empty/loading).
-final globalSearchOnlyHasResultsProvider = StateProvider<bool>((ref) => false);
+final globalSearchOnlyHasResultsProvider = StateProvider<bool>((Ref ref) => false);
 
 typedef QuickSearchResults = ({
   SourceDto source,
@@ -108,7 +109,7 @@ AsyncValue<List<QuickSearchResults>> quickSearchResults(Ref ref,
   final sourcesData = ref.watch(searchableSourcesProvider);
   final scope = ref.watch(globalSearchScopeProvider);
   final pinned = ref.watch(pinnedSourcesProvider);
-  final allSources = sourcesData.valueOrNull ?? const <SourceDto>[];
+  final allSources = sourcesData.value ?? const <SourceDto>[];
   final sourceList =
       (scope == GlobalSearchSourceFilter.pinned && pinned.isNotEmpty)
           ? pinned

--- a/lib/src/features/browse_center/presentation/global_search/global_search_screen.dart
+++ b/lib/src/features/browse_center/presentation/global_search/global_search_screen.dart
@@ -105,7 +105,7 @@ class GlobalSearchScreen extends HookConsumerWidget {
                 final visible = onlyHasResults
                     ? data
                         .where((e) =>
-                            (e.mangaList.valueOrNull?.isNotEmpty).ifNull())
+                            (e.mangaList.value?.isNotEmpty).ifNull())
                         .toList()
                     : data;
                 return ListView.builder(

--- a/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
+++ b/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
@@ -72,7 +72,7 @@ Map<String, List<SourceDto>> groupSourcesByLanguage(
 /// language filter.
 @riverpod
 List<SourceDto> pinnedSources(Ref ref) => pinnedSourcesFrom(
-    ref.watch(visibleSourceListProvider).valueOrNull ?? const []);
+    ref.watch(visibleSourceListProvider).value ?? const []);
 
 @riverpod
 AsyncValue<Map<String, List<SourceDto>>> sourceMap(Ref ref) {
@@ -87,7 +87,7 @@ AsyncValue<Map<String, List<SourceDto>>> sourceMap(Ref ref) {
 class SourceFilterLangMap extends _$SourceFilterLangMap {
   @override
   Map<String, bool> build() {
-    final sourceMap = {...?ref.watch(sourceMapProvider).valueOrNull};
+    final sourceMap = {...?ref.watch(sourceMapProvider).value};
     final enabledLanguages = ref.watch(sourceLanguageFilterProvider);
     sourceMap.remove("lastUsed");
     sourceMap.remove("localsourcelang");
@@ -113,7 +113,7 @@ class SourceFilterLangMap extends _$SourceFilterLangMap {
 AsyncValue<Map<String, List<SourceDto>>?> sourceMapFiltered(Ref ref) {
   final sourceMapFiltered = <String, List<SourceDto>>{};
   final sourceMapData = ref.watch(sourceMapProvider);
-  final sourceMap = {...?sourceMapData.valueOrNull};
+  final sourceMap = {...?sourceMapData.value};
   final enabledLangList = [...?ref.watch(sourceLanguageFilterProvider)]..sort();
   for (final e in enabledLangList) {
     if (sourceMap.containsKey(e)) sourceMapFiltered[e] = sourceMap[e]!;
@@ -140,7 +140,7 @@ AsyncValue<List<SourceDto>> searchableSources(Ref ref) {
 
 @riverpod
 List<SourceDto>? sourceQuery(Ref ref, {String? query}) {
-  final sourceMap = {...?ref.watch(sourceMapFilteredProvider).valueOrNull}
+  final sourceMap = {...?ref.watch(sourceMapFilteredProvider).value}
     ..remove('lastUsed');
   if (query.isNotBlank) {
     return sourceMap.values
@@ -158,7 +158,7 @@ List<SourceDto>? sourceQuery(Ref ref, {String? query}) {
 @riverpod
 AsyncValue<Map<String, List<SourceDto>>?> sourceMapFilteredAndQueried(Ref ref) {
   final sourceMapData = ref.watch(sourceMapFilteredProvider);
-  final sourceMap = {...?sourceMapData.valueOrNull};
+  final sourceMap = {...?sourceMapData.value};
   final query = ref.watch(sourceSearchQueryProvider);
   if (query.isBlank) return sourceMapData;
   return sourceMapData.copyWithData(

--- a/lib/src/features/browse_center/presentation/source/source_screen.dart
+++ b/lib/src/features/browse_center/presentation/source/source_screen.dart
@@ -28,7 +28,7 @@ class SourceScreen extends HookConsumerWidget {
         ? allPinned
         : allPinned.where((s) => s.name.query(query)).toList();
 
-    final sourceMap = {...?sourceMapData.valueOrNull};
+    final sourceMap = {...?sourceMapData.value};
     final localSource = sourceMap.remove("localsourcelang");
     final lastUsed = sourceMap.remove("lastUsed");
     final allSource = sourceMap.remove("all");
@@ -45,7 +45,7 @@ class SourceScreen extends HookConsumerWidget {
         withMicrotask: true,
       );
       return;
-    }, [sourceMapData.valueOrNull]);
+    }, [sourceMapData.value]);
 
     final body = sourceMapData.showUiWhenData(
       context,

--- a/lib/src/features/browse_center/presentation/source_manga_list/source_manga_list_screen.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/source_manga_list_screen.dart
@@ -78,7 +78,7 @@ class SourceMangaListScreen extends HookConsumerWidget {
     final sourceRepository = ref.watch(sourceRepositoryProvider);
     final appliedFilter = useState<List<FilterChange>>([]);
     final filterList =
-        ref.watch(baseSourceMangaFilterListProvider(sourceId)).valueOrNull;
+        ref.watch(baseSourceMangaFilterListProvider(sourceId)).value;
     final source = ref.watch(sourceProvider(sourceId));
 
     final query = useState(initialQuery);

--- a/lib/src/features/browse_center/presentation/source_preference/source_preference_screen.dart
+++ b/lib/src/features/browse_center/presentation/source_preference/source_preference_screen.dart
@@ -23,11 +23,11 @@ class SourcePreferenceScreen extends HookConsumerWidget {
     final source = ref.watch(sourceProvider(sourceId));
     final preferenceProvider = baseSourcePreferenceListProvider(sourceId);
     final networkPreferences = ref.watch(preferenceProvider);
-    final preferences = networkPreferences.valueOrNull;
+    final preferences = networkPreferences.value;
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          source.valueOrNull?.displayName ?? "",
+          source.value?.displayName ?? "",
           style: context.textTheme.titleLarge,
         ),
       ),

--- a/lib/src/features/history/domain/history_group.dart
+++ b/lib/src/features/history/domain/history_group.dart
@@ -15,7 +15,7 @@ import 'history_item.dart';
 part 'history_group.freezed.dart';
 
 @freezed
-class HistoryGroup with _$HistoryGroup {
+abstract class HistoryGroup with _$HistoryGroup {
   const factory HistoryGroup({
     required String title,
     required List<HistoryItemDto> items,

--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -43,7 +43,7 @@ class ReadingHistory extends _$ReadingHistory {
   }
 
   Future<void> loadMore() async {
-    final currentItems = state.valueOrNull ?? [];
+    final currentItems = state.value ?? [];
     final pageNo = (currentItems.length / 50).floor() + 1;
 
     final result = await AsyncValue.guard(
@@ -69,7 +69,7 @@ class ReadingHistory extends _$ReadingHistory {
   Future<void> removeFromHistory(int chapterId) async {
     state = await AsyncValue.guard(() async {
       // First get the chapter to extract mangaId for cache invalidation
-      final currentItems = state.valueOrNull ?? [];
+      final currentItems = state.value ?? [];
       HistoryItemDto? chapterToRemove;
 
       try {
@@ -125,7 +125,7 @@ class MangaReadingHistory extends _$MangaReadingHistory {
 
 @riverpod
 List<HistoryGroup> historyGroupedByDate(Ref ref) {
-  final historyItems = ref.watch(readingHistoryProvider).valueOrNull ?? [];
+  final historyItems = ref.watch(readingHistoryProvider).value ?? [];
 
   if (historyItems.isEmpty) return [];
 

--- a/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
+++ b/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
@@ -94,7 +94,7 @@ List<CategoryDto>? categoryListQuery(
   Ref ref, {
   required String query,
 }) {
-  final categoryList = ref.watch(categoryControllerProvider).valueOrNull;
+  final categoryList = ref.watch(categoryControllerProvider).value;
   return categoryList
       ?.where((element) => (element.name.query(query)).ifNull())
       .toList();
@@ -103,7 +103,7 @@ List<CategoryDto>? categoryListQuery(
 @riverpod
 AsyncValue<List<CategoryDto>?> nonZeroCategoryList(Ref ref) {
   final categoryList = ref.watch(categoryControllerProvider);
-  return categoryList.copyWithData((_) => categoryList.valueOrNull
+  return categoryList.copyWithData((_) => categoryList.value
       ?.where((element) => element.mangas.totalCount > 0)
       .toList());
 }
@@ -116,7 +116,7 @@ AsyncValue<List<CategoryDto>?> nonZeroCategoryList(Ref ref) {
 AsyncValue<List<CategoryDto>?> visibleCategoryList(Ref ref) {
   final categoryList = ref.watch(nonZeroCategoryListProvider);
   final showHidden = ref.watch(showHiddenCategoriesProvider).ifNull(false);
-  return categoryList.copyWithData((_) => categoryList.valueOrNull
+  return categoryList.copyWithData((_) => categoryList.value
       ?.where((element) => showHidden || !element.isHidden)
       .toList());
 }

--- a/lib/src/features/library/presentation/category/edit_category_screen.dart
+++ b/lib/src/features/library/presentation/category/edit_category_screen.dart
@@ -28,7 +28,7 @@ class EditCategoryScreen extends HookConsumerWidget {
         withMicrotask: true,
       );
       return;
-    }, [categoryList.valueOrNull]);
+    }, [categoryList.value]);
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -256,7 +256,7 @@ class CategoryMangaListWithQueryAndFilter
         ref.watch(libraryMangaFilterBookmarkedProvider);
     final mangaFilterOffline = ref.watch(libraryMangaFilterOfflineProvider);
     final offlineMangaIds =
-        ref.watch(offlineDeviceMangaIdsProvider).valueOrNull ?? const <int>{};
+        ref.watch(offlineDeviceMangaIdsProvider).value ?? const <int>{};
     final mangaFilterLewd = ref.watch(libraryMangaFilterLewdProvider);
     final filterCategories =
         ref.watch(libraryFilterCategoriesProvider).ifNull(false);
@@ -281,10 +281,10 @@ class CategoryMangaListWithQueryAndFilter
         ref.watch(librarySortRandomSeedProvider) ?? DBKeys.librarySortRandomSeed.initial as int;
 
     return mangaList.map<AsyncValue<List<MangaDto>?>>(
-      data: (e) => AsyncData(e.valueOrNull == null
+      data: (e) => AsyncData(e.value == null
           ? null
           : applyLibraryFilterSort(
-              e.valueOrNull!,
+              e.value!,
               query: query,
               mangaFilterUnread: mangaFilterUnread,
               mangaFilterDownloaded: mangaFilterDownloaded,
@@ -490,7 +490,7 @@ class LibraryMangaFilterTracker extends _$LibraryMangaFilterTracker {
   bool? build({required int trackerId}) {
     final prefs = ref.watch(sharedPreferencesProvider);
     final key = 'mangaFilterTracker_$trackerId';
-    ref.listenSelf((_, next) {
+    listenSelf((_, next) {
       if (next == null) {
         prefs.remove(key);
       } else {
@@ -508,7 +508,7 @@ class LibraryMangaFilterTracker extends _$LibraryMangaFilterTracker {
 @riverpod
 Map<int, bool?> libraryTrackerFilters(Ref ref) {
   final loggedIn =
-      ref.watch(loggedInTrackersProvider).valueOrNull ?? const [];
+      ref.watch(loggedInTrackersProvider).value ?? const [];
   final Map<int, bool?> result = {};
   for (final tracker in loggedIn) {
     final pref = ref.watch(
@@ -530,7 +530,7 @@ Map<int, bool?> libraryTrackerFilters(Ref ref) {
 @riverpod
 Map<int, double> libraryTrackerScales(Ref ref) {
   final loggedIn =
-      ref.watch(loggedInTrackersProvider).valueOrNull ?? const [];
+      ref.watch(loggedInTrackersProvider).value ?? const [];
   return {
     for (final t in loggedIn)
       t.id: t.scores.isEmpty
@@ -545,7 +545,7 @@ Map<int, double> libraryTrackerScales(Ref ref) {
 /// logged-in ones, so a bound record still resolves after a logout.
 @riverpod
 Map<int, String> libraryTrackerNames(Ref ref) {
-  final all = ref.watch(trackersProvider).valueOrNull ?? const [];
+  final all = ref.watch(trackersProvider).value ?? const [];
   return {for (final t in all) t.id: t.name};
 }
 
@@ -606,7 +606,7 @@ class GroupedMangaListWithQueryAndFilter
     // value equality, so passing a freshly-built Set as the family key minted a
     // new provider on every rebuild and thrashed into an infinite loading
     // flicker. Resolve the id-set here from the grouped-tabs provider instead.
-    final tabs = ref.watch(libraryGroupedTabsProvider).valueOrNull;
+    final tabs = ref.watch(libraryGroupedTabsProvider).value;
     Set<int> mangaIds = const <int>{};
     if (tabs != null) {
       for (final t in tabs) {
@@ -627,7 +627,7 @@ class GroupedMangaListWithQueryAndFilter
         ref.watch(libraryMangaFilterBookmarkedProvider);
     final mangaFilterOffline = ref.watch(libraryMangaFilterOfflineProvider);
     final offlineMangaIds =
-        ref.watch(offlineDeviceMangaIdsProvider).valueOrNull ?? const <int>{};
+        ref.watch(offlineDeviceMangaIdsProvider).value ?? const <int>{};
     final mangaFilterLewd = ref.watch(libraryMangaFilterLewdProvider);
     final filterCategories =
         ref.watch(libraryFilterCategoriesProvider).ifNull(false);
@@ -652,10 +652,10 @@ class GroupedMangaListWithQueryAndFilter
         ref.watch(librarySortRandomSeedProvider) ?? DBKeys.librarySortRandomSeed.initial as int;
 
     return allAsync.map<AsyncValue<List<MangaDto>?>>(
-      data: (e) => AsyncData(e.valueOrNull == null
+      data: (e) => AsyncData(e.value == null
           ? null
           : applyLibraryFilterSort(
-              e.valueOrNull!,
+              e.value!,
               mangaIds: mangaIds,
               query: query,
               mangaFilterUnread: mangaFilterUnread,

--- a/lib/src/features/library/presentation/library/controller/library_grouping.dart
+++ b/lib/src/features/library/presentation/library/controller/library_grouping.dart
@@ -249,7 +249,7 @@ Future<List<GroupedTab>> libraryGroupedTabs(Ref ref) async {
   // don't watch the category provider at all — it just couples them into the
   // loop above and isn't used.
   final List<CategoryProxy> catProxies = groupType == LibraryGroup.byDefault
-      ? (ref.watch(visibleCategoryListProvider).valueOrNull ?? const [])
+      ? (ref.watch(visibleCategoryListProvider).value ?? const [])
           .map(categoryToProxy)
           .toList()
       : const [];

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -62,7 +62,7 @@ class LibraryScreen extends HookConsumerWidget {
     // transient null frames a socket reconnect emits.
     final lastRunning = useRef<bool>(false);
     ref.listen(updateRunningSocketProvider, (_, next) {
-      final running = next.valueOrNull;
+      final running = next.value;
       if (running == null) return;
       if (lastRunning.value && !running) {
         ref.invalidate(libraryMangaListProvider);
@@ -94,7 +94,7 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
     useEffect(() {
       categoryList.showToastOnError(toast, withMicrotask: true);
       return;
-    }, [categoryList.valueOrNull]);
+    }, [categoryList.value]);
 
     return categoryList.showUiWhenData(
       context,
@@ -260,7 +260,7 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
     useEffect(() {
       groupedTabsAsync.showToastOnError(toast, withMicrotask: true);
       return;
-    }, [groupedTabsAsync.valueOrNull]);
+    }, [groupedTabsAsync.value]);
 
     return groupedTabsAsync.showUiWhenData(
       context,
@@ -390,7 +390,7 @@ class _CategoryTab extends ConsumerWidget {
         categoryId: category.id,
       ),
     );
-    final count = mangaListAsync.valueOrNull?.length;
+    final count = mangaListAsync.value?.length;
     final label = count != null ? '${category.name} ($count)' : category.name;
     return Tab(text: label);
   }

--- a/lib/src/features/library/presentation/library/widgets/edit_mangas_category_dialog.dart
+++ b/lib/src/features/library/presentation/library/widgets/edit_mangas_category_dialog.dart
@@ -28,7 +28,7 @@ class EditMangasCategoryDialog extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final categories =
-        (ref.watch(categoryControllerProvider).valueOrNull ?? const [])
+        (ref.watch(categoryControllerProvider).value ?? const [])
             .where((c) => c.id != 0)
             .toList();
 

--- a/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_filter.dart
@@ -121,7 +121,7 @@ class _TrackerFilterSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final loggedIn =
-        ref.watch(loggedInTrackersProvider).valueOrNull ?? const [];
+        ref.watch(loggedInTrackersProvider).value ?? const [];
     if (loggedIn.isEmpty) return const SizedBox.shrink();
 
     if (loggedIn.length == 1) {
@@ -349,7 +349,7 @@ class _TagFilterDialog extends ConsumerWidget {
           .update(newExclude.toList());
     }
 
-    final tags = tagsAsync.valueOrNull ?? const <String>[];
+    final tags = tagsAsync.value ?? const <String>[];
 
     return AlertDialog(
       title: Text(context.l10n.tags),
@@ -450,7 +450,7 @@ class _CategoryFilterDialog extends ConsumerWidget {
           .update(newExclude.toList());
     }
 
-    final categories = categoriesAsync.valueOrNull ?? [];
+    final categories = categoriesAsync.value ?? [];
 
     return AlertDialog(
       title: Text(context.l10n.categories),

--- a/lib/src/features/library/presentation/library/widgets/library_manga_group.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_group.dart
@@ -24,7 +24,7 @@ class LibraryMangaGroup extends ConsumerWidget {
     final current =
         ref.watch(libraryGroupTypeProvider) ?? kDefaultLibraryGroupType;
     final hasTrackers =
-        ref.watch(loggedInTrackersProvider).valueOrNull?.isNotEmpty ?? false;
+        ref.watch(loggedInTrackersProvider).value?.isNotEmpty ?? false;
 
     final modes = [
       (value: LibraryGroup.byDefault, label: context.l10n.groupByDefault),

--- a/lib/src/features/library/presentation/library/widgets/library_manga_organizer.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_organizer.dart
@@ -37,7 +37,7 @@ class LibraryMangaOrganizer extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final hasTrackers =
-        ref.watch(loggedInTrackersProvider).valueOrNull?.isNotEmpty ?? false;
+        ref.watch(loggedInTrackersProvider).value?.isNotEmpty ?? false;
     return DefaultTabController(
       length: 4,
       child: _OrganizerBody(hasTrackers: hasTrackers),

--- a/lib/src/features/manga_book/domain/chapter_patch/chapter_put_model.dart
+++ b/lib/src/features/manga_book/domain/chapter_patch/chapter_put_model.dart
@@ -10,7 +10,7 @@ part 'chapter_put_model.freezed.dart';
 part 'chapter_put_model.g.dart';
 
 @freezed
-class ChapterPut with _$ChapterPut {
+abstract class ChapterPut with _$ChapterPut {
   factory ChapterPut({
     bool? read,
     bool? bookmarked,

--- a/lib/src/features/manga_book/domain/manga/manga_model.dart
+++ b/lib/src/features/manga_book/domain/manga/manga_model.dart
@@ -56,7 +56,7 @@ extension MangaExtensions on MangaDto {
 }
 
 @freezed
-class MangaMeta with _$MangaMeta {
+abstract class MangaMeta with _$MangaMeta {
   factory MangaMeta({
     @JsonKey(
       name: "flutter_readerNavigationLayoutInvert",

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -50,8 +50,8 @@ class DownloadsMap extends _$DownloadsMap {
   @override
   Map<int, DownloadDto> build() {
     ref.listen(downloadUpdatesProvider,
-        (_, next) => updateDownloadStatus(next.valueOrNull));
-    final downloadStatusDto = ref.watch(downloadStatusProvider).valueOrNull;
+        (_, next) => updateDownloadStatus(next.value));
+    final downloadStatusDto = ref.watch(downloadStatusProvider).value;
     return getStateFromUpdates(downloadStatusDto);
   }
 
@@ -104,9 +104,9 @@ AsyncValue<DownloaderState?> downloaderState(Ref ref) {
 @riverpod
 bool showDownloadsFAB(Ref ref) {
   final downloads = ref.watch(downloadUpdatesProvider);
-  return downloads.valueOrNull?.state == DownloaderState.STARTED ||
-      (downloads.valueOrNull?.updates).isNotBlank &&
-          downloads.valueOrNull!.updates.any(
+  return downloads.value?.state == DownloaderState.STARTED ||
+      (downloads.value?.updates).isNotBlank &&
+          downloads.value!.updates.any(
             (element) =>
                 element.download.state != DownloadState.ERROR ||
                 element.download.tries != 3,

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -60,7 +60,7 @@ class DownloadsScreen extends HookConsumerWidget {
           ? const OfflineDownloadsFab()
           : (showDownloadsFAB
               ? DownloadsFab(
-                  status: downloadsGlobalStatus.valueOrNull ??
+                  status: downloadsGlobalStatus.value ??
                       DownloaderState.STARTED)
               : null),
       body: TabBarView(
@@ -85,7 +85,7 @@ class OfflineDownloadsFab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final hasPending = ref.watch(offlineHasPendingProvider).valueOrNull ?? false;
+    final hasPending = ref.watch(offlineHasPendingProvider).value ?? false;
     final paused = ref.watch(offlineDownloadsPausedProvider) ?? false;
     // Hide when idle (no pending work) — paused-but-idle included; the next
     // enqueue flips it back to Resume.

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -143,7 +143,7 @@ class MangaChapterList extends _$MangaChapterList {
       state = result.copyWithPrevious(state);
     } else {
       state = result;
-      final chapters = result.valueOrNull;
+      final chapters = result.value;
       if (chapters != null) {
         // Mirror build(): down-sync the fresh list (which orphans chapters the
         // server no longer lists) then reconcile to evict them — so a
@@ -158,7 +158,7 @@ class MangaChapterList extends _$MangaChapterList {
 
   void updateChapter(int index, ChapterDto chapter) {
     try {
-      final newList = [...?state.valueOrNull];
+      final newList = [...?state.value];
       newList[index] = chapter;
       state = AsyncData<List<ChapterDto>?>(newList).copyWithPrevious(state);
     } catch (e) {
@@ -187,7 +187,7 @@ class MangaChapterFilterScanlator extends _$MangaChapterFilterScanlator {
   @override
   String build({required int mangaId}) {
     final manga = ref.watch(mangaWithIdProvider(mangaId: mangaId));
-    return manga.valueOrNull?.metaData.scanlator ?? MangaMetaKeys.scanlator.key;
+    return manga.value?.metaData.scanlator ?? MangaMetaKeys.scanlator.key;
   }
 
   void update(String? scanlator) async {
@@ -210,7 +210,7 @@ class MangaRating extends _$MangaRating {
   @override
   int build({required int mangaId}) {
     final manga = ref.watch(mangaWithIdProvider(mangaId: mangaId));
-    return (manga.valueOrNull?.metaData.rating ?? 0).clamp(0, 5);
+    return (manga.value?.metaData.rating ?? 0).clamp(0, 5);
   }
 
   Future<void> update(int rating) async {
@@ -239,7 +239,7 @@ class MangaUserTags extends _$MangaUserTags {
   @override
   List<String> build({required int mangaId}) {
     final manga = ref.watch(mangaWithIdProvider(mangaId: mangaId));
-    return manga.valueOrNull?.metaData.userTags ?? const [];
+    return manga.value?.metaData.userTags ?? const [];
   }
 
   Future<void> _persist(List<String> tags) async {
@@ -334,7 +334,7 @@ ChapterDto? firstUnreadInFilteredChapterList(
       DBKeys.chapterSortDirection.initial;
   final filteredList = ref
       .watch(mangaChapterListWithFilterProvider(mangaId: mangaId))
-      .valueOrNull;
+      .value;
   if (filteredList == null) {
     return null;
   } else {
@@ -359,7 +359,7 @@ ChapterDto? firstUnreadInFilteredChapterList(
       DBKeys.chapterSortDirection.initial;
   final filteredList = ref
       .watch(mangaChapterListWithFilterProvider(mangaId: mangaId))
-      .valueOrNull;
+      .value;
   if (filteredList == null) {
     return null;
   } else {

--- a/lib/src/features/manga_book/presentation/manga_details/controller/next_update_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/next_update_controller.dart
@@ -17,7 +17,7 @@ part 'next_update_controller.g.dart';
 @riverpod
 NextUpdatePrediction? mangaNextUpdate(Ref ref, {required int mangaId}) {
   final chapters =
-      ref.watch(mangaChapterListProvider(mangaId: mangaId)).valueOrNull;
+      ref.watch(mangaChapterListProvider(mangaId: mangaId)).value;
   if (chapters == null || chapters.isEmpty) return null;
   final releases = <ChapterRelease>[
     for (final c in chapters)

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -156,7 +156,7 @@ class MangaDetailsScreen extends HookConsumerWidget {
                     IconButton(
                       onPressed: () {
                         final chapterList = [
-                          ...?filteredChapterList.valueOrNull
+                          ...?filteredChapterList.value
                         ];
                         selectedChapters.value =
                             ({for (ChapterDto i in chapterList) i.id: i});
@@ -166,7 +166,7 @@ class MangaDetailsScreen extends HookConsumerWidget {
                     IconButton(
                       onPressed: () {
                         final chapterList = [
-                          ...?filteredChapterList.valueOrNull
+                          ...?filteredChapterList.value
                         ];
                         selectedChapters.value = ({
                           for (ChapterDto i in chapterList)
@@ -442,7 +442,7 @@ class MultiSelectPopupButton extends StatelessWidget {
         PopupMenuItem(
           onTap: () {
             List<ChapterDto> chapterList = [
-              ...?filteredChapterList.valueOrNull
+              ...?filteredChapterList.value
             ];
             final lastId = selectedChapters.value.keys.last;
             final lastIndex =
@@ -458,7 +458,7 @@ class MultiSelectPopupButton extends StatelessWidget {
         ),
         PopupMenuItem(
           onTap: () {
-            final chapterList = [...?filteredChapterList.valueOrNull];
+            final chapterList = [...?filteredChapterList.value];
 
             selectedChapters.value = ({
               for (ChapterDto i in chapterList)
@@ -469,7 +469,7 @@ class MultiSelectPopupButton extends StatelessWidget {
         ),
         PopupMenuItem(
           onTap: () {
-            final chapterList = [...?filteredChapterList.valueOrNull];
+            final chapterList = [...?filteredChapterList.value];
             final selectedChapterIds =
                 selectedChapters.value.keys.toList(growable: false);
             final firstSelectedIndex = chapterList.indexWhere(

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/big_screen_manga_details.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/big_screen_manga_details.dart
@@ -37,7 +37,7 @@ class BigScreenMangaDetails extends ConsumerWidget {
   final AsyncValue<List<ChapterDto>?> chapterList;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final filteredChapterList = chapterList.valueOrNull;
+    final filteredChapterList = chapterList.value;
     return RefreshIndicator(
       onRefresh: () => onRefresh(true),
       child: Row(

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
@@ -32,7 +32,7 @@ class ChapterDownloadPresetsButton extends ConsumerWidget {
     WidgetRef ref,
     DownloadPreset preset,
   ) async {
-    final chapters = chapterList.valueOrNull ?? const [];
+    final chapters = chapterList.value ?? const [];
     final candidates = [
       for (final c in chapters)
         ChapterDownloadCandidate(

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/small_screen_manga_details.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/small_screen_manga_details.dart
@@ -37,7 +37,7 @@ class SmallScreenMangaDetails extends ConsumerWidget {
   final AsyncValueSetter<bool> onDescriptionRefresh;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final filteredChapterList = chapterList.valueOrNull;
+    final filteredChapterList = chapterList.value;
     return RefreshIndicator(
       onRefresh: () => onRefresh(true),
       child: CustomScrollView(

--- a/lib/src/features/manga_book/presentation/reader/controller/reader_setting.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/reader_setting.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/misc.dart';
 
 import '../../../domain/manga/manga_model.dart';
 

--- a/lib/src/features/manga_book/presentation/reader/controller/reader_settings_model.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/reader_settings_model.dart
@@ -368,7 +368,7 @@ abstract final class ReaderSettings {
 }
 
 @freezed
-class ReaderSettingsState with _$ReaderSettingsState {
+abstract class ReaderSettingsState with _$ReaderSettingsState {
   const factory ReaderSettingsState({
     required ReaderMode readerMode,
     required ReaderNavigationLayout navigationLayout,
@@ -545,7 +545,7 @@ class ReaderSettingsModel extends _$ReaderSettingsModel {
     _readerPaddingKey = ref.read(readerPaddingKeyProvider.notifier);
     _readerMagnifierSizeKey = ref.read(readerMagnifierSizeKeyProvider.notifier);
     final meta =
-        ref.watch(mangaWithIdProvider(mangaId: mangaId)).valueOrNull?.metaData;
+        ref.watch(mangaWithIdProvider(mangaId: mangaId)).value?.metaData;
     return ReaderSettingsState(
       readerMode: ReaderSettings.mode.resolveWith(ref, meta?.readerMode),
       navigationLayout: ReaderSettings.navigationLayout

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -74,7 +74,7 @@ class ReaderScreen extends HookConsumerWidget {
     // manga) THIS session; never written to meta. Null when auto-detect is off,
     // the series has an explicit per-series mode, or the type carries no
     // opinion — in which case the per-series/global default takes over below.
-    final mangaData = manga.valueOrNull;
+    final mangaData = manga.value;
     final autoReaderMode = (ref.watch(autoWebtoonModeProvider).ifNull(true) &&
             mangaData != null &&
             (mangaData.metaData.readerMode ?? ReaderMode.defaultReader) ==
@@ -111,8 +111,8 @@ class ReaderScreen extends HookConsumerWidget {
       // both the debounced call and the PopScope flush). The PopScope's own
       // provider invalidations still run — they're outside this callback.
       if (incognitoMode) return;
-      final chapterValue = chapter.valueOrNull;
-      final chapterPagesValue = chapterPages.valueOrNull;
+      final chapterValue = chapter.value;
+      final chapterPagesValue = chapterPages.value;
       if (chapterValue == null || chapterPagesValue == null) return;
 
       // Use the actual loaded pages count, not the chapter's pageCount metadata
@@ -162,8 +162,8 @@ class ReaderScreen extends HookConsumerWidget {
       // Invalidate history to refresh the reading progress
       providerContainer.invalidate(readingHistoryProvider);
     }, [
-      chapter.valueOrNull,
-      chapterPages.valueOrNull,
+      chapter.value,
+      chapterPages.value,
       incognitoMode,
       offlineEnabled,
       offlineDatabase,
@@ -175,8 +175,8 @@ class ReaderScreen extends HookConsumerWidget {
       (int index) async {
         // Incognito: don't track progress (also avoids needless debounce churn).
         if (ref.read(incognitoModeProvider)) return;
-        final chapterValue = chapter.valueOrNull;
-        final chapterPagesValue = chapterPages.valueOrNull;
+        final chapterValue = chapter.value;
+        final chapterPagesValue = chapterPages.value;
         if (chapterValue == null || chapterPagesValue == null) return;
 
         // Consume the initial restore emit — don't record or complete off it.

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bookmark_button.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bookmark_button.dart
@@ -25,7 +25,7 @@ class ReaderBookmarkButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isBookmarked = ref.watch(
           chapterProvider(chapterId: chapterId)
-              .select((c) => c.valueOrNull?.isBookmarked),
+              .select((c) => c.value?.isBookmarked),
         ) ??
         fallbackIsBookmarked;
     return SingleChapterActionIcon(

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
@@ -100,12 +100,12 @@ class ReaderBottomControls extends ConsumerWidget {
 
     return MeasureSize(
       onChange: (size) {
-        final current = ref.read(chromeExtentsNotifierProvider);
+        final current = ref.read(chromeExtentsProvider);
         final next = ChromeExtents(
           topInset: current.topInset,
           bottomInset: size.height,
         );
-        ref.read(chromeExtentsNotifierProvider.notifier).update(next);
+        ref.read(chromeExtentsProvider.notifier).update(next);
       },
       child: ExcludeFocus(
         child: Column(

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
@@ -229,7 +229,7 @@ class ReaderChrome extends HookConsumerWidget {
     // Adding 8 dp of breathing room keeps the seekbar from kissing the bar edge.
     // When [forceHorizontalSeekbar] is true, the vertical side seekbar is hidden
     // and the horizontal bottom seekbar serves all modes (including webtoon).
-    final extents = ref.watch(chromeExtentsNotifierProvider);
+    final extents = ref.watch(chromeExtentsProvider);
     final forceHorizontal =
         ref.watch(forceHorizontalSeekbarProvider).ifNull(false);
     final leftHanded =
@@ -294,7 +294,7 @@ class ReaderChrome extends HookConsumerWidget {
             // is a separate, local AnimatedSize.
             //
             // MeasureSize now wraps BOTH bars (moved down from ReaderTopBar
-            // alone) so chromeExtentsNotifierProvider's topInset covers the
+            // alone) so chromeExtentsProvider's topInset covers the
             // utils bar's height too when it's expanded — otherwise the side
             // seekbar's `top` offset would sit above the top bar only and
             // overlap the expanded utils bar.
@@ -316,13 +316,13 @@ class ReaderChrome extends HookConsumerWidget {
                         // Fires from a post-frame callback; the reader may have
                         // unmounted by then, so never touch ref after dispose.
                         if (!context.mounted) return;
-                        final current = ref.read(chromeExtentsNotifierProvider);
+                        final current = ref.read(chromeExtentsProvider);
                         final next = ChromeExtents(
                           topInset: size.height,
                           bottomInset: current.bottomInset,
                         );
                         ref
-                            .read(chromeExtentsNotifierProvider.notifier)
+                            .read(chromeExtentsProvider.notifier)
                             .update(next);
                       },
                       child: Column(

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_page_actions_sheet.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_page_actions_sheet.dart
@@ -357,7 +357,7 @@ String? _buildPageUrl(
 
   if (withToken && ref.read(authTypeKeyProvider) == AuthType.uiLogin) {
     final token =
-        ref.read(authCredentialsStoreProvider).valueOrNull?.uiAccessToken;
+        ref.read(authCredentialsStoreProvider).value?.uiAccessToken;
     if (token != null && token.isNotEmpty) {
       final sep = url.contains('?') ? '&' : '?';
       url = "$url${sep}token=${Uri.encodeQueryComponent(token)}";
@@ -372,12 +372,12 @@ String? _buildPageUrl(
 Map<String, String>? _buildHttpHeaders(WidgetRef ref) {
   final authType = ref.read(authTypeKeyProvider);
   if (authType == AuthType.basic) {
-    final basicToken = ref.read(credentialsProvider).valueOrNull;
+    final basicToken = ref.read(credentialsProvider).value;
     if (basicToken != null) return {"Authorization": basicToken};
   } else if (authType == AuthType.simpleLogin) {
     return ref
         .read(authCredentialsStoreProvider)
-        .valueOrNull
+        .value
         ?.simpleLoginCookieHeader;
   }
   return null;

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_top_bar.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_top_bar.dart
@@ -22,7 +22,7 @@ import 'reader_bookmark_button.dart';
 /// live in the body [Stack] and be driven by a shared animation controller.
 /// Visual output is byte-identical to the old AppBar.
 ///
-/// Height measurement ([MeasureSize] → `chromeExtentsNotifierProvider`) lives
+/// Height measurement ([MeasureSize] → `chromeExtentsProvider`) lives
 /// one level up in `ReaderChrome`, wrapping this bar together with
 /// [ReaderUtilsBar] — so the reported inset covers both, and the side
 /// seekbar clears the utils bar when it's expanded.

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_android_volume_keydown/flutter_android_volume_keydown.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/legacy.dart';
 
 import '../../../../../constants/app_constants.dart';
 import '../../../../../constants/app_sizes.dart';
@@ -105,7 +106,7 @@ class ReaderInputScope extends InheritedWidget {
 bool _noBoundaryNavigation() => false;
 
 final _readerChromeSessionVisibilityProvider =
-    StateProvider.autoDispose<bool?>((ref) {
+    StateProvider.autoDispose<bool?>((Ref ref) {
   final link = ref.keepAlive();
   Timer? timer;
   ref

--- a/lib/src/features/manga_book/presentation/updates/updates_screen.dart
+++ b/lib/src/features/manga_book/presentation/updates/updates_screen.dart
@@ -61,9 +61,9 @@ class UpdatesScreen extends HookConsumerWidget {
     final updatesRepository = ref.watch(updatesRepositoryProvider);
     final isUpdatesChecking = ref
         .watch(updatesSocketProvider
-            .select((value) => value.valueOrNull?.isRunning))
+            .select((value) => value.value?.isRunning))
         .ifNull();
-    final lastUpdated = ref.watch(libraryLastUpdatedProvider).valueOrNull;
+    final lastUpdated = ref.watch(libraryLastUpdatedProvider).value;
     final selectedChapters = useState<Map<int, ChapterDto>>({});
     useEffect(() {
       controller.addPageRequestListener((pageKey) => _fetchPage(

--- a/lib/src/features/manga_book/widgets/update_status_fab.dart
+++ b/lib/src/features/manga_book/widgets/update_status_fab.dart
@@ -20,7 +20,7 @@ class UpdateStatusFab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final updateStatus = ref.watch(updatesSocketProvider);
-    final showStatus = (updateStatus.valueOrNull?.isUpdateChecking).ifNull();
+    final showStatus = (updateStatus.value?.isUpdateChecking).ifNull();
     return BrandFab(
       icon: showStatus ? null : const Icon(Icons.refresh_rounded),
       onPressed: () {
@@ -32,8 +32,8 @@ class UpdateStatusFab extends ConsumerWidget {
         }
       },
       label: showStatus
-          ? Text("${updateStatus.valueOrNull?.updateChecked.padLeft()}"
-              "/${updateStatus.valueOrNull?.total.padLeft()}")
+          ? Text("${updateStatus.value?.updateChecked.padLeft()}"
+              "/${updateStatus.value?.total.padLeft()}")
           : Text(context.l10n.update),
     );
   }

--- a/lib/src/features/manga_book/widgets/update_status_summary_sheet.dart
+++ b/lib/src/features/manga_book/widgets/update_status_summary_sheet.dart
@@ -26,7 +26,7 @@ class UpdateStatusSummaryDialog extends ConsumerWidget {
     final statusUpdate = ref.watch(updateSummaryProvider);
     final statusUpdateStream = ref.watch(updatesSocketProvider);
     final AsyncValue<UpdateStatusDto?> finalStatus =
-        (statusUpdateStream.valueOrNull?.total.isGreaterThan(0)).ifNull()
+        (statusUpdateStream.value?.total.isGreaterThan(0)).ifNull()
             ? statusUpdateStream
             : statusUpdate;
     return Scaffold(

--- a/lib/src/features/migration/controller/migration_controller.dart
+++ b/lib/src/features/migration/controller/migration_controller.dart
@@ -109,7 +109,7 @@ AsyncValue<List<MigrationQuickSearchResults>> migrationGlobalSearchResults(
   // Pinned-first list of every searchable source (shared with global search;
   // pinned sources are otherwise excluded from the grouped map).
   final sourcesData = ref.watch(searchableSourcesProvider);
-  final sourceList = sourcesData.valueOrNull ?? const <SourceDto>[];
+  final sourceList = sourcesData.value ?? const <SourceDto>[];
 
   final List<MigrationQuickSearchResults> sourceMangaListPairList = [];
   for (SourceDto source in sourceList) {
@@ -243,7 +243,7 @@ class MigrationExecution extends _$MigrationExecution {
       // per-category slices so all reactive descendants re-partition.
       ref.invalidate(libraryMangaListProvider);
       // Invalidate all category manga lists to refresh library
-      final categories = ref.read(categoryControllerProvider).valueOrNull ?? [];
+      final categories = ref.read(categoryControllerProvider).value ?? [];
       for (final category in categories) {
         ref.invalidate(categoryMangaListProvider(category.id));
       }

--- a/lib/src/features/migration/data/migration_repository.dart
+++ b/lib/src/features/migration/data/migration_repository.dart
@@ -422,5 +422,5 @@ class MigrationRepositoryImpl implements MigrationRepository {
 }
 
 @riverpod
-MigrationRepository migrationRepository(ref) =>
+MigrationRepository migrationRepository(Ref ref) =>
     MigrationRepositoryImpl(ref.watch(graphQlClientProvider));

--- a/lib/src/features/migration/domain/migration_models.dart
+++ b/lib/src/features/migration/domain/migration_models.dart
@@ -13,7 +13,7 @@ part 'migration_models.freezed.dart';
 part 'migration_models.g.dart';
 
 @freezed
-class MigrationSource with _$MigrationSource {
+abstract class MigrationSource with _$MigrationSource {
   const factory MigrationSource({
     required String id,
     required String name,
@@ -29,7 +29,7 @@ class MigrationSource with _$MigrationSource {
 }
 
 @freezed
-class MigrationOption with _$MigrationOption {
+abstract class MigrationOption with _$MigrationOption {
   const factory MigrationOption({
     @Default(true) bool migrateChapters,
     @Default(true) bool migrateCategories,
@@ -43,7 +43,7 @@ class MigrationOption with _$MigrationOption {
 }
 
 @freezed
-class MigrationResult with _$MigrationResult {
+abstract class MigrationResult with _$MigrationResult {
   const factory MigrationResult({
     required bool success,
     String? error,
@@ -79,7 +79,7 @@ enum MigrationStep {
 }
 
 @freezed
-class MigrationProgress with _$MigrationProgress {
+abstract class MigrationProgress with _$MigrationProgress {
   const factory MigrationProgress({
     required MigrationStep currentStep,
     @Default(0.0) double percentage,
@@ -94,7 +94,7 @@ class MigrationProgress with _$MigrationProgress {
 }
 
 @freezed
-class MangaSearchResult with _$MangaSearchResult {
+abstract class MangaSearchResult with _$MangaSearchResult {
   const factory MangaSearchResult({
     required Fragment$MangaDto manga,
     @Default(0.0) double similarity,
@@ -108,14 +108,14 @@ class MangaSearchResult with _$MangaSearchResult {
 // Route Data Classes to replace Map<String, dynamic>
 // These classes don't need JSON serialization since they're only used for navigation
 @freezed
-class MigrationRouteData with _$MigrationRouteData {
+abstract class MigrationRouteData with _$MigrationRouteData {
   const factory MigrationRouteData({
     required Fragment$MangaDto sourceManga,
   }) = _MigrationRouteData;
 }
 
 @freezed
-class MigrationSearchRouteData with _$MigrationSearchRouteData {
+abstract class MigrationSearchRouteData with _$MigrationSearchRouteData {
   const factory MigrationSearchRouteData({
     required Fragment$MangaDto sourceManga,
     required Fragment$SourceDto targetSource,
@@ -123,7 +123,7 @@ class MigrationSearchRouteData with _$MigrationSearchRouteData {
 }
 
 @freezed
-class MigrationPreviewRouteData with _$MigrationPreviewRouteData {
+abstract class MigrationPreviewRouteData with _$MigrationPreviewRouteData {
   const factory MigrationPreviewRouteData({
     required Fragment$MangaDto sourceManga,
     required Fragment$MangaDto targetManga,
@@ -132,7 +132,7 @@ class MigrationPreviewRouteData with _$MigrationPreviewRouteData {
 }
 
 @freezed
-class MigrationProgressRouteData with _$MigrationProgressRouteData {
+abstract class MigrationProgressRouteData with _$MigrationProgressRouteData {
   const factory MigrationProgressRouteData({
     required Fragment$MangaDto sourceManga,
     required Fragment$MangaDto targetManga,

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -402,8 +402,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// only the fields relevant to the active auth type.
   BackgroundTokenRecord _snapshotAuth() {
     final authType = _ref.read(authTypeKeyProvider) ?? AuthType.none;
-    final basicToken = _ref.read(credentialsProvider).valueOrNull;
-    final creds = _ref.read(authCredentialsStoreProvider).valueOrNull;
+    final basicToken = _ref.read(credentialsProvider).value;
+    final creds = _ref.read(authCredentialsStoreProvider).value;
     return BackgroundTokenRecord(
       gen: 0,
       authType: authType.name,
@@ -547,7 +547,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
 /// (`background_download_controller_shim.dart`) swaps in a no-op stub.
 final backgroundDownloadControllerProvider =
     Provider<BackgroundDownloadController>(
-        (ref) => BackgroundDownloadController(ref));
+        (Ref ref) => BackgroundDownloadController(ref));
 
 /// Initialise `flutter_foreground_task` (communication port + notification
 /// channel/options). Call once early in `main()`. Android-only; no-op elsewhere.

--- a/lib/src/features/offline/data/background/background_download_controller_stub.dart
+++ b/lib/src/features/offline/data/background/background_download_controller_stub.dart
@@ -35,7 +35,7 @@ class BackgroundDownloadController {
 /// Web no-op mirror of the native provider.
 final backgroundDownloadControllerProvider =
     Provider<BackgroundDownloadController>(
-        (ref) => BackgroundDownloadController(ref));
+        (Ref ref) => BackgroundDownloadController(ref));
 
 /// Web no-op: there is no foreground task service to initialise.
 void initForegroundTaskService() {}

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -6,20 +6,11 @@
 
 import 'package:drift/drift.dart';
 
+import 'offline_types.dart';
+
+export 'offline_types.dart';
+
 part 'offline_database.g.dart';
-
-/// On-device state of a chapter's bytes.
-enum OfflineDeviceState {
-  none,
-  queued,
-  downloading,
-  downloaded,
-  error,
-  orphaned
-}
-
-/// How many of a series' chapters to keep on this device automatically.
-enum OfflineKeepRule { off, nUnread, allUnread, all }
 
 /// Library manga mirrored for offline browsing. Keyed by the server's stable
 /// manga id.

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -38,7 +38,9 @@ import 'offline_download_manager.dart';
 import 'offline_page_store.dart';
 import 'offline_reconciler.dart';
 import 'offline_repository.dart';
+import 'offline_series_entry.dart';
 import 'offline_settings_providers.dart';
+import 'offline_types.dart';
 import 'reconcile_types.dart';
 
 part 'offline_download_providers.g.dart';
@@ -52,7 +54,7 @@ bool get _useBgService => isAndroidNative;
 /// starts the foreground-service worker, elsewhere it drains via the
 /// main-isolate pump. Centralised (and overridable in tests) so no trigger can
 /// ever again silently rely on the Android-disabled pump.
-final downloadStarterProvider = Provider<Future<void> Function()>((ref) {
+final downloadStarterProvider = Provider<Future<void> Function()>((Ref ref) {
   return () async {
     if (!ref.read(offlineActiveProvider)) return;
     if (isAndroidNative) {
@@ -213,7 +215,7 @@ Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
   if (serverHasIt) {
     final fresh = await AsyncValue.guard(() =>
         ref.read(mangaBookRepositoryProvider).getChapter(chapterId: chapterId));
-    serverHasIt = fresh.valueOrNull?.isDownloaded ?? serverHasIt;
+    serverHasIt = fresh.value?.isDownloaded ?? serverHasIt;
   }
   if (!serverHasIt) {
     // Commit a server download too (grows the server library). The device copy
@@ -331,7 +333,7 @@ int? _whileReadingTarget(
     WidgetRef ref, int mangaId, int readChapterId, int slots) {
   final chapters = ref
       .read(mangaChapterListWithFilterProvider(mangaId: mangaId))
-      .valueOrNull;
+      .value;
   if (chapters == null) return null;
   final isAsc = ref.read(mangaChapterSortDirectionProvider) ??
       (DBKeys.chapterSortDirection.initial as bool);
@@ -444,7 +446,7 @@ Future<void> _deleteServerCopyIfDeletable(
 ) async {
   try {
     final chapters =
-        ref.read(mangaChapterListProvider(mangaId: mangaId)).valueOrNull;
+        ref.read(mangaChapterListProvider(mangaId: mangaId)).value;
     final idx = chapters?.indexWhere((e) => e.id == chapterId) ?? -1;
     if (chapters == null || idx < 0) return;
     final c = chapters[idx];
@@ -620,8 +622,8 @@ OfflineDownloadManager? offlineDownloadManager(Ref ref) {
 /// retries; any other non-200 is a plain (transient) exception.
 Future<PageBytes> fetchOfflinePageBytes(Ref ref, String pageUrl) async {
   final authType = ref.read(authTypeKeyProvider);
-  final basicToken = ref.read(credentialsProvider).valueOrNull;
-  final creds = ref.read(authCredentialsStoreProvider).valueOrNull;
+  final basicToken = ref.read(credentialsProvider).value;
+  final creds = ref.read(authCredentialsStoreProvider).value;
   final base = Endpoints.baseApi(
     baseUrl: ref.read(serverUrlProvider),
     port: ref.read(serverPortProvider),
@@ -727,11 +729,18 @@ Stream<({int downloaded, int inFlight})> mangaOfflineProgress(
 /// Downloads → On device tab, which both shows what's downloaded AND manages the
 /// keep-rules. Sorted active-first, then biggest, then strongest rule.
 @riverpod
-Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
-    offlineSeries(Ref ref) {
+Stream<List<OfflineSeriesEntry>> offlineSeries(Ref ref) {
   if (!ref.watch(offlineActiveProvider)) return Stream.value(const []);
   return ref.watch(offlineDatabaseProvider).watchOfflineSeries().map((rows) {
-    final sorted = [...rows];
+    final sorted = [
+      for (final r in rows)
+        OfflineSeriesEntry(
+          manga: r.manga,
+          downloaded: r.downloaded,
+          inFlight: r.inFlight,
+          bytes: r.bytes,
+        ),
+    ];
     sorted.sort((a, b) {
       if ((a.inFlight > 0) != (b.inFlight > 0)) return a.inFlight > 0 ? -1 : 1;
       if (a.bytes != b.bytes) return b.bytes.compareTo(a.bytes);

--- a/lib/src/features/offline/data/offline_nav_status.dart
+++ b/lib/src/features/offline/data/offline_nav_status.dart
@@ -19,5 +19,5 @@ part 'offline_nav_status.g.dart';
 bool downloadsPausedBadge(Ref ref) {
   final paused = ref.watch(offlineDownloadsPausedProvider) ?? false;
   if (!paused) return false;
-  return ref.watch(offlineHasPendingProvider).valueOrNull ?? false;
+  return ref.watch(offlineHasPendingProvider).value ?? false;
 }

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -166,7 +166,7 @@ bool offlineActive(Ref ref) {
   final stamp = ref.watch(sharedPreferencesProvider).getString(
         DBKeys.offlineCatalogServerId.name,
       );
-  final current = ref.watch(serverInstanceIdProvider).valueOrNull;
+  final current = ref.watch(serverInstanceIdProvider).value;
   if (current == null) return false;
   return isOfflineCatalogActive(
     offlineEnabled: true,
@@ -249,7 +249,7 @@ OfflineDatabase? offlineReadDatabase(Ref ref) {
 @riverpod
 OfflineSync? offlineSync(Ref ref) {
   if (!ref.watch(offlineActiveProvider)) return null;
-  final identity = ref.watch(serverInstanceIdProvider).valueOrNull;
+  final identity = ref.watch(serverInstanceIdProvider).value;
   if (identity == null) return null;
   final preferences = ref.watch(sharedPreferencesProvider);
   return OfflineSync(

--- a/lib/src/features/offline/data/offline_series_entry.dart
+++ b/lib/src/features/offline/data/offline_series_entry.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'offline_database.dart';
+
+/// One Downloads → On device row. A nominal class (not a record) on purpose:
+/// a record type inlines drift's generated OfflineManga into the provider
+/// signature, which riverpod_generator can't resolve in its build phase.
+/// Member types are never emitted, so the drift row is fine as a field.
+class OfflineSeriesEntry {
+  const OfflineSeriesEntry({
+    required this.manga,
+    required this.downloaded,
+    required this.inFlight,
+    required this.bytes,
+  });
+
+  final OfflineManga manga;
+  final int downloaded;
+  final int inFlight;
+  final int bytes;
+}

--- a/lib/src/features/offline/data/offline_types.dart
+++ b/lib/src/features/offline/data/offline_types.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// These live outside offline_database.dart on purpose: riverpod_generator
+// resolves provider signature types in a build phase where drift's generated
+// part doesn't exist yet, so any type reached through that library reads as
+// invalid. A part-free file keeps them resolvable everywhere.
+
+/// On-device state of a chapter's bytes.
+enum OfflineDeviceState {
+  none,
+  queued,
+  downloading,
+  downloaded,
+  error,
+  orphaned
+}
+
+/// How many of a series' chapters to keep on this device automatically.
+enum OfflineKeepRule { off, nUnread, allUnread, all }

--- a/lib/src/features/offline/presentation/offline_files_view.dart
+++ b/lib/src/features/offline/presentation/offline_files_view.dart
@@ -16,10 +16,11 @@ import '../../../widgets/server_image.dart';
 import '../data/offline_database.dart';
 import '../data/offline_download_providers.dart';
 import '../data/offline_repository.dart';
+import '../data/offline_series_entry.dart';
 import 'keep_rule_picker.dart';
 import 'offline_settings_format.dart';
 
-typedef _SeriesRow = ({OfflineManga manga, int downloaded, int inFlight, int bytes});
+typedef _SeriesRow = OfflineSeriesEntry;
 
 /// The "On device" segment of the Downloads tab — the single surface for
 /// on-device downloads: every series with files saved here OR an active
@@ -45,8 +46,8 @@ class OfflineFilesView extends HookConsumerWidget {
     if (!ref.watch(offlineEnabledProvider)) {
       return Center(child: Text(context.l10n.offlineNotAvailable));
     }
-    final series = ref.watch(offlineSeriesProvider).valueOrNull ?? const [];
-    final totalBytes = ref.watch(offlineUsageBytesProvider).valueOrNull ?? 0;
+    final series = ref.watch(offlineSeriesProvider).value ?? const [];
+    final totalBytes = ref.watch(offlineUsageBytesProvider).value ?? 0;
     final selection = useState<Set<int>>(const {});
     final selecting = selection.value.isNotEmpty;
 

--- a/lib/src/features/offline/presentation/offline_save_button.dart
+++ b/lib/src/features/offline/presentation/offline_save_button.dart
@@ -31,7 +31,7 @@ class OfflineSaveButton extends ConsumerWidget {
     }
     final state = ref
         .watch(offlineChapterStateProvider(chapterId))
-        .valueOrNull ??
+        .value ??
         OfflineDeviceState.none;
     final cs = Theme.of(context).colorScheme;
 
@@ -81,7 +81,7 @@ class _DownloadingIndicator extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final progress =
-        ref.watch(offlineChapterProgressProvider(chapterId)).valueOrNull;
+        ref.watch(offlineChapterProgressProvider(chapterId)).value;
     // Spin (indeterminate) while queued or at 0% so the icon is
     // never invisible; switch to a determinate fill only once pages land.
     final value = (progress == null || progress <= 0.0) ? null : progress;

--- a/lib/src/features/offline/presentation/offline_server_mismatch_banner.dart
+++ b/lib/src/features/offline/presentation/offline_server_mismatch_banner.dart
@@ -21,7 +21,7 @@ class OfflineServerMismatchBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final mismatch = ref.watch(offlineServerMismatchProvider).valueOrNull;
+    final mismatch = ref.watch(offlineServerMismatchProvider).value;
     if (mismatch == null || (mismatch.dismissed && !showAfterDismissal)) {
       return const SizedBox.shrink();
     }

--- a/lib/src/features/offline/presentation/offline_settings_screen.dart
+++ b/lib/src/features/offline/presentation/offline_settings_screen.dart
@@ -35,7 +35,7 @@ List<Widget> buildOnDeviceStorageTiles(BuildContext context, WidgetRef ref) {
     ListTile(
       title: Text(context.l10n.offlineStorageUsage),
       subtitle: Text(
-        formatBytes(ref.watch(offlineUsageBytesProvider).valueOrNull ?? 0),
+        formatBytes(ref.watch(offlineUsageBytesProvider).value ?? 0),
       ),
     ),
     ListTile(

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -28,14 +28,14 @@ class SeriesOfflineButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     if (!ref.watch(offlineEnabledProvider)) return const SizedBox.shrink();
     final progress =
-        ref.watch(mangaOfflineProgressProvider(mangaId)).valueOrNull;
+        ref.watch(mangaOfflineProgressProvider(mangaId)).value;
     final downloaded = progress?.downloaded ?? 0;
     final inFlight = progress?.inFlight ?? 0;
     final onDevice = downloaded > 0;
     final downloading = inFlight > 0;
     // Surface the active keep-rule on the button so users can see at a glance
     // why a series keeps re-downloading, without opening the sheet (#74).
-    final config = ref.watch(mangaKeepConfigProvider(mangaId)).valueOrNull;
+    final config = ref.watch(mangaKeepConfigProvider(mangaId)).value;
     return MangaActionButton(
       active: onDevice || downloading,
       icon: downloading
@@ -68,7 +68,7 @@ class SeriesOfflineButton extends ConsumerWidget {
       };
 
   void _openSheet(BuildContext context, WidgetRef ref, bool onDevice) {
-    final config = ref.read(mangaKeepConfigProvider(mangaId)).valueOrNull ??
+    final config = ref.read(mangaKeepConfigProvider(mangaId)).value ??
         (rule: OfflineKeepRule.off, count: 5);
     final rule = config.rule;
     showModalBottomSheet<void>(

--- a/lib/src/features/onboarding/presentation/onboarding_screen.dart
+++ b/lib/src/features/onboarding/presentation/onboarding_screen.dart
@@ -273,7 +273,7 @@ enum _TestState {
 /// Factory for the throwaway HTTP client the resolver probes use. Overridable
 /// in widget tests so the connection flow can be driven against a MockClient.
 final onboardingHttpClientProvider =
-    Provider<http.Client Function()>((ref) => http.Client.new);
+    Provider<http.Client Function()>((Ref ref) => http.Client.new);
 
 class _ServerStep extends HookConsumerWidget {
   const _ServerStep({required this.onVerifiedChanged});
@@ -383,7 +383,7 @@ class _ServerStep extends HookConsumerWidget {
       await Future<void>.delayed(const Duration(milliseconds: 150));
       final result = await AsyncValue.guard(
           () => ref.read(aboutRepositoryProvider).getAbout());
-      if (result.hasError || result.valueOrNull == null) {
+      if (result.hasError || result.value == null) {
         errorDetail.value = result.error?.toString();
         state.value = _TestState.failed;
         onVerifiedChanged(false);

--- a/lib/src/features/quick_open/presentation/search_stack/search_stack_screen.dart
+++ b/lib/src/features/quick_open/presentation/search_stack/search_stack_screen.dart
@@ -8,6 +8,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/legacy.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../settings/presentation/general/quick_search_toggle/quick_search_toggle_tile.dart';
@@ -17,7 +18,7 @@ import '../unified_search/unified_search_screen.dart';
 /// open it live in the app-wide GlobalShortcutHost (which holds focus, unlike
 /// this deep-in-the-tree widget), so they toggle this provider rather than a
 /// local state.
-final quickOpenVisibleProvider = StateProvider<bool>((ref) => false);
+final quickOpenVisibleProvider = StateProvider<bool>((Ref ref) => false);
 
 class SearchStackScreen extends ConsumerWidget {
   const SearchStackScreen({super.key, this.child});

--- a/lib/src/features/quick_open/presentation/unified_search/unified_search_facets.dart
+++ b/lib/src/features/quick_open/presentation/unified_search/unified_search_facets.dart
@@ -88,7 +88,7 @@ LibraryFacets buildLibraryFacets(Iterable<LibraryFilterFields> fields) {
 
 /// Library facets for autocomplete — recomputed only when the library changes,
 /// not per keystroke.
-final unifiedLibraryFacetsProvider = Provider<LibraryFacets>((ref) {
-  final library = ref.watch(libraryMangaListProvider).valueOrNull ?? const [];
+final unifiedLibraryFacetsProvider = Provider<LibraryFacets>((Ref ref) {
+  final library = ref.watch(libraryMangaListProvider).value ?? const [];
   return buildLibraryFacets(library.map((m) => m.filterFields()));
 });

--- a/lib/src/features/quick_open/presentation/unified_search/unified_search_providers.dart
+++ b/lib/src/features/quick_open/presentation/unified_search/unified_search_providers.dart
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/legacy.dart';
 
 import '../../../library/domain/library_search_query.dart';
 import '../../../library/presentation/library/controller/library_manga_list.dart';
@@ -24,7 +25,7 @@ bool queryUsesOperator(String q) => LibrarySearchQuery.hasOperator(q);
 String plainQueryText(String q) => LibrarySearchQuery.plainText(q);
 
 /// The live query text in the unified search field.
-final unifiedSearchQueryProvider = StateProvider<String>((ref) => '');
+final unifiedSearchQueryProvider = StateProvider<String>((Ref ref) => '');
 
 /// Generic, testable filter+cap over a list, using an injected predicate.
 /// Extracted so the matching/cap rule is unit-testable without GraphQL DTOs.
@@ -55,9 +56,9 @@ bool titleMatchesQuery(String title, String query) =>
 /// Hybrid: plain words match the TITLE only (keeps "bad" clean); the moment the
 /// query contains a metatag operator it runs the full library DSL, so quick
 /// search is never weaker than the library filter bar.
-final unifiedLibraryResultsProvider = Provider<List<MangaDto>>((ref) {
+final unifiedLibraryResultsProvider = Provider<List<MangaDto>>((Ref ref) {
   final query = ref.watch(unifiedSearchQueryProvider);
-  final library = ref.watch(libraryMangaListProvider).valueOrNull ?? const [];
+  final library = ref.watch(libraryMangaListProvider).value ?? const [];
   final useDsl = queryUsesOperator(query);
   return matchLibraryTitles<MangaDto>(
     library,

--- a/lib/src/features/quick_open/presentation/unified_search/unified_search_screen.dart
+++ b/lib/src/features/quick_open/presentation/unified_search/unified_search_screen.dart
@@ -69,7 +69,7 @@ class UnifiedSearchScreen extends HookConsumerWidget {
     final facets = ref.watch(unifiedLibraryFacetsProvider);
     // Same visible set the library tab bar uses: non-empty AND not-hidden.
     final categories =
-        ref.watch(visibleCategoryListProvider).valueOrNull ?? const [];
+        ref.watch(visibleCategoryListProvider).value ?? const [];
 
     final caretRaw = controller.selection.baseOffset;
     final caret = caretRaw < 0 ? controller.text.length : caretRaw;

--- a/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/backup_and_restore_section.dart
+++ b/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/backup_and_restore_section.dart
@@ -64,11 +64,11 @@ class BackupAndRestoreSection extends HookConsumerWidget {
 
     String? backupId;
     bool restoreBackup = true;
-    if (validateResult.valueOrNull.isNotBlank && context.mounted) {
+    if (validateResult.value.isNotBlank && context.mounted) {
       restoreBackup = (await showDialog<bool>(
         context: context,
         builder: (context) =>
-            BackupMissingDialog(backupMissing: validateResult.valueOrNull!),
+            BackupMissingDialog(backupMissing: validateResult.value!),
       ))
           .ifNull();
     }

--- a/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/widgets/create_backup_dialog.dart
+++ b/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/widgets/create_backup_dialog.dart
@@ -72,7 +72,7 @@ class CreateBackupDialog extends HookConsumerWidget {
                   includeClientData: includeClientData.value,
                 ));
             if (!context.mounted) return;
-            if (backupUrl.hasError || backupUrl.valueOrNull.isBlank) {
+            if (backupUrl.hasError || backupUrl.value.isBlank) {
               {
                 toast?.showError(
                   backupUrl.error?.toString() ?? context.l10n.errorBackupCreate,

--- a/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/widgets/restore_status_progress.dart
+++ b/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/widgets/restore_status_progress.dart
@@ -19,7 +19,7 @@ class RestoreStatusProgress extends HookConsumerWidget {
   Widget build(context, ref) {
     final statusProvider = restoreStatusProvider(restoreRequestId);
     final asyncRestoreStatus = ref.watch(statusProvider);
-    final restoreStatus = asyncRestoreStatus.valueOrNull;
+    final restoreStatus = asyncRestoreStatus.value;
 
     usePolling(
       pollingInterval: const Duration(milliseconds: 500),

--- a/lib/src/features/settings/presentation/browse/browse_settings_screen.dart
+++ b/lib/src/features/settings/presentation/browse/browse_settings_screen.dart
@@ -24,7 +24,7 @@ class BrowseSettingsScreen extends ConsumerWidget {
   Widget build(context, ref) {
     final repository = ref.watch(browseSettingsRepositoryProvider);
     final serverSettings = ref.watch(settingsProvider);
-    final BrowserSettingsDto? browseSettings = serverSettings.valueOrNull;
+    final BrowserSettingsDto? browseSettings = serverSettings.value;
     onRefresh() => ref.refresh(settingsProvider.future);
     return Scaffold(
       appBar: AppBar(title: Text(context.l10n.browse)),
@@ -54,7 +54,7 @@ class BrowseSettingsScreen extends ConsumerWidget {
                 ],
               ),
               const Divider(),
-              if (serverSettings.valueOrNull != null) ...[
+              if (serverSettings.value != null) ...[
                 SettingsPropTile(
                   leading: const Icon(Icons.swap_vert_rounded),
                   title: context.l10n.parallelSourceRequest,

--- a/lib/src/features/settings/presentation/browse/widgets/extension_repository/extension_repository_screen.dart
+++ b/lib/src/features/settings/presentation/browse/widgets/extension_repository/extension_repository_screen.dart
@@ -18,7 +18,7 @@ class ExtensionRepositoryScreen extends ConsumerWidget {
     final repository = ref.watch(browseSettingsRepositoryProvider);
     final serverSettings = ref.watch(settingsProvider);
     final List<String> repoList = [
-      ...?serverSettings.valueOrNull?.extensionRepos
+      ...?serverSettings.value?.extensionRepos
     ];
     onRefresh() => ref.refresh(settingsProvider.future);
     return Scaffold(

--- a/lib/src/features/settings/presentation/downloads/data/delete_chapters_settings_repository.dart
+++ b/lib/src/features/settings/presentation/downloads/data/delete_chapters_settings_repository.dart
@@ -120,7 +120,7 @@ class DeleteChaptersSettingsController
   }
 
   DeleteChaptersSettings get _current =>
-      state.valueOrNull ?? const DeleteChaptersSettings();
+      state.value ?? const DeleteChaptersSettings();
 
   Future<void> setDeleteManuallyMarkedRead(bool value) => _write(
         kDeleteChaptersManuallyMarkedReadKey,

--- a/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
+++ b/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
@@ -130,11 +130,11 @@ class _ServerDownloadsTab extends ConsumerWidget {
     final repository = ref.watch(downloadsSettingsRepositoryProvider);
     final serverSettings = ref.watch(settingsProvider);
     final serverDelete =
-        ref.watch(deleteChaptersSettingsControllerProvider).valueOrNull ??
+        ref.watch(deleteChaptersSettingsControllerProvider).value ??
             const DeleteChaptersSettings();
     final serverDeleteController =
         ref.read(deleteChaptersSettingsControllerProvider.notifier);
-    final categories = ref.watch(categoryControllerProvider).valueOrNull ??
+    final categories = ref.watch(categoryControllerProvider).value ??
         const <CategoryDto>[];
     return RefreshIndicator(
       onRefresh: () => ref.refresh(settingsProvider.future),

--- a/lib/src/features/settings/presentation/library/library_settings_screen.dart
+++ b/lib/src/features/settings/presentation/library/library_settings_screen.dart
@@ -35,7 +35,7 @@ class LibrarySettingsScreen extends ConsumerWidget {
   Widget build(context, ref) {
     final repository = ref.watch(librarySettingsRepositoryProvider);
     final serverSettings = ref.watch(settingsProvider);
-    final categories = ref.watch(categoryControllerProvider).valueOrNull ??
+    final categories = ref.watch(categoryControllerProvider).value ??
         const <CategoryDto>[];
 
     return ListTileTheme(

--- a/lib/src/features/settings/presentation/library/widgets/skip_updating_entries_popup.dart
+++ b/lib/src/features/settings/presentation/library/widgets/skip_updating_entries_popup.dart
@@ -16,7 +16,7 @@ class SkipUpdatingEntriesPopup extends ConsumerWidget {
   Widget build(context, ref) {
     final settingsDto = ref.watch(settingsProvider);
     final repository = ref.watch(librarySettingsRepositoryProvider);
-    final LibrarySettingsDto? librarySettingsDto = settingsDto.valueOrNull;
+    final LibrarySettingsDto? librarySettingsDto = settingsDto.value;
     return AlertDialog(
       title: Text(context.l10n.skipUpdatingEntries),
       contentPadding: KEdgeInsets.v8.size,

--- a/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
+++ b/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/misc.dart';
 
 import '../../../../constants/db_keys.dart';
 import '../../../../constants/enum.dart';

--- a/lib/src/features/settings/presentation/server/server_screen.dart
+++ b/lib/src/features/settings/presentation/server/server_screen.dart
@@ -68,7 +68,7 @@ class ServerScreen extends ConsumerWidget {
                     child: Center(child: Text(error.toString())),
                   );
                 }),
-              if (serverSettings.valueOrNull != null) ...[
+              if (serverSettings.value != null) ...[
                 ServerBindingSection(serverBindingDto: serverSettings.value!),
                 SocksProxySection(socksProxyDto: serverSettings.value!),
                 CloudFlareSection(cloudFlareDto: serverSettings.value!),

--- a/lib/src/features/tracking/domain/track_progress_gate.dart
+++ b/lib/src/features/tracking/domain/track_progress_gate.dart
@@ -121,6 +121,6 @@ Future<void> maybeTrackProgressOnReadFetch(
     mangaId: mangaId,
     isRead: isRead,
     manual: manual,
-    trackRecordCount: records.valueOrNull?.length ?? 0,
+    trackRecordCount: records.value?.length ?? 0,
   );
 }

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -36,7 +36,7 @@ part 'global_providers.g.dart';
 @riverpod
 GraphQLClient graphQlClient(Ref ref) {
   final authType = ref.watch(authTypeKeyProvider) ?? DBKeys.authType.initial;
-  final credentials = ref.watch(credentialsProvider).valueOrNull;
+  final credentials = ref.watch(credentialsProvider).value;
 
   // Timeout settings
   final timeoutMs = ref.watch(serverRequestTimeoutProvider) ??
@@ -146,7 +146,7 @@ GraphQLClient graphQlClient(Ref ref) {
 @riverpod
 GraphQLClient graphQlSubscriptionClient(Ref ref) {
   final authType = ref.watch(authTypeKeyProvider) ?? DBKeys.authType.initial;
-  final credentials = ref.watch(credentialsProvider).valueOrNull;
+  final credentials = ref.watch(credentialsProvider).value;
   // Watch ONLY the socket-relevant auth material (cookie + token raw strings)
   // so this client is rebuilt — and the socket reconnects with fresh auth — on
   // a re-login or token/cookie refresh. Reading it once (the old behaviour) left
@@ -157,8 +157,8 @@ GraphQLClient graphQlSubscriptionClient(Ref ref) {
   // also writes the saved password, which would otherwise reconnect twice.
   final socketAuth = ref.watch(authCredentialsStoreProvider.select(
     (s) => (
-      cookie: s.valueOrNull?.simpleLoginCookie,
-      token: s.valueOrNull?.uiAccessToken,
+      cookie: s.value?.simpleLoginCookie,
+      token: s.value?.uiAccessToken,
     ),
   ));
   final wsUrl = Endpoints.baseApi(
@@ -225,8 +225,12 @@ GraphQLClient graphQlSubscriptionClient(Ref ref) {
   );
 }
 
+// Named "holder" so its generated provider can't collide with
+// graphQlClientProvider: riverpod_generator 4 strips a trailing "Notifier"
+// from provider names, which made the old graphQlClientNotifier fold into
+// the same name as the client provider above.
 @riverpod
-ValueNotifier<GraphQLClient> graphQlClientNotifier(Ref ref) {
+ValueNotifier<GraphQLClient> graphQlClientHolder(Ref ref) {
   final notifier = ValueNotifier(ref.watch(graphQlClientProvider));
   // Dispose of the notifier when the provider is destroyed
   ref.onDispose(notifier.dispose);
@@ -271,7 +275,7 @@ class L10n extends _$L10n with SharedPreferenceClientMixin<Locale> {
 }
 
 @riverpod
-SharedPreferences sharedPreferences(ref) => throw UnimplementedError();
+SharedPreferences sharedPreferences(Ref ref) => throw UnimplementedError();
 
 @riverpod
 HiveStore hiveStore(Ref ref) => throw UnimplementedError();

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -122,7 +122,7 @@ abstract class Routes {
 }
 
 @riverpod
-GoRouter routerConfig(ref) {
+GoRouter routerConfig(Ref ref) {
   return GoRouter(
     routes: $appRoutes,
     debugLogDiagnostics: true,

--- a/lib/src/routes/sub_routes/browser_routes.dart
+++ b/lib/src/routes/sub_routes/browser_routes.dart
@@ -34,7 +34,7 @@ class BrowseExtensionBranch extends StatefulShellBranchData {
   static final $initialLocation = const BrowseExtensionRoute().location;
 }
 
-class BrowseExtensionRoute extends GoRouteData {
+class BrowseExtensionRoute extends GoRouteData with $BrowseExtensionRoute {
   const BrowseExtensionRoute();
 
   @override
@@ -46,14 +46,14 @@ class BrowseSourceBranch extends StatefulShellBranchData {
   static final $initialLocation = const BrowseSourceRoute().location;
 }
 
-class BrowseSourceRoute extends GoRouteData {
+class BrowseSourceRoute extends GoRouteData with $BrowseSourceRoute {
   const BrowseSourceRoute();
 
   @override
   Widget build(context, state) => const SourceScreen();
 }
 
-class SourceTypeRoute extends GoRouteData {
+class SourceTypeRoute extends GoRouteData with $SourceTypeRoute {
   const SourceTypeRoute({
     required this.sourceId,
     required this.sourceType,
@@ -74,7 +74,7 @@ class SourceTypeRoute extends GoRouteData {
       );
 }
 
-class SourcePreferenceRoute extends GoRouteData {
+class SourcePreferenceRoute extends GoRouteData with $SourcePreferenceRoute {
   const SourcePreferenceRoute({required this.sourceId});
 
   static final $parentNavigatorKey = _quickOpenNavigatorKey;

--- a/lib/src/routes/sub_routes/common_routes.dart
+++ b/lib/src/routes/sub_routes/common_routes.dart
@@ -1,7 +1,7 @@
 part of '../router_config.dart';
 
 //
-class MangaRoute extends GoRouteData {
+class MangaRoute extends GoRouteData with $MangaRoute {
   const MangaRoute({required this.mangaId, this.categoryId});
   final int mangaId;
   final int? categoryId;
@@ -11,14 +11,14 @@ class MangaRoute extends GoRouteData {
       MangaDetailsScreen(mangaId: mangaId, categoryId: categoryId);
 }
 
-class UpdateStatusRoute extends GoRouteData {
+class UpdateStatusRoute extends GoRouteData with $UpdateStatusRoute {
   const UpdateStatusRoute();
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const UpdateStatusSummaryDialog();
 }
 
-class ReaderRoute extends GoRouteData {
+class ReaderRoute extends GoRouteData with $ReaderRoute {
   const ReaderRoute({
     required this.mangaId,
     required this.chapterId,
@@ -86,7 +86,7 @@ class _ReaderRouteTransition extends ConsumerWidget {
   }
 }
 
-class GlobalSearchRoute extends GoRouteData {
+class GlobalSearchRoute extends GoRouteData with $GlobalSearchRoute {
   const GlobalSearchRoute({this.query});
   final String? query;
 
@@ -98,7 +98,7 @@ class GlobalSearchRoute extends GoRouteData {
 }
 
 @TypedGoRoute<UpcomingRoute>(path: Routes.upcoming)
-class UpcomingRoute extends GoRouteData {
+class UpcomingRoute extends GoRouteData with $UpcomingRoute {
   const UpcomingRoute();
 
   static final $parentNavigatorKey = rootNavigatorKey;
@@ -109,7 +109,7 @@ class UpcomingRoute extends GoRouteData {
 }
 
 @TypedGoRoute<OnboardingRoute>(path: Routes.onboarding)
-class OnboardingRoute extends GoRouteData {
+class OnboardingRoute extends GoRouteData with $OnboardingRoute {
   const OnboardingRoute();
 
   static final $parentNavigatorKey = rootNavigatorKey;

--- a/lib/src/routes/sub_routes/downloads_routes.dart
+++ b/lib/src/routes/sub_routes/downloads_routes.dart
@@ -4,7 +4,7 @@ class DownloadsBranch extends StatefulShellBranchData {
   const DownloadsBranch();
 }
 
-class DownloadsRoute extends GoRouteData {
+class DownloadsRoute extends GoRouteData with $DownloadsRoute {
   const DownloadsRoute();
   @override
   Widget build(context, state) => const DownloadsScreen();

--- a/lib/src/routes/sub_routes/history_routes.dart
+++ b/lib/src/routes/sub_routes/history_routes.dart
@@ -7,14 +7,14 @@ class HistoryBranch extends StatefulShellBranchData {
 }
 
 // History route for tablet navigation tab
-class HistoryTabRoute extends GoRouteData {
+class HistoryTabRoute extends GoRouteData with $HistoryTabRoute {
   const HistoryTabRoute();
   @override
   Widget build(context, state) => const HistoryScreen();
 }
 
 // History route for phone navigation (under More)
-class HistoryRoute extends GoRouteData {
+class HistoryRoute extends GoRouteData with $HistoryRoute {
   const HistoryRoute();
   @override
   Widget build(context, state) => const HistoryScreen();

--- a/lib/src/routes/sub_routes/library_routes.dart
+++ b/lib/src/routes/sub_routes/library_routes.dart
@@ -6,7 +6,7 @@ class LibraryBranch extends StatefulShellBranchData {
   const LibraryBranch();
 }
 
-class LibraryRoute extends GoRouteData {
+class LibraryRoute extends GoRouteData with $LibraryRoute {
   const LibraryRoute({required this.categoryId});
   final int categoryId;
   @override

--- a/lib/src/routes/sub_routes/migration_routes.dart
+++ b/lib/src/routes/sub_routes/migration_routes.dart
@@ -1,6 +1,6 @@
 part of '../router_config.dart';
 
-class MigrationGlobalSearchRoute extends GoRouteData {
+class MigrationGlobalSearchRoute extends GoRouteData with $MigrationGlobalSearchRoute {
   const MigrationGlobalSearchRoute({this.$extra});
 
   static final $parentNavigatorKey = _quickOpenNavigatorKey;
@@ -22,7 +22,7 @@ class MigrationGlobalSearchRoute extends GoRouteData {
   }
 }
 
-class MigrationSourceSelectionRoute extends GoRouteData {
+class MigrationSourceSelectionRoute extends GoRouteData with $MigrationSourceSelectionRoute {
   const MigrationSourceSelectionRoute({this.$extra});
 
   static final $parentNavigatorKey = _quickOpenNavigatorKey;
@@ -44,7 +44,7 @@ class MigrationSourceSelectionRoute extends GoRouteData {
   }
 }
 
-class MigrationSearchRoute extends GoRouteData {
+class MigrationSearchRoute extends GoRouteData with $MigrationSearchRoute {
   const MigrationSearchRoute({this.$extra});
 
   static final $parentNavigatorKey = _quickOpenNavigatorKey;
@@ -69,7 +69,7 @@ class MigrationSearchRoute extends GoRouteData {
   }
 }
 
-class MigrationPreviewRoute extends GoRouteData {
+class MigrationPreviewRoute extends GoRouteData with $MigrationPreviewRoute {
   const MigrationPreviewRoute({this.$extra});
 
   static final $parentNavigatorKey = _quickOpenNavigatorKey;
@@ -95,7 +95,7 @@ class MigrationPreviewRoute extends GoRouteData {
   }
 }
 
-class MigrationProgressRoute extends GoRouteData {
+class MigrationProgressRoute extends GoRouteData with $MigrationProgressRoute {
   const MigrationProgressRoute({this.$extra});
 
   static final $parentNavigatorKey = _quickOpenNavigatorKey;

--- a/lib/src/routes/sub_routes/more_routes.dart
+++ b/lib/src/routes/sub_routes/more_routes.dart
@@ -4,118 +4,118 @@ class MoreBranch extends StatefulShellBranchData {
   const MoreBranch();
 }
 
-class MoreRoute extends GoRouteData {
+class MoreRoute extends GoRouteData with $MoreRoute {
   const MoreRoute();
   @override
   Page<void> buildPage(context, state) =>
       const NoTransitionPage(child: MoreScreen());
 }
 
-class AboutRoute extends GoRouteData {
+class AboutRoute extends GoRouteData with $AboutRoute {
   const AboutRoute();
 
   @override
   Widget build(context, state) => const AboutScreen();
 }
 
-class SettingsRoute extends GoRouteData {
+class SettingsRoute extends GoRouteData with $SettingsRoute {
   const SettingsRoute();
 
   @override
   Widget build(context, state) => const SettingsScreen();
 }
 
-class LibrarySettingsRoute extends GoRouteData {
+class LibrarySettingsRoute extends GoRouteData with $LibrarySettingsRoute {
   const LibrarySettingsRoute();
 
   @override
   Widget build(context, state) => const LibrarySettingsScreen();
 }
 
-class EditCategoriesRoute extends GoRouteData {
+class EditCategoriesRoute extends GoRouteData with $EditCategoriesRoute {
   const EditCategoriesRoute();
 
   @override
   Widget build(context, state) => const EditCategoryScreen();
 }
 
-class ReaderSettingsRoute extends GoRouteData {
+class ReaderSettingsRoute extends GoRouteData with $ReaderSettingsRoute {
   const ReaderSettingsRoute();
 
   @override
   Widget build(context, state) => const ReaderSettingsScreen();
 }
 
-class AppearanceSettingsRoute extends GoRouteData {
+class AppearanceSettingsRoute extends GoRouteData with $AppearanceSettingsRoute {
   const AppearanceSettingsRoute();
 
   @override
   Widget build(context, state) => const AppearanceScreen();
 }
 
-class GeneralSettingsRoute extends GoRouteData {
+class GeneralSettingsRoute extends GoRouteData with $GeneralSettingsRoute {
   const GeneralSettingsRoute();
 
   @override
   Widget build(context, state) => const GeneralScreen();
 }
 
-class BrowseSettingsRoute extends GoRouteData {
+class BrowseSettingsRoute extends GoRouteData with $BrowseSettingsRoute {
   const BrowseSettingsRoute();
 
   @override
   Widget build(context, state) => const BrowseSettingsScreen();
 }
 
-class ExtensionRepositoryRoute extends GoRouteData {
+class ExtensionRepositoryRoute extends GoRouteData with $ExtensionRepositoryRoute {
   const ExtensionRepositoryRoute();
 
   @override
   Widget build(context, state) => const ExtensionRepositoryScreen();
 }
 
-class BackupRoute extends GoRouteData {
+class BackupRoute extends GoRouteData with $BackupRoute {
   const BackupRoute();
   @override
   Widget build(context, state) => const BackupScreen();
 }
 
-class ServerSettingsRoute extends GoRouteData {
+class ServerSettingsRoute extends GoRouteData with $ServerSettingsRoute {
   const ServerSettingsRoute();
 
   @override
   Widget build(context, state) => const ServerScreen();
 }
 
-class DownloadsSettingsRoute extends GoRouteData {
+class DownloadsSettingsRoute extends GoRouteData with $DownloadsSettingsRoute {
   const DownloadsSettingsRoute();
 
   @override
   Widget build(context, state) => const DownloadsSettingsScreen();
 }
 
-class OfflineSettingsRoute extends GoRouteData {
+class OfflineSettingsRoute extends GoRouteData with $OfflineSettingsRoute {
   const OfflineSettingsRoute();
 
   @override
   Widget build(context, state) => const OfflineSettingsScreen();
 }
 
-class ConnectionRoute extends GoRouteData {
+class ConnectionRoute extends GoRouteData with $ConnectionRoute {
   const ConnectionRoute();
 
   @override
   Widget build(context, state) => const ConnectionScreen();
 }
 
-class TrackingSettingsRoute extends GoRouteData {
+class TrackingSettingsRoute extends GoRouteData with $TrackingSettingsRoute {
   const TrackingSettingsRoute();
 
   @override
   Widget build(context, state) => const TrackingSettingsScreen();
 }
 
-class HotkeysSettingsRoute extends GoRouteData {
+class HotkeysSettingsRoute extends GoRouteData with $HotkeysSettingsRoute {
   const HotkeysSettingsRoute();
   @override
   Widget build(BuildContext context, GoRouterState state) =>

--- a/lib/src/routes/sub_routes/updates_routes.dart
+++ b/lib/src/routes/sub_routes/updates_routes.dart
@@ -4,7 +4,7 @@ class UpdatesBranch extends StatefulShellBranchData {
   const UpdatesBranch();
 }
 
-class UpdatesRoute extends GoRouteData {
+class UpdatesRoute extends GoRouteData with $UpdatesRoute {
   const UpdatesRoute();
   @override
   Widget build(context, state) => const UpdatesScreen();

--- a/lib/src/sorayomi.dart
+++ b/lib/src/sorayomi.dart
@@ -33,7 +33,7 @@ class Sorayomi extends ConsumerWidget {
     final appTheme = ref.watch(appThemeKeyProvider) ?? AppTheme.indigoNight;
     final customSeed = ref.watch(customThemeColorProvider);
     final isTrueBlack = ref.watch(isTrueBlackProvider).ifNull();
-    final client = ref.watch(graphQlClientNotifierProvider);
+    final client = ref.watch(graphQlClientHolderProvider);
     // Honour the portrait-lock preference on launch and whenever it changes
     // (phones only; idempotent so re-applying on rebuild is harmless).
     applyForcePortrait(ref.watch(forcePortraitProvider).ifNull());

--- a/lib/src/utils/extensions/cache_manager_extensions.dart
+++ b/lib/src/utils/extensions/cache_manager_extensions.dart
@@ -22,8 +22,8 @@ extension CacheManagerExtension on CacheManager {
   Future<File> getServerFile(WidgetRef ref, String url,
       {bool appendApiToUrl = true}) async {
     final authType = ref.read(authTypeKeyProvider);
-    final basicToken = ref.read(credentialsProvider).valueOrNull;
-    final creds = ref.read(authCredentialsStoreProvider).valueOrNull;
+    final basicToken = ref.read(credentialsProvider).value;
+    final creds = ref.read(authCredentialsStoreProvider).value;
     final baseApi = "${Endpoints.baseApi(
       baseUrl: ref.read(serverUrlProvider),
       port: ref.read(serverPortProvider),

--- a/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
@@ -30,7 +30,7 @@ extension AsyncValueExtensions<T> on AsyncValue<T> {
   }
 
   T? valueOrToast(Toast? toast, {bool withMicrotask = false}) =>
-      (this..showToastOnError(toast, withMicrotask: withMicrotask)).valueOrNull;
+      (this..showToastOnError(toast, withMicrotask: withMicrotask)).value;
 
   Widget showUiWhenData(
     BuildContext context,

--- a/lib/src/utils/logger/provider_state_logger.dart
+++ b/lib/src/utils/logger/provider_state_logger.dart
@@ -9,22 +9,21 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Useful to log state change in our application
 /// Read the logs and you'll better understand what's going on under the hood
-class ProviderStateLogger extends ProviderObserver {
+final class ProviderStateLogger extends ProviderObserver {
   const ProviderStateLogger();
   @override
   void didUpdateProvider(
-    ProviderBase provider,
+    ProviderObserverContext context,
     Object? previousValue,
     Object? newValue,
-    ProviderContainer container,
   ) {
     debugPrint('''
 {
-  provider: ${provider.name ?? provider.runtimeType},
+  provider: ${context.provider.name ?? context.provider.runtimeType},
   oldValue: $previousValue,
   newValue: $newValue
 }
 ''');
-    super.didUpdateProvider(provider, previousValue, newValue, container);
+    super.didUpdateProvider(context, previousValue, newValue);
   }
 }

--- a/lib/src/utils/mixin/shared_preferences_client_mixin.dart
+++ b/lib/src/utils/mixin/shared_preferences_client_mixin.dart
@@ -32,7 +32,14 @@ mixin SharedPreferenceClientMixin<T extends Object> {
   T? get state;
   late final dynamic Function(T)? _toJson;
   late final T? Function(dynamic)? _fromJson;
-  AutoDisposeNotifierProviderRef<T?> get ref;
+  Ref get ref;
+
+  /// Satisfied by the Notifier this mixes into — Riverpod 3 moved listenSelf
+  /// off Ref onto the notifier itself.
+  void Function() listenSelf(
+    void Function(T? previous, T? next) listener, {
+    void Function(Object error, StackTrace stackTrace)? onError,
+  });
 
   T? initialize(
     DBKeys key, {
@@ -45,7 +52,7 @@ mixin SharedPreferenceClientMixin<T extends Object> {
     _initial = initial ?? key.initial;
     _toJson = toJson;
     _fromJson = fromJson;
-    _persistenceRefreshLogic(ref);
+    _persistenceRefreshLogic();
     return _get ?? _initial;
   }
 
@@ -69,8 +76,7 @@ mixin SharedPreferenceClientMixin<T extends Object> {
     return value is T? ? value : _initial;
   }
 
-  void _persistenceRefreshLogic(AutoDisposeNotifierProviderRef<T?> ref) =>
-      ref.listenSelf((_, next) => _set(next));
+  void _persistenceRefreshLogic() => listenSelf((_, next) => _set(next));
 
   Future<bool> _set(T? value) async {
     if (value == null) return _client.remove(_key);
@@ -103,14 +109,21 @@ mixin SharedPreferenceEnumClientMixin<T extends Enum> {
   T? _initial;
   late List<T> _enumList;
   set state(T? newState);
-  AutoDisposeNotifierProviderRef<T?> get ref;
+  Ref get ref;
+
+  /// Satisfied by the Notifier this mixes into — Riverpod 3 moved listenSelf
+  /// off Ref onto the notifier itself.
+  void Function() listenSelf(
+    void Function(T? previous, T? next) listener, {
+    void Function(Object error, StackTrace stackTrace)? onError,
+  });
 
   T? initialize(DBKeys key, {required List<T> enumList}) {
     _client = ref.watch(sharedPreferencesProvider);
     _key = key.name;
     _initial = key.initial;
     _enumList = enumList;
-    _persistenceRefreshLogic(ref);
+    _persistenceRefreshLogic();
     return _get;
   }
 
@@ -128,8 +141,7 @@ mixin SharedPreferenceEnumClientMixin<T extends Enum> {
     return _client.setInt(_key, value);
   }
 
-  void _persistenceRefreshLogic(AutoDisposeNotifierProviderRef<T?> ref) =>
-      ref.listenSelf(
+  void _persistenceRefreshLogic() => listenSelf(
         (_, next) => _set(
           next == null ? null : _enumList.indexOf(next),
         ),

--- a/lib/src/widgets/custom_checkbox_list_tile.dart
+++ b/lib/src/widgets/custom_checkbox_list_tile.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hooks_riverpod/misc.dart';
 
 import '../utils/extensions/custom_extensions.dart';
 
@@ -20,8 +21,10 @@ import '../utils/extensions/custom_extensions.dart';
 /// In binary mode (`tristate: false`) the widget falls back to Flutter's
 /// `CheckboxListTile`, which is what existing display-preference callers
 /// (e.g. badge toggles) rely on.
-class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
-    extends ConsumerWidget {
+// Reads any bool? provider: mutation flows through onChanged, so the loose
+// ProviderListenable type is enough — and riverpod_generator 4's provider
+// classes no longer subtype the public NotifierProvider this used to require.
+class CustomCheckboxListTile extends ConsumerWidget {
   const CustomCheckboxListTile({
     super.key,
     required this.title,
@@ -30,7 +33,7 @@ class CustomCheckboxListTile<NotifierT extends AutoDisposeNotifier<bool?>>
     this.tristate = true,
   });
   final String title;
-  final AutoDisposeNotifierProvider<NotifierT, bool?> provider;
+  final ProviderListenable<bool?> provider;
   final ValueChanged<bool?> onChanged;
   final bool tristate;
 

--- a/lib/src/widgets/manga_cover/widgets/manga_badges.dart
+++ b/lib/src/widgets/manga_cover/widgets/manga_badges.dart
@@ -42,7 +42,7 @@ class MangaBadgesRow extends ConsumerWidget {
     // At least one chapter downloaded to THIS device — a subset of the server.
     // Empty set when the offline feature is off, so the badge self-hides.
     final onDevice = showCountBadges &&
-        (ref.watch(offlineDeviceMangaIdsProvider).valueOrNull ?? const <int>{})
+        (ref.watch(offlineDeviceMangaIdsProvider).value ?? const <int>{})
             .contains(manga.id);
 
     final source = manga.source;

--- a/lib/src/widgets/server_image.dart
+++ b/lib/src/widgets/server_image.dart
@@ -132,7 +132,7 @@ class ServerImage extends HookConsumerWidget {
 
     // Providers
     final authType = ref.watch(authTypeKeyProvider);
-    final basicToken = ref.watch(credentialsProvider).valueOrNull;
+    final basicToken = ref.watch(credentialsProvider).value;
 
     // Watch ONLY the simple-login cookie via `select` — never the
     // uiAccessToken. Watching the whole credentials state caused a
@@ -145,12 +145,12 @@ class ServerImage extends HookConsumerWidget {
     // because the lookup hits via the stable cacheKey (baseApi).
     final simpleCookieHeader = ref.watch(
       authCredentialsStoreProvider.select(
-        (async) => async.valueOrNull?.simpleLoginCookieHeader,
+        (async) => async.value?.simpleLoginCookieHeader,
       ),
     );
     final uiAccessTokenSnapshot = ref
         .read(authCredentialsStoreProvider)
-        .valueOrNull
+        .value
         ?.uiAccessToken;
 
     final baseApi = "${Endpoints.baseApi(
@@ -350,8 +350,8 @@ class ServerImageWithCpi extends StatelessWidget {
   }
 
   final authType = ref.read(authTypeKeyProvider);
-  final basicToken = ref.read(credentialsProvider).valueOrNull;
-  final creds = ref.read(authCredentialsStoreProvider).valueOrNull;
+  final basicToken = ref.read(credentialsProvider).value;
+  final creds = ref.read(authCredentialsStoreProvider).value;
 
   final cacheKey = "${Endpoints.baseApi(
     baseUrl: ref.read(serverUrlProvider),
@@ -393,8 +393,8 @@ ImageProvider serverPageImageProvider(
   if (localPath != null) return offlineImageProvider(localPath);
 
   final authType = ref.read(authTypeKeyProvider);
-  final basicToken = ref.read(credentialsProvider).valueOrNull;
-  final creds = ref.read(authCredentialsStoreProvider).valueOrNull;
+  final basicToken = ref.read(credentialsProvider).value;
+  final creds = ref.read(authCredentialsStoreProvider).value;
 
   final baseApi = "${Endpoints.baseApi(
     baseUrl: ref.read(serverUrlProvider),

--- a/lib/src/widgets/shell/update_banner_state.dart
+++ b/lib/src/widgets/shell/update_banner_state.dart
@@ -41,7 +41,7 @@ class UpdateOptimistic extends _$UpdateOptimistic {
     // second pull mid-run), treat it as already-seen so the next idle edge
     // releases the hold — otherwise the change-only running stream never
     // re-delivers `true` and only the safety timeout would clear it.
-    _sawRealRunning = ref.read(updateRunningSocketProvider).valueOrNull ?? false;
+    _sawRealRunning = ref.read(updateRunningSocketProvider).value ?? false;
     _safety?.cancel();
     _safety = Timer(const Duration(seconds: 12), _clear);
     state = true;

--- a/lib/src/widgets/shell/update_progress_banner.dart
+++ b/lib/src/widgets/shell/update_progress_banner.dart
@@ -56,7 +56,7 @@ class UpdateProgressBanner extends HookConsumerWidget {
         ref.invalidate(updateRunningSummaryProvider);
       }
       // Hand the optimistic hold back to the real running signal.
-      final running = next.valueOrNull;
+      final running = next.value;
       if (running != null) {
         ref.read(updateOptimisticProvider.notifier).onRealRunning(running);
       }
@@ -69,7 +69,7 @@ class UpdateProgressBanner extends HookConsumerWidget {
       }
     });
 
-    final rawRunning = effectiveRun.valueOrNull ?? false;
+    final rawRunning = effectiveRun.value ?? false;
 
     final debouncedRunning = useState(false);
     final timer = useRef<Timer?>(null);
@@ -112,9 +112,9 @@ class UpdateProgressBanner extends HookConsumerWidget {
     if (visible && debouncedRunning.value) {
       final heavySocket = ref.watch(updatesSocketProvider);
       final heavyFallback = ref.watch(updateSummaryProvider);
-      status = (heavySocket.valueOrNull?.total.isGreaterThan(0)).ifNull()
-          ? heavySocket.valueOrNull
-          : heavyFallback.valueOrNull;
+      status = (heavySocket.value?.total.isGreaterThan(0)).ifNull()
+          ? heavySocket.value
+          : heavyFallback.value;
     }
 
     // The colour fills up behind the status bar and the content pads below it

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.0"
-  analyzer_plugin:
+    version: "8.4.1"
+  analyzer_buffer:
     dependency: transitive
     description:
-      name: analyzer_plugin
-      sha256: a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce
+      name: analyzer_buffer
+      sha256: aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.4"
+    version: "0.1.11"
   ansicolor:
     dependency: transitive
     description:
@@ -101,18 +101,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.3.1"
   build_daemon:
     dependency: transitive
     description:
@@ -121,30 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.2"
+    version: "2.15.1"
   built_collection:
     dependency: "direct main"
     description:
@@ -209,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -265,6 +257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.1"
   cross_file:
     dependency: transitive
     description:
@@ -297,30 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
-  custom_lint_core:
-    dependency: transitive
-    description:
-      name: custom_lint_core
-      sha256: "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.5"
-  custom_lint_visitor:
-    dependency: transitive
-    description:
-      name: custom_lint_visitor
-      sha256: "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0+7.7.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   dbus:
     dependency: transitive
     description:
@@ -341,10 +325,10 @@ packages:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "68c138e884527d2bd61df2ade276c3a144df84d1adeb0ab8f3196b5afe021bd4"
+      sha256: "4db0eeedc7e8bed117a9f22d867ab7a3a294300fed5c269aac90d0b3545967ca"
       url: "https://pub.dev"
     source: hosted
-    version: "2.28.0"
+    version: "2.28.3"
   extension_type_unions:
     dependency: "direct main"
     description:
@@ -443,10 +427,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_hooks
-      sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
+      sha256: "8ae1f090e5f4ef5cfa6670ce1ab5dddadd33f3533a7f9ba19d9f958aa2a89f42"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.5"
+    version: "0.21.3+1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -496,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      sha256: "38ec6c303e2c83ee84512f5fc2a82ae311531021938e63d7137eccc107bf3c02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.1.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -586,18 +570,18 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
+      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.8"
+    version: "3.2.3"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -634,18 +618,18 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: "5922b2861e2235a3504896f0d6fa07d84141b480cf52eecd2f42cd25585a9e8a"
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "17.3.0"
   go_router_builder:
     dependency: "direct dev"
     description:
       name: go_router_builder
-      sha256: "63a1ebd575411216599055ec203014964b8e2b5af8f3b2e501447f87b492200b"
+      sha256: d67db3885eb0255e3782369c265be2d56050481ad9e56eec010cbffd7bf53ae2
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.5"
+    version: "4.3.1"
   gql:
     dependency: "direct main"
     description:
@@ -658,10 +642,10 @@ packages:
     dependency: transitive
     description:
       name: gql_code_builder
-      sha256: ce60e637b7b5250bebd6a136e5fd784bc94b860ecdcb745163ce27201023816e
+      sha256: ad16d7cca772439c2a45d0ea47f9f526dea5f6c97b9e955a42a7a7b979602a5f
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.15.1"
   gql_code_builder_serializers:
     dependency: transitive
     description:
@@ -738,10 +722,10 @@ packages:
     dependency: "direct dev"
     description:
       name: graphql_codegen
-      sha256: "402aad923673bfbe8ee6fc7e22be165bc3ebd6bf06cd95ac95e23a9ef65e9dfe"
+      sha256: "875ac7c3572e383ae1a9e2590a6d833dd3e2c256594b8448bc1af481e8455416"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "3.0.2"
   graphql_flutter:
     dependency: "direct main"
     description:
@@ -794,10 +778,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: "70bba33cfc5670c84b796e6929c54b8bc5be7d0fe15bb28c2560500b9ad06966"
+      sha256: b880efcd17757af0aa242e5dceac2fb781a014c22a32435a5daa8f17e9d5d8a9
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.1.0"
   html:
     dependency: transitive
     description:
@@ -906,10 +890,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.11.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -998,6 +982,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mockito:
+    dependency: transitive
+    description:
+      name: mockito
+      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.6.4"
   network_info_plus:
     dependency: "direct main"
     description:
@@ -1022,6 +1014,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   normalize:
     dependency: transitive
     description:
@@ -1242,34 +1242,34 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      sha256: "16ff608d21e8ea64364f2b7c049c94a02ab81668f78845862b6e88b71dd4935a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.1.0"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "837a6dc33f490706c7f4632c516bcd10804ee4d9ccc8046124ca56388715fdf3"
+      sha256: "947b05d04c52a546a2ac6b19ef2a54b08520ff6bdf9f23d67957a4c8df1c3bc0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "1.0.0-dev.8"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
+      sha256: cc1474bc2df55ec3c1da1989d139dcef22cd5e2bd78da382e867a69a8eca2e46
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "4.0.0"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "120d3310f687f43e7011bb213b90a436f1bbc300f0e4b251a72c39bccb017a4f"
+      sha256: e43b1537229cc8f487f09b0c20d15dba840acbadcf5fc6dad7ad5e8ab75950dc
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.4"
+    version: "4.0.0+1"
   rxdart:
     dependency: transitive
     description:
@@ -1423,6 +1423,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -1456,18 +1472,34 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "4.2.3"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: a447acb083d3a5ef17f983dd36201aeea33fedadb3228fa831f2f0c92f0f3aca
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.7"
+    version: "1.3.8"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -1596,6 +1628,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
@@ -1604,14 +1644,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
-  timing:
+  test_core:
     dependency: transitive
     description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      name: test_core
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -1764,6 +1804,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:
@@ -1797,5 +1845,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.35.6"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,26 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "99.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.1"
+    version: "12.1.0"
   analyzer_buffer:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033
+      sha256: "445b77e2054fa3e8c8a8ef1b5e9e6b23bb8028fffd34b5e60eaef315b7750674"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.11"
+    version: "0.3.3"
   ansicolor:
     dependency: transitive
     description:
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   code_builder:
     dependency: transitive
     description:
@@ -301,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   dbus:
     dependency: transitive
     description:
@@ -317,18 +325,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "540cf382a3bfa99b76e51514db5b0ebcd81ce3679b7c1c9cb9478ff3735e47a1"
+      sha256: "84688491040b0ceb26575709a84d701c84ad4df4d8aff020adf6d85f155fb0dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.28.2"
+    version: "2.34.2"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "4db0eeedc7e8bed117a9f22d867ab7a3a294300fed5c269aac90d0b3545967ca"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.28.3"
+    version: "2.34.0"
   extension_type_unions:
     dependency: "direct main"
     description:
@@ -480,10 +488,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: "38ec6c303e2c83ee84512f5fc2a82ae311531021938e63d7137eccc107bf3c02"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -570,10 +578,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
+      sha256: "8599ba37236328ff6f97269ecce875d251a367eb2929c9bbf9b811b2ce56c74e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.6-dev.1"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -642,10 +650,10 @@ packages:
     dependency: transitive
     description:
       name: gql_code_builder
-      sha256: ad16d7cca772439c2a45d0ea47f9f526dea5f6c97b9e955a42a7a7b979602a5f
+      sha256: deb9a659b7236edfe9d0b72c5b724cf4a33ce50686b7eac97cc48ba2bf5615d2
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.1"
+    version: "0.15.2"
   gql_code_builder_serializers:
     dependency: transitive
     description:
@@ -774,14 +782,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   hooks_riverpod:
     dependency: "direct main"
     description:
       name: hooks_riverpod
-      sha256: b880efcd17757af0aa242e5dceac2fb781a014c22a32435a5daa8f17e9d5d8a9
+      sha256: dcaf59f0f41489ff08ce61438ada564d67f40cfa37cc7c8589da78fb600c2edc
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.2"
   html:
     dependency: transitive
     description:
@@ -882,18 +898,18 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
+      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.2"
+    version: "6.14.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -990,6 +1006,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.4"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.2"
   network_info_plus:
     dependency: "direct main"
     description:
@@ -1238,38 +1262,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   riverpod:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "16ff608d21e8ea64364f2b7c049c94a02ab81668f78845862b6e88b71dd4935a"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.2"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "947b05d04c52a546a2ac6b19ef2a54b08520ff6bdf9f23d67957a4c8df1c3bc0"
+      sha256: "3e275138862ccc22ed61444a1f9a840f753094c367f28f4123f50289cd204d68"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.8"
+    version: "1.0.0-dev.10"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: cc1474bc2df55ec3c1da1989d139dcef22cd5e2bd78da382e867a69a8eca2e46
+      sha256: "674dbb26e2db3d9253166faf4758c796af14146b8fbcf5e7102bc8a04cd359b8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.3"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: e43b1537229cc8f487f09b0c20d15dba840acbadcf5fc6dad7ad5e8ab75950dc
+      sha256: "54d790c3fee1ae281c448801bfdbfaa9fd961a9d3998494e0fcd9ee32184d7eb"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0+1"
+    version: "4.0.4"
   rxdart:
     dependency: transitive
     description:
@@ -1480,10 +1512,10 @@ packages:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1552,10 +1584,10 @@ packages:
     dependency: "direct dev"
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: "61c7930bebf32c552ac5808c91bf33802e66711c9216090d3b5579c9f862e80c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.4.0"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1568,10 +1600,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "57090342af1ce32bb499aa641f4ecdd2d6231b9403cea537ac059e803cc20d67"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.41.2"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   connectivity_plus: ^6.1.3
   wakelock_plus: ^1.3.3
   cupertino_icons: ^1.0.5
-  drift: ^2.20.0
+  drift: ^2.32.0
   extension_type_unions: ^1.0.10
   file_picker: ^8.0.0+1
   flex_color_picker: 3.7.1
@@ -83,7 +83,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.14
   # flutter_flavorizr: ^2.1.5
-  drift_dev: ^2.20.0
+  drift_dev: ^2.32.0
   flutter_launcher_icons: ^0.14.1
   flutter_lints: ^5.0.0
   flutter_native_splash: ^2.2.14
@@ -97,8 +97,8 @@ dev_dependencies:
   graphql_codegen: ^3.0.0
   json_serializable: ^6.5.4
   lints: ^5.0.0
-  riverpod_generator: ^4.0.0
-  sqlite3: ^2.9.4
+  riverpod_generator: ^4.0.4
+  sqlite3: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,23 +30,23 @@ dependencies:
       ref: "9db2306fd2b4f804f5b9fbf69b97b211f47f527c"
   flutter_cache_manager: ^3.3.0
   flutter_foreground_task: ^9.2.2
-  flutter_hooks: ^0.20.0
+  flutter_hooks: ^0.21.0
   flutter_localizations:
     sdk: flutter
   flutter_markdown: ^0.7.1
   flutter_secure_storage: ^9.2.2
   fluttertoast: ^8.1.1
   font_awesome_flutter: ^11.0.0
-  freezed_annotation: ^2.2.0
+  freezed_annotation: ^3.0.0
   gap: ^3.0.1
-  go_router: ^14.0.2
+  go_router: ^17.0.0
   gql: ^1.0.1-alpha+1730759315362
   gql_http_link: ^1.0.1+1
   graphql: ^5.2.0-beta.10
   graphql_flutter: ^5.2.0-beta.8
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  hooks_riverpod: ^2.1.1
+  hooks_riverpod: ^3.0.0
   http: ^1.2.0
   infinite_scroll_pagination: ^4.0.0
   intl: ^0.20.2
@@ -59,7 +59,7 @@ dependencies:
   permission_handler: ^11.0.0
   pub_semver: ^2.1.2
   queue: ^3.1.0+2
-  riverpod_annotation: ^2.0.0
+  riverpod_annotation: ^4.0.0
   # Pinned to yakagami's fork (2-line addition over upstream) which exposes
   # ScrollPosition on ScrollOffsetController. Required for zoom_view to
   # coordinate scroll position with pinch-zoom in the multi-image readers.
@@ -89,15 +89,15 @@ dev_dependencies:
   flutter_native_splash: ^2.2.14
   flutter_test:
     sdk: flutter
-  freezed: ^2.2.1
+  freezed: ^3.0.0
   # Pinned to the 2.7.x line: 2.8.0+ targets go_router 15 (adds TypedGoRoute
   # .caseSensitive), but go_router itself is held at ^14 here — the go_router 15→17
   # major bump is a separate, deliberate migration. Keep builder + runtime aligned.
-  go_router_builder: ">=2.7.5 <2.8.0"
-  graphql_codegen: ^1.1.1
+  go_router_builder: ^4.0.0
+  graphql_codegen: ^3.0.0
   json_serializable: ^6.5.4
   lints: ^5.0.0
-  riverpod_generator: ^2.0.0
+  riverpod_generator: ^4.0.0
   sqlite3: ^2.9.4
 
 flutter:

--- a/test/helpers/offline_test_db.dart
+++ b/test/helpers/offline_test_db.dart
@@ -4,42 +4,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import 'dart:ffi';
 import 'dart:io';
 
 import 'package:drift/native.dart';
-import 'package:sqlite3/open.dart';
 import 'package:tsumiru/src/features/offline/data/offline_database.dart';
 
-
-bool _configured = false;
-
-/// Point the `sqlite3` package at the versioned host library in tests.
-///
-/// On a device `sqlite3_flutter_libs` bundles the lib, but the Dart VM test
-/// host has only `libsqlite3.so.0` (no unversioned `libsqlite3.so`, which ships
-/// in the `-dev` package). Test-only workaround; no production effect.
-void _ensureSqlite() {
-  if (_configured) return;
-  _configured = true;
-  if (Platform.isLinux) {
-    open.overrideFor(
-      OperatingSystem.linux,
-      () => DynamicLibrary.open('libsqlite3.so.0'),
-    );
-  }
-}
+// sqlite3 3.x loads its own SQLite via Dart build hooks, so the old
+// DynamicLibrary override (pointing the VM test host at libsqlite3.so.0)
+// is gone along with the API that provided it.
 
 /// A fresh in-memory [OfflineDatabase] for tests.
 OfflineDatabase testOfflineDatabase() {
-  _ensureSqlite();
   return OfflineDatabase(NativeDatabase.memory());
 }
 
 /// An on-disk [OfflineDatabase] at [path] — for migration tests that need
-/// close-and-reopen semantics. The sqlite3 host shim is applied so the same
-/// versioned library is used as in [testOfflineDatabase].
+/// close-and-reopen semantics.
 OfflineDatabase testOfflineDatabaseFile(String path) {
-  _ensureSqlite();
   return OfflineDatabase(NativeDatabase(File(path)));
 }

--- a/test/offline/offline_server_mismatch_banner_test.dart
+++ b/test/offline/offline_server_mismatch_banner_test.dart
@@ -18,6 +18,7 @@ import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
 import 'package:tsumiru/src/features/offline/presentation/offline_server_mismatch_banner.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
 import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:hooks_riverpod/misc.dart';
 
 /// Load the SDK's Roboto so captured screenshots have readable text (test hosts
 /// otherwise render the Ahem box font). Best-effort — falls through on CI.

--- a/test/src/features/browse_center/presentation/source/source_controller_test.dart
+++ b/test/src/features/browse_center/presentation/source/source_controller_test.dart
@@ -99,7 +99,7 @@ void main() {
         'en': [mangaDex, allManga],
         'ko': [bato],
       });
-      final out = c.read(sourceMapFilteredAndQueriedProvider).valueOrNull!;
+      final out = c.read(sourceMapFilteredAndQueriedProvider).value!;
       expect(out['en']!.map((e) => e.name), ['MangaDex', 'allmanga']);
       expect(out['ko']!.map((e) => e.name), ['Bato']);
     });
@@ -110,7 +110,7 @@ void main() {
         'ko': [bato],
       });
       c.read(sourceSearchQueryProvider.notifier).update('dex');
-      final out = c.read(sourceMapFilteredAndQueriedProvider).valueOrNull!;
+      final out = c.read(sourceMapFilteredAndQueriedProvider).value!;
       expect(out['en']!.map((e) => e.name), ['MangaDex']);
       expect(out['ko'], isEmpty);
     });

--- a/test/src/features/manga_book/reader/side_seekbar_position_test.dart
+++ b/test/src/features/manga_book/reader/side_seekbar_position_test.dart
@@ -8,7 +8,7 @@
 // [Positioned] offsets (top: 80, bottom: 100) that overlapped the chrome bars on
 // every device with a tall status bar or gesture-nav inset.
 //
-// The fix: ReaderChrome reads [chromeExtentsNotifierProvider] at build time and
+// The fix: ReaderChrome reads [chromeExtentsProvider] at build time and
 // computes:
 //
 //   top:    e.topInset    + 8   (breathing room)
@@ -36,7 +36,7 @@ class _TestSeekbarHost extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final extents = ref.watch(chromeExtentsNotifierProvider);
+    final extents = ref.watch(chromeExtentsProvider);
     final forceHorizontal =
         ref.watch(forceHorizontalSeekbarProvider) ?? false;
     final leftHanded =
@@ -77,7 +77,7 @@ void main() {
           overrides: [
             // Override the notifier to return the fixed extents immediately —
             // no MeasureSize, no timing.
-            chromeExtentsNotifierProvider.overrideWith(
+            chromeExtentsProvider.overrideWith(
               () => _FixedExtentsNotifier(extents),
             ),
             // Default prefs: force-horizontal OFF, left-handed OFF.
@@ -157,7 +157,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            chromeExtentsNotifierProvider.overrideWith(
+            chromeExtentsProvider.overrideWith(
               () => _FixedExtentsNotifier(testExtents),
             ),
             forceHorizontalSeekbarProvider.overrideWith(
@@ -193,7 +193,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            chromeExtentsNotifierProvider.overrideWith(
+            chromeExtentsProvider.overrideWith(
               () => _FixedExtentsNotifier(testExtents),
             ),
             forceHorizontalSeekbarProvider.overrideWith(

--- a/test/src/features/offline/data/offline_screen_gates_test.dart
+++ b/test/src/features/offline/data/offline_screen_gates_test.dart
@@ -19,6 +19,7 @@ import 'package:tsumiru/src/features/offline/data/offline_dto_mappers.dart';
 import 'package:tsumiru/src/features/offline/data/offline_read_fallback.dart';
 import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:hooks_riverpod/misc.dart';
 
 import '../../../../helpers/offline_test_db.dart';
 

--- a/test/src/features/offline/push_pending_progress_tracking_test.dart
+++ b/test/src/features/offline/push_pending_progress_tracking_test.dart
@@ -18,6 +18,7 @@ import 'package:tsumiru/src/features/tracking/data/graphql/__generated__/query.g
 import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
 import 'package:tsumiru/src/features/tracking/domain/tracking_settings_providers.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:hooks_riverpod/misc.dart';
 
 import '../../../helpers/offline_test_db.dart';
 

--- a/test/src/widgets/shell/update_banner_state_test.dart
+++ b/test/src/widgets/shell/update_banner_state_test.dart
@@ -18,6 +18,10 @@ ProviderContainer _container({bool runningNow = false}) {
           .overrideWith((ref) => Stream.value(runningNow)),
     ],
   );
+  // Riverpod 3 pauses/disposes unlistened providers, so a one-shot .future
+  // read leaves the socket provider mid-loading at teardown ("disposed during
+  // loading state"). A persistent listener keeps it alive and settled.
+  container.listen(updateRunningSocketProvider, (_, __) {});
   addTearDown(container.dispose);
   return container;
 }


### PR DESCRIPTION
Moves the entire code-generation and state stack to current stable in one coordinated pass: **Riverpod 3, freezed 3, graphql_codegen 3, go_router 17**, plus drift 2.34 and analyzer 12. These share one build-toolchain floor, so they can only move together — this clears every major migration that was deferred during the Flutter 3.44.6 bump.

## The interesting part: a build-ordering trap

riverpod_generator 4 resolves provider signature types for real (v2 copied names as text). build_runner phases unordered builders reverse-alphabetically, so riverpod_generator ran **before** graphql_codegen — and every provider whose signature touches a GraphQL-generated type failed with a nameless `InvalidTypeException` (22 files, including files that look completely innocent). Upstream considers this by-design.

Fixes:
- `build.yaml` now orders `graphql_codegen` before `riverpod_generator` (22 → 1).
- Types that live inside drift's generated part can't be ordering-fixed, so the offline enums moved to a part-free file and the on-device series row is a nominal class instead of a record — the generator resolves signature types only, so generated types are fine as members (1 → 0).

## API migration

- `.valueOrNull` → `.value` (~157 sites; Riverpod 3 made `.value` the safe accessor)
- The generator now strips a trailing `Notifier` from provider names — renamed `graphQlClientNotifier` → `graphQlClientHolder` to break a resulting name collision, call sites moved to `chromeExtentsProvider`
- `StateProvider` via `hooks_riverpod/legacy.dart`; `Override`/`ProviderListenable`/`Refreshable` via `misc.dart`; `AutoDispose*` types folded into their base names
- `ProviderObserver` on the new single-context signature; `listenSelf` moved off `Ref` onto notifiers (preference mixins updated)
- Widgets taking "any provider" parameters now use `ProviderListenable<T>` — generated providers no longer subtype the public `NotifierProvider`
- sqlite3 3.x loads natively via build hooks, so the test-only `DynamicLibrary` override is gone

## Verification

- `flutter analyze` clean; **all 943 tests pass** (one test now keeps its socket provider listened — Riverpod 3 disposes unlistened providers mid-load)
- Web build driven end-to-end against a live server: library, details, reader resume, navigation, search
- On-device: profile build vs the current release app, identical scripted chapter-list scroll, screen-recorded and frame-analyzed — **1.9% vs 2.0% dropped frames**, i.e. no measurable regression. (Debug builds do feel slower on Riverpod 3 — it runs heavy debug-mode checks; profile/release are unaffected.)
