### PR TITLE
Sync desktop builds with the sqlite3 migration, drop dead jsoncpp

### DIFF
--- a/flatpak/io.github.aaronbamblett.tsumiru.yml
+++ b/flatpak/io.github.aaronbamblett.tsumiru.yml
@@ -20,17 +20,9 @@ finish-args:
   - --talk-name=org.freedesktop.secrets   # libsecret credential store (host keyring)
 
 modules:
-  # flutter_secure_storage_linux needs libsecret + jsoncpp, which aren't in the
-  # freedesktop runtime. Build them against the SDK so they're ABI-compatible.
-  - name: jsoncpp
-    buildsystem: meson
-    config-opts:
-      - -Dtests=false
-    sources:
-      - type: archive
-        url: https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.6.tar.gz
-        sha256: f93b6dd7ce796b13d02c108bc9f79812245a82e577581c4c9aabe57075c90ea2
-
+  # flutter_secure_storage_linux needs libsecret, which isn't in the
+  # freedesktop runtime. Build it against the SDK so it's ABI-compatible.
+  # (jsoncpp was dropped: secure_storage 10's Linux impl no longer uses it.)
   - name: libsecret
     buildsystem: meson
     config-opts:

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,7 +9,6 @@
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -23,9 +22,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,7 +6,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
   gtk
   screen_retriever_linux
-  sqlite3_flutter_libs
   url_launcher_linux
   window_manager
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -18,7 +18,6 @@ import screen_retriever_macos
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
-import sqlite3_flutter_libs
 import url_launcher_macos
 import wakelock_plus
 import window_manager
@@ -37,7 +36,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -451,10 +451,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -562,10 +562,10 @@ packages:
     dependency: "direct main"
     description:
       name: fluttertoast
-      sha256: "90778fe0497fe3a09166e8cf2e0867310ff434b794526589e77ec03cf08ba8e8"
+      sha256: "7903c9d5339173497bfecbc23bc4212f5a87e0edfac2e1693fb74465ea67da7e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.14"
+    version: "9.1.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -930,10 +930,10 @@ packages:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.1.0"
   logger:
     dependency: "direct main"
     description:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -13,7 +13,6 @@
 #include <screen_brightness_windows/screen_brightness_windows_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -32,8 +31,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -10,7 +10,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   screen_brightness_windows
   screen_retriever_windows
   share_plus
-  sqlite3_flutter_libs
   url_launcher_windows
   window_manager
 )


### PR DESCRIPTION
Follow-up to tonight's dependency wave, closing out the desktop side.

- sqlite3_flutter_libs 0.6 (#211) is an end-of-life stub — sqlite3 3.x now bundles the native library via its own build. The committed desktop plugin registrants still referenced the old plugin; this syncs the regenerated versions (and pubspec.lock, which #227's fluttertoast bump left stale).
- Removes the flatpak manifest's jsoncpp module: flutter_secure_storage_linux 3.x requires only libsecret (checked its CMakeLists).

Verified locally, not just compiled: full Linux release build, flatpak packaged and installed without jsoncpp, app launched in the sandbox, libsqlite3.so present in the bundle, offline catalog database created and opened, no dynamic loader errors. Android cross-checked: libsqlite3.so present in the APK for all ABIs.