### PR TITLE
Fix chapters reverting to unread after being marked read

### DIFF
--- a/docs/architecture/offline.md
+++ b/docs/architecture/offline.md
@@ -4,10 +4,10 @@ Save chapters to the device and read them with **no server connection**, with au
 
 ## On-device catalog
 
-`data/offline_database.dart` — a Drift / SQLite database (`OfflineDatabase`, schemaVersion 3) at `<appSupport>/offline/catalog.sqlite`. Tables:
+`data/offline_database.dart` — a Drift / SQLite database (`OfflineDatabase`, schemaVersion 7) at `<appSupport>/offline/catalog.sqlite`. Tables:
 
 - `OfflineMangas` — `id` (server manga id) PK; `title`, `thumbnailUrl`, `thumbnailRelPath`, `keepRule` (`OfflineKeepRule`, default `off`), `keepUnreadCount` (default 3).
-- `OfflineChapters` — `id` (server chapter id) PK, indexed by `mangaId`; `deviceState` (`OfflineDeviceState`, default `none`), `pageCount`, `bytes`, `pinned`, `downloadedAt`, `serverIsDownloaded`, `progressDirty`, plus read state.
+- `OfflineChapters` — `id` (server chapter id) PK, indexed by `mangaId`; `deviceState` (`OfflineDeviceState`, default `none`), `pageCount`, `bytes`, `pinned`, `downloadedAt`, `serverIsDownloaded`, read state, and three independent "not yet pushed" flags — `progressDirty` (position), `readStateDirty` (isRead), `bookmarkDirty` (isBookmarked). Each field syncs under its own flag so a position-only write can never push a stale isRead (the ch-99 un-read loop) and a read/bookmark change set elsewhere still lands locally while another is pending.
 - `OfflineCategories`, `OfflineMangaCategories`, and `OfflinePages` (`(chapterId, pageIndex)` → `relativePath`).
 
 Design notes: there is **no foreign key** from chapters to mangas — a chapter whose server manga is gone becomes `deviceState = orphaned` instead of cascade-deleting. The metadata upserts (`upsertMangaMetadata` / `upsertChapterMetadata`) deliberately exclude device-managed columns (`deviceState`, `bytes`, `thumbnailRelPath`) from `ON CONFLICT UPDATE`, so a metadata sync can never clobber download state.
@@ -20,7 +20,7 @@ Four layers, all driven through one entry point — **`downloadStarterProvider`*
 
 1. `chapter_download_engine.dart` — `ChapterDownloadEngine` downloads one chapter's pages with up to N concurrent workers (N = `OfflineDownloadConcurrency`, default 2), each page retried 3× with backoff. `PageAuthException` → one auth refresh + retry; `PageOfflineException` → stop and leave the run resumable.
 2. `offline_download_coordinator.dart` — `OfflineDownloadCoordinator` queues and runs **one chapter at a time** (Komikku model) via the engine; `pumpDownloads()` drains the queue. Process-wide single-flight via a `static _pumping` flag.
-3. `offline_download_providers.dart` — the wiring + the public surface: `saveChapterToDevice`, `deleteChapterFromDevice`, `reconcileManga`, `recordReadingProgress`, `pushPendingProgress`, and the state streams (`offlineChapterStateProvider`, `mangaOfflineProgressProvider`, `mangaKeepRuleProvider`, …).
+3. `offline_download_providers.dart` — the wiring + the public surface: `saveChapterToDevice`, `deleteChapterFromDevice`, `reconcileManga`, `recordReadingProgress`, `recordReadState` (offline-aware write-through for mark-read/unread), `pushPendingProgress`, and the state streams (`offlineChapterStateProvider`, `mangaOfflineProgressProvider`, `mangaKeepRuleProvider`, …).
 4. `data/background/` — **Android only**: `BackgroundDownloadController` owns a `FlutterForegroundTask` foreground service (its own isolate, `download_task_handler.dart`) so downloads survive leaving the app. Auth is snapshotted into a `BackgroundWorkOrder`; completions are durably logged to a file and replayed into Drift on resume; rotated `ui_login` tokens are written back via `BackgroundTokenRecord`.
 
 > **Single-owner invariant:** on Android the in-process pump is a hard no-op (`pumpDownloads()` returns early on `isAndroidNative`) — the foreground service is the sole downloader. Everywhere else the coordinator pumps on the main isolate.
@@ -45,7 +45,7 @@ Four layers, all driven through one entry point — **`downloadStarterProvider`*
 
 ## Sync + read fallback
 
-`offline_sync.dart` — `OfflineSync` mirrors GraphQL DTOs into the catalog during normal online use, preserving locally-dirty read progress over incoming server values (an offline read is never overwritten by a stale down-sync). `offline_read_fallback.dart` — five wrappers (`libraryWithOfflineFallback`, `mangaWithOfflineFallback`, `chaptersWithOfflineFallback`, `chapterMetaWithOfflineFallback`, `categoriesWithOfflineFallback`): on a network error, if offline is enabled and the catalog has data, they return mapped local rows (categories synthesise a single "Default" so the Library tab still renders). The reader serves pages via `OfflineRepository.localChapterPages(chapterId)` when `deviceState == downloaded`.
+`offline_sync.dart` — `OfflineSync` mirrors GraphQL DTOs into the catalog during normal online use, preserving each locally-dirty field (position / read-state / bookmark) over the incoming server value independently — so an offline read is never overwritten by a stale down-sync, yet a server-side read/bookmark set on another client still lands locally while a different field is pending up-sync. `offline_read_fallback.dart` — five wrappers (`libraryWithOfflineFallback`, `mangaWithOfflineFallback`, `chaptersWithOfflineFallback`, `chapterMetaWithOfflineFallback`, `categoriesWithOfflineFallback`): on a network error, if offline is enabled and the catalog has data, they return mapped local rows (categories synthesise a single "Default" so the Library tab still renders). The reader serves pages via `OfflineRepository.localChapterPages(chapterId)` when `deviceState == downloaded`.
 
 ## Server-switch guard
 

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -115,6 +115,7 @@ class CategoryMangaList extends HookConsumerWidget {
       final ids = selection.value.toList();
       selection.value = const {};
       final repo = ref.read(mangaBookRepositoryProvider);
+      var allOk = true;
       for (final id in ids) {
         final chapters = await repo.getChapterList(id);
         final cids = <int>[for (final c in chapters ?? const []) c.id];
@@ -122,10 +123,11 @@ class CategoryMangaList extends HookConsumerWidget {
           // Offline-aware write-through: the local rows are updated first (so
           // the change survives offline + restart and keeps Resume truthful),
           // then the server bulk write — same fix as the chapter-list icons.
-          await recordReadState(ref, chapterIds: cids, isRead: read);
+          final ok = await recordReadState(ref, chapterIds: cids, isRead: read);
+          if (!ok) allOk = false;
           // Marking a whole series read here bypasses the reader, so push the
           // new progress to the bound tracker(s) explicitly (manual path).
-          if (read) {
+          if (read && ok) {
             unawaited(maybeTrackProgressOnReadFetch(
               ref,
               mangaId: id,
@@ -136,13 +138,21 @@ class CategoryMangaList extends HookConsumerWidget {
         }
       }
       refresh();
-      if (context.mounted) {
+      if (!context.mounted) return;
+      // A server failure with offline inactive means nothing was persisted, so
+      // surface it instead of a false success. (An offline-active failure is
+      // queued locally and up-syncs later, so the success message still holds.)
+      if (!allOk && !ref.read(offlineActiveProvider)) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(read
-              ? 'Marked ${ids.length} series read'
-              : 'Marked ${ids.length} series unread'),
+          content: Text(context.l10n.errorSomethingWentWrong),
         ));
+        return;
       }
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(read
+            ? 'Marked ${ids.length} series read'
+            : 'Marked ${ids.length} series unread'),
+      ));
     }
 
     return mangaList.showUiWhenData(

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -25,7 +25,6 @@ import '../../../../widgets/shell/update_banner_state.dart';
 import '../../../manga_book/data/downloads/downloads_repository.dart';
 import '../../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../../manga_book/data/updates/updates_repository.dart';
-import '../../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../../manga_book/domain/manga/manga_model.dart';
 import '../../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import '../../../manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart';
@@ -120,8 +119,10 @@ class CategoryMangaList extends HookConsumerWidget {
         final chapters = await repo.getChapterList(id);
         final cids = <int>[for (final c in chapters ?? const []) c.id];
         if (cids.isNotEmpty) {
-          await repo.modifyBulkChapters(
-              ChapterBatch(ids: cids, patch: ChapterChange(isRead: read)));
+          // Offline-aware write-through: the local rows are updated first (so
+          // the change survives offline + restart and keeps Resume truthful),
+          // then the server bulk write — same fix as the chapter-list icons.
+          await recordReadState(ref, chapterIds: cids, isRead: read);
           // Marking a whole series read here bypasses the reader, so push the
           // new progress to the bound tracker(s) explicitly (manual path).
           if (read) {

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -13,6 +13,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../offline/data/offline_download_providers.dart';
+import '../../../offline/data/offline_repository.dart';
 import '../../../tracking/domain/track_progress_gate.dart';
 import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/chapter/chapter_model.dart';
@@ -43,22 +44,39 @@ class MultiChaptersActionIcon extends ConsumerWidget {
     return IconButton(
       icon: icon ?? Icon(iconData),
       onPressed: () async {
-        final result = await AsyncValue.guard(
-          () => ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
-                ChapterBatch(
-                  ids: [for (final c in chapters) c.id],
-                  patch: change,
+        final ids = [for (final c in chapters) c.id];
+        final bool ok;
+        if (change.isRead != null) {
+          // Read/unread goes through the offline-aware write-through path: the
+          // local row is updated first (so it survives offline + restart and
+          // keeps Resume truthful), then the server. A failure with offline
+          // active is queued, not lost, so only surface an error when there's
+          // no local fallback.
+          ok = await recordReadState(
+            ref,
+            chapterIds: ids,
+            isRead: change.isRead!,
+            resetPosition: change.lastPageRead == 0 && change.isRead == true,
+          );
+          if (!ok && !ref.read(offlineActiveProvider) && context.mounted) {
+            ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+          }
+        } else {
+          final result = await AsyncValue.guard(
+            () => ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
+                  ChapterBatch(ids: ids, patch: change),
                 ),
-              ),
-        );
-        if (context.mounted) {
-          result.showToastOnError(ref.read(toastProvider));
+          );
+          if (context.mounted) {
+            result.showToastOnError(ref.read(toastProvider));
+          }
+          ok = !result.hasError;
         }
         // On a successful mark-read, sync each affected manga to its tracker and
         // honour the delete-on-manual-read setting — keyed off each chapter's
         // own mangaId, so a multi-manga selection (updates screen) syncs them
         // all instead of being silently skipped.
-        if (!result.hasError && change.isRead == true) {
+        if (ok && change.isRead == true) {
           for (final mangaId in {for (final c in chapters) c.mangaId}) {
             unawaited(maybeTrackProgressOnReadFetch(
               ref,

--- a/lib/src/features/manga_book/widgets/chapter_actions/single_chapter_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/single_chapter_action_icon.dart
@@ -38,6 +38,16 @@ class SingleChapterActionIcon extends ConsumerWidget {
           // Bookmark toggles go through the offline-aware path (#33): recorded
           // on-device + dirty-flagged, so they stick offline and sync later.
           await recordBookmark(ref, chapterId: chapterId, isBookmarked: bookmark);
+        } else if (change.isRead != null) {
+          // Read-state toggles use the same offline-aware write-through as the
+          // bulk action (no production caller sends isRead here today; wired for
+          // consistency and future use).
+          await recordReadState(
+            ref,
+            chapterIds: [chapterId],
+            isRead: change.isRead!,
+            resetPosition: change.lastPageRead == 0 && change.isRead == true,
+          );
         } else {
           final result = (await AsyncValue.guard(
             () => ref.read(mangaBookRepositoryProvider).putChapter(

--- a/lib/src/features/manga_book/widgets/chapter_actions/single_chapter_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/single_chapter_action_icon.dart
@@ -11,6 +11,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../offline/data/offline_download_providers.dart';
+import '../../../offline/data/offline_repository.dart';
 import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/chapter_batch/chapter_batch_model.dart';
 
@@ -42,12 +43,15 @@ class SingleChapterActionIcon extends ConsumerWidget {
           // Read-state toggles use the same offline-aware write-through as the
           // bulk action (no production caller sends isRead here today; wired for
           // consistency and future use).
-          await recordReadState(
+          final ok = await recordReadState(
             ref,
             chapterIds: [chapterId],
             isRead: change.isRead!,
             resetPosition: change.lastPageRead == 0 && change.isRead == true,
           );
+          if (!ok && !ref.read(offlineActiveProvider) && context.mounted) {
+            ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+          }
         } else {
           final result = (await AsyncValue.guard(
             () => ref.read(mangaBookRepositoryProvider).putChapter(

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -398,9 +398,23 @@ class OfflineDatabase extends _$OfflineDatabase {
       (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
         OfflineChaptersCompanion(
           lastPageRead: Value(lastPageRead),
-          // null → leave read-state untouched (a partial write must not un-read).
-          isRead: isRead == null ? const Value.absent() : Value(isRead),
           progressDirty: const Value(true),
+          // null → leave read-state untouched (a partial write must not un-read).
+          // A read-state change rides its OWN flag so a position-only write can
+          // never push a stale isRead (the ch-99 un-read loop).
+          isRead: isRead == null ? const Value.absent() : Value(isRead),
+          readStateDirty:
+              isRead == null ? const Value.absent() : const Value(true),
+        ),
+      );
+
+  /// Record a local read/unread change (list actions, mark-read). Position
+  /// untouched; pushed under its own flag on the next online sync.
+  Future<void> setChapterReadState(int chapterId, bool isRead) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        OfflineChaptersCompanion(
+          isRead: Value(isRead),
+          readStateDirty: const Value(true),
         ),
       );
 
@@ -419,15 +433,20 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// clean and lost (the snapshot-then-clear race). A non-matching row keeps its
   /// flag and re-syncs on the next pass.
   Future<void> clearProgressDirtyIfUnchanged(int chapterId,
-          {required int lastPageRead, bool? isRead}) =>
+          {required int lastPageRead}) =>
       (update(offlineChapters)
-            ..where((t) {
-              final matches =
-                  t.id.equals(chapterId) & t.lastPageRead.equals(lastPageRead);
-              // isRead null → match on position alone (we never set it).
-              return isRead == null ? matches : matches & t.isRead.equals(isRead);
-            }))
+            ..where((t) =>
+                t.id.equals(chapterId) & t.lastPageRead.equals(lastPageRead)))
           .write(const OfflineChaptersCompanion(progressDirty: Value(false)));
+
+  /// Clear readStateDirty only if the row's isRead still matches what was
+  /// pushed — the same race guard as [clearProgressDirtyIfUnchanged], mirroring
+  /// [clearBookmarkDirtyIfUnchanged].
+  Future<void> clearReadStateDirtyIfUnchanged(int chapterId,
+          {required bool isRead}) =>
+      (update(offlineChapters)
+            ..where((t) => t.id.equals(chapterId) & t.isRead.equals(isRead)))
+          .write(const OfflineChaptersCompanion(readStateDirty: Value(false)));
 
   /// Clear bookmarkDirty only if the bookmark still matches what was pushed —
   /// same race guard as [clearProgressDirtyIfUnchanged].
@@ -457,8 +476,10 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// Chapters with any unpushed local change — read progress OR bookmark — for
   /// the up-sync to flush and the down-sync to preserve.
   Future<List<OfflineChapter>> dirtyChapters() => (select(offlineChapters)
-        ..where(
-            (t) => t.progressDirty.equals(true) | t.bookmarkDirty.equals(true)))
+        ..where((t) =>
+            t.progressDirty.equals(true) |
+            t.bookmarkDirty.equals(true) |
+            t.readStateDirty.equals(true)))
       .get();
 
   // --- offline queries -------------------------------------------------------

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -83,6 +83,13 @@ class OfflineChapters extends Table {
   BoolColumn get bookmarkDirty =>
       boolean().withDefault(const Constant(false))();
 
+  /// True when this chapter's read-STATE (isRead) was changed locally but not
+  /// yet pushed. Tracked separately from [progressDirty] so a position-only
+  /// write can never push a stale isRead (the ch-99 un-read loop), mirroring
+  /// [bookmarkDirty] (#13).
+  BoolColumn get readStateDirty =>
+      boolean().withDefault(const Constant(false))();
+
   /// The server's last-read timestamp (epoch millis as a string, matching the
   /// server's LongString) — synced down so the offline library can sort by
   /// "Last Read". Server is the source of truth; this is never the device clock.
@@ -134,7 +141,7 @@ class OfflineDatabase extends _$OfflineDatabase {
   OfflineDatabase(super.e);
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -187,6 +194,18 @@ class OfflineDatabase extends _$OfflineDatabase {
                 m, offlineMangas, offlineMangas.latestUploadedAt);
             await _addColumnIfMissing(
                 m, offlineMangas, offlineMangas.totalChapters);
+          }
+          if (from < 7) {
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.readStateDirty);
+            // Carry pending reads across the split: a progress-dirty row with
+            // isRead=true is usually a completed offline read awaiting push
+            // (it may also be a server-sourced true on a partial re-read —
+            // pushing true is the safe direction). is_read=0 dirty rows are
+            // exactly the stale class; they stay position-only.
+            await customStatement(
+                'UPDATE offline_chapters SET read_state_dirty = 1 '
+                'WHERE progress_dirty = 1 AND is_read = 1');
           }
         },
       );

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -322,6 +322,72 @@ Future<void> recordBookmark(
   }
 }
 
+/// Mark chapters read/unread, offline-aware. Writes the local row FIRST (so the
+/// change survives offline + restart and keeps Resume and the offline UI
+/// truthful — the root of the ch-99 loop was that list mark-read never touched
+/// the local row), then the server bulk write; on failure the change stays
+/// dirty and up-syncs on reconnect. [resetPosition] mirrors the mark-read
+/// action's `lastPageRead: 0` reset (recorded locally as a deliberate position
+/// write); mark-unread leaves position alone. Returns the server write's
+/// success, so callers keep firing trackers / delete-on-manual online only.
+Future<bool> recordReadStateWithDependencies({
+  required bool offlineEnabled,
+  required OfflineDatabase? offlineDatabase,
+  required MangaBookRepository repository,
+  required List<int> chapterIds,
+  required bool isRead,
+  bool resetPosition = false,
+}) async {
+  final db = offlineDatabase;
+  if (offlineEnabled && db != null) {
+    for (final id in chapterIds) {
+      if (resetPosition) {
+        await db.setChapterProgress(id, lastPageRead: 0, isRead: isRead);
+      } else {
+        await db.setChapterReadState(id, isRead);
+      }
+    }
+  }
+  final result = await AsyncValue.guard(
+    () => repository.modifyBulkChapters(
+      ChapterBatch(
+        ids: chapterIds,
+        patch: resetPosition
+            ? ChapterChange(isRead: isRead, lastPageRead: 0)
+            : ChapterChange(isRead: isRead),
+      ),
+    ),
+  );
+  if (offlineEnabled && db != null && !result.hasError) {
+    for (final id in chapterIds) {
+      await db.clearReadStateDirtyIfUnchanged(id, isRead: isRead);
+      if (resetPosition) {
+        await db.clearProgressDirtyIfUnchanged(id, lastPageRead: 0);
+      }
+    }
+  }
+  return !result.hasError;
+}
+
+/// Widget entry point for [recordReadStateWithDependencies] — resolves the
+/// offline deps from [ref]. Mirrors [recordReadingProgress].
+Future<bool> recordReadState(
+  WidgetRef ref, {
+  required List<int> chapterIds,
+  required bool isRead,
+  bool resetPosition = false,
+}) {
+  final offline = ref.read(offlineActiveProvider);
+  return recordReadStateWithDependencies(
+    offlineEnabled: offline,
+    offlineDatabase: offline ? ref.read(offlineDatabaseProvider) : null,
+    repository: ref.read(mangaBookRepositoryProvider),
+    chapterIds: chapterIds,
+    isRead: isRead,
+    resetPosition: resetPosition,
+  );
+}
+
 // === Delete-on-read =========================================================
 // Two INDEPENDENT features, each with its own settings (see
 // delete_chapters_settings_repository): the on-device set (local prefs) deletes

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -282,7 +282,12 @@ Future<void> recordReadingProgressWithDependencies({
   );
   if (offlineEnabled && db != null && !result.hasError) {
     await db.clearProgressDirtyIfUnchanged(chapterId,
-        lastPageRead: lastPageRead, isRead: markRead);
+        lastPageRead: lastPageRead);
+    // Completion set isRead (and thus readStateDirty) too — clear that flag on
+    // the same successful push so a completed read isn't re-pushed forever.
+    if (markRead != null) {
+      await db.clearReadStateDirtyIfUnchanged(chapterId, isRead: markRead);
+    }
   }
 }
 
@@ -503,7 +508,7 @@ Future<void> pushPendingProgress(ProviderContainer container) async {
       // re-syncs on the next pass (no silent data loss).
       if (c.progressDirty) {
         await db.clearProgressDirtyIfUnchanged(c.id,
-            lastPageRead: c.lastPageRead, isRead: c.isRead);
+            lastPageRead: c.lastPageRead);
       }
       if (c.bookmarkDirty) {
         await db.clearBookmarkDirtyIfUnchanged(c.id,

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -493,11 +493,12 @@ Future<void> pushPendingProgress(ProviderContainer container) async {
         chapterId: c.id,
         patch: ChapterChange(
           // Send only the locally-changed fields (null = omitted from the
-          // patch), so a progress sync never overwrites a server bookmark that
-          // hasn't down-synced, and a bookmark sync never overwrites pending
-          // read progress (#13).
+          // patch), each gated on its OWN dirty flag. isRead rides
+          // readStateDirty — NOT progressDirty — so a position-only write can
+          // never push a stale isRead (the ch-99 un-read loop), just as a
+          // bookmark sync never overwrites pending read progress (#13).
           lastPageRead: c.progressDirty ? c.lastPageRead : null,
-          isRead: c.progressDirty ? c.isRead : null,
+          isRead: c.readStateDirty ? c.isRead : null,
           isBookmarked: c.bookmarkDirty ? c.isBookmarked : null,
         ),
       ),
@@ -510,11 +511,14 @@ Future<void> pushPendingProgress(ProviderContainer container) async {
         await db.clearProgressDirtyIfUnchanged(c.id,
             lastPageRead: c.lastPageRead);
       }
+      if (c.readStateDirty) {
+        await db.clearReadStateDirtyIfUnchanged(c.id, isRead: c.isRead);
+      }
       if (c.bookmarkDirty) {
         await db.clearBookmarkDirtyIfUnchanged(c.id,
             isBookmarked: c.isBookmarked);
       }
-      if (c.progressDirty && c.isRead) syncedReadMangaIds.add(c.mangaId);
+      if (c.readStateDirty && c.isRead) syncedReadMangaIds.add(c.mangaId);
     }
   }
 

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -57,21 +57,22 @@ class OfflineSync {
     };
     for (final c in chapters) {
       final local = dirty[c.id];
-      // Keep a locally-changed value only while its own flag is still dirty;
-      // otherwise take the server's. Tracking read-progress and bookmark
-      // dirtiness separately means a server bookmark set elsewhere still
-      // propagates to the device even while a read is pending up-sync, and
-      // vice versa — instead of the old code pinning ALL of progress+bookmark
-      // to the stale local value whenever either was dirty (#13).
-      final keepProgress = local?.progressDirty ?? false;
+      // Keep a locally-changed value only while its OWN flag is still dirty;
+      // otherwise take the server's. Position, read-state, and bookmark each
+      // have their own flag, so a server change to one still lands locally
+      // while another is pending up-sync — instead of the old code pinning
+      // isRead to the stale local value whenever position was dirty (the ch-99
+      // un-read loop), and vice versa (#13).
+      final keepPosition = local?.progressDirty ?? false;
+      final keepReadState = local?.readStateDirty ?? false;
       final keepBookmark = local?.bookmarkDirty ?? false;
       await _db.upsertChapterMetadata(
         id: c.id,
         mangaId: c.mangaId,
         name: c.name,
         chapterIndex: c.sourceOrder,
-        isRead: keepProgress ? local!.isRead : c.isRead,
-        lastPageRead: keepProgress ? local!.lastPageRead : c.lastPageRead,
+        isRead: keepReadState ? local!.isRead : c.isRead,
+        lastPageRead: keepPosition ? local!.lastPageRead : c.lastPageRead,
         isBookmarked: keepBookmark ? local!.isBookmarked : c.isBookmarked,
         serverIsDownloaded: c.isDownloaded,
         pageCount: c.pageCount,

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -16,8 +16,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 6', () {
-    expect(db.schemaVersion, 6);
+  test('opens at schema version 7', () {
+    expect(db.schemaVersion, 7);
   });
 
   test('inserts and reads a manga', () async {

--- a/test/src/features/offline/data/offline_download_manager_force_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_force_test.dart
@@ -45,6 +45,7 @@ void main() {
         downloadedAt: null,
         progressDirty: false,
         bookmarkDirty: false,
+        readStateDirty: false,
         updatedAt: DateTime(2026),
       );
 

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 6', () {
-    expect(db.schemaVersion, 6);
+  test('opens at schema version 7', () {
+    expect(db.schemaVersion, 7);
   });
 
   test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',

--- a/test/src/features/offline/data/offline_progress_test.dart
+++ b/test/src/features/offline/data/offline_progress_test.dart
@@ -114,12 +114,52 @@ void main() {
     // A newer local write arrives (e.g. during the up-sync push).
     await db.setChapterProgress(10, lastPageRead: 9, isRead: false);
     // Clearing with the OLD pushed values must NOT mark the newer row clean.
-    await db.clearProgressDirtyIfUnchanged(10, lastPageRead: 5, isRead: false);
+    await db.clearProgressDirtyIfUnchanged(10, lastPageRead: 5);
     final c = await db.chapterById(10);
     expect(c!.progressDirty, true); // newer write still pending up-sync
     expect(c.lastPageRead, 9);
     // Clearing with the CURRENT values clears it.
-    await db.clearProgressDirtyIfUnchanged(10, lastPageRead: 9, isRead: false);
+    await db.clearProgressDirtyIfUnchanged(10, lastPageRead: 9);
     expect((await db.chapterById(10))!.progressDirty, false);
+  });
+
+  test('partial write dirties position only; completion dirties both', () async {
+    await seed(5);
+    await db.setChapterProgress(5, lastPageRead: 4, isRead: null);
+    var c = (await db.chapterById(5))!;
+    expect(c.progressDirty, isTrue);
+    expect(c.readStateDirty, isFalse);
+    await db.setChapterProgress(5, lastPageRead: 0, isRead: true);
+    c = (await db.chapterById(5))!;
+    expect(c.readStateDirty, isTrue);
+    expect(c.isRead, isTrue);
+  });
+
+  test('setChapterReadState writes isRead + readStateDirty, not position',
+      () async {
+    await seed(5);
+    await db.setChapterProgress(5, lastPageRead: 4, isRead: null);
+    await db.clearProgressDirtyIfUnchanged(5, lastPageRead: 4);
+    await db.setChapterReadState(5, true);
+    final c = (await db.chapterById(5))!;
+    expect(c.isRead, isTrue);
+    expect(c.readStateDirty, isTrue);
+    expect(c.progressDirty, isFalse);
+    expect(c.lastPageRead, 4);
+  });
+
+  test('read-state clear-if-unchanged mirrors bookmark race guard', () async {
+    await seed(5);
+    await db.setChapterReadState(5, true);
+    await db.clearReadStateDirtyIfUnchanged(5, isRead: false); // mismatch
+    expect((await db.chapterById(5))!.readStateDirty, isTrue);
+    await db.clearReadStateDirtyIfUnchanged(5, isRead: true); // match
+    expect((await db.chapterById(5))!.readStateDirty, isFalse);
+  });
+
+  test('dirtyChapters includes read-state-only-dirty rows', () async {
+    await seed(5);
+    await db.setChapterReadState(5, true);
+    expect((await db.dirtyChapters()).map((e) => e.id), contains(5));
   });
 }

--- a/test/src/features/offline/data/offline_sync_preserve_test.dart
+++ b/test/src/features/offline/data/offline_sync_preserve_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_sync.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+ChapterDto chapterDto(
+  int id, {
+  required int lastPageRead,
+  required bool isRead,
+  bool isBookmarked = false,
+}) =>
+    Fragment$ChapterDto(
+      id: id, mangaId: 1, name: 'c$id', chapterNumber: id.toDouble(),
+      sourceOrder: id, isRead: isRead, isBookmarked: isBookmarked,
+      isDownloaded: true, lastPageRead: lastPageRead, pageCount: 30,
+      fetchedAt: '0', uploadDate: '0', lastReadAt: '0', url: '',
+      meta: const <Fragment$ChapterDto$meta>[],
+    );
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seedChapter(int id,
+          {bool isRead = false, int lastPageRead = 0}) =>
+      db.upsertChapterMetadata(
+        id: id, mangaId: 1, name: 'c$id', chapterIndex: id, isRead: isRead,
+        lastPageRead: lastPageRead, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 30, updatedAt: DateTime(2026),
+      );
+
+  test('down-sync takes server isRead when only position is dirty', () async {
+    await seedChapter(10); // clean row
+    await db.setChapterProgress(10, lastPageRead: 5, isRead: null); // partial
+    await OfflineSync(db)
+        .syncChapters([chapterDto(10, lastPageRead: 0, isRead: true)]);
+    final c = (await db.chapterById(10))!;
+    expect(c.isRead, isTrue); // server's read-state accepted (was blocked)
+    expect(c.lastPageRead, 5); // dirty position preserved
+  });
+
+  test('down-sync keeps a dirty local read-state, ignoring the server', () async {
+    await seedChapter(10);
+    await db.setChapterReadState(10, true); // marked read locally, not yet pushed
+    await OfflineSync(db)
+        .syncChapters([chapterDto(10, lastPageRead: 0, isRead: false)]);
+    final c = (await db.chapterById(10))!;
+    expect(c.isRead, isTrue); // local read-state kept, not clobbered
+    expect(c.readStateDirty, isTrue); // still pending up-sync
+  });
+}

--- a/test/src/features/offline/data/read_state_dirty_migration_test.dart
+++ b/test/src/features/offline/data/read_state_dirty_migration_test.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late Directory tmp;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('read_state_dirty_migration_');
+  });
+
+  tearDown(() async {
+    await tmp.delete(recursive: true);
+  });
+
+  Future<void> seedRow(OfflineDatabase db, int id,
+      {required bool isRead, required bool progressDirty}) async {
+    await db.upsertChapterMetadata(
+      id: id,
+      mangaId: 1,
+      name: 'c$id',
+      chapterIndex: id,
+      isRead: isRead,
+      lastPageRead: isRead ? 0 : 5,
+      isBookmarked: false,
+      serverIsDownloaded: true,
+      pageCount: 30,
+      updatedAt: DateTime(2026),
+    );
+    // setChapterProgress marks progressDirty without touching isRead (isRead:
+    // null), so we can arm the dirty flag independently of the read-state.
+    if (progressDirty) {
+      await db.setChapterProgress(id, lastPageRead: isRead ? 0 : 5);
+    }
+  }
+
+  test('v6→v7 seeds readStateDirty only for progress-dirty completed reads',
+      () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    // Create a v7 DB, seed the three classes, then rewind it to a v6 shape by
+    // dropping the new column and forcing the recorded version back — exactly
+    // the on-disk state a pre-upgrade device carries.
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      // A: pending completed offline read (progressDirty + isRead) → carried.
+      await seedRow(db, 1, isRead: true, progressDirty: true);
+      // B: the stale class — position dirty but not read → stays position-only.
+      await seedRow(db, 2, isRead: false, progressDirty: true);
+      // C: clean server-read row → nothing pending, no read-state flag.
+      await seedRow(db, 3, isRead: true, progressDirty: false);
+      await db.customStatement(
+          'ALTER TABLE offline_chapters DROP COLUMN read_state_dirty');
+      await db.customStatement('PRAGMA user_version = 6');
+      await db.close();
+    }
+
+    // Reopen: onUpgrade(6, 7) re-adds the column and runs the seed UPDATE.
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      final a = (await db.chapterById(1))!;
+      final b = (await db.chapterById(2))!;
+      final c = (await db.chapterById(3))!;
+      expect(a.readStateDirty, isTrue, reason: 'pending read carried over');
+      expect(b.readStateDirty, isFalse, reason: 'stale class neutralized');
+      expect(c.readStateDirty, isFalse, reason: 'clean row untouched');
+      // Position dirtiness is untouched by the split.
+      expect(a.progressDirty, isTrue);
+      expect(b.progressDirty, isTrue);
+      await db.close();
+    }
+  });
+}

--- a/test/src/features/offline/data/reconcile_desired_set_test.dart
+++ b/test/src/features/offline/data/reconcile_desired_set_test.dart
@@ -8,7 +8,7 @@ OfflineChapter ch(int id, int idx, {bool read = false, bool pinned = false}) =>
       lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
       deviceState: OfflineDeviceState.none, pageCount: 1, bytes: 0,
       pinned: pinned, downloadedAt: null, progressDirty: false,
-      bookmarkDirty: false, updatedAt: DateTime(2026),
+      bookmarkDirty: false, readStateDirty: false, updatedAt: DateTime(2026),
     );
 
 void main() {

--- a/test/src/features/offline/data/reconcile_eviction_test.dart
+++ b/test/src/features/offline/data/reconcile_eviction_test.dart
@@ -15,7 +15,8 @@ OfflineChapter dl(int id, {int bytes = 100, DateTime? at, bool pinned = false}) 
       lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
       deviceState: OfflineDeviceState.downloaded, pageCount: 1, bytes: bytes,
       pinned: pinned, downloadedAt: at ?? DateTime(2026, 1, id),
-      progressDirty: false, bookmarkDirty: false, updatedAt: DateTime(2026),
+      progressDirty: false, bookmarkDirty: false, readStateDirty: false,
+      updatedAt: DateTime(2026),
     );
 
 void main() {

--- a/test/src/features/offline/data/record_read_state_test.dart
+++ b/test/src/features/offline/data/record_read_state_test.dart
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+/// modifyBulkChapters succeeds — mimics an online mark-read.
+class _OkRepo extends MangaBookRepository {
+  _OkRepo() : super(_dummyClient());
+  final List<ChapterBatch> batches = [];
+  @override
+  Future<void> modifyBulkChapters(ChapterBatch batch) async {
+    batches.add(batch);
+  }
+}
+
+/// modifyBulkChapters throws — mimics an offline (unreachable-server) mark-read.
+class _FailingRepo extends MangaBookRepository {
+  _FailingRepo() : super(_dummyClient());
+  @override
+  Future<void> modifyBulkChapters(ChapterBatch batch) async {
+    throw Exception('offline — mutation failed');
+  }
+}
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seedChapter(int id,
+          {bool isRead = false, int lastPageRead = 0}) =>
+      db.upsertChapterMetadata(
+        id: id, mangaId: 1, name: 'c$id', chapterIndex: id, isRead: isRead,
+        lastPageRead: lastPageRead, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 30, updatedAt: DateTime(2026),
+      );
+
+  test('offline mark-read lands locally and stays queued for sync', () async {
+    await seedChapter(10);
+    final ok = await recordReadStateWithDependencies(
+      offlineEnabled: true,
+      offlineDatabase: db,
+      repository: _FailingRepo(),
+      chapterIds: [10],
+      isRead: true,
+      resetPosition: true,
+    );
+    expect(ok, isFalse);
+    final c = (await db.chapterById(10))!;
+    expect(c.isRead, isTrue);
+    expect(c.readStateDirty, isTrue); // queued for pushPendingProgress
+    expect(c.lastPageRead, 0);
+  });
+
+  test('online mark-read clears the flag on server success', () async {
+    await seedChapter(10);
+    final ok = await recordReadStateWithDependencies(
+      offlineEnabled: true,
+      offlineDatabase: db,
+      repository: _OkRepo(),
+      chapterIds: [10],
+      isRead: true,
+      resetPosition: true,
+    );
+    expect(ok, isTrue);
+    final c = (await db.chapterById(10))!;
+    expect(c.readStateDirty, isFalse);
+    expect(c.progressDirty, isFalse);
+  });
+
+  test('mark-unread is symmetric and does not touch position', () async {
+    await seedChapter(10, isRead: true, lastPageRead: 7);
+    final ok = await recordReadStateWithDependencies(
+      offlineEnabled: true,
+      offlineDatabase: db,
+      repository: _OkRepo(),
+      chapterIds: [10],
+      isRead: false,
+    );
+    expect(ok, isTrue);
+    final c = (await db.chapterById(10))!;
+    expect(c.isRead, isFalse);
+    expect(c.lastPageRead, 7); // resetPosition:false → position untouched
+  });
+
+  test('mark-read patch carries the position reset the server expects',
+      () async {
+    await seedChapter(10);
+    final repo = _OkRepo();
+    await recordReadStateWithDependencies(
+      offlineEnabled: true,
+      offlineDatabase: db,
+      repository: repo,
+      chapterIds: [10],
+      isRead: true,
+      resetPosition: true,
+    );
+    expect(repo.batches.single.patch.isRead, isTrue);
+    expect(repo.batches.single.patch.lastPageRead, 0);
+  });
+}

--- a/test/src/features/offline/push_pending_progress_tracking_test.dart
+++ b/test/src/features/offline/push_pending_progress_tracking_test.dart
@@ -361,5 +361,52 @@ void main() {
       expect(repo.patches.single.isRead, isTrue);
       expect((await db.chapterById(10))!.readStateDirty, isFalse);
     });
+
+    // The full reported loop, end to end. Pre-fix this reverted 100%: the
+    // partial read left the row position-dirty with isRead=false, list
+    // mark-read never touched the local row, and the reconnect push sent that
+    // stale isRead=false — reverting the chapter to unread on the server.
+    test('ch-99 loop is dead: offline partial-read then mark-read syncs '
+        'read=true, never a stale unread', () async {
+      final repo = _CapturingMangaBookRepository();
+      final (:container, :db, :tracker) =
+          await _build(mangaIds: [1], repository: repo);
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 99, mangaId: 1);
+      // Offline partial read of ch 99 (back out): records position only.
+      await recordReadingProgressWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: _FailingMangaBookRepository(),
+        chapterId: 99,
+        lastPageRead: 5,
+        isRead: false,
+      );
+      // Offline mark-read from the list: write-through updates the local row.
+      await recordReadStateWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: _FailingMangaBookRepository(),
+        chapterIds: [99],
+        isRead: true,
+        resetPosition: true,
+      );
+
+      // Reconnect and flush.
+      await pushPendingProgress(container);
+
+      final patch = repo.patches.single;
+      expect(patch.isRead, isTrue,
+          reason: 'the mark-read reaches the server (used to revert to unread)');
+      expect(patch.lastPageRead, 0, reason: 'mark-read reset the position');
+      final c = (await db.chapterById(99))!;
+      expect(c.isRead, isTrue);
+      expect(c.progressDirty, isFalse);
+      expect(c.readStateDirty, isFalse);
+    });
   });
 }

--- a/test/src/features/offline/push_pending_progress_tracking_test.dart
+++ b/test/src/features/offline/push_pending_progress_tracking_test.dart
@@ -60,6 +60,22 @@ class _FakeMangaBookRepository extends MangaBookRepository {
   }
 }
 
+/// Captures every pushed patch so a test can assert exactly which fields the
+/// up-sync sent (the ch-99 fix: a position-dirty row must push no isRead).
+class _CapturingMangaBookRepository extends MangaBookRepository {
+  _CapturingMangaBookRepository() : super(_dummyClient());
+
+  final List<ChapterChange> patches = [];
+
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {
+    patches.add(patch);
+  }
+}
+
 /// putChapter that fails like an offline mutation — used to prove a failed push
 /// keeps the dirty flag (the bug where offline progress/bookmarks were cleared
 /// without ever reaching the server).
@@ -142,12 +158,13 @@ Future<
   required List<int> mangaIds,
   int trackRecordCount = 1,
   bool toggleOn = true,
+  MangaBookRepository? repository,
 }) async {
   SharedPreferences.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
   final db = testOfflineDatabase();
   final fakeTracker = _FakeTrackerRepository();
-  final fakeMangaBook = _FakeMangaBookRepository();
+  final fakeMangaBook = repository ?? _FakeMangaBookRepository();
 
   final records = List.generate(trackRecordCount, (_) => _fakeRecord());
 
@@ -304,6 +321,45 @@ void main() {
 
       expect(tracker.trackProgressCalls, isEmpty,
           reason: 'isRead=false chapters must not trigger tracker');
+    });
+  });
+
+  group('pushPendingProgress → per-field push', () {
+    test('position-dirty row never pushes isRead (ch-99 revert)', () async {
+      final repo = _CapturingMangaBookRepository();
+      final (:container, :db, :tracker) =
+          await _build(mangaIds: [1], repository: repo);
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1); // clean row
+      await db.setChapterProgress(10, lastPageRead: 5, isRead: null); // partial
+
+      await pushPendingProgress(container);
+
+      expect(repo.patches.single.lastPageRead, 5);
+      expect(repo.patches.single.isRead, isNull); // THE fix
+      expect((await db.chapterById(10))!.progressDirty, isFalse);
+    });
+
+    test('read-state-dirty row pushes isRead and clears its flag', () async {
+      final repo = _CapturingMangaBookRepository();
+      final (:container, :db, :tracker) =
+          await _build(mangaIds: [1], repository: repo);
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await db.setChapterReadState(10, true);
+
+      await pushPendingProgress(container);
+
+      expect(repo.patches.single.isRead, isTrue);
+      expect((await db.chapterById(10))!.readStateDirty, isFalse);
     });
   });
 }


### PR DESCRIPTION
## The bug

A chapter you marked read could silently revert to unread after relaunching, stuck in a loop (reported on a chapter that had been partially read, then marked read from the list).

Root cause: the offline catalog tracked read *position* and read *state* under a single `progressDirty` flag. So a partial read (position only) left the row dirty, list "mark read" was server-only and never touched the local row, and the next launch pushed the row's stale `isRead: false` back to the server — reverting it. The down-sync also refused to accept the server's read-state while a position was pending.

## The fix

Give read-state its own "not yet pushed" flag, exactly like bookmarks already have (`bookmarkDirty`, #13):

- **Schema v7** adds `readStateDirty`, with a migration that carries pending offline reads across the upgrade and never flags the stale class.
- **Up-sync** now sends each field only under its own flag — a position-only change can no longer push a stale `isRead`.
- **Down-sync** preserves position, read-state, and bookmark independently, so a read-state set on another client lands locally even while a position is queued.
- **Mark-read / mark-unread** (chapter list, library bulk, single-chapter) now write through to the local row first, so the change is truthful locally, survives offline + restart, and syncs up on reconnect — which also makes marking read work offline.

## Tests

TDD throughout: a schema-migration test covering all three seed classes, per-field up/down-sync regression tests, write-through helper coverage, and an end-to-end test that walks the exact reported loop (offline partial-read → offline mark-read → reconnect push) and asserts it no longer reverts. Full suite green.
