### PR TITLE
Bundle sqlite3 native library on Windows desktop builds

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -177,13 +177,16 @@ jobs:
         run: |
           mkdir -p dist
           APP=$(find build/macos/Build/Products/Release -maxdepth 1 -name "*.app" | head -1)
-          # Guard: the SQLite dylib must be bundled inside the app. Its absence
-          # is the error-126 DB-open crash we shipped on Windows in 0.9.0/0.9.1.
-          if ! find "$APP" -iname '*sqlite3*.dylib' | grep -q .; then
+          # Guard: the SQLite native lib must be bundled inside the app. On macOS
+          # it ships as a code-asset framework (sqlite3.framework), not a loose
+          # dylib. Absence is the error-126 DB-open crash we shipped on Windows
+          # in 0.9.0/0.9.1.
+          sqlite=$(find "$APP" \( -iname '*sqlite3*.dylib' -o -iname 'sqlite3*.framework' \))
+          if [ -z "$sqlite" ]; then
             echo "::error::sqlite3 native library missing from the macOS bundle"
-            find "$APP" -iname '*.dylib'; exit 1
+            find "$APP/Contents/Frameworks" -maxdepth 1 2>/dev/null; exit 1
           fi
-          echo "Bundled SQLite: $(find "$APP" -iname '*sqlite3*.dylib')"
+          echo "Bundled SQLite: $sqlite"
           ditto -c -k --sequesterRsrc --keepParent "$APP" "dist/${pkg_name}-${{ github.ref_name }}-macos-x64.zip"
 
       - name: Package iOS (unsigned IPA)

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -177,6 +177,13 @@ jobs:
         run: |
           mkdir -p dist
           APP=$(find build/macos/Build/Products/Release -maxdepth 1 -name "*.app" | head -1)
+          # Guard: the SQLite dylib must be bundled inside the app. Its absence
+          # is the error-126 DB-open crash we shipped on Windows in 0.9.0/0.9.1.
+          if ! find "$APP" -iname '*sqlite3*.dylib' | grep -q .; then
+            echo "::error::sqlite3 native library missing from the macOS bundle"
+            find "$APP" -iname '*.dylib'; exit 1
+          fi
+          echo "Bundled SQLite: $(find "$APP" -iname '*sqlite3*.dylib')"
           ditto -c -k --sequesterRsrc --keepParent "$APP" "dist/${pkg_name}-${{ github.ref_name }}-macos-x64.zip"
 
       - name: Package iOS (unsigned IPA)
@@ -200,6 +207,15 @@ jobs:
           # paints — a blank white screen — on otherwise-fine PCs.
           $redist = vswhere -latest -find 'VC\Redist\MSVC\*\x64\*\*.dll'
           Copy-Item $redist build\windows\x64\runner\Release\ -Force
+          # Guard: the SQLite native library must be bundled next to the exe.
+          # Its absence was the error-126 DB-open crash in 0.9.0/0.9.1.
+          $sqlite = Get-ChildItem build\windows\x64\runner\Release\ -Filter *.dll |
+            Where-Object { $_.Name -match 'sqlite3' }
+          if (-not $sqlite) {
+            Get-ChildItem build\windows\x64\runner\Release\ | Select-Object Name
+            throw "sqlite3 native library missing from the Windows bundle"
+          }
+          Write-Host "Bundled SQLite: $($sqlite.Name)"
           Compress-Archive -Path build\windows\x64\runner\Release\* -DestinationPath "dist\${env:pkg_name}-${{ github.ref_name }}-windows-x64.zip"
 
       - name: Attach to the draft release

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1572,14 +1572,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0"
-  sqlite3_flutter_libs:
-    dependency: "direct main"
-    description:
-      name: sqlite3_flutter_libs
-      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,7 +71,6 @@ dependencies:
       ref: "4641e83"
   shared_preferences: ^2.0.15
   shimmer: ^3.0.0
-  sqlite3_flutter_libs: ^0.6.0
   url_launcher: ^6.1.6
   web_socket_channel: ^3.0.0
   screen_brightness: ^2.1.11

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -89,6 +89,14 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy native assets (Dart code-assets) into the bundle. sqlite3 3.x ships its
+# own sqlite3.dll this way; without this step the .dll is built but never
+# bundled, so the loader can't find it and the app dies at DB open with
+# "Failed to load dynamic library 'sqlite3.dll'" (error 126). Mirrors linux/.
+install(DIRECTORY "${PROJECT_BUILD_DIR}/native_assets/windows/"
+  DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")


### PR DESCRIPTION
## What
Windows desktop builds crash on launch with `Failed to load dynamic library 'sqlite3.dll'` (error 126), starting in 0.9.0. 

## Why
The sqlite3 3.x migration dropped `sqlite3_flutter_libs` (now a dead end-of-life stub) in favour of sqlite3 3.x's native-assets build hook, which builds and bundles SQLite itself. Native assets is on by default on Flutter stable, so the hook does build `sqlite3.dll` — but `windows/CMakeLists.txt` was missing the install rule that copies code-assets into the bundle, so the DLL was never shipped next to the exe. `linux/CMakeLists.txt` already carries this rule (why Linux/flatpak worked); Windows was simply missed. macOS bundles code-assets via Xcode automatically.

## Changes
- Add the native-assets install rule to `windows/CMakeLists.txt`, mirroring `linux/`.
- Remove the defunct `sqlite3_flutter_libs` stub (step 1 of the official v3 upgrade guide).
- CI: fail the release build if the SQLite native library isn't in the Windows/macOS bundle — a durable guard against this regression class.

## Verification
All-platform dry-run dispatched on this branch; the new CI guard asserts a `sqlite3` native lib is present in the Windows and macOS bundles before packaging.