### PR TITLE
Release notes template: platform order by user share, install lines for every platform

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -10,6 +10,10 @@ A manga and webtoon reader for your [Suwayomi](https://suwayomi.org/) server.
 
 You'll need a running Suwayomi server. See [Getting started](https://tsumiru.app/docs/guides/getting-started).
 
+**Android:** download the universal APK below and open it to install (smaller APKs for specific chip types are also attached).
+
+**Windows:** download the `…-windows-x64.zip` below, extract it anywhere, and run `tsumiru.exe`.
+
 **Linux - Flatpak (recommended, auto-updates):**
 ```sh
 flatpak remote-add --if-not-exists tsumiru https://suwayomi.github.io/Suwayomi-Tsumiru/index.flatpakrepo
@@ -19,8 +23,6 @@ flatpak install tsumiru io.github.aaronbamblett.tsumiru
 
 **Linux - AppImage (portable):** download the `…-linux-x86_64.AppImage` below, mark it executable (`chmod +x`), and run it.
 
-**Android:** grab the universal APK (or a per-ABI build). **Windows / macOS / Web:** attached below.
-
 **iOS (sideload only, advanced):** the `…-ios.ipa` below is **unsigned**, so you can't just download and open it. Apple requires every app to be signed to your own account first, using one of these tools:
 
 - **[SideStore](https://sidestore.io/):** signs and refreshes the app *on-device*, no computer needed after setup. For most people this is the best option.
@@ -28,5 +30,9 @@ flatpak install tsumiru io.github.aaronbamblett.tsumiru
 - **[TrollStore](https://ios.cfw.guide/installing-trollstore/):** permanent install with no expiry, but only works on older iPhones/iOS versions with the required vulnerability.
 
 With SideStore or AltStore the app must be re-signed periodically (the tools automate this). Only TrollStore avoids that. There is no App Store build.
+
+**macOS:** download the `…-macos-x64.zip` below, extract it, and move the app to Applications. If macOS blocks the first launch, approve the app under System Settings → Privacy & Security (Open Anyway).
+
+**Web:** download the `…-web.zip` below and serve its contents with any static web server.
 
 Full docs at [tsumiru.app](https://tsumiru.app/).


### PR DESCRIPTION
Download stats across all releases: Android 54%, Windows 20%, iOS 13%, Web 5%, Linux direct 5% (undercounted, flatpak channel users don't appear in release downloads), macOS 4%.

The Install section previously led with Linux and gave Windows, the second-largest platform, no instructions beyond "attached below". Now:

- Platform order: Android, Windows, Linux (Flatpak + AppImage), iOS, macOS, Web.
- Every platform gets a real install line (Windows: extract and run tsumiru.exe; macOS: includes the Gatekeeper Open Anyway step for the unsigned app; Web: serve the static build).
- Android's per-ABI note reworded in plain language.