### PR TITLE
feat(search): replace toggled search with inline sticky-on-scroll bar

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -156,6 +156,10 @@ enum DBKeys {
   showHiddenCategories(false),
   // When true, each tab label appends "(N)" where N is the filtered manga count.
   categoryNumberOfItems(false),
+  // When true, the library search bar is always visible under the app bar and
+  // sticks into it on scroll (Yokai/TachiyomiJ2K style). When false (default),
+  // search hides behind the app-bar search button (Mihon/Komikku style).
+  libraryPersistentSearchBar(false),
   // How the library tabs are grouped: 0=by category (default), 1=by source,
   // 2=by status, 3=by track status (reserved; filled in Task 8), 4=ungrouped.
   libraryGroupType(0),

--- a/lib/src/features/browse_center/presentation/extension/extension_screen.dart
+++ b/lib/src/features/browse_center/presentation/extension/extension_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../constants/app_sizes.dart';
 import '../../../../constants/language_list.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
@@ -128,12 +129,20 @@ class ExtensionScreen extends HookConsumerWidget {
 
     return Column(
       children: [
-        SearchField(
-          autofocus: false,
-          hintText: context.l10n.searchForExtensions,
-          initialText: ref.watch(extensionQueryProvider),
-          onChanged: (val) =>
-              ref.read(extensionQueryProvider.notifier).update(val),
+        SizedBox(
+          width: context.isLargeTablet
+              ? context.widthScale(scale: .5)
+              : null,
+          child: Padding(
+            padding: KEdgeInsets.h16v4.size,
+            child: SearchField(
+              autofocus: false,
+              labelText: context.l10n.searchForExtensions,
+              initialText: ref.watch(extensionQueryProvider),
+              onChanged: (val) =>
+                  ref.read(extensionQueryProvider.notifier).update(val),
+            ),
+          ),
         ),
         Expanded(child: body),
       ],

--- a/lib/src/features/browse_center/presentation/global_search/global_search_screen.dart
+++ b/lib/src/features/browse_center/presentation/global_search/global_search_screen.dart
@@ -37,9 +37,17 @@ class GlobalSearchScreen extends HookConsumerWidget {
             children: [
               Align(
                 alignment: Alignment.centerRight,
-                child: SearchField(
-                  initialText: query.value,
-                  onSubmitted: (value) => query.value = value,
+                child: SizedBox(
+                  width: context.isLargeTablet
+                      ? context.widthScale(scale: .5)
+                      : null,
+                  child: Padding(
+                    padding: KEdgeInsets.h16v4.size,
+                    child: SearchField(
+                      initialText: query.value,
+                      onSubmitted: (value) => query.value = value,
+                    ),
+                  ),
                 ),
               ),
             ],

--- a/lib/src/features/browse_center/presentation/source/source_screen.dart
+++ b/lib/src/features/browse_center/presentation/source/source_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../constants/app_sizes.dart';
 import '../../../../constants/language_list.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
@@ -139,12 +140,20 @@ class SourceScreen extends HookConsumerWidget {
 
     return Column(
       children: [
-        SearchField(
-          autofocus: false,
-          hintText: context.l10n.searchForSources,
-          initialText: query,
-          onChanged: (val) =>
-              ref.read(sourceSearchQueryProvider.notifier).update(val),
+        SizedBox(
+          width: context.isLargeTablet
+              ? context.widthScale(scale: .5)
+              : null,
+          child: Padding(
+            padding: KEdgeInsets.h16v4.size,
+            child: SearchField(
+              autofocus: false,
+              labelText: context.l10n.searchForSources,
+              initialText: query,
+              onChanged: (val) =>
+                  ref.read(sourceSearchQueryProvider.notifier).update(val),
+            ),
+          ),
         ),
         Expanded(child: body),
       ],

--- a/lib/src/features/browse_center/presentation/source_manga_list/source_manga_list_screen.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/source_manga_list_screen.dart
@@ -161,22 +161,30 @@ class SourceMangaListScreen extends HookConsumerWidget {
                 if (showSearch.value)
                   Align(
                     alignment: Alignment.centerRight,
-                    child: SearchField(
-                      initialText: query.value,
-                      onClose: () => showSearch.value = (false),
-                      onSubmitted: (val) {
-                        if (sourceType == SourceType.SEARCH) {
-                          query.value = (val);
-                          controller.refresh();
-                        } else {
-                          if (val == null) return;
-                          SourceTypeRoute(
-                            sourceId: sourceId,
-                            sourceType: SourceType.SEARCH,
-                            query: val,
-                          ).go(context);
-                        }
-                      },
+                    child: SizedBox(
+                      width: context.isLargeTablet
+                          ? context.widthScale(scale: .5)
+                          : null,
+                      child: Padding(
+                        padding: KEdgeInsets.h16v4.size,
+                        child: SearchField(
+                          initialText: query.value,
+                          onClose: () => showSearch.value = (false),
+                          onSubmitted: (val) {
+                            if (sourceType == SourceType.SEARCH) {
+                              query.value = (val);
+                              controller.refresh();
+                            } else {
+                              if (val == null) return;
+                              SourceTypeRoute(
+                                sourceId: sourceId,
+                                sourceType: SourceType.SEARCH,
+                                query: val,
+                              ).go(context);
+                            }
+                          },
+                        ),
+                      ),
                     ),
                   ),
               ],

--- a/lib/src/features/browse_center/presentation/source_manga_list/widgets/filter_to_widget.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/widgets/filter_to_widget.dart
@@ -40,13 +40,16 @@ class FilterToWidget extends StatelessWidget {
         name: String? name,
         textState: String? state,
       ) =>
-        SearchField(
-          autofocus: false,
-          onChanged: (val) => onChanged([
-            FilterChange(textState: val, position: kPositionPlaceholder),
-          ]),
-          hintText: name,
-          initialText: firstCurrentChange?.textState ?? state,
+        Padding(
+          padding: KEdgeInsets.h16v4.size,
+          child: SearchField(
+            autofocus: false,
+            onChanged: (val) => onChanged([
+              FilterChange(textState: val, position: kPositionPlaceholder),
+            ]),
+            labelText: name,
+            initialText: firstCurrentChange?.textState ?? state,
+          ),
         ),
       FilterCheckBox(
         name: String? name,

--- a/lib/src/features/history/presentation/history_screen.dart
+++ b/lib/src/features/history/presentation/history_screen.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../constants/app_sizes.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../../widgets/emoticons.dart';
 import '../../../widgets/search_field.dart';
@@ -39,16 +40,24 @@ class HistoryScreen extends ConsumerWidget {
           // Search bar
           Padding(
             padding: const EdgeInsets.all(8),
-            child: SearchField(
-              initialText: searchQuery,
-              onChanged: (query) => ref
-                  .read(historySearchQueryProvider.notifier)
-                  .updateQuery(query ?? ''),
-              onSubmitted: (query) => ref
-                  .read(historySearchQueryProvider.notifier)
-                  .updateQuery(query ?? ''),
-              hintText: l10n.searchHistory,
-              autofocus: false,
+            child: SizedBox(
+              width: context.isLargeTablet
+                  ? context.widthScale(scale: .5)
+                  : null,
+              child: Padding(
+                padding: KEdgeInsets.h16v4.size,
+                child: SearchField(
+                  initialText: searchQuery,
+                  onChanged: (query) => ref
+                      .read(historySearchQueryProvider.notifier)
+                      .updateQuery(query ?? ''),
+                  onSubmitted: (query) => ref
+                      .read(historySearchQueryProvider.notifier)
+                      .updateQuery(query ?? ''),
+                  labelText: l10n.searchHistory,
+                  autofocus: false,
+                ),
+              ),
             ),
           ),
           // History content

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -27,6 +27,7 @@ import '../../../manga_book/widgets/update_status_popup_menu.dart';
 import '../../../offline/presentation/offline_server_mismatch_banner.dart';
 import '../../../offline/presentation/server_unreachable_banner.dart';
 import '../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
+import '../../../settings/presentation/library/widgets/persistent_search_bar/persistent_search_bar.dart';
 import '../../domain/category/category_model.dart';
 import '../../domain/library_group.dart';
 import '../category/controller/edit_category_controller.dart';
@@ -39,12 +40,12 @@ import 'widgets/library_manga_organizer.dart';
 /// Wraps a library Scaffold body so the offline server-mismatch banner sits
 /// below the app bar (inside the Scaffold), not floating over the status bar.
 Widget _libraryBody(Widget body) => Column(
-      children: [
-        const ServerUnreachableBanner(),
-        const OfflineServerMismatchBanner(),
-        Expanded(child: body),
-      ],
-    );
+  children: [
+    const ServerUnreachableBanner(),
+    const OfflineServerMismatchBanner(),
+    Expanded(child: body),
+  ],
+);
 
 class LibraryScreen extends HookConsumerWidget {
   const LibraryScreen({super.key, required this.categoryId});
@@ -76,10 +77,87 @@ class LibraryScreen extends HookConsumerWidget {
   }
 }
 
+// ─────────────────── shared pieces ───────────────────────────────────────────
+
+/// Filter/sort/display organizer button: end-drawer on tablets, bottom sheet
+/// on phones.
+Widget _organizerButton() => Builder(
+  builder: (context) => IconButton(
+    onPressed: () {
+      if (context.isTablet) {
+        Scaffold.of(context).openEndDrawer();
+      } else {
+        showModalBottomSheet(
+          context: context,
+          isScrollControlled: true,
+          shape: RoundedRectangleBorder(
+            borderRadius: KBorderRadius.rT16.radius,
+          ),
+          clipBehavior: Clip.hardEdge,
+          // The organizer sizes itself to the active tab's content
+          // (capped at 72% height), so no fixed-height wrapper.
+          builder: (_) => const LibraryMangaOrganizer(),
+        );
+      }
+    },
+    icon: const Icon(Icons.filter_list_rounded),
+  ),
+);
+
+/// Whether the inline search bar (located via [searchBarKey]) has scrolled out
+/// of the viewport, meaning the pinned app bar should host the search field
+/// instead.
+///
+/// Evaluated defensively:
+///  - a missing or zero-height bar (the library is still loading, so
+///    [_LibrarySearchBar] collapsed) is never "hidden" — reporting hidden then
+///    leaves the app-bar field up while the inline bar reappears at offset 0,
+///    showing both bars at once (the pull-to-refresh glitch);
+///  - re-evaluated after every build, not only on scroll events, because a
+///    refresh can change the header extent (clamping the offset) without
+///    emitting any further scroll notification.
+bool _useIsSearchBarHidden(
+  ScrollController controller,
+  GlobalKey searchBarKey,
+) {
+  final context = useContext();
+  final isHidden = useState(false);
+  final evaluate = useCallback(() {
+    final box = searchBarKey.currentContext?.findRenderObject() as RenderBox?;
+    final height = (box != null && box.hasSize) ? box.size.height : 0.0;
+    final offset = controller.hasClients ? controller.offset : 0.0;
+    isHidden.value = height > 0 && offset >= height - 4;
+  }, [controller, searchBarKey]);
+  useEffect(() {
+    controller.addListener(evaluate);
+    return () => controller.removeListener(evaluate);
+  }, [controller, evaluate]);
+  useEffect(() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (context.mounted) evaluate();
+    });
+    return null;
+  });
+  return isHidden.value;
+}
+
 // ─────────────────── BY_DEFAULT (unchanged behaviour) ───────────────────────
 
-class _DefaultLibraryScreen extends HookConsumerWidget {
+class _DefaultLibraryScreen extends ConsumerWidget {
   const _DefaultLibraryScreen({required this.categoryId});
+  final int categoryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) =>
+      ref.watch(libraryPersistentSearchBarProvider).ifNull()
+      ? _DefaultLibraryStickySearch(categoryId: categoryId)
+      : _DefaultLibraryToggledSearch(categoryId: categoryId);
+}
+
+/// Default layout (setting off): the search field lives behind the app-bar
+/// search button, Mihon/Komikku style.
+class _DefaultLibraryToggledSearch extends HookConsumerWidget {
+  const _DefaultLibraryToggledSearch({required this.categoryId});
   final int categoryId;
 
   @override
@@ -119,75 +197,68 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
               appBar: AppBar(
                 title: !showSearch
                     ? Text(context.l10n.library)
-                    : SearchField(
-                        initialText: ref.read(libraryQueryProvider),
-                        highlightDsl: true,
-                        // Only grab focus when the user opened search; a tag-set
-                        // query shows results without popping the keyboard.
-                        autofocus: searchToggled.value,
-                        onChanged: (val) =>
-                            ref.read(libraryQueryProvider.notifier).update(val),
-                        onClose: () => searchToggled.value = false,
-                        actions: [
-                          IconButton(
-                            icon: const Icon(Icons.help_outline_rounded),
-                            tooltip: context.l10n.searchTips,
-                            onPressed: () => showSearchTips(context),
+                    // SearchField no longer pads itself; keep the pre-refactor
+                    // inset and large-tablet width cap here.
+                    : SizedBox(
+                        width: context.isLargeTablet
+                            ? context.widthScale(scale: .5)
+                            : null,
+                        child: Padding(
+                          padding: KEdgeInsets.h16v4.size,
+                          child: SearchField(
+                            initialText: ref.read(libraryQueryProvider),
+                            highlightDsl: true,
+                            // Only grab focus when the user opened search; a
+                            // tag-set query shows results without popping the
+                            // keyboard.
+                            autofocus: searchToggled.value,
+                            onChanged: (val) => ref
+                                .read(libraryQueryProvider.notifier)
+                                .update(val),
+                            onClose: () => searchToggled.value = false,
+                            actions: [
+                              IconButton(
+                                icon: const Icon(Icons.help_outline_rounded),
+                                tooltip: context.l10n.searchTips,
+                                onPressed: () => showSearchTips(context),
+                              ),
+                              Consumer(
+                                builder: (context, ref, child) => IconButton(
+                                  icon: const Icon(
+                                    Icons.travel_explore_rounded,
+                                  ),
+                                  tooltip: context.l10n.globalSearch,
+                                  onPressed:
+                                      ref.watch(libraryQueryProvider).isNotBlank
+                                      ? () => GlobalSearchRoute(
+                                          query: ref.read(libraryQueryProvider),
+                                        ).go(context)
+                                      : null,
+                                ),
+                              ),
+                            ],
                           ),
-                          Consumer(
-                            builder: (context, ref, child) => IconButton(
-                              icon: Icon(Icons.travel_explore_rounded),
-                              tooltip: context.l10n.globalSearch,
-                              onPressed: ref
-                                      .watch(libraryQueryProvider)
-                                      .isNotBlank
-                                  ? () => GlobalSearchRoute(
-                                        query: ref.read(libraryQueryProvider),
-                                      ).go(context)
-                                  : null,
-                            ),
-                          )
-                        ],
+                        ),
                       ),
-                bottom: data.length.isGreaterThan(1) &&
+                bottom:
+                    data.length.isGreaterThan(1) &&
                         ref.watch(categoryTabsProvider).ifNull(true)
                     ? TabBar(
                         isScrollable: true,
-                        tabs:
-                            data.map((e) => _CategoryTab(category: e)).toList(),
+                        tabs: data
+                            .map((e) => _CategoryTab(category: e))
+                            .toList(),
                         dividerColor: Colors.transparent,
                       )
                     : null,
                 actions: showSearch
-                    ? [SizedBox.shrink()]
+                    ? const [SizedBox.shrink()]
                     : [
                         IconButton(
                           onPressed: () => searchToggled.value = true,
                           icon: const Icon(Icons.search_rounded),
                         ),
-                        Builder(
-                          builder: (context) => IconButton(
-                            onPressed: () {
-                              if (context.isTablet) {
-                                Scaffold.of(context).openEndDrawer();
-                              } else {
-                                showModalBottomSheet(
-                                  context: context,
-                                  isScrollControlled: true,
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: KBorderRadius.rT16.radius,
-                                  ),
-                                  clipBehavior: Clip.hardEdge,
-                                  // The organizer sizes itself to the active
-                                  // tab's content (capped at 72% height), so no
-                                  // fixed-height wrapper.
-                                  builder: (_) => const LibraryMangaOrganizer(),
-                                );
-                              }
-                            },
-                            icon: const Icon(Icons.filter_list_rounded),
-                          ),
-                        ),
+                        _organizerButton(),
                         Builder(
                           builder: (context) {
                             return UpdateStatusPopupMenu(
@@ -206,30 +277,19 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
                 child: LibraryMangaOrganizer(),
               ),
               body: _libraryBody(
-                data.isBlank
-                    ? Emoticons(
-                        title: context.l10n.noCategoriesFound,
-                        button: TextButton(
-                          onPressed: () =>
-                              ref.refresh(categoryControllerProvider.future),
-                          child: Text(context.l10n.refresh),
-                        ),
-                      )
-                    : Padding(
-                        padding: KEdgeInsets.h8.size,
-                        child: TabBarView(
-                          children: data
-                              .map((e) => CategoryMangaList(
-                                    // Keyed so element reuse can't leak one
-                                    // category's multi-select into another.
-                                    key: ValueKey(
-                                        e.id.getValueOnNullOrNegative()),
-                                    categoryId:
-                                        e.id.getValueOnNullOrNegative(),
-                                  ))
-                              .toList(),
-                        ),
-                      ),
+                Padding(
+                  padding: KEdgeInsets.h8.size,
+                  child: TabBarView(
+                    children: data
+                        .map(
+                          (e) => CategoryMangaList(
+                            key: ValueKey(e.id.getValueOnNullOrNegative()),
+                            categoryId: e.id.getValueOnNullOrNegative(),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
               ),
             ),
           );
@@ -237,9 +297,146 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
       },
       refresh: () => ref.refresh(categoryControllerProvider.future),
       wrapper: (body) => Scaffold(
-        appBar: AppBar(
-          title: Text(context.l10n.library),
-        ),
+        appBar: AppBar(title: Text(context.l10n.library)),
+        body: _libraryBody(body),
+      ),
+    );
+  }
+}
+
+/// Opt-in layout (More → Settings → Library): the search bar is always visible
+/// under the app bar and sticks into it when scrolled away, Yokai/J2K style.
+class _DefaultLibraryStickySearch extends HookConsumerWidget {
+  const _DefaultLibraryStickySearch({required this.categoryId});
+  final int categoryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final toast = ref.watch(toastProvider);
+    final categoryList = ref.watch(visibleCategoryListProvider);
+    final scrollController = useScrollController();
+    final searchBarKey = useMemoized(() => GlobalKey());
+    final isSearchBarHidden = _useIsSearchBarHidden(
+      scrollController,
+      searchBarKey,
+    );
+
+    useEffect(() {
+      categoryList.showToastOnError(toast, withMicrotask: true);
+      return;
+    }, [categoryList.value]);
+
+    return categoryList.showUiWhenData(
+      context,
+      (data) {
+        if (data.isBlank) {
+          return Scaffold(
+            appBar: AppBar(title: Text(context.l10n.library)),
+            body: Emoticons(
+              title: context.l10n.noCategoriesFound,
+              button: TextButton(
+                onPressed: () => ref.refresh(categoryControllerProvider.future),
+                child: Text(context.l10n.refresh),
+              ),
+            ),
+          );
+        }
+
+        final showTabs =
+            data!.length > 1 && ref.watch(categoryTabsProvider).ifNull(true);
+
+        return DefaultTabController(
+          length: data.length,
+          // The route param is a category ID (e.g. from quick-search), not a
+          // positional tab index — the visible list filters out empty/hidden
+          // categories, so id != index. Select the tab whose category matches
+          // the id, falling back to the first tab if it isn't visible (#284).
+          initialIndex: max(0, data.indexWhere((c) => c.id == categoryId)),
+          child: Scaffold(
+            endDrawerEnableOpenDragGesture: false,
+            endDrawer: const Drawer(
+              width: kDrawerWidth,
+              shape: RoundedRectangleBorder(),
+              child: LibraryMangaOrganizer(),
+            ),
+            body: NestedScrollView(
+              controller: scrollController,
+              headerSliverBuilder: (context, innerBoxIsScrolled) {
+                return [
+                  SliverAppBar(
+                    pinned: true,
+                    floating: false,
+                    title: isSearchBarHidden
+                        ? const _LibrarySearchBar(inAppBar: true)
+                        : Text(context.l10n.library),
+                    actions: [
+                      _organizerButton(),
+                      Builder(
+                        builder: (context) {
+                          return UpdateStatusPopupMenu(
+                            getCategory: () => data.isNotBlank
+                                ? data[DefaultTabController.of(context).index]
+                                : null,
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                  SliverToBoxAdapter(
+                    child: KeyedSubtree(
+                      key: searchBarKey,
+                      child: const _LibrarySearchBar(inAppBar: false),
+                    ),
+                  ),
+                  if (showTabs)
+                    SliverPersistentHeader(
+                      pinned: true,
+                      delegate: _SliverTabBarDelegate(
+                        TabBar(
+                          isScrollable: true,
+                          tabs: data
+                              .map((e) => _CategoryTab(category: e))
+                              .toList(),
+                          dividerColor: Colors.transparent,
+                        ),
+                      ),
+                    ),
+                ];
+              },
+              // This Scaffold has no appBar (the header slivers replace it), so
+              // its body still carries the status-bar padding and the grids
+              // inside would re-apply it as list padding — a dead gap between
+              // the tab bar and the first row. The header slivers consume that
+              // inset; drop it for the body. The Builder matters: removePadding
+              // must start from the MediaQuery inside the Scaffold body slot.
+              body: Builder(
+                builder: (context) => MediaQuery.removePadding(
+                  context: context,
+                  removeTop: true,
+                  child: _libraryBody(
+                    Padding(
+                      padding: KEdgeInsets.h8.size,
+                      child: TabBarView(
+                        children: data
+                            .map(
+                              (e) => CategoryMangaList(
+                                key: ValueKey(e.id.getValueOnNullOrNegative()),
+                                categoryId: e.id.getValueOnNullOrNegative(),
+                              ),
+                            )
+                            .toList(),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+      refresh: () => ref.refresh(categoryControllerProvider.future),
+      wrapper: (body) => Scaffold(
+        appBar: AppBar(title: Text(context.l10n.library)),
         body: _libraryBody(body),
       ),
     );
@@ -248,8 +445,20 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
 
 // ─────────────────── non-default group modes ────────────────────────────────
 
-class _GroupedLibraryScreen extends HookConsumerWidget {
+class _GroupedLibraryScreen extends ConsumerWidget {
   const _GroupedLibraryScreen({required this.groupType});
+  final int groupType;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) =>
+      ref.watch(libraryPersistentSearchBarProvider).ifNull()
+      ? _GroupedLibraryStickySearch(groupType: groupType)
+      : _GroupedLibraryToggledSearch(groupType: groupType);
+}
+
+/// Default layout (setting off): search behind the app-bar toggle.
+class _GroupedLibraryToggledSearch extends HookConsumerWidget {
+  const _GroupedLibraryToggledSearch({required this.groupType});
   final int groupType;
 
   @override
@@ -293,20 +502,31 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
             appBar: AppBar(
               title: !showSearch
                   ? Text(context.l10n.library)
-                  : SearchField(
-                      initialText: ref.read(libraryQueryProvider),
-                      highlightDsl: true,
-                      autofocus: searchToggled.value,
-                      onChanged: (val) =>
-                          ref.read(libraryQueryProvider.notifier).update(val),
-                      onClose: () => searchToggled.value = false,
-                      actions: [
-                        IconButton(
-                          icon: const Icon(Icons.help_outline_rounded),
-                          tooltip: context.l10n.searchTips,
-                          onPressed: () => showSearchTips(context),
+                  // SearchField no longer pads itself; keep the pre-refactor
+                  // inset and large-tablet width cap here.
+                  : SizedBox(
+                      width: context.isLargeTablet
+                          ? context.widthScale(scale: .5)
+                          : null,
+                      child: Padding(
+                        padding: KEdgeInsets.h16v4.size,
+                        child: SearchField(
+                          initialText: ref.read(libraryQueryProvider),
+                          highlightDsl: true,
+                          autofocus: searchToggled.value,
+                          onChanged: (val) => ref
+                              .read(libraryQueryProvider.notifier)
+                              .update(val),
+                          onClose: () => searchToggled.value = false,
+                          actions: [
+                            IconButton(
+                              icon: const Icon(Icons.help_outline_rounded),
+                              tooltip: context.l10n.searchTips,
+                              onPressed: () => showSearchTips(context),
+                            ),
+                          ],
                         ),
-                      ],
+                      ),
                     ),
               bottom: tabs.length > 1
                   ? TabBar(
@@ -316,7 +536,7 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
                     )
                   : null,
               actions: showSearch
-                  ? [SizedBox.shrink()]
+                  ? const [SizedBox.shrink()]
                   : [
                       IconButton(
                         onPressed: () => searchToggled.value = true,
@@ -328,26 +548,7 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
                             const MigrationSourcePickerRoute().push(context),
                         icon: const Icon(Icons.swap_horiz_rounded),
                       ),
-                      Builder(
-                        builder: (context) => IconButton(
-                          onPressed: () {
-                            if (context.isTablet) {
-                              Scaffold.of(context).openEndDrawer();
-                            } else {
-                              showModalBottomSheet(
-                                context: context,
-                                isScrollControlled: true,
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: KBorderRadius.rT16.radius,
-                                ),
-                                clipBehavior: Clip.hardEdge,
-                                builder: (_) => const LibraryMangaOrganizer(),
-                              );
-                            }
-                          },
-                          icon: const Icon(Icons.filter_list_rounded),
-                        ),
-                      ),
+                      _organizerButton(),
                     ],
             ),
             endDrawerEnableOpenDragGesture: false,
@@ -361,9 +562,129 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
                 padding: KEdgeInsets.h8.size,
                 child: TabBarView(
                   children: tabs
-                      .map((t) =>
-                          _GroupedMangaList(key: ValueKey(t.id), tabId: t.id))
+                      .map(
+                        (t) =>
+                            _GroupedMangaList(key: ValueKey(t.id), tabId: t.id),
+                      )
                       .toList(),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+      refresh: () => ref.refresh(libraryGroupedTabsProvider.future),
+      wrapper: (body) => Scaffold(
+        appBar: AppBar(title: Text(context.l10n.library)),
+        body: _libraryBody(body),
+      ),
+    );
+  }
+}
+
+/// Opt-in layout: always-visible search bar that sticks into the app bar.
+class _GroupedLibraryStickySearch extends HookConsumerWidget {
+  const _GroupedLibraryStickySearch({required this.groupType});
+  final int groupType;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final toast = ref.watch(toastProvider);
+    final groupedTabsAsync = ref.watch(libraryGroupedTabsProvider);
+    final scrollController = useScrollController();
+    final searchBarKey = useMemoized(() => GlobalKey());
+    final isSearchBarHidden = _useIsSearchBarHidden(
+      scrollController,
+      searchBarKey,
+    );
+
+    useEffect(() {
+      groupedTabsAsync.showToastOnError(toast, withMicrotask: true);
+      return;
+    }, [groupedTabsAsync.value]);
+
+    return groupedTabsAsync.showUiWhenData(
+      context,
+      (tabs) {
+        if (tabs.isEmpty) {
+          return Scaffold(
+            appBar: AppBar(title: Text(context.l10n.library)),
+            body: Emoticons(
+              title: context.l10n.noCategoriesFound,
+              button: TextButton(
+                onPressed: () => ref.refresh(libraryGroupedTabsProvider.future),
+                child: Text(context.l10n.refresh),
+              ),
+            ),
+          );
+        }
+        return DefaultTabController(
+          // Key on the tab set so the controller fully rebuilds (resetting the
+          // selected index to 0) when the group mode changes the tab count.
+          // Without this, switching e.g. By Source (many tabs) → By Status
+          // (fewer) leaves the controller's index out of range and it churns
+          // into an infinite rebuild flicker.
+          key: ValueKey('group-$groupType-${tabs.length}'),
+          length: tabs.length,
+          child: Scaffold(
+            endDrawerEnableOpenDragGesture: false,
+            endDrawer: const Drawer(
+              width: kDrawerWidth,
+              shape: RoundedRectangleBorder(),
+              child: LibraryMangaOrganizer(),
+            ),
+            body: NestedScrollView(
+              controller: scrollController,
+              headerSliverBuilder: (context, innerBoxIsScrolled) {
+                return [
+                  SliverAppBar(
+                    pinned: true,
+                    floating: false,
+                    title: isSearchBarHidden
+                        ? const _LibrarySearchBar(inAppBar: true)
+                        : Text(context.l10n.library),
+                    actions: [_organizerButton()],
+                  ),
+                  SliverToBoxAdapter(
+                    child: KeyedSubtree(
+                      key: searchBarKey,
+                      child: const _LibrarySearchBar(inAppBar: false),
+                    ),
+                  ),
+                  if (tabs.length > 1)
+                    SliverPersistentHeader(
+                      pinned: true,
+                      delegate: _SliverTabBarDelegate(
+                        TabBar(
+                          isScrollable: true,
+                          tabs: tabs.map((t) => Tab(text: t.name)).toList(),
+                          dividerColor: Colors.transparent,
+                        ),
+                      ),
+                    ),
+                ];
+              },
+              // See _DefaultLibraryStickySearch: drop the status-bar padding
+              // the header slivers already consumed, from inside the body slot.
+              body: Builder(
+                builder: (context) => MediaQuery.removePadding(
+                  context: context,
+                  removeTop: true,
+                  child: _libraryBody(
+                    Padding(
+                      padding: KEdgeInsets.h8.size,
+                      child: TabBarView(
+                        children: tabs
+                            .map(
+                              (t) => _GroupedMangaList(
+                                key: ValueKey(t.id),
+                                tabId: t.id,
+                              ),
+                            )
+                            .toList(),
+                      ),
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -398,9 +719,7 @@ class _CategoryTab extends ConsumerWidget {
       return Tab(text: category.name);
     }
     final mangaListAsync = ref.watch(
-      categoryMangaListWithQueryAndFilterProvider(
-        categoryId: category.id,
-      ),
+      categoryMangaListWithQueryAndFilterProvider(categoryId: category.id),
     );
     final count = mangaListAsync.value?.length;
     final label = count != null ? '${category.name} ($count)' : category.name;
@@ -436,98 +755,96 @@ class _GroupedMangaList extends ConsumerWidget {
           )
         : mangaCoverGridDelegate(gridWidth, titleBelow: titleBelow);
 
-    return mangaListAsync.showUiWhenData(
-      context,
-      (data) {
-        if (data == null || data.isEmpty) {
-          return Emoticons(title: context.l10n.noCategoryMangaFound);
-        }
-        final items = data;
-        return RefreshIndicator(
-          // Grouped views (by source/status/ungrouped) have no single category
-          // to update, so pull triggers a whole-library source-check (matches
-          // Komikku's non-BY_DEFAULT rule). The banner shows its progress; the
-          // spinner only waits on the immediate server re-read.
-          onRefresh: () async {
-            ref.read(updateOptimisticProvider.notifier).arm();
-            unawaited(ref
+    return mangaListAsync.showUiWhenData(context, (data) {
+      if (data == null || data.isEmpty) {
+        return Emoticons(title: context.l10n.noCategoryMangaFound);
+      }
+      final items = data;
+      return RefreshIndicator(
+        // Grouped views (by source/status/ungrouped) have no single category
+        // to update, so pull triggers a whole-library source-check (matches
+        // Komikku's non-BY_DEFAULT rule). The banner shows its progress; the
+        // spinner only waits on the immediate server re-read.
+        onRefresh: () async {
+          ref.read(updateOptimisticProvider.notifier).arm();
+          unawaited(
+            ref
                 .read(updatesRepositoryProvider)
                 .fetchUpdates()
-                .catchError((Object _) {}));
-            ref.invalidate(libraryMangaListProvider);
-            await ref.read(libraryMangaListProvider.future);
-          },
-          child: switch (displayMode) {
-            DisplayMode.list || null => ListView.builder(
-                itemExtent: 96,
-                itemCount: items.length,
-                itemBuilder: (context, index) => MangaCoverListTile(
-                  manga: items[index],
-                  selected: false,
-                  onPressed: () =>
-                      MangaRoute(mangaId: items[index].id).push(context),
-                  onLongPress: () {},
-                  showCountBadges: true,
-                ),
-              ),
-            DisplayMode.grid => GridView.builder(
-                gridDelegate: gridDelegate(),
-                itemCount: items.length,
-                itemBuilder: (context, index) => MangaCoverGridTile(
-                  manga: items[index],
-                  selected: false,
-                  onLongPress: () {},
-                  onPressed: () =>
-                      MangaRoute(mangaId: items[index].id).push(context),
-                  showCountBadges: true,
-                  showDarkOverlay: false,
-                ),
-              ),
-            DisplayMode.comfortableGrid => GridView.builder(
-                gridDelegate: gridDelegate(titleBelow: true),
-                itemCount: items.length,
-                itemBuilder: (context, index) => MangaCoverGridTile(
-                  manga: items[index],
-                  selected: false,
-                  onLongPress: () {},
-                  onPressed: () =>
-                      MangaRoute(mangaId: items[index].id).push(context),
-                  showCountBadges: true,
-                  titleBelow: true,
-                  showDarkOverlay: false,
-                ),
-              ),
-            DisplayMode.descriptiveList => ListView.builder(
-                itemExtent: 176,
-                itemCount: items.length,
-                itemBuilder: (context, index) => MangaCoverDescriptiveListTile(
-                  manga: items[index],
-                  selected: false,
-                  onPressed: () =>
-                      MangaRoute(mangaId: items[index].id).push(context),
-                  onLongPress: () {},
-                  showBadges: true,
-                ),
-              ),
-            DisplayMode.coverOnly => GridView.builder(
-                gridDelegate: gridDelegate(),
-                itemCount: items.length,
-                itemBuilder: (context, index) => MangaCoverGridTile(
-                  manga: items[index],
-                  selected: false,
-                  onLongPress: () {},
-                  onPressed: () =>
-                      MangaRoute(mangaId: items[index].id).push(context),
-                  showCountBadges: true,
-                  showTitle: false,
-                  showDarkOverlay: false,
-                ),
-              ),
-          },
-        );
-      },
-      refresh: () => ref.refresh(libraryMangaListProvider),
-    );
+                .catchError((Object _) {}),
+          );
+          ref.invalidate(libraryMangaListProvider);
+          await ref.read(libraryMangaListProvider.future);
+        },
+        child: switch (displayMode) {
+          DisplayMode.list || null => ListView.builder(
+            itemExtent: 96,
+            itemCount: items.length,
+            itemBuilder: (context, index) => MangaCoverListTile(
+              manga: items[index],
+              selected: false,
+              onPressed: () =>
+                  MangaRoute(mangaId: items[index].id).push(context),
+              onLongPress: () {},
+              showCountBadges: true,
+            ),
+          ),
+          DisplayMode.grid => GridView.builder(
+            gridDelegate: gridDelegate(),
+            itemCount: items.length,
+            itemBuilder: (context, index) => MangaCoverGridTile(
+              manga: items[index],
+              selected: false,
+              onLongPress: () {},
+              onPressed: () =>
+                  MangaRoute(mangaId: items[index].id).push(context),
+              showCountBadges: true,
+              showDarkOverlay: false,
+            ),
+          ),
+          DisplayMode.comfortableGrid => GridView.builder(
+            gridDelegate: gridDelegate(titleBelow: true),
+            itemCount: items.length,
+            itemBuilder: (context, index) => MangaCoverGridTile(
+              manga: items[index],
+              selected: false,
+              onLongPress: () {},
+              onPressed: () =>
+                  MangaRoute(mangaId: items[index].id).push(context),
+              showCountBadges: true,
+              titleBelow: true,
+              showDarkOverlay: false,
+            ),
+          ),
+          DisplayMode.descriptiveList => ListView.builder(
+            itemExtent: 176,
+            itemCount: items.length,
+            itemBuilder: (context, index) => MangaCoverDescriptiveListTile(
+              manga: items[index],
+              selected: false,
+              onPressed: () =>
+                  MangaRoute(mangaId: items[index].id).push(context),
+              onLongPress: () {},
+              showBadges: true,
+            ),
+          ),
+          DisplayMode.coverOnly => GridView.builder(
+            gridDelegate: gridDelegate(),
+            itemCount: items.length,
+            itemBuilder: (context, index) => MangaCoverGridTile(
+              manga: items[index],
+              selected: false,
+              onLongPress: () {},
+              onPressed: () =>
+                  MangaRoute(mangaId: items[index].id).push(context),
+              showCountBadges: true,
+              showTitle: false,
+              showDarkOverlay: false,
+            ),
+          ),
+        },
+      );
+    }, refresh: () => ref.refresh(libraryMangaListProvider));
   }
 }
 
@@ -552,4 +869,78 @@ void showSearchTips(BuildContext context) {
       ],
     ),
   );
+}
+
+/// The persistent-mode search field. Rendered in two hosts: inline under the
+/// app bar ([inAppBar] false, with its own inset) and as the pinned app bar's
+/// title once the inline instance scrolls away ([inAppBar] true).
+class _LibrarySearchBar extends ConsumerWidget {
+  const _LibrarySearchBar({required this.inAppBar});
+  final bool inAppBar;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mangaListLoaded = ref.watch(libraryMangaListProvider).value != null;
+    if (!mangaListLoaded) return const SizedBox.shrink();
+
+    final query = ref.watch(libraryQueryProvider) ?? '';
+    final field = SearchField(
+      initialText: query,
+      hintText: context.l10n.searchLibraryHint,
+      onChanged: (val) => ref.read(libraryQueryProvider.notifier).update(val),
+      onClose: () => ref.read(libraryQueryProvider.notifier).update(''),
+      autofocus: false,
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.help_outline_rounded),
+          tooltip: context.l10n.searchTips,
+          onPressed: () => showSearchTips(context),
+        ),
+        if (query.isNotEmpty)
+          IconButton(
+            icon: const Icon(Icons.travel_explore_rounded),
+            tooltip: context.l10n.globalSearch,
+            onPressed: () => GlobalSearchRoute(query: query).go(context),
+          ),
+      ],
+      highlightDsl: true,
+      hintBehavior: SearchFieldHintBehavior.forceHint,
+    );
+
+    return inAppBar
+        ? field
+        : Padding(
+            padding: const EdgeInsets.fromLTRB(11, 0, 11, 4),
+            child: field,
+          );
+  }
+}
+
+class _SliverTabBarDelegate extends SliverPersistentHeaderDelegate {
+  _SliverTabBarDelegate(this.tabBar);
+  final TabBar tabBar;
+
+  @override
+  double get minExtent => tabBar.preferredSize.height;
+  @override
+  double get maxExtent => tabBar.preferredSize.height;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return Container(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      child: tabBar,
+    );
+  }
+
+  // The header builder recreates the TabBar whenever the screen rebuilds, so
+  // comparing instances keeps the pinned row current — returning false froze
+  // the first TabBar forever, so renamed/added categories never showed up.
+  @override
+  bool shouldRebuild(_SliverTabBarDelegate oldDelegate) =>
+      tabBar != oldDelegate.tabBar;
 }

--- a/lib/src/features/migration/presentation/screens/migration_global_search_screen.dart
+++ b/lib/src/features/migration/presentation/screens/migration_global_search_screen.dart
@@ -49,9 +49,17 @@ class MigrationGlobalSearchScreen extends HookConsumerWidget {
             children: [
               Align(
                 alignment: Alignment.centerRight,
-                child: SearchField(
-                  initialText: query.value,
-                  onSubmitted: (value) => query.value = value,
+                child: SizedBox(
+                  width: context.isLargeTablet
+                      ? context.widthScale(scale: .5)
+                      : null,
+                  child: Padding(
+                    padding: KEdgeInsets.h16v4.size,
+                    child: SearchField(
+                      initialText: query.value,
+                      onSubmitted: (value) => query.value = value,
+                    ),
+                  ),
                 ),
               ),
             ],

--- a/lib/src/features/settings/presentation/library/library_settings_screen.dart
+++ b/lib/src/features/settings/presentation/library/library_settings_screen.dart
@@ -23,6 +23,7 @@ import '../../../library/presentation/library/controller/library_controller.dart
 import '../../controller/server_controller.dart';
 import '../../domain/settings/settings.dart';
 import 'data/library_settings_repository.dart';
+import 'widgets/persistent_search_bar/persistent_search_bar.dart';
 import 'widgets/refresh_chapters_from_source_tile/refresh_chapters_from_source_tile.dart';
 import 'widgets/show_update_progress_banner/show_update_progress_banner.dart';
 import 'widgets/skip_updating_entries_popup.dart';
@@ -118,6 +119,7 @@ class LibrarySettingsScreen extends ConsumerWidget {
                   ),
                   // HideEmptyCategoryTile(),
                   const RefreshChaptersFromSourceTile(),
+                  const PersistentSearchBarTile(),
                   SectionTitle(title: context.l10n.globalUpdate),
                   const ShowUpdateProgressBannerTile(),
                   SettingsPropTile(

--- a/lib/src/features/settings/presentation/library/widgets/persistent_search_bar/persistent_search_bar.dart
+++ b/lib/src/features/settings/presentation/library/widgets/persistent_search_bar/persistent_search_bar.dart
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'persistent_search_bar.g.dart';
+
+@riverpod
+class LibraryPersistentSearchBar extends _$LibraryPersistentSearchBar
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.libraryPersistentSearchBar);
+}
+
+class PersistentSearchBarTile extends ConsumerWidget {
+  const PersistentSearchBarTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.search_rounded),
+      title: Text(context.l10n.libraryPersistentSearchBar),
+      subtitle: Text(context.l10n.libraryPersistentSearchBarSubtitle),
+      onChanged: ref.read(libraryPersistentSearchBarProvider.notifier).update,
+      value: ref.watch(libraryPersistentSearchBarProvider).ifNull(),
+    );
+  }
+}

--- a/lib/src/features/tracking/presentation/hub/widgets/tracker_search.dart
+++ b/lib/src/features/tracking/presentation/hub/widgets/tracker_search.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../../constants/app_sizes.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/hooks/debounced_hook.dart';
 import '../../../../../utils/misc/toast/toast.dart';
@@ -94,13 +95,21 @@ class TrackerSearch extends HookConsumerWidget {
             ),
           ),
 
-          // Search field pre-filled with manga title.
-          SearchField(
-            initialText: mangaTitle,
-            hintText: context.l10n.search,
-            autofocus: false,
-            onSubmitted: onInput,
-            onChanged: onInput,
+          // Search field pre-filled with manga title (with tablet constraint & padding).
+          SizedBox(
+            width: context.isLargeTablet
+                ? context.widthScale(scale: .5)
+                : null,
+            child: Padding(
+              padding: KEdgeInsets.h16v4.size,
+              child: SearchField(
+                initialText: mangaTitle,
+                hintText: context.l10n.search,
+                autofocus: false,
+                onSubmitted: onInput,
+                onChanged: onInput,
+              ),
+            ),
           ),
 
           // Track / Track privately buttons (shown once a result is selected

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1068,6 +1068,9 @@
     "@search": {
         "description": "Search field hint Text"
     },
+    "@searchLibraryHint": {
+        "description": "Placeholder text in the library search field"
+    },
     "@searchingForUpdates": {
         "description": "Toast Text for searching for updates of the App/Server"
     },
@@ -1708,6 +1711,14 @@
     "hideCategory": "Hide category",
     "showCategory": "Show category",
     "showUpdateProgressBanner": "Show update progress banner",
+    "libraryPersistentSearchBar": "Persistent search bar",
+    "@libraryPersistentSearchBar": {
+        "description": "Library setting: always show the search bar under the app bar instead of behind the search button"
+    },
+    "libraryPersistentSearchBarSubtitle": "Always show the search bar below the app bar. It sticks to the top while scrolling",
+    "@libraryPersistentSearchBarSubtitle": {
+        "description": "Subtitle for the persistent search bar library setting"
+    },
     "incognitoMode": "Incognito mode",
     "incognitoModeDescription": "Pauses reading history",
     "emptyCategory": "Category name can't be Empty",
@@ -2214,6 +2225,7 @@
     "saveAsCBZArchive": "Save as CBZ archive",
     "scanlators": "Scanlators",
     "search": "Search",
+    "searchLibraryHint": "Search title, author, source...",
     "searchingForUpdates": "Searching for updates",
     "selectInBetween": "Select in between",
     "selectNext10": "Select next 10",

--- a/lib/src/widgets/search_field.dart
+++ b/lib/src/widgets/search_field.dart
@@ -7,9 +7,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 
-import '../constants/app_sizes.dart';
 import '../features/library/domain/library_search_query.dart';
 import '../utils/extensions/custom_extensions.dart';
+
+enum SearchFieldHintBehavior { auto, forceHint, forceLabel }
 
 class SearchField extends HookWidget {
   const SearchField({
@@ -18,11 +19,14 @@ class SearchField extends HookWidget {
     this.onClose,
     this.initialText,
     this.onSubmitted,
+    this.labelText,
     this.hintText,
     this.autofocus = true,
     this.actions,
     this.highlightDsl = false,
+    this.hintBehavior = SearchFieldHintBehavior.auto,
   });
+  final String? labelText;
   final String? hintText;
   final String? initialText;
   final ValueChanged<String?>? onChanged;
@@ -35,6 +39,8 @@ class SearchField extends HookWidget {
   /// the user types, so the search box reads as a query language, not free text.
   final bool highlightDsl;
 
+  final SearchFieldHintBehavior hintBehavior;
+
   @override
   Widget build(BuildContext context) {
     final controller = useMemoized(
@@ -45,38 +51,69 @@ class SearchField extends HookWidget {
     );
     useEffect(() => controller.dispose, [controller]);
 
+    final focusNode = useFocusNode();
+    useListenable(focusNode);
+
+    void closeAction() {
+      controller.clear();
+      onClose?.call();
+      onChanged?.call(null);
+      onSubmitted?.call(null);
+    }
+
+    void prefixAction() {
+      if (focusNode.hasFocus) {
+        focusNode.unfocus();
+        closeAction();
+      } else {
+        focusNode.requestFocus();
+      }
+    }
+
+    final unfocusedText = labelText ?? context.l10n.search;
+    final focusedText = hintText ?? unfocusedText;
+    final (String? decorationLabel, String? decorationHint) = switch (hintBehavior) {
+      SearchFieldHintBehavior.auto => (unfocusedText, hintText),
+      SearchFieldHintBehavior.forceHint => (
+          null,
+          focusNode.hasFocus ? focusedText : unfocusedText
+        ),
+      SearchFieldHintBehavior.forceLabel => (
+          focusNode.hasFocus ? focusedText : unfocusedText,
+          null
+        ),
+    };
+
     final closeIcon = onClose != null
         ? IconButton(
-            onPressed: () {
-              onClose?.call();
-              onChanged?.call(null);
-              onSubmitted?.call(null);
-            },
+            onPressed: closeAction,
             icon: const Icon(Icons.close_rounded),
           )
         : null;
 
-    return SizedBox(
-      width: context.isLargeTablet ? context.widthScale(scale: .5) : null,
-      child: Padding(
-        padding: KEdgeInsets.h16v4.size,
-        child: TextField(
-          onChanged: onChanged,
-          autofocus: autofocus,
-          controller: controller,
-          onSubmitted: onSubmitted,
-          decoration: InputDecoration(
-            isDense: true,
-            border: const OutlineInputBorder(),
-            labelText: hintText ?? context.l10n.search,
-            suffixIcon: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ...?actions,
-                if (closeIcon != null) closeIcon,
-              ],
-            ),
-          ),
+    return TextField(
+      onChanged: onChanged,
+      autofocus: autofocus,
+      controller: controller,
+      focusNode: focusNode,
+      onSubmitted: onSubmitted,
+      decoration: InputDecoration(
+        isDense: true,
+        border: const OutlineInputBorder(),
+        labelText: decorationLabel,
+        hintText: decorationHint,
+        prefixIcon: IconButton(
+          icon: Icon(focusNode.hasFocus
+              ? Icons.arrow_back_rounded
+              : Icons.search_rounded),
+          onPressed: prefixAction,
+        ),
+        suffixIcon: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ...?actions,
+            if (closeIcon != null) closeIcon,
+          ],
         ),
       ),
     );

--- a/lib/src/widgets/shell/navigation_shell_screen.dart
+++ b/lib/src/widgets/shell/navigation_shell_screen.dart
@@ -124,12 +124,18 @@ class NavigationShellScreen extends HookConsumerWidget {
     // While the update banner occupies the top (incl. the status-bar strip),
     // drop the redundant status-bar inset on the content below so the pushed-
     // down screen's own app bar doesn't reserve it a second time (dead gap).
+    // A Builder is required to get the context inside the Scaffold's body.
+    // There, resizeToAvoidBottomInset has already consumed the keyboard inset.
+    // Using the outer context passes unconsumed insets down, making nested
+    // Scaffolds apply the keyboard padding twice and overflow the layout.
     final bannerVisible = ref.watch(updateBannerVisibleProvider);
     final content = bannerVisible
-        ? MediaQuery.removePadding(
-            context: context,
-            removeTop: true,
-            child: child,
+        ? Builder(
+            builder: (context) => MediaQuery.removePadding(
+              context: context,
+              removeTop: true,
+              child: child,
+            ),
           )
         : child;
 


### PR DESCRIPTION
**Context & Motivation**
This proposal redesigns the library search interaction to align with the persistent search bar layout seen in forks like Yokai or TachiyomiJ2K. Instead of hiding the library title under a manually toggled App Bar overlay, the search bar is now visible by default inline, keeping the interface intuitive and reducing tap steps.

**Changes**
- Removed the manual `searchToggled` state and its corresponding search icon button from the App Bar.
- Positioned the `SearchField` inline, sitting directly below the navigation bar at scroll offset zero.
- Implemented a `ScrollController` listener that monitors the layout geometry (`RenderBox`) of the inline search bar. As the page scrolls down, the search bar seamlessly transitions to a sticky position inside the pinned `SliverAppBar` the moment it exits the main viewport.
- Refactored `SearchField` to support dynamic label/hint configurations through `SearchFieldHintBehavior`, introducing a focus-sensitive prefix icon that switches between search and back-arrow states.