### PR TITLE
Add the missing On device badge toggle

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -36,6 +36,8 @@ enum DBKeys {
   scrollAnimation(true),
   showNSFW(true),
   downloadedBadge(false),
+  // On by default: the badge shipped always-on, so off would change behavior.
+  onDeviceBadge(true),
   unreadBadge(true),
   readProgressBar(false),
   languageBadge(false),

--- a/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
+++ b/lib/src/features/library/presentation/library/widgets/library_manga_display.dart
@@ -103,6 +103,12 @@ class LibraryMangaDisplay extends ConsumerWidget {
           tristate: false,
         ),
         CustomCheckboxListTile(
+          title: context.l10n.onDevice,
+          provider: onDeviceBadgeProvider,
+          onChanged: ref.read(onDeviceBadgeProvider.notifier).update,
+          tristate: false,
+        ),
+        CustomCheckboxListTile(
           title: context.l10n.unread,
           provider: unreadBadgeProvider,
           onChanged: ref.read(unreadBadgeProvider.notifier).update,

--- a/lib/src/widgets/manga_cover/providers/manga_cover_providers.dart
+++ b/lib/src/widgets/manga_cover/providers/manga_cover_providers.dart
@@ -19,6 +19,13 @@ class DownloadedBadge extends _$DownloadedBadge
 }
 
 @riverpod
+class OnDeviceBadge extends _$OnDeviceBadge
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.onDeviceBadge);
+}
+
+@riverpod
 class UnreadBadge extends _$UnreadBadge with SharedPreferenceClientMixin<bool> {
   @override
   bool? build() => initialize(DBKeys.unreadBadge);

--- a/lib/src/widgets/manga_cover/widgets/manga_badges.dart
+++ b/lib/src/widgets/manga_cover/widgets/manga_badges.dart
@@ -42,6 +42,7 @@ class MangaBadgesRow extends ConsumerWidget {
     // At least one chapter downloaded to THIS device — a subset of the server.
     // Empty set when the offline feature is off, so the badge self-hides.
     final onDevice = showCountBadges &&
+        ref.watch(onDeviceBadgeProvider).ifNull(true) &&
         (ref.watch(offlineDeviceMangaIdsProvider).value ?? const <int>{})
             .contains(manga.id);
 

--- a/test/src/widgets/manga_cover/on_device_badge_test.dart
+++ b/test/src/widgets/manga_cover/on_device_badge_test.dart
@@ -36,8 +36,12 @@ MangaDto _manga(int id) => Fragment$MangaDto(
       url: '/manga/$id',
     );
 
-Future<Widget> _harness(Set<int> deviceIds, MangaDto manga) async {
-  SharedPreferences.setMockInitialValues({});
+Future<Widget> _harness(
+  Set<int> deviceIds,
+  MangaDto manga, {
+  Map<String, Object> prefValues = const {},
+}) async {
+  SharedPreferences.setMockInitialValues(prefValues);
   final prefs = await SharedPreferences.getInstance();
   return ProviderScope(
     overrides: [
@@ -63,6 +67,17 @@ void main() {
   testWidgets('no badge when the series has nothing on this device',
       (tester) async {
     await tester.pumpWidget(await _harness({7}, _manga(5)));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.offline_pin_rounded), findsNothing);
+  });
+
+  testWidgets('no badge when the On device badge setting is off',
+      (tester) async {
+    await tester.pumpWidget(await _harness(
+      {5},
+      _manga(5),
+      prefValues: {'onDeviceBadge': false},
+    ));
     await tester.pumpAndSettle();
     expect(find.byIcon(Icons.offline_pin_rounded), findsNothing);
   });


### PR DESCRIPTION
The on-device badge (#186) shipped without a checkbox in the library Display sheet — every other badge has one (screenshot in #186 discussion). Adds **On device** under Badges, wired like its siblings, default on so existing behavior is unchanged. Includes a test for the off state.