### PR TITLE
Fix startup UnmountedRefException: keep the offline download pipeline providers alive

### DIFF
--- a/docs/architecture/offline.md
+++ b/docs/architecture/offline.md
@@ -19,7 +19,7 @@ Design notes: there is **no foreign key** from chapters to mangas — a chapter 
 Four layers, all driven through one entry point — **`downloadStarterProvider`** (never call the lower layers directly):
 
 1. `chapter_download_engine.dart` — `ChapterDownloadEngine` downloads one chapter's pages with up to N concurrent workers (N = `OfflineDownloadConcurrency`, default 2), each page retried 3× with backoff. `PageAuthException` → one auth refresh + retry; `PageOfflineException` → stop and leave the run resumable.
-2. `offline_download_coordinator.dart` — `OfflineDownloadCoordinator` queues and runs **one chapter at a time** (Komikku model) via the engine; `pumpDownloads()` drains the queue. Process-wide single-flight via a `static _pumping` flag.
+2. `offline_download_coordinator.dart` — `OfflineDownloadCoordinator` queues and runs **one chapter at a time** (Komikku model) via the engine; `pumpDownloads()` drains the queue. Process-wide single-flight via a `static _pumping` flag. The coordinator and engine providers are **keep-alive**: nothing watches them (all consumers are one-shot reads), and an auto-dispose Ref dies at the first async gap — under Riverpod 3 its call-time reads then throw `UnmountedRefException`, which silently killed launch resume and the desktop pump.
 3. `offline_download_providers.dart` — the wiring + the public surface: `saveChapterToDevice`, `deleteChapterFromDevice`, `reconcileManga`, `recordReadingProgress`, `recordReadState` (offline-aware write-through for mark-read/unread), `pushPendingProgress`, and the state streams (`offlineChapterStateProvider`, `mangaOfflineProgressProvider`, `mangaKeepRuleProvider`, …).
 4. `data/background/` — **Android only**: `BackgroundDownloadController` owns a `FlutterForegroundTask` foreground service (its own isolate, `download_task_handler.dart`) so downloads survive leaving the app. Auth is snapshotted into a `BackgroundWorkOrder`; completions are durably logged to a file and replayed into Drift on resume; rotated `ui_login` tokens are written back via `BackgroundTokenRecord`.
 
@@ -64,6 +64,6 @@ A mismatch with catalog data shows a persistent warning in Library and Offline s
 ## Gotchas
 
 - **Android downloads ride entirely on the foreground service.** If `ensureServiceRunning()` can't start (e.g. notification permission denied), chapters queue in Drift but nothing downloads.
-- **`_pumping` is a process-wide static.** If the coordinator provider rebuilds mid-drain (e.g. a concurrency change), the new instance is blocked until the old drain finishes or the app restarts.
+- **`_pumping` is a process-wide static.** If the coordinator provider rebuilds mid-drain (a concurrency change, or a token refresh rotating the GraphQL client → repo dependency), the new instance is blocked until the old drain finishes or the app restarts. Pause still reaches the old drain via the persisted flag (captured prefs, read live per chapter); cancelling an in-flight chapter across a rebuild does not.
 - **Wi-Fi-only** is enforced when work starts, but a Wi-Fi → mobile switch while the app is backgrounded isn't currently caught.
 - **`offlineDatabaseProvider` (and the other storage providers) throw on web** by design — never touch them without the `offlineEnabledProvider` guard.

--- a/docs/architecture/offline.md
+++ b/docs/architecture/offline.md
@@ -64,6 +64,6 @@ A mismatch with catalog data shows a persistent warning in Library and Offline s
 ## Gotchas
 
 - **Android downloads ride entirely on the foreground service.** If `ensureServiceRunning()` can't start (e.g. notification permission denied), chapters queue in Drift but nothing downloads.
-- **`_pumping` is a process-wide static.** If the coordinator provider rebuilds mid-drain (a concurrency change, or a token refresh rotating the GraphQL client → repo dependency), the new instance is blocked until the old drain finishes or the app restarts. Pause still reaches the old drain via the persisted flag (captured prefs, read live per chapter); cancelling an in-flight chapter across a rebuild does not.
+- **`_pumping` is a process-wide static.** If the coordinator provider rebuilds mid-drain (a concurrency change, or a token refresh rotating the GraphQL client → repo dependency), the new instance is blocked until the old drain finishes or the app restarts. Pause still reaches the old drain via the persisted flag (captured prefs, read live per chapter); cancelling an in-flight chapter across a rebuild does not. A chapter mid-download when the engine itself rebuilds fails its next page fetch, is marked `error`, and self-heals via the launch requeue.
 - **Wi-Fi-only** is enforced when work starts, but a Wi-Fi → mobile switch while the app is backgrounded isn't currently caught.
 - **`offlineDatabaseProvider` (and the other storage providers) throw on web** by design — never touch them without the `offlineEnabledProvider` guard.

--- a/lib/src/features/offline/data/offline_background_downloads.dart
+++ b/lib/src/features/offline/data/offline_background_downloads.dart
@@ -5,7 +5,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:graphql_flutter/graphql_flutter.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../constants/db_keys.dart';
@@ -32,7 +31,11 @@ part 'offline_background_downloads.g.dart';
 /// (resolving the server base + current auth at request time), the on-disk page
 /// store, and a token refresher. Pure Dart — runs the same on Android and the
 /// Linux desktop build. Null on web / when offline storage is unavailable.
-@riverpod
+///
+/// Keep-alive: nothing watches the download pipeline — it's only read by
+/// fire-and-forget triggers — and an auto-dispose Ref dies at the first async
+/// gap, so the engine's run-time auth reads would throw mid-download.
+@Riverpod(keepAlive: true)
 ChapterDownloadEngine? chapterDownloadEngine(Ref ref) {
   if (!ref.watch(offlineActiveProvider)) return null;
   // Page-level parallelism. One chapter downloads
@@ -72,13 +75,20 @@ ChapterDownloadEngine? chapterDownloadEngine(Ref ref) {
 /// The offline download orchestrator (one chapter at a time,
 /// page-parallel inside the engine, run-time auth). Null on web / when offline
 /// storage is unavailable.
-@riverpod
+///
+/// Keep-alive so every trigger (launch resume, download starter, pause,
+/// catalog clear) reaches the SAME live instance — the in-memory
+/// active/cancelled state is only meaningful on the instance actually pumping.
+@Riverpod(keepAlive: true)
 OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
   if (!ref.watch(offlineActiveProvider)) return null;
   final engine = ref.watch(chapterDownloadEngineProvider);
   if (engine == null) return null;
   final repo = ref.watch(mangaBookRepositoryProvider);
   final store = ref.watch(offlinePageStoreProvider);
+  // Captured at build, read live per call: a rebuild mid-pump unmounts the old
+  // Ref, and the old instance still polls this between chapters.
+  final prefs = ref.watch(sharedPreferencesProvider);
   return OfflineDownloadCoordinator(
     db: ref.watch(offlineDatabaseProvider),
     engine: engine,
@@ -87,10 +97,7 @@ OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
         const <String>[],
     measureChapterBytes: store.chapterBytes,
     persistedPaused: () =>
-        ref
-            .read(sharedPreferencesProvider)
-            .getBool(DBKeys.offlineDownloadsPaused.name) ??
-        false,
+        prefs.getBool(DBKeys.offlineDownloadsPaused.name) ?? false,
   );
 }
 

--- a/test/src/features/offline/data/offline_coordinator_lifetime_test.dart
+++ b/test/src/features/offline/data/offline_coordinator_lifetime_test.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Regression guard for the startup UnmountedRefException: the download
+// coordinator is a process-wide background worker, so its provider must be
+// keep-alive. An auto-dispose coordinator read once (no listeners) is torn
+// down at the next async gap, and its persistedPaused callback then dies on a
+// dead Ref — which killed launch download-resume and every desktop pump.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/offline/data/offline_background_downloads.dart';
+import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+class _FakeStore implements OfflinePageStore {
+  @override
+  Future<({String relPath, int bytes})> writePage(
+          int m, int c, int i, List<int> b, String e) async =>
+      (relPath: '$m/$c/$i.$e', bytes: b.length);
+  @override
+  Future<void> deleteChapter(int m, int c) async {}
+  @override
+  Future<int> chapterBytes(int m, int c) async => 0;
+  @override
+  Future<void> clearAll() async {}
+}
+
+/// Let the auto-dispose scheduler run: an unlistened auto-dispose element is
+/// disposed asynchronously, so identity/liveness checks need real event-loop
+/// turns between reads.
+Future<void> settle() async {
+  for (var i = 0; i < 5; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<ProviderContainer> makeContainer() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final db = testOfflineDatabase();
+    addTearDown(db.close);
+    final container = ProviderContainer(overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      offlineEnabledProvider.overrideWithValue(true),
+      offlineActiveProvider.overrideWithValue(true),
+      offlineDatabaseProvider.overrideWithValue(db),
+      offlinePathsProvider.overrideWithValue(const OfflinePaths('/tmp/x')),
+      offlinePageStoreProvider.overrideWithValue(_FakeStore()),
+      // A repo with a dummy client: never called here, but building the real
+      // one pulls the auth/Hive chain that tests don't have.
+      mangaBookRepositoryProvider.overrideWithValue(MangaBookRepository(
+        GraphQLClient(
+          link: HttpLink('http://127.0.0.1:1'),
+          cache: GraphQLCache(),
+        ),
+      )),
+    ]);
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('coordinator survives an async gap after an unlistened read', () async {
+    final container = await makeContainer();
+    final coord = container.read(offlineDownloadCoordinatorProvider);
+    expect(coord, isNotNull);
+    await settle();
+    // Pre-fix: auto-dispose already unmounted the provider, so isPaused →
+    // persistedPaused → ref.read throws UnmountedRefException.
+    expect(coord!.isPaused, isFalse);
+  });
+
+  test('reads across an async gap return the same coordinator', () async {
+    final container = await makeContainer();
+    final first = container.read(offlineDownloadCoordinatorProvider);
+    await settle();
+    final second = container.read(offlineDownloadCoordinatorProvider);
+    // One live instance per build generation — otherwise pause/cancel act on
+    // a throwaway object instead of the pumping one.
+    expect(identical(first, second), isTrue);
+  });
+}


### PR DESCRIPTION
## Problem

On desktop, every launch logged a caught `UnmountedRefException` for `offlineDownloadCoordinatorProvider`, and the offline launch resume silently aborted before pumping the queue. Any desktop download trigger could die the same way after its first async gap.

## Root cause

The download engine and coordinator providers were auto-dispose, but nothing ever watches them — every consumer (launch resume, download starter, pause, catalog clear, save-to-device, reconcile) does a one-shot read. With no listener, the provider element is torn down at the next async gap, and the coordinator's `persistedPaused` callback then used the dead `Ref` at call time.

Riverpod 2 only guarded this with debug-mode asserts, so release builds silently worked; Riverpod 3 (#200) enforces it at runtime and throws. The lifetime mismatch predates the migration — the migration made it visible.

## Fix

- `@Riverpod(keepAlive: true)` on `chapterDownloadEngine` and `offlineDownloadCoordinator`: they are process-wide background workers, and every trigger now reaches the same live instance (in-memory pause/cancel state is only meaningful on the instance actually pumping). Both still return null when offline is inactive.
- Capture `SharedPreferences` at build instead of `ref.read` at call time in `persistedPaused`, so a provider rebuild mid-pump (e.g. a token refresh rotating the GraphQL client dependency) can't reintroduce the throw on the old instance.

## Verification

- New regression test reproduces the exact production exception on unfixed code and pins the lifetime contract (survives async gaps; identical instance across reads).
- Full suite: 959 tests pass.
- Live: release flatpak from this branch — startup crash-log clean (previously errored every launch), chapters download end-to-end, pause works.