### PR TITLE
flatpak/linux: bundle sqlite3's native-asset libsqlite3.so (fix DB-open crash)

### DIFF
--- a/flatpak/io.github.aaronbamblett.tsumiru.yml
+++ b/flatpak/io.github.aaronbamblett.tsumiru.yml
@@ -43,31 +43,6 @@ modules:
         url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.7.tar.xz
         sha256: 6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e
 
-  # sqlite3 3.x (pulled in by the drift/codegen upgrade) switched the Dart
-  # `sqlite3` package to native-FFI symbol resolution, which needs a real
-  # `libsqlite3.so`. sqlite3_flutter_libs compiles SQLite into its plugin with
-  # hidden symbols and never emits that file, and the freedesktop runtime only
-  # ships `libsqlite3.so.0` — so on Linux the app can't open its database and
-  # dies at startup. Build the SQLite amalgamation here (matching the feature
-  # flags sqlite3_flutter_libs enables) and drop it in /app/lib.
-  - name: sqlite3
-    buildsystem: simple
-    build-commands:
-      - |
-        gcc -shared -fPIC -O2 -o libsqlite3.so.0 sqlite3.c \
-          -DSQLITE_ENABLE_DBSTAT_VTAB -DSQLITE_ENABLE_FTS5 \
-          -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_MATH_FUNCTIONS \
-          -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK \
-          -DSQLITE_DQS=0 -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_TEMP_STORE=2 \
-          -DSQLITE_STRICT_SUBTYPE=1 -DSQLITE_THREADSAFE=1 \
-          -Wl,-soname,libsqlite3.so.0 -lm -lpthread
-      - install -Dm755 libsqlite3.so.0 /app/lib/libsqlite3.so.0
-      - ln -sf libsqlite3.so.0 /app/lib/libsqlite3.so
-    sources:
-      - type: archive
-        url: https://sqlite.org/2026/sqlite-autoconf-3520000.tar.gz
-        sha256: f6b50b0c103392af32a8be15b2b9d25959de9a00a70c3979128aafeaa5338b3f
-
   - name: tsumiru
     buildsystem: simple
     build-commands:

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -126,6 +126,14 @@ foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
     COMPONENT Runtime)
 endforeach(bundled_library)
 
+# Copy native assets (Dart code-assets) into the bundle. sqlite3 3.x ships its
+# own libsqlite3.so this way; without this step the .so is built but never
+# bundled, so the native-asset loader can't find it, falls back to an external
+# libsqlite3.so, and SQLite crashes on a null call at DB open (Linux flatpak).
+install(DIRECTORY "${PROJECT_BUILD_DIR}/native_assets/linux/"
+  DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")


### PR DESCRIPTION
## Problem

The codegen migration (#200) bumped the Dart `sqlite3` package to 3.x, which loads SQLite through Dart **native assets** (`@Native` / `@DefaultAsset`) instead of an external `DynamicLibrary`. `flutter build linux` correctly produces `build/native_assets/linux/libsqlite3.so` and a `NativeAssetsManifest.json`, but **`linux/CMakeLists.txt` never copied the native asset into the bundle**. At runtime the loader couldn't find `libsqlite3.so` where the manifest points, fell back to an external `libsqlite3.so`, and SQLite crashed on a **null function-pointer call at database open** — the app died ~1.2s after launch.

Linux-only (Android/web link SQLite differently, so they were unaffected and it passed testing). Pre-migration releases still run fine because they used sqlite3 2.x's old loading model — this only breaks builds from current `main`, i.e. the **next** Linux release.

The earlier flatpak change (#205) worked around the *symptom* (the "can't find libsqlite3.so" error) by hand-compiling an external `libsqlite3.so` into the manifest — but that external library is exactly the unsupported path that causes the null-call crash.

## Fix

1. **`linux/CMakeLists.txt`**: add the native-assets install step so `build/native_assets/linux/` (sqlite3 3.x's own `libsqlite3.so`) is copied into the app bundle's `lib/`, where the native-asset loader resolves it the supported way.
2. **flatpak manifest**: remove the hand-compiled external `libsqlite3.so` module from #205 — no longer needed, and it was the cause of the double-load crash.

Documented approach per the `sqlite3.dart` maintainer (native assets on desktop; drop external-lib loading). `sqlite3_flutter_libs` is left in place for now (its embedded copy is harmless); it's EOL and can be dropped in a follow-up.

## Verification

Built + installed the flatpak locally: `bundle/lib/libsqlite3.so` now ships, and the app **launches and loads the library** instead of crashing at startup. Confirmed the DB-open crash is gone.

Release-blocker for the next Linux release.
