### PR TITLE
Chapter sort and display options (Komikku parity)

### DIFF
--- a/docs/architecture/manga-details-downloads.md
+++ b/docs/architecture/manga-details-downloads.md
@@ -19,7 +19,7 @@
 | `.../manga_details/widgets/chapter_grid_tile.dart` | Compact number tile for the grid view (read/downloaded/bookmark/in-progress states) |
 | `.../manga_details/widgets/chapter_list_mode_toggle.dart` | List/grid segmented toggle in the chapter-count header |
 | `.../manga_details/widgets/chapter_download_presets_button.dart` | Bulk-download presets (operates on the **unfiltered** list) |
-| `.../manga_details/widgets/manga_chapter_{organizer,filter}.dart` | Filter/Sort sheet (tri-state + scanlator radio) |
+| `.../manga_details/widgets/manga_chapter_{organizer,filter,sort,display}.dart` | Filter/Sort/Display sheet (tri-state + scanlator radio; sort radios; title-vs-number display) |
 | `manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart` | Multi-select action bar |
 | `manga_book/widgets/download_status_icon.dart` | Inline per-chapter download progress/state |
 | `.../downloads/downloads_screen.dart` (+ `controller/`, `widgets/`) | Standalone queue screen |
@@ -30,7 +30,7 @@
 
 ## Chapters & actions
 
-- Filtering/sorting is client-side in `mangaChapterListWithFilterProvider`. Filter/sort state is **global** (SharedPreferences); the **scanlator** filter is **per-manga** (server meta `flutter_scanlator`). `ChapterSort`: `source`, `fetchedDate`, `uploadDate`.
+- Filtering/sorting is client-side in `mangaChapterListWithFilterProvider`. Filter/sort/display state is **global** (SharedPreferences); the **scanlator** filter is **per-manga** (server meta `flutter_scanlator`). `ChapterSort`: `source`, `fetchedDate`, `uploadDate`, `chapterNumber`, `alphabetical` (enum indices are persisted — append new values last). `ChapterDisplay` (`sourceTitle` | `chapterNumber`) swaps the tile title between `chapter.name` and a formatted "Chapter N" (Komikku-style `#.###` number formatting); offline-fallback rows fake `chapterNumber` from `chapterIndex`, so number display/sort degrade to source order there.
 - **List vs grid** (`ChapterListMode`) is **per-manga** (server meta `flutter_chapterListMode`, default list) via `mangaChapterListModeProvider`. Grid tiles show the chapter number only (`ChapterGridTile.label`: whole numbers drop `.0`, unparsed fall back to `#sourceOrder`); states = dim read, gradient dot downloaded, bookmark icon, gradient ring + page marker on the in-progress chapter. Same tap/long-press/right-click semantics as list rows.
 - Tile: tap → reader; long-press / right-click → multi-select.
 - Multi-select bar: bookmark add/remove, mark-previous-read, mark read (`lastPageRead: 0`), mark unread, download, delete — then clears selection + refreshes.

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -65,6 +65,7 @@ enum DBKeys {
   mangaSortDirection(false),
   chapterSort(ChapterSort.source),
   chapterSortDirection(false), // asc=true, dsc=false
+  chapterDisplay(ChapterDisplay.sourceTitle),
   libraryDisplayMode(DisplayMode.grid),
   sourceDisplayMode(DisplayMode.grid),
   globalSearchSourceFilter(GlobalSearchSourceFilter.pinned),

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -356,12 +356,15 @@ enum MangaSort {
 enum ChapterSort {
   source,
   uploadDate,
-  fetchedDate;
+  fetchedDate,
+  // Appended last: saved prefs store the index into [values].
+  alphabetical;
 
   String toLocale(BuildContext context) => switch (this) {
         ChapterSort.source => context.l10n.chapterSortSource,
         ChapterSort.fetchedDate => context.l10n.chapterSortFetchedDate,
-        ChapterSort.uploadDate => context.l10n.chapterSortUploadDate
+        ChapterSort.uploadDate => context.l10n.chapterSortUploadDate,
+        ChapterSort.alphabetical => context.l10n.chapterSortAlphabetical,
       };
 }
 

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -358,13 +358,26 @@ enum ChapterSort {
   uploadDate,
   fetchedDate,
   // Appended last: saved prefs store the index into [values].
+  chapterNumber,
   alphabetical;
 
   String toLocale(BuildContext context) => switch (this) {
         ChapterSort.source => context.l10n.chapterSortSource,
         ChapterSort.fetchedDate => context.l10n.chapterSortFetchedDate,
         ChapterSort.uploadDate => context.l10n.chapterSortUploadDate,
+        ChapterSort.chapterNumber => context.l10n.chapterSortChapterNumber,
         ChapterSort.alphabetical => context.l10n.chapterSortAlphabetical,
+      };
+}
+
+enum ChapterDisplay {
+  sourceTitle,
+  chapterNumber;
+
+  String toLocale(BuildContext context) => switch (this) {
+        ChapterDisplay.sourceTitle => context.l10n.chapterDisplaySourceTitle,
+        ChapterDisplay.chapterNumber =>
+          context.l10n.chapterDisplayChapterNumber,
       };
 }
 

--- a/lib/src/features/manga_book/domain/chapter/chapter_model.dart
+++ b/lib/src/features/manga_book/domain/chapter/chapter_model.dart
@@ -11,6 +11,9 @@ import 'graphql/__generated__/fragment.graphql.dart';
 
 typedef ChapterDto = Fragment$ChapterDto;
 
+// Matches Komikku's formatter: up to 3 decimals, trailing zeros dropped.
+final _chapterNumberFormat = NumberFormat('#.###', 'en_US');
+
 typedef ChapterWithMangaDto = Fragment$ChapterWithMangaDto;
 
 extension ChapterExtension on Fragment$ChapterDto {
@@ -20,9 +23,8 @@ extension ChapterExtension on Fragment$ChapterDto {
 
   int get index => sourceOrder;
 
-  // Matches Komikku's formatter: up to 3 decimals, trailing zeros dropped.
   String get formattedChapterNumber =>
-      NumberFormat('#.###', 'en_US').format(chapterNumber);
+      _chapterNumberFormat.format(chapterNumber);
 
   bool get hasReadingProgress =>
       isRead || lastPageRead > 0 || lastReadAt != '0';

--- a/lib/src/features/manga_book/domain/chapter/chapter_model.dart
+++ b/lib/src/features/manga_book/domain/chapter/chapter_model.dart
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'package:intl/intl.dart';
+
 import '../../../../utils/extensions/custom_extensions.dart';
 import 'graphql/__generated__/fragment.graphql.dart';
 
@@ -17,6 +19,10 @@ extension ChapterExtension on Fragment$ChapterDto {
   }
 
   int get index => sourceOrder;
+
+  // Matches Komikku's formatter: up to 3 decimals, trailing zeros dropped.
+  String get formattedChapterNumber =>
+      NumberFormat('#.###', 'en_US').format(chapterNumber);
 
   bool get hasReadingProgress =>
       isRead || lastPageRead > 0 || lastReadAt != '0';

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -333,7 +333,7 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
 
   int applyChapterSort(ChapterDto m1, ChapterDto m2) {
     final sortDirToggle = (sortedDirection ? 1 : -1);
-    return (switch (sortedBy) {
+    final result = (switch (sortedBy) {
           ChapterSort.fetchedDate => (int.tryParse(m1.fetchedAt) ?? 0)
               .compareTo(int.tryParse(m2.fetchedAt) ?? 0),
           ChapterSort.source => (m1.index).compareTo(m2.index),
@@ -345,6 +345,9 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
             m1.name.toLowerCase().compareTo(m2.name.toLowerCase()),
         }) *
         sortDirToggle;
+    // List.sort is unstable; keep ties in source order (matches Komikku,
+    // whose stable sort degrades to source order when numbers don't parse).
+    return result != 0 ? result : m1.index.compareTo(m2.index);
   }
 
   return chapterList.copyWithData(

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -300,8 +300,8 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
   final chapterFilterDownloaded =
       ref.watch(mangaChapterFilterDownloadedProvider);
   final chapterFilterBookmark = ref.watch(mangaChapterFilterBookmarkedProvider);
-  final ChapterSort sortedBy = ref.watch(mangaChapterSortProvider) ??
-      DBKeys.chapterSortDirection.initial;
+  final ChapterSort sortedBy =
+      ref.watch(mangaChapterSortProvider) ?? DBKeys.chapterSort.initial;
   final sortedDirection =
       ref.watch(mangaChapterSortDirectionProvider).ifNull(true);
 
@@ -339,6 +339,8 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
           ChapterSort.source => (m1.index).compareTo(m2.index),
           ChapterSort.uploadDate => (int.tryParse(m1.uploadDate) ?? 0)
               .compareTo(int.tryParse(m2.uploadDate) ?? 0),
+          ChapterSort.alphabetical =>
+            m1.name.toLowerCase().compareTo(m2.name.toLowerCase()),
         }) *
         sortDirToggle;
   }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -339,6 +339,8 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
           ChapterSort.source => (m1.index).compareTo(m2.index),
           ChapterSort.uploadDate => (int.tryParse(m1.uploadDate) ?? 0)
               .compareTo(int.tryParse(m2.uploadDate) ?? 0),
+          ChapterSort.chapterNumber =>
+            m1.chapterNumber.compareTo(m2.chapterNumber),
           ChapterSort.alphabetical =>
             m1.name.toLowerCase().compareTo(m2.name.toLowerCase()),
         }) *
@@ -415,6 +417,16 @@ class MangaChapterSortDirection extends _$MangaChapterSortDirection
     with SharedPreferenceClientMixin<bool> {
   @override
   bool? build() => initialize(DBKeys.chapterSortDirection);
+}
+
+@riverpod
+class MangaChapterDisplayMode extends _$MangaChapterDisplayMode
+    with SharedPreferenceEnumClientMixin<ChapterDisplay> {
+  @override
+  ChapterDisplay? build() => initialize(
+        DBKeys.chapterDisplay,
+        enumList: ChapterDisplay.values,
+      );
 }
 
 @riverpod

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_list_tile.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_list_tile.dart
@@ -7,15 +7,18 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../../constants/enum.dart';
 import '../../../../../routes/router_config.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../offline/presentation/offline_save_button.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/manga/manga_model.dart';
 import '../../../widgets/download_status_icon.dart';
+import '../controller/manga_details_controller.dart';
 
-class ChapterListTile extends StatelessWidget {
+class ChapterListTile extends ConsumerWidget {
   const ChapterListTile({
     super.key,
     required this.manga,
@@ -32,7 +35,9 @@ class ChapterListTile extends StatelessWidget {
   final bool canTapSelect;
   final bool isSelected;
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final showChapterNumber = ref.watch(mangaChapterDisplayModeProvider) ==
+        ChapterDisplay.chapterNumber;
     return GestureDetector(
       key: Key("manga-${manga.id}-chapter-${chapter.id}"),
       onSecondaryTap: () => toggleSelect(chapter),
@@ -51,7 +56,9 @@ class ChapterListTile extends StatelessWidget {
             ],
             Expanded(
               child: Text(
-                chapter.name,
+                showChapterNumber
+                    ? context.l10n.chapterNumber(chapter.formattedChapterNumber)
+                    : chapter.name,
                 style: TextStyle(
                   color: chapter.isRead.ifNull() ? Colors.grey : null,
                 ),

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_display.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_display.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../constants/db_keys.dart';
+import '../../../../../constants/enum.dart';
+import '../controller/manga_details_controller.dart';
+
+class MangaChapterDisplay extends ConsumerWidget {
+  const MangaChapterDisplay({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ChapterDisplay display =
+        ref.watch(mangaChapterDisplayModeProvider) ?? DBKeys.chapterDisplay.initial;
+    return ListView(
+      children: [
+        const Divider(height: .5),
+        for (final ChapterDisplay mode in ChapterDisplay.values)
+          RadioListTile<ChapterDisplay>(
+            title: Text(mode.toLocale(context)),
+            value: mode,
+            groupValue: display,
+            onChanged: (value) => ref
+                .read(mangaChapterDisplayModeProvider.notifier)
+                .update(value),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_organizer.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_organizer.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../../utils/extensions/custom_extensions.dart';
+import 'manga_chapter_display.dart';
 import 'manga_chapter_filter.dart';
 import 'manga_chapter_sort.dart';
 
@@ -16,7 +17,7 @@ class MangaChapterOrganizer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         appBar: TabBar(
           // Fill alignment so the underline aligns under each tab (the global
@@ -25,12 +26,14 @@ class MangaChapterOrganizer extends StatelessWidget {
           tabs: [
             Tab(text: context.l10n.filter),
             Tab(text: context.l10n.sort),
+            Tab(text: context.l10n.display),
           ],
         ),
         body: TabBarView(
           children: [
             MangaChapterFilter(mangaId: mangaId),
             const MangaChapterSort(),
+            const MangaChapterDisplay(),
           ],
         ),
       ),

--- a/lib/src/l10n/app_ar.arb
+++ b/lib/src/l10n/app_ar.arb
@@ -73,7 +73,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_de.arb
+++ b/lib/src/l10n/app_de.arb
@@ -75,7 +75,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -270,6 +270,9 @@
             }
         }
     },
+    "@chapterSortAlphabetical": {
+        "description": "Radio button text for sort Alphabetically"
+    },
     "@chapterSortFetchedDate": {
         "description": "Radio button text for sort by Fetched Date"
     },
@@ -1509,6 +1512,7 @@
     "chapterDownloadLimit": "Chapter download limit",
     "chapterDownloadLimitDesc": "Limit the amount of new chapters that are going to get downloaded.",
     "chapterNumber": "Chapter {number}",
+    "chapterSortAlphabetical": "Alphabetically",
     "chapterSortFetchedDate": "By Fetched Date",
     "chapterSortSource": "By Source",
     "chapterSortUploadDate": "By Upload Date",

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -261,17 +261,26 @@
     "@chapterDownloadLimitDesc": {
         "description": "Sub Title Text for changing Chapter download limit settings"
     },
+    "@chapterDisplayChapterNumber": {
+        "description": "Radio button text for displaying chapters by chapter number"
+    },
+    "@chapterDisplaySourceTitle": {
+        "description": "Radio button text for displaying chapters by source title"
+    },
     "@chapterNumber": {
         "description": "Text title for Chapter name in chapter list",
         "placeholders": {
             "number": {
                 "example": "12.5",
-                "type": "double"
+                "type": "String"
             }
         }
     },
     "@chapterSortAlphabetical": {
         "description": "Radio button text for sort Alphabetically"
+    },
+    "@chapterSortChapterNumber": {
+        "description": "Radio button text for sort by Chapter Number"
     },
     "@chapterSortFetchedDate": {
         "description": "Radio button text for sort by Fetched Date"
@@ -1511,8 +1520,11 @@
     "channel": "Channel",
     "chapterDownloadLimit": "Chapter download limit",
     "chapterDownloadLimitDesc": "Limit the amount of new chapters that are going to get downloaded.",
+    "chapterDisplayChapterNumber": "Chapter number",
+    "chapterDisplaySourceTitle": "Source title",
     "chapterNumber": "Chapter {number}",
     "chapterSortAlphabetical": "Alphabetically",
+    "chapterSortChapterNumber": "By Chapter Number",
     "chapterSortFetchedDate": "By Fetched Date",
     "chapterSortSource": "By Source",
     "chapterSortUploadDate": "By Upload Date",

--- a/lib/src/l10n/app_fr.arb
+++ b/lib/src/l10n/app_fr.arb
@@ -57,7 +57,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_id.arb
+++ b/lib/src/l10n/app_id.arb
@@ -73,7 +73,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_it.arb
+++ b/lib/src/l10n/app_it.arb
@@ -41,7 +41,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_ja.arb
+++ b/lib/src/l10n/app_ja.arb
@@ -83,7 +83,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_ko.arb
+++ b/lib/src/l10n/app_ko.arb
@@ -37,7 +37,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_nb_NO.arb
+++ b/lib/src/l10n/app_nb_NO.arb
@@ -139,7 +139,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_ru.arb
+++ b/lib/src/l10n/app_ru.arb
@@ -89,7 +89,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_ta.arb
+++ b/lib/src/l10n/app_ta.arb
@@ -1113,7 +1113,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_tr.arb
+++ b/lib/src/l10n/app_tr.arb
@@ -81,7 +81,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_uk.arb
+++ b/lib/src/l10n/app_uk.arb
@@ -527,7 +527,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_vi.arb
+++ b/lib/src/l10n/app_vi.arb
@@ -89,7 +89,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_zh.arb
+++ b/lib/src/l10n/app_zh.arb
@@ -59,7 +59,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_zh_Hans.arb
+++ b/lib/src/l10n/app_zh_Hans.arb
@@ -59,7 +59,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/lib/src/l10n/app_zh_Hant.arb
+++ b/lib/src/l10n/app_zh_Hant.arb
@@ -379,7 +379,7 @@
     "placeholders": {
       "number": {
         "example": "12.5",
-        "type": "double"
+        "type": "String"
       }
     }
   },

--- a/test/src/features/manga_book/chapter_sort_test.dart
+++ b/test/src/features/manga_book/chapter_sort_test.dart
@@ -120,6 +120,9 @@ void main() {
     c.read(mangaChapterSortProvider.notifier).update(ChapterSort.chapterNumber);
     c.read(mangaChapterSortDirectionProvider.notifier).update(true);
     expect(_names(c), ['C', 'A', 'B']);
+    // Ties keep source order under either direction (stable-sort semantics).
+    c.read(mangaChapterSortDirectionProvider.notifier).update(false);
+    expect(_names(c), ['C', 'A', 'B']);
   });
 
   group('formattedChapterNumber', () {
@@ -128,6 +131,9 @@ void main() {
       expect(_chapter(id: 1, name: '', chapterNumber: 218.5).formattedChapterNumber, '218.5');
       expect(_chapter(id: 1, name: '', chapterNumber: 12.345).formattedChapterNumber, '12.345');
       expect(_chapter(id: 1, name: '', chapterNumber: 0).formattedChapterNumber, '0');
+      expect(_chapter(id: 1, name: '', chapterNumber: 0.5).formattedChapterNumber, '0.5');
+      // Unparsed numbers come through as -1; shown as-is (matches Komikku).
+      expect(_chapter(id: 1, name: '', chapterNumber: -1).formattedChapterNumber, '-1');
     });
   });
 }

--- a/test/src/features/manga_book/chapter_sort_test.dart
+++ b/test/src/features/manga_book/chapter_sort_test.dart
@@ -1,0 +1,98 @@
+// Tests for the chapter sort modes in mangaChapterListWithFilter().
+// Uses the real Fragment$ChapterDto constructor (plain data class) and a fake
+// chapter-list notifier so no repository/network is involved.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+ChapterDto _chapter({
+  required int id,
+  required String name,
+  int sourceOrder = 0,
+  String uploadDate = '0',
+}) =>
+    Fragment$ChapterDto(
+      chapterNumber: id.toDouble(),
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: name,
+      pageCount: 0,
+      sourceOrder: sourceOrder,
+      uploadDate: uploadDate,
+      url: '',
+      meta: const [],
+    );
+
+class _FakeChapterList extends MangaChapterList {
+  _FakeChapterList(this.chapters);
+  final List<ChapterDto> chapters;
+
+  @override
+  Future<List<ChapterDto>?> build({required int mangaId}) async => chapters;
+}
+
+Future<ProviderContainer> _container(List<ChapterDto> chapters) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final c = ProviderContainer(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      mangaChapterListProvider(mangaId: 1)
+          .overrideWith(() => _FakeChapterList(chapters)),
+    ],
+  );
+  addTearDown(c.dispose);
+  await c.read(mangaChapterListProvider(mangaId: 1).future);
+  return c;
+}
+
+List<String> _names(ProviderContainer c) =>
+    (c.read(mangaChapterListWithFilterProvider(mangaId: 1)).value ?? [])
+        .map((ch) => ch.name)
+        .toList();
+
+void main() {
+  final chapters = [
+    _chapter(id: 1, name: 'Gamma', sourceOrder: 1, uploadDate: '300'),
+    _chapter(id: 2, name: 'alpha', sourceOrder: 2, uploadDate: '100'),
+    _chapter(id: 3, name: 'Beta', sourceOrder: 3, uploadDate: '200'),
+  ];
+
+  test('default sort is by source order, newest (descending) first', () async {
+    final c = await _container(chapters);
+    expect(_names(c), ['Beta', 'alpha', 'Gamma']);
+  });
+
+  test('alphabetical sort is case-insensitive on chapter name', () async {
+    final c = await _container(chapters);
+    c.read(mangaChapterSortProvider.notifier).update(ChapterSort.alphabetical);
+    c.read(mangaChapterSortDirectionProvider.notifier).update(true);
+    expect(_names(c), ['alpha', 'Beta', 'Gamma']);
+  });
+
+  test('alphabetical sort respects descending direction', () async {
+    final c = await _container(chapters);
+    c.read(mangaChapterSortProvider.notifier).update(ChapterSort.alphabetical);
+    c.read(mangaChapterSortDirectionProvider.notifier).update(false);
+    expect(_names(c), ['Gamma', 'Beta', 'alpha']);
+  });
+
+  test('upload date sort still orders numerically', () async {
+    final c = await _container(chapters);
+    c.read(mangaChapterSortProvider.notifier).update(ChapterSort.uploadDate);
+    c.read(mangaChapterSortDirectionProvider.notifier).update(true);
+    expect(_names(c), ['alpha', 'Beta', 'Gamma']);
+  });
+}

--- a/test/src/features/manga_book/chapter_sort_test.dart
+++ b/test/src/features/manga_book/chapter_sort_test.dart
@@ -110,6 +110,18 @@ void main() {
     expect(_names(c), ['Beta', 'Gamma', 'alpha']);
   });
 
+  test('tied chapter numbers fall back to source order', () async {
+    final tied = [
+      _chapter(id: 1, name: 'C', sourceOrder: 1, chapterNumber: -1),
+      _chapter(id: 2, name: 'A', sourceOrder: 2, chapterNumber: -1),
+      _chapter(id: 3, name: 'B', sourceOrder: 3, chapterNumber: -1),
+    ];
+    final c = await _container(tied);
+    c.read(mangaChapterSortProvider.notifier).update(ChapterSort.chapterNumber);
+    c.read(mangaChapterSortDirectionProvider.notifier).update(true);
+    expect(_names(c), ['C', 'A', 'B']);
+  });
+
   group('formattedChapterNumber', () {
     test('drops trailing zeros and keeps up to 3 decimals', () {
       expect(_chapter(id: 1, name: '', chapterNumber: 218).formattedChapterNumber, '218');

--- a/test/src/features/manga_book/chapter_sort_test.dart
+++ b/test/src/features/manga_book/chapter_sort_test.dart
@@ -16,9 +16,10 @@ ChapterDto _chapter({
   required String name,
   int sourceOrder = 0,
   String uploadDate = '0',
+  double chapterNumber = 0,
 }) =>
     Fragment$ChapterDto(
-      chapterNumber: id.toDouble(),
+      chapterNumber: chapterNumber,
       fetchedAt: '0',
       id: id,
       isBookmarked: false,
@@ -64,10 +65,15 @@ List<String> _names(ProviderContainer c) =>
         .toList();
 
 void main() {
+  // Chapter numbers deliberately disagree with source order so the two sorts
+  // are distinguishable.
   final chapters = [
-    _chapter(id: 1, name: 'Gamma', sourceOrder: 1, uploadDate: '300'),
-    _chapter(id: 2, name: 'alpha', sourceOrder: 2, uploadDate: '100'),
-    _chapter(id: 3, name: 'Beta', sourceOrder: 3, uploadDate: '200'),
+    _chapter(
+        id: 1, name: 'Gamma', sourceOrder: 1, uploadDate: '300', chapterNumber: 2.5),
+    _chapter(
+        id: 2, name: 'alpha', sourceOrder: 2, uploadDate: '100', chapterNumber: 10),
+    _chapter(
+        id: 3, name: 'Beta', sourceOrder: 3, uploadDate: '200', chapterNumber: 1),
   ];
 
   test('default sort is by source order, newest (descending) first', () async {
@@ -94,5 +100,22 @@ void main() {
     c.read(mangaChapterSortProvider.notifier).update(ChapterSort.uploadDate);
     c.read(mangaChapterSortDirectionProvider.notifier).update(true);
     expect(_names(c), ['alpha', 'Beta', 'Gamma']);
+  });
+
+  test('chapter number sort orders by parsed number, not source order',
+      () async {
+    final c = await _container(chapters);
+    c.read(mangaChapterSortProvider.notifier).update(ChapterSort.chapterNumber);
+    c.read(mangaChapterSortDirectionProvider.notifier).update(true);
+    expect(_names(c), ['Beta', 'Gamma', 'alpha']);
+  });
+
+  group('formattedChapterNumber', () {
+    test('drops trailing zeros and keeps up to 3 decimals', () {
+      expect(_chapter(id: 1, name: '', chapterNumber: 218).formattedChapterNumber, '218');
+      expect(_chapter(id: 1, name: '', chapterNumber: 218.5).formattedChapterNumber, '218.5');
+      expect(_chapter(id: 1, name: '', chapterNumber: 12.345).formattedChapterNumber, '12.345');
+      expect(_chapter(id: 1, name: '', chapterNumber: 0).formattedChapterNumber, '0');
+    });
   });
 }


### PR DESCRIPTION
Adds the missing Komikku chapter-organizer options on manga details:

**Sort** — two new modes alongside By Source / By Upload Date / By Fetched Date:
- **By Chapter Number** — orders by the parsed chapter number instead of the source's listing order.
- **Alphabetically** — case-insensitive sort on the chapter name.

**Display** — a new third tab with **Source title** / **Chapter number** radios. Chapter number mode swaps each row's title for a normalized "Chapter N" (formatted like Komikku: up to 3 decimals, trailing zeros dropped, so 218.0 renders as "Chapter 218").

Details:
- Sort/display preferences are global and persist by enum index, so new `ChapterSort` values are appended after the released ones — existing saved settings are unaffected.
- `List.sort` is unstable, so all sorts tie-break by source order. Without this, a series whose chapter numbers fail to parse (all -1) would shuffle randomly under By Chapter Number; Komikku degrades to source order there via its stable sort, and now we match.
- The previously unused `chapterNumber` l10n string is now used for the number display; its placeholder became a pre-formatted String across all locale arbs.
- Fixes a latent wrong-key fallback in the sort provider (`chapterSortDirection` default read where `chapterSort` was meant).
- Known gap: offline-fallback rows fake `chapterNumber` from `chapterIndex` (the on-device catalog doesn't store real numbers), so number sort/display degrade to source order when offline. Documented in `docs/architecture/manga-details-downloads.md`; needs a schema change to fix properly.

Testing: 7 new unit tests (all sort modes, tie-break stability in both directions, number formatting incl. fractional and unparsed -1); full suite green (983). Verified live in the web build against a real server and on-device via the dev APK.