### PR TITLE
v0.9.1: fix infinity scroll dead-ending at chapter boundaries

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -174,21 +174,18 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // only when the user scrolls TOWARD an edge — never on initial open.
     final lastTop = useRef<({int index, double edge})?>(null);
 
+    // WATCH, not a one-time read: on a cold open the filtered chapter list is
+    // still loading, so a read-once here pinned both neighbours to null for
+    // the whole session (no next/previous chapter ever loaded). Mirrored into
+    // a ref so the once-bound scroll listener below reads the live value.
     final nextPrevChapterPair =
-        useState<({ChapterDto? first, ChapterDto? second})?>(null);
-    useEffect(() {
-      try {
-        nextPrevChapterPair.value = ref.read(
-          getNextAndPreviousChaptersProvider(
-            mangaId: manga.id,
-            chapterId: currentVisibleChapter.value.id,
-          ),
-        );
-      } catch (_) {
-        nextPrevChapterPair.value = null;
-      }
-      return null;
-    }, [currentVisibleChapter.value.id]);
+        useRef<({ChapterDto? first, ChapterDto? second})?>(null);
+    nextPrevChapterPair.value = ref.watch(
+      getNextAndPreviousChaptersProvider(
+        mangaId: manga.id,
+        chapterId: currentVisibleChapter.value.id,
+      ),
+    );
 
     // --- reading-progress recording -------------------------------------
     // Record progress for the CURRENTLY VISIBLE chapter, not the chapter the
@@ -454,10 +451,16 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           InfinityContinuousFeedback.showLoadingNextChapterFeedback(
               context, next.name);
         }
-        final pages =
-            await ref.read(chapterPagesProvider(chapterId: next.id).future);
+        // Timeout so a hung fetch (Riverpod 3 retries a failing provider
+        // while .future waits) releases the loading guard; a failed or null
+        // fetch stays retryable on the next edge gesture instead of latching
+        // "end reached" for the whole session.
+        final pages = await ref
+            .read(chapterPagesProvider(chapterId: next.id).future)
+            .timeout(const Duration(seconds: 15));
         if (pages == null) {
-          hasReachedEnd.value = true;
+          // Drop the cached null so the next gesture refetches.
+          ref.invalidate(chapterPagesProvider(chapterId: next.id));
           return;
         }
         if (loadedRef.value.any((e) => e.chapterId == next.id)) return;
@@ -472,7 +475,9 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
               context, next.name);
         }
       } catch (_) {
-        hasReachedEnd.value = true;
+        // Transient failure — leave unlatched and refetchable so the next
+        // gesture retries.
+        ref.invalidate(chapterPagesProvider(chapterId: next.id));
       } finally {
         loadingNext.value = false;
       }
@@ -487,10 +492,12 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
               context, prev.name);
         }
-        final pages =
-            await ref.read(chapterPagesProvider(chapterId: prev.id).future);
+        // Same timeout/no-latch/refetch treatment as loadNextChapter above.
+        final pages = await ref
+            .read(chapterPagesProvider(chapterId: prev.id).future)
+            .timeout(const Duration(seconds: 15));
         if (pages == null) {
-          hasReachedStart.value = true;
+          ref.invalidate(chapterPagesProvider(chapterId: prev.id));
           return;
         }
         if (loadedRef.value.any((e) => e.chapterId == prev.id)) return;
@@ -539,7 +546,9 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
               context, prev.name);
         }
       } catch (_) {
-        hasReachedStart.value = true;
+        // Transient failure — leave unlatched and refetchable so the next
+        // gesture retries.
+        ref.invalidate(chapterPagesProvider(chapterId: prev.id));
       } finally {
         loadingPrevious.value = false;
       }
@@ -636,10 +645,15 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         }
 
         if (scrollingDown && maxIdx >= total - 2) {
-          final next = nextPrevChapterPair.value?.first;
+          final pair = nextPrevChapterPair.value;
+          final next = pair?.first;
           if (next != null) {
             loadNextChapter(next);
-          } else if (!hasReachedEnd.value) {
+          } else if (pair != null && !hasReachedEnd.value) {
+            // The list resolved and there is genuinely no next chapter — the
+            // only state that may latch the end (a null pair just means the
+            // chapter list hasn't loaded yet).
+            hasReachedEnd.value = true;
             // Only surface the end-of-manga toast once the bottom of the very
             // last page is actually on screen. On long webtoon pages the last
             // page item becomes "visible" (counts toward maxIdx) long before
@@ -656,12 +670,16 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           }
         }
         if (scrollingUp && minIdx <= 0) {
-          final prev = nextPrevChapterPair.value?.second;
+          final pair = nextPrevChapterPair.value;
+          final prev = pair?.second;
           if (prev != null) {
             loadPreviousChapter(prev);
-          } else if (!hasReachedStart.value && readerToastsEnabled()) {
-            InfinityContinuousFeedback.showStartOfMangaFeedback(
-                context, lastStartFeedbackTime);
+          } else if (pair != null && !hasReachedStart.value) {
+            hasReachedStart.value = true;
+            if (readerToastsEnabled()) {
+              InfinityContinuousFeedback.showStartOfMangaFeedback(
+                  context, lastStartFeedbackTime);
+            }
           }
         }
       }
@@ -967,6 +985,36 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       child: positionedList,
     );
 
+    // Pinned at the scroll clamp a drag moves nothing, so the position
+    // listener above never ticks and the direction-gated boundary triggers
+    // can never fire — a resume landing on page 0 was an upward dead-end.
+    // Clamping physics still reports every blocked drag as overscroll, so
+    // treat edge overscroll as the boundary gesture.
+    final edgeAwareList = NotificationListener<OverscrollNotification>(
+      onNotification: (n) {
+        if (isAdjustingScroll.value || programmaticScroll.value) return false;
+        final positions = positionsListener.itemPositions.value;
+        if (positions.isEmpty) return false;
+        var minIdx = positions.first.index;
+        var maxIdx = positions.first.index;
+        for (final p in positions) {
+          if (p.index < minIdx) minIdx = p.index;
+          if (p.index > maxIdx) maxIdx = p.index;
+        }
+        if (n.overscroll < 0 && minIdx <= 0) {
+          final prev = nextPrevChapterPair.value?.second;
+          if (prev != null) loadPreviousChapter(prev);
+        } else if (n.overscroll > 0 &&
+            maxIdx >=
+                InfinityContinuousUtils.getTotalPages(loadedRef.value) - 1) {
+          final next = nextPrevChapterPair.value?.first;
+          if (next != null) loadNextChapter(next);
+        }
+        return false;
+      },
+      child: autoScrollAwareList,
+    );
+
     final child = AppUtils.wrapOn(
       !kIsWeb &&
               (Platform.isAndroid || Platform.isIOS) &&
@@ -982,7 +1030,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
                 child: child,
               )
           : null,
-      autoScrollAwareList,
+      edgeAwareList,
     );
 
     return ReaderWrapper(

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -461,16 +461,22 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           InfinityContinuousFeedback.showLoadingNextChapterFeedback(
               context, next.name);
         }
-        // Timeout so a hung fetch (Riverpod 3 retries a failing provider
-        // while .future waits) releases the loading guard; a failed or null
-        // fetch stays retryable on the next edge gesture instead of latching
-        // "end reached" for the whole session. On timeout the underlying
-        // fetch keeps running and caches its result for the next attempt.
+        // Hold a subscription for the whole fetch: chapterPages is autoDispose
+        // and nothing else listens to the NEIGHBOUR chapter's instance, so
+        // under Riverpod 3 an unheld read gets disposed mid-fetch and its
+        // future never completes (the "loading…" that never loads). The
+        // timeout releases the loading guard; the held fetch finishes and
+        // caches for the next attempt.
+        final sub = ref.listenManual(
+            chapterPagesProvider(chapterId: next.id), (_, __) {});
+        final fetch =
+            ref.read(chapterPagesProvider(chapterId: next.id).future);
+        // Release the hold when the FETCH ends, not when the timeout fires —
+        // a late result must still land in the cache for the next attempt.
+        fetch.whenComplete(sub.close).ignore();
         final ChapterPagesDto? pages;
         try {
-          pages = await ref
-              .read(chapterPagesProvider(chapterId: next.id).future)
-              .timeout(const Duration(seconds: 15));
+          pages = await fetch.timeout(const Duration(seconds: 15));
         } on TimeoutException {
           return;
         }
@@ -508,14 +514,15 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
               context, prev.name);
         }
-        // Same timeout/no-latch treatment as loadNextChapter above. On
-        // timeout the underlying fetch keeps running and caches its result,
-        // so a later attempt picks it up instead of restarting from zero.
+        // Same held-subscription + timeout treatment as loadNextChapter above.
+        final sub = ref.listenManual(
+            chapterPagesProvider(chapterId: prev.id), (_, __) {});
+        final fetch =
+            ref.read(chapterPagesProvider(chapterId: prev.id).future);
+        fetch.whenComplete(sub.close).ignore();
         final ChapterPagesDto? pages;
         try {
-          pages = await ref
-              .read(chapterPagesProvider(chapterId: prev.id).future)
-              .timeout(const Duration(seconds: 15));
+          pages = await fetch.timeout(const Duration(seconds: 15));
         } on TimeoutException {
           return;
         }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -106,6 +106,11 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
   final ReaderMode effectiveReaderMode;
   final bool openAtEnd;
 
+  /// Minimum gap between edge-overscroll boundary attempts. Widget tests
+  /// can't advance wall-clock time, so they shrink this.
+  @visibleForTesting
+  static Duration edgeAttemptCooldown = const Duration(seconds: 4);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // Whether the reader feedback snackbars are enabled (user setting). Read
@@ -173,6 +178,11 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // tick, used to derive scroll direction so neighbour chapters load
     // only when the user scrolls TOWARD an edge — never on initial open.
     final lastTop = useRef<({int index, double edge})?>(null);
+
+    // Edge-overscroll trigger state: deliberate-pull accumulation + cooldown.
+    final edgeOverscrollAccum = useRef<double>(0);
+    final lastEdgeOverscrollAt = useRef<DateTime?>(null);
+    final lastEdgeAttemptAt = useRef<DateTime?>(null);
 
     // WATCH, not a one-time read: on a cold open the filtered chapter list is
     // still loading, so a read-once here pinned both neighbours to null for
@@ -454,10 +464,16 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // Timeout so a hung fetch (Riverpod 3 retries a failing provider
         // while .future waits) releases the loading guard; a failed or null
         // fetch stays retryable on the next edge gesture instead of latching
-        // "end reached" for the whole session.
-        final pages = await ref
-            .read(chapterPagesProvider(chapterId: next.id).future)
-            .timeout(const Duration(seconds: 15));
+        // "end reached" for the whole session. On timeout the underlying
+        // fetch keeps running and caches its result for the next attempt.
+        final ChapterPagesDto? pages;
+        try {
+          pages = await ref
+              .read(chapterPagesProvider(chapterId: next.id).future)
+              .timeout(const Duration(seconds: 15));
+        } on TimeoutException {
+          return;
+        }
         if (pages == null) {
           // Drop the cached null so the next gesture refetches.
           ref.invalidate(chapterPagesProvider(chapterId: next.id));
@@ -492,10 +508,17 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
               context, prev.name);
         }
-        // Same timeout/no-latch/refetch treatment as loadNextChapter above.
-        final pages = await ref
-            .read(chapterPagesProvider(chapterId: prev.id).future)
-            .timeout(const Duration(seconds: 15));
+        // Same timeout/no-latch treatment as loadNextChapter above. On
+        // timeout the underlying fetch keeps running and caches its result,
+        // so a later attempt picks it up instead of restarting from zero.
+        final ChapterPagesDto? pages;
+        try {
+          pages = await ref
+              .read(chapterPagesProvider(chapterId: prev.id).future)
+              .timeout(const Duration(seconds: 15));
+        } on TimeoutException {
+          return;
+        }
         if (pages == null) {
           ref.invalidate(chapterPagesProvider(chapterId: prev.id));
           return;
@@ -989,10 +1012,26 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // listener above never ticks and the direction-gated boundary triggers
     // can never fire — a resume landing on page 0 was an upward dead-end.
     // Clamping physics still reports every blocked drag as overscroll, so
-    // treat edge overscroll as the boundary gesture.
+    // treat edge overscroll as the boundary gesture. Gated on a deliberate
+    // pull (accumulated distance) and a per-attempt cooldown so a failing
+    // fetch retries calmly instead of on every blocked drag pixel.
     final edgeAwareList = NotificationListener<OverscrollNotification>(
       onNotification: (n) {
         if (isAdjustingScroll.value || programmaticScroll.value) return false;
+        final now = DateTime.now();
+        // A pause resets the pull: separate gestures don't add up.
+        if (lastEdgeOverscrollAt.value == null ||
+            now.difference(lastEdgeOverscrollAt.value!) >
+                const Duration(milliseconds: 800)) {
+          edgeOverscrollAccum.value = 0;
+        }
+        lastEdgeOverscrollAt.value = now;
+        edgeOverscrollAccum.value += n.overscroll;
+        if (edgeOverscrollAccum.value.abs() < 48) return false;
+        if (lastEdgeAttemptAt.value != null &&
+            now.difference(lastEdgeAttemptAt.value!) < edgeAttemptCooldown) {
+          return false;
+        }
         final positions = positionsListener.itemPositions.value;
         if (positions.isEmpty) return false;
         var minIdx = positions.first.index;
@@ -1001,14 +1040,22 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           if (p.index < minIdx) minIdx = p.index;
           if (p.index > maxIdx) maxIdx = p.index;
         }
-        if (n.overscroll < 0 && minIdx <= 0) {
+        if (edgeOverscrollAccum.value < 0 && minIdx <= 0) {
           final prev = nextPrevChapterPair.value?.second;
-          if (prev != null) loadPreviousChapter(prev);
-        } else if (n.overscroll > 0 &&
+          if (prev != null) {
+            lastEdgeAttemptAt.value = now;
+            edgeOverscrollAccum.value = 0;
+            loadPreviousChapter(prev);
+          }
+        } else if (edgeOverscrollAccum.value > 0 &&
             maxIdx >=
                 InfinityContinuousUtils.getTotalPages(loadedRef.value) - 1) {
           final next = nextPrevChapterPair.value?.first;
-          if (next != null) loadNextChapter(next);
+          if (next != null) {
+            lastEdgeAttemptAt.value = now;
+            edgeOverscrollAccum.value = 0;
+            loadNextChapter(next);
+          }
         }
         return false;
       },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.9.0+42
+version: 0.9.1+43
 
 environment:
   sdk: ">=3.9.0 <4.0.0"

--- a/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
+++ b/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
@@ -1,0 +1,279 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Regression tests for the v0.9.0 infinity-scroll boundary deadlocks:
+// 1. Resume on page 0 → an upward drag is fully clamped, the position
+//    listener never ticks, and the previous chapter could never load.
+// 2. One failed/null page fetch latched "reached start/end" for the session.
+// 3. A cold open read the next/prev pair once while the chapter list was
+//    still loading, pinning both neighbours to null for the session.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_page/chapter_page_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/reader_screen.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/domain/tracking_settings_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+const _png1x1 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+class _FakeMangaWithId extends MangaWithId {
+  _FakeMangaWithId(this.manga);
+  final MangaDto? manga;
+  @override
+  Future<MangaDto?> build({required int mangaId}) async => manga;
+}
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _FakeTrackerRepository extends TrackerRepository {
+  _FakeTrackerRepository() : super(_dummyClient());
+  @override
+  Future<void> trackProgress(int mangaId) async {}
+}
+
+class _QuietRepo extends Fake implements MangaBookRepository {
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {}
+}
+
+/// Whether the cold-open pair test has "resolved" its chapter list yet.
+class _PairReady extends Notifier<bool> {
+  @override
+  bool build() => false;
+  void set(bool value) => state = value;
+}
+
+final _pairReadyProvider = NotifierProvider<_PairReady, bool>(_PairReady.new);
+
+List<String> _localPages(int count, String tag) {
+  final dir = Directory.systemTemp.createTempSync('tsumiru-scrollback-$tag-');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final bytes = base64Decode(_png1x1);
+  return [
+    for (var i = 0; i < count; i++)
+      (File('${dir.path}/$i.png')..writeAsBytesSync(bytes)).uri.toString(),
+  ];
+}
+
+MangaDto _webtoonManga() => Fragment$MangaDto(
+      id: 1,
+      title: 'Test Webtoon',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 2),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: ReaderMode.webtoon.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 2,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
+
+ChapterDto _chapter({required int id, required int sourceOrder}) =>
+    Fragment$ChapterDto(
+      chapterNumber: sourceOrder.toDouble(),
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: 'Chapter $id',
+      pageCount: 3,
+      sourceOrder: sourceOrder,
+      uploadDate: '0',
+      url: '/chapter/$id',
+      meta: const [],
+    );
+
+ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
+      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+      pages: _localPages(count, 'c$id'),
+    );
+
+/// Pumps the reader open on chapter 2 page 0 (chapter 1 is its previous).
+/// [prevPages] controls what chapterPagesProvider(1) produces per fetch.
+/// [coldOpenPair] gates ch2's next/prev pair behind [_pairReadyProvider].
+Future<void> _pumpReaderOnChapter2(
+  WidgetTester tester, {
+  required ChapterPagesDto? Function() prevPages,
+  bool coldOpenPair = false,
+}) async {
+  tester.view.physicalSize = const Size(800, 1600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  SharedPreferences.setMockInitialValues(const {});
+  final prefs = await SharedPreferences.getInstance();
+
+  final ch1 = _chapter(id: 1, sourceOrder: 1);
+  final ch2 = _chapter(id: 2, sourceOrder: 2);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        mangaBookRepositoryProvider.overrideWithValue(_QuietRepo()),
+        mangaWithIdProvider(mangaId: 1)
+            .overrideWith(() => _FakeMangaWithId(_webtoonManga())),
+        chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
+        chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
+        chapterPagesProvider(chapterId: 1).overrideWith((ref) => prevPages()),
+        chapterPagesProvider(chapterId: 2).overrideWith((ref) => _pages(2, 3)),
+        if (coldOpenPair)
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
+              .overrideWith((ref) => ref.watch(_pairReadyProvider)
+                  ? (first: null, second: ch1)
+                  : null)
+        else
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
+              .overrideWithValue((first: null, second: ch1)),
+        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+            .overrideWithValue((first: ch2, second: null)),
+        trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const ReaderScreen(mangaId: 1, chapterId: 2),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// An upward scroll gesture (drag the content downward) on the reader body.
+Future<void> _dragUp(WidgetTester tester) async {
+  await tester.timedDrag(
+    find.byType(Scrollable).first,
+    const Offset(0, 300),
+    const Duration(milliseconds: 120),
+  );
+  await tester.pumpAndSettle();
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets(
+      'resume at page 0: an upward drag at the clamp loads the previous chapter',
+      (tester) async {
+    var prevFetches = 0;
+    await _pumpReaderOnChapter2(
+      tester,
+      prevPages: () {
+        prevFetches++;
+        return _pages(1, 3);
+      },
+    );
+
+    // No downward movement first — the deadlock precondition.
+    await _dragUp(tester);
+
+    expect(prevFetches, greaterThanOrEqualTo(1),
+        reason: 'blocked upward drag at page 0 never asked for the previous '
+            'chapter (the resume deadlock)');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a failed previous-chapter fetch does not latch for the session',
+      (tester) async {
+    var prevFetches = 0;
+    await _pumpReaderOnChapter2(
+      tester,
+      prevPages: () {
+        prevFetches++;
+        // First fetch fails (returns nothing); later fetches succeed.
+        if (prevFetches == 1) return null;
+        return _pages(1, 3);
+      },
+    );
+
+    // The gesture must retry past the failed fetch instead of latching a
+    // "reached start" state (pre-fix, the count froze at 1 forever).
+    await _dragUp(tester);
+    await _dragUp(tester);
+    expect(prevFetches, greaterThanOrEqualTo(2),
+        reason: 'failed fetch latched the boundary; no retry happened');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'cold open: neighbours resolving after mount still enable the boundary',
+      (tester) async {
+    var prevFetches = 0;
+
+    await _pumpReaderOnChapter2(
+      tester,
+      prevPages: () {
+        prevFetches++;
+        return _pages(1, 3);
+      },
+      // Pair is null (chapter list "still loading") until the switch flips.
+      coldOpenPair: true,
+    );
+
+    // While unresolved, an upward drag can't load anything — and must not latch.
+    await _dragUp(tester);
+    expect(prevFetches, 0);
+
+    // The chapter list "finishes loading".
+    final container = ProviderScope.containerOf(
+        tester.element(find.byType(ReaderScreen)));
+    container.read(_pairReadyProvider.notifier).set(true);
+    await tester.pumpAndSettle();
+
+    // The same gesture now works — the reader watched the pair instead of
+    // reading it once at mount.
+    await _dragUp(tester);
+    expect(prevFetches, greaterThanOrEqualTo(1),
+        reason: 'neighbours resolved after mount were never picked up '
+            '(the cold-open race)');
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
+++ b/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
@@ -30,6 +30,7 @@ import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/reader_screen.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart';
 import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
 import 'package:tsumiru/src/features/tracking/domain/tracking_settings_providers.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
@@ -200,6 +201,16 @@ Future<void> _dragUp(WidgetTester tester) async {
 }
 
 void main() {
+  setUp(() {
+    // Wall-clock time doesn't advance in widget tests; drop the gesture
+    // cooldown so successive drags count as separate attempts.
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown = Duration.zero;
+  });
+  tearDown(() {
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown =
+        const Duration(seconds: 4);
+  });
+
   testWidgets(
       'resume at page 0: an upward drag at the clamp loads the previous chapter',
       (tester) async {

--- a/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
+++ b/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
@@ -11,6 +11,7 @@
 // 3. A cold open read the next/prev pair once while the chapter list was
 //    still loading, pinning both neighbours to null for the session.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -142,7 +143,7 @@ ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
 /// [coldOpenPair] gates ch2's next/prev pair behind [_pairReadyProvider].
 Future<void> _pumpReaderOnChapter2(
   WidgetTester tester, {
-  required ChapterPagesDto? Function() prevPages,
+  required FutureOr<ChapterPagesDto?> Function() prevPages,
   bool coldOpenPair = false,
 }) async {
   tester.view.physicalSize = const Size(800, 1600);
@@ -217,18 +218,33 @@ void main() {
     var prevFetches = 0;
     await _pumpReaderOnChapter2(
       tester,
-      prevPages: () {
+      // Async with a real delay: an unheld autoDispose fetch gets disposed
+      // mid-flight and never completes (the "loading… that never loads").
+      prevPages: () async {
         prevFetches++;
+        await Future<void>.delayed(const Duration(milliseconds: 100));
         return _pages(1, 3);
       },
     );
 
     // No downward movement first — the deadlock precondition.
     await _dragUp(tester);
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
 
     expect(prevFetches, greaterThanOrEqualTo(1),
         reason: 'blocked upward drag at page 0 never asked for the previous '
             'chapter (the resume deadlock)');
+
+    // A second pull must be a no-op: the chapter LOADED, so the engine's
+    // already-loaded guard stops a refetch. If the fetch had been disposed
+    // mid-flight (never completing), this drag would fetch again.
+    await _dragUp(tester);
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+    expect(prevFetches, 1,
+        reason: 'previous chapter never finished loading; the fetch was '
+            'disposed mid-flight and the gesture refetched');
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
Fixes the 0.9.0 regression where infinity scroll dead-ended at chapter boundaries: resume on page 0 could never load the previous chapter (blocked drags produce no scroll movement, and movement was the only trigger), a cold open could pin both neighbours to null for the session (one-time read of an async provider), one failed fetch latched a boundary permanently, and the neighbour-chapter fetch could be disposed mid-flight under Riverpod 3 so it never completed ('loading previous chapter' forever).

Boundary gestures now also fire on deliberate edge overscroll (48px pull, 4s cooldown), the neighbour pair is watched, failures stay retryable, fetches are pinned alive for their duration and time out cleanly.

Three regression tests cover the user-visible deadlocks and fail against the pre-fix reader. Full suite green (987). Verified on-device (Android): the exact scenarios that failed on v0.9.0 now work.