### PR TITLE
Renovate: ignore the SDK-local flutter-plugin-loader Gradle plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":dependencyDashboard"],
   "enabledManagers": ["fvm", "pub", "github-actions", "gradle", "cocoapods", "custom.regex"],
+  "ignoreDeps": ["dev.flutter.flutter-plugin-loader"],
   "constraints": {
     "flutter": "3.44.6"
   },


### PR DESCRIPTION
The dependency dashboard warns about a failed Maven lookup for `dev.flutter.flutter-plugin-loader` (`android/settings.gradle`). That plugin is resolved via `includeBuild` from the local Flutter SDK and never published to a registry, so the lookup can only fail — and it never needs updating, since the SDK pin owns its version. Ignoring it removes the standing warning from the dashboard.