### PR TITLE
style(ui): apply flex spacing in Emoticons and ServerUnreachableView

### DIFF
--- a/lib/src/widgets/emoticons.dart
+++ b/lib/src/widgets/emoticons.dart
@@ -6,7 +6,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:gap/gap.dart';
 
 import '../constants/app_sizes.dart';
 import '../utils/extensions/custom_extensions.dart';
@@ -44,14 +43,16 @@ class Emoticons extends HookWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           spacing: 8,
           children: [
-            iconData != null
-                ? Icon(iconData, size: context.height * .2)
-                : Text(
-                    errorFace,
-                    textAlign: TextAlign.center,
-                    style: context.textTheme.displayMedium,
-                  ),
-            const Gap(8),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: iconData != null
+                  ? Icon(iconData, size: context.height * .2)
+                  : Text(
+                      errorFace,
+                      textAlign: TextAlign.center,
+                      style: context.textTheme.displayMedium,
+                    ),
+            ),
             if (title.isNotBlank)
               Text(
                 title!,

--- a/lib/src/widgets/emoticons.dart
+++ b/lib/src/widgets/emoticons.dart
@@ -42,6 +42,7 @@ class Emoticons extends HookWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
+          spacing: 8,
           children: [
             iconData != null
                 ? Icon(iconData, size: context.height * .2)
@@ -50,7 +51,7 @@ class Emoticons extends HookWidget {
                     textAlign: TextAlign.center,
                     style: context.textTheme.displayMedium,
                   ),
-            const Gap(16),
+            const Gap(8),
             if (title.isNotBlank)
               Text(
                 title!,

--- a/lib/src/widgets/server_unreachable_view.dart
+++ b/lib/src/widgets/server_unreachable_view.dart
@@ -31,6 +31,7 @@ class ServerUnreachableView extends StatelessWidget {
       subTitle: context.l10n.serverUnreachableSubtitle,
       button: Column(
         mainAxisSize: MainAxisSize.min,
+        spacing: 8,
         children: [
           FilledButton.tonalIcon(
             onPressed: () => const ConnectionRoute().go(context),


### PR DESCRIPTION
**Context & Motivation**
While viewing the connection error state (rendered when the server is unreachable or not yet configured), the layout elements appeared excessively tight, lacking appropriate visual separation.

**Changes**
- Implemented the native `spacing: 8` property on the `Column` layout within both `Emoticons` and `ServerUnreachableView` to manage child element separation automatically.
- In `Emoticons`, reduced the manual `Gap` from `16` to `8`. When combined with the new `8` flex spacing of the column, this maintains the original `16` pixel layout offset between specific elements while utilizing a cleaner, more robust structure.