### PR TITLE
Plugin majors: app_links 7, flutter_secure_storage 10, flutter_foreground_task 10; drop permission_handler

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/src/features/auth/data/secure_credentials_provider.dart
+++ b/lib/src/features/auth/data/secure_credentials_provider.dart
@@ -12,13 +12,15 @@ part 'secure_credentials_provider.g.dart';
 
 /// A platform-backed secure key/value store for credentials.
 ///
-/// On Android this is backed by EncryptedSharedPreferences (Keystore-backed
-/// AES key); on iOS by the Keychain; on desktop/web by best-available
-/// platform stores. Always preferred over SharedPreferences for anything
-/// bearer-equivalent (passwords, JWTs, session cookies).
+/// On Android this is Keystore-backed AES-GCM (v10 migrates old
+/// EncryptedSharedPreferences data on first access; the backup keeps a failed
+/// migration from destroying stored logins); on iOS the Keychain; on
+/// desktop/web best-available platform stores. Always preferred over
+/// SharedPreferences for anything bearer-equivalent (passwords, JWTs,
+/// session cookies).
 @Riverpod(keepAlive: true)
 FlutterSecureStorage secureStorage(Ref ref) => const FlutterSecureStorage(
       aOptions: AndroidOptions(
-        encryptedSharedPreferences: true,
+        migrateWithBackup: true,
       ),
     );

--- a/lib/src/features/auth/data/secure_credentials_provider.dart
+++ b/lib/src/features/auth/data/secure_credentials_provider.dart
@@ -18,6 +18,10 @@ part 'secure_credentials_provider.g.dart';
 /// desktop/web best-available platform stores. Always preferred over
 /// SharedPreferences for anything bearer-equivalent (passwords, JWTs,
 /// session cookies).
+///
+/// v10's resetOnError default is accepted deliberately: an unrecoverable
+/// keystore/decrypt error wipes the store (clean re-login) instead of
+/// crashing every read.
 @Riverpod(keepAlive: true)
 FlutterSecureStorage secureStorage(Ref ref) => const FlutterSecureStorage(
       aOptions: AndroidOptions(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,7 @@ import Foundation
 import app_links
 import connectivity_plus
 import file_picker
-import flutter_secure_storage_macos
+import flutter_secure_storage_darwin
 import gal
 import network_info_plus
 import package_info_plus
@@ -27,7 +27,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
-  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: app_links
-      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      sha256: f8db46d2ea9ff6f3a37191a7fd5b7813da1253ace8c32c1b9eadace41d1188ea
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "7.2.1"
   app_links_linux:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: app_links_platform_interface
-      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      sha256: "7546f09a6e93f4a2df2fe2bd40a5c6c64310ac461b036d82b43033be7a59f809"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.4"
   app_links_web:
     dependency: transitive
     description:
@@ -427,10 +427,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_foreground_task
-      sha256: fc5c01a5e1b8f7bb51d0c737714f0c50440dbdf1aeddc5f8cbba313aa6fd4856
+      sha256: "0dad7e6a4ac57aeb0e680e35ec7ae997f1a2b8579fdb85b16dd16e299b634f4f"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.2"
+    version: "10.0.0"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -496,50 +496,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.1.0"
   flutter_staggered_grid_view:
     dependency: transitive
     description:
@@ -886,14 +886,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
@@ -1142,54 +1134,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  permission_handler:
-    dependency: "direct main"
-    description:
-      name: permission_handler
-      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
-      url: "https://pub.dev"
-    source: hosted
-    version: "11.4.0"
-  permission_handler_android:
-    dependency: transitive
-    description:
-      name: permission_handler_android
-      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
-      url: "https://pub.dev"
-    source: hosted
-    version: "12.1.0"
-  permission_handler_apple:
-    dependency: transitive
-    description:
-      name: permission_handler_apple
-      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.4.10"
-  permission_handler_html:
-    dependency: transitive
-    description:
-      name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3+5"
-  permission_handler_platform_interface:
-    dependency: transitive
-    description:
-      name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.3.0"
-  permission_handler_windows:
-    dependency: transitive
-    description:
-      name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -1925,5 +1869,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
-  app_links: ^6.4.0
+  app_links: ^7.2.1
   built_collection: ^5.1.1
   collection: ^1.19.0
   cached_network_image: ^3.2.2
@@ -29,12 +29,12 @@ dependencies:
       url: https://github.com/DattatreyaReddy/flutter_android_volume_keydown
       ref: "9db2306fd2b4f804f5b9fbf69b97b211f47f527c"
   flutter_cache_manager: ^3.3.0
-  flutter_foreground_task: ^9.2.2
+  flutter_foreground_task: ^10.0.0
   flutter_hooks: ^0.21.0
   flutter_localizations:
     sdk: flutter
   flutter_markdown: ^0.7.1
-  flutter_secure_storage: ^9.2.2
+  flutter_secure_storage: ^10.3.1
   fluttertoast: ^8.1.1
   font_awesome_flutter: ^11.0.0
   freezed_annotation: ^3.0.0
@@ -56,7 +56,6 @@ dependencies:
   package_info_plus: ^8.0.0
   path: ^1.8.3
   path_provider: ^2.0.11
-  permission_handler: ^11.0.0
   pub_semver: ^2.1.2
   queue: ^3.1.0+2
   riverpod_annotation: ^4.0.0

--- a/test/src/features/auth/data/auth_credentials_store_test.dart
+++ b/test/src/features/auth/data/auth_credentials_store_test.dart
@@ -25,11 +25,11 @@ class _InMemorySecureStorage implements FlutterSecureStorage {
   Future<void> write({
     required String key,
     required String? value,
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
     if (value == null) {
@@ -42,11 +42,11 @@ class _InMemorySecureStorage implements FlutterSecureStorage {
   @override
   Future<String?> read({
     required String key,
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async =>
       _store[key];
@@ -54,11 +54,11 @@ class _InMemorySecureStorage implements FlutterSecureStorage {
   @override
   Future<void> delete({
     required String key,
-    IOSOptions? iOptions,
+    AppleOptions? iOptions,
     AndroidOptions? aOptions,
     LinuxOptions? lOptions,
     WebOptions? webOptions,
-    MacOsOptions? mOptions,
+    AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
     _store.remove(key);

--- a/test/src/features/auth/data/basic_auth_migration_test.dart
+++ b/test/src/features/auth/data/basic_auth_migration_test.dart
@@ -9,19 +9,19 @@ class _InMemorySecureStorage implements FlutterSecureStorage {
   final Map<String, String> _store = {};
   @override
   Future<void> write({required String key, required String? value,
-      IOSOptions? iOptions, AndroidOptions? aOptions, LinuxOptions? lOptions,
-      WebOptions? webOptions, MacOsOptions? mOptions,
+      AppleOptions? iOptions, AndroidOptions? aOptions, LinuxOptions? lOptions,
+      WebOptions? webOptions, AppleOptions? mOptions,
       WindowsOptions? wOptions}) async {
     if (value == null) _store.remove(key); else _store[key] = value;
   }
   @override
-  Future<String?> read({required String key, IOSOptions? iOptions,
+  Future<String?> read({required String key, AppleOptions? iOptions,
       AndroidOptions? aOptions, LinuxOptions? lOptions, WebOptions? webOptions,
-      MacOsOptions? mOptions, WindowsOptions? wOptions}) async => _store[key];
+      AppleOptions? mOptions, WindowsOptions? wOptions}) async => _store[key];
   @override
-  Future<void> delete({required String key, IOSOptions? iOptions,
+  Future<void> delete({required String key, AppleOptions? iOptions,
       AndroidOptions? aOptions, LinuxOptions? lOptions, WebOptions? webOptions,
-      MacOsOptions? mOptions, WindowsOptions? wOptions}) async => _store.remove(key);
+      AppleOptions? mOptions, WindowsOptions? wOptions}) async => _store.remove(key);
   @override
   noSuchMethod(Invocation i) => throw UnimplementedError();
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -10,7 +10,6 @@
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <gal/gal_plugin_c_api.h>
-#include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -27,8 +26,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   GalPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GalPluginCApi"));
-  PermissionHandlerWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   ScreenBrightnessWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPluginCApi"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -7,7 +7,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
   flutter_secure_storage_windows
   gal
-  permission_handler_windows
   screen_brightness_windows
   screen_retriever_windows
   share_plus


### PR DESCRIPTION
One tested batch of the dashboard-gated plugin majors that need on-device verification (supersedes #219, #220, #222 — Renovate will close them once main is current).

- **app_links 6.4.1 → 7.2.1** — backward-compatible by design; deep-link handling unchanged. Verified: tracker OAuth round-trip works on-device.
- **flutter_secure_storage 9.2.4 → 10.3.1** — replaces the deprecated Jetpack-backed Android store; existing entries migrate on first access. `migrateWithBackup` is enabled so a failed migration can't destroy stored logins (upstream #1043 history). The deprecated `encryptedSharedPreferences` flag is ignored in 10.3.1 and removed here. The v10 iOS/macOS option-type merge (`AppleOptions`) required updating the test fakes. Verified: in-place upgrade on a device with stored credentials — login survives, including across restart.
- **flutter_foreground_task 9.2.2 → 10.0.0** — changelog is SDK-floor + iOS-only changes; Android service surface untouched. Verified: background download with live progress notification completes on-device.
- **permission_handler removed** — dead dependency: never imported; the download service requests notification permission via flutter_foreground_task's own API.

969 tests pass, analyzer error-free.