### PR TITLE
Release v0.9.0

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -1,10 +1,17 @@
 A manga and webtoon reader for your [Suwayomi](https://suwayomi.org/) server.
 
-## What's new in vX.Y.Z
+<!-- Verb-led single-line bullets with no trailing period, each ending with the
+     author's (@handle). Use only the sections that have content. "Fixed X"
+     beats explaining what broke; root-cause detail belongs in the PR, not
+     here. Setting and button names bold and exactly as the app shows them. -->
 
-<!-- Short single-line bullets: what changed or got fixed, from the user's side.
-     "Fixed X" beats explaining what broke; root-cause detail belongs in the PR,
-     not here. Setting and button names exactly as the app shows them. -->
+### ✨ New Features
+
+### ⚙️ Changes
+
+### 🚀 Improvements
+
+### 🧩 Fixes
 
 ## Install
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.8.5+41
+version: 0.9.0+42
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
Version bump to 0.9.0+42 and the Mihon-style release notes template. Everything in this release is merged, tested on device (Android APK, Linux flatpak), and proven across all six platforms by the release dry run.