### PR TITLE
Fix Riverpod-3 disposed-ref crashes and post-migration render regressions

### DIFF
--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -23,7 +23,9 @@ class ReadingHistory extends _$ReadingHistory {
   Future<List<HistoryItemDto>?> build() async {
     final result =
         await ref.watch(historyRepositoryProvider).getReadingHistory();
-    ref.keepAlive();
+    // Guard the post-await ref use: the provider may have been disposed during
+    // the fetch, and keepAlive() on a dead ref throws UnmountedRefException.
+    if (ref.mounted) ref.keepAlive();
     return result?.nodes;
   }
 

--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -30,18 +30,13 @@ class ReadingHistory extends _$ReadingHistory {
   }
 
   Future<void> refresh() async {
-    state = const AsyncLoading();
-
+    // Don't reset to AsyncLoading — that blanks the list to a full-screen
+    // spinner on pull-to-refresh. Keep the current items visible until fresh
+    // data lands (the RefreshIndicator already shows the pull spinner).
     final result = await AsyncValue.guard(
       () => ref.read(historyRepositoryProvider).getReadingHistory(),
     );
-
-    ref.keepAlive();
-    state = result.when(
-      data: (data) => AsyncData(data?.nodes),
-      error: (error, stackTrace) => AsyncError(error, stackTrace),
-      loading: () => const AsyncLoading(),
-    );
+    if (ref.mounted) state = result.whenData((data) => data?.nodes);
   }
 
   Future<void> loadMore() async {
@@ -120,8 +115,7 @@ class MangaReadingHistory extends _$MangaReadingHistory {
           .read(historyRepositoryProvider)
           .getMangaReadingHistory(mangaId: mangaId),
     );
-
-    state = result;
+    if (ref.mounted) state = result;
   }
 }
 

--- a/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
+++ b/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
@@ -22,13 +22,18 @@ part 'edit_category_controller.g.dart';
 class CategoryController extends _$CategoryController {
   @override
   Future<List<CategoryDto>?> build() async {
+    // Capture every ref-backed dependency BEFORE the await. This provider
+    // auto-disposes and can be torn down mid-build (e.g. add-to-library reading
+    // .future), after which any ref access throws "used after it has been
+    // disposed" — the crash this guards against.
     final offlineDb = ref.watch(offlineReadDatabaseProvider);
+    final categoryRepository = ref.watch(categoryRepositoryProvider);
+    final sync = ref.read(offlineSyncProvider);
     final result = await categoriesWithOfflineFallback(
-      fetch: () => ref.watch(categoryRepositoryProvider).getCategoryList(),
+      fetch: () => categoryRepository.getCategoryList(),
       db: offlineDb,
       offlineEnabled: offlineDb != null,
     );
-    final sync = ref.read(offlineSyncProvider);
     if (sync != null && result != null) {
       unawaited(sync.syncCategories(result));
     }

--- a/lib/src/features/library/presentation/library/controller/library_manga_list.dart
+++ b/lib/src/features/library/presentation/library/controller/library_manga_list.dart
@@ -20,10 +20,13 @@ part 'library_manga_list.g.dart';
 @riverpod
 Future<List<MangaDto>?> libraryMangaList(Ref ref) async {
   final offlineDb = ref.watch(offlineReadDatabaseProvider);
-  // Captured before the await; the keepAlive notifier outlives this provider.
+  final categoryRepository = ref.watch(categoryRepositoryProvider);
+  // Captured before the await; touching ref after the async gap throws if this
+  // provider was disposed mid-build. The keepAlive notifier outlives it.
   final reachability = ref.read(serverUnreachableProvider.notifier);
+  final sync = ref.read(offlineSyncProvider);
   final list = await libraryWithOfflineFallback(
-    fetch: () => ref.watch(categoryRepositoryProvider).getAllLibraryMangas(),
+    fetch: () => categoryRepository.getAllLibraryMangas(),
     // Only read the native-only DB when offline is available (never on web).
     db: offlineDb,
     offlineEnabled: offlineDb != null,
@@ -36,7 +39,6 @@ Future<List<MangaDto>?> libraryMangaList(Ref ref) async {
       } catch (_) {}
     }),
   );
-  final sync = ref.read(offlineSyncProvider);
   if (sync != null && list != null) {
     for (final manga in list) {
       unawaited(sync.syncManga(manga));

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -30,6 +30,9 @@ part 'manga_details_controller.g.dart';
 class MangaWithId extends _$MangaWithId {
   @override
   Future<MangaDto?> build({required int mangaId}) async {
+    // Read before the await: touching ref after the async gap throws if this
+    // provider was disposed mid-build.
+    final sync = ref.read(offlineSyncProvider);
     final manga = await mangaWithOfflineFallback(
       fetch: () =>
           ref.watch(mangaBookRepositoryProvider).getManga(mangaId: mangaId),
@@ -39,8 +42,7 @@ class MangaWithId extends _$MangaWithId {
     );
     // Don't mirror browsed (non-library) manga into the offline catalog.
     if (manga != null && manga.inLibrary) {
-      unawaited(
-          ref.read(offlineSyncProvider)?.syncManga(manga) ?? Future.value());
+      unawaited(sync?.syncManga(manga) ?? Future.value());
     }
     return manga;
   }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -40,6 +40,9 @@ class MangaWithId extends _$MangaWithId {
       offlineEnabled: ref.watch(offlineActiveProvider),
       mangaId: mangaId,
     );
+    // Keep this cached like its sibling MangaChapterList so revisiting details
+    // doesn't refetch. Guarded: keepAlive on a disposed ref throws.
+    if (ref.mounted) ref.keepAlive();
     // Don't mirror browsed (non-library) manga into the offline catalog.
     if (manga != null && manga.inLibrary) {
       unawaited(sync?.syncManga(manga) ?? Future.value());
@@ -63,6 +66,9 @@ class MangaChapterList extends _$MangaChapterList {
     // scrape (getChapterList) also populates the manga's description/metadata
     // server-side, so afterwards we refresh MangaWithId to pick it up (#363).
     var didSourceFetch = false;
+    // Read before the await: touching ref after the async gap throws if this
+    // provider was disposed mid-build.
+    final sync = ref.read(offlineSyncProvider);
     final result = await chaptersWithOfflineFallback(
       fetch: () async {
         // Read the chapters the server already has stored (like the WebUI).
@@ -88,10 +94,9 @@ class MangaChapterList extends _$MangaChapterList {
       offlineEnabled: ref.watch(offlineActiveProvider),
       mangaId: mangaId,
     );
-    ref.keepAlive();
+    if (ref.mounted) ref.keepAlive();
     if (result != null) {
-      unawaited((ref.read(offlineSyncProvider)?.syncChapters(result) ??
-              Future.value())
+      unawaited((sync?.syncChapters(result) ?? Future.value())
           .then((_) => reconcileManga(ref, mangaId)));
     }
     if (didSourceFetch) {
@@ -101,8 +106,9 @@ class MangaChapterList extends _$MangaChapterList {
       // details screen shows the metadata on first open instead of only after a
       // manual refresh (#363). Deferred past this build so we don't invalidate a
       // provider mid-build.
-      Future.microtask(
-          () => ref.invalidate(mangaWithIdProvider(mangaId: mangaId)));
+      Future.microtask(() {
+        if (ref.mounted) ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
+      });
     }
     return result;
   }
@@ -140,32 +146,33 @@ class MangaChapterList extends _$MangaChapterList {
           offlineEnabled: offlineDb != null,
           mangaId: mangaId,
         ));
-    ref.keepAlive();
-    if (result.hasError) {
-      state = result.copyWithPrevious(state);
-    } else {
-      state = result;
-      final chapters = result.value;
-      if (chapters != null) {
-        // Mirror build(): down-sync the fresh list (which orphans chapters the
-        // server no longer lists) then reconcile to evict them — so a
-        // server-side delete discovered via pull-to-refresh is cleaned up too,
-        // not only on a cold provider rebuild.
-        unawaited((ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
-                Future.value())
-            .then((_) => reconcileManga(ref, mangaId)));
-      }
+    if (ref.mounted) ref.keepAlive();
+    // On a refresh failure keep the current chapters visible instead of
+    // overwriting the list with an errored state (drops the internal
+    // copyWithPrevious API the analyzer flagged).
+    if (result.hasError) return;
+    state = result;
+    final chapters = result.value;
+    if (chapters != null) {
+      // Mirror build(): down-sync the fresh list (which orphans chapters the
+      // server no longer lists) then reconcile to evict them — so a
+      // server-side delete discovered via pull-to-refresh is cleaned up too,
+      // not only on a cold provider rebuild.
+      unawaited((ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
+              Future.value())
+          .then((_) => reconcileManga(ref, mangaId)));
     }
   }
 
   void updateChapter(int index, ChapterDto chapter) {
-    try {
-      final newList = [...?state.value];
-      newList[index] = chapter;
-      state = AsyncData<List<ChapterDto>?>(newList).copyWithPrevious(state);
-    } catch (e) {
-      //
-    }
+    // Explicit bounds check instead of a bare try/catch that silently dropped
+    // the edit (and dropped the internal copyWithPrevious API the analyzer
+    // flagged). A no-op when the list isn't loaded / index is stale.
+    final current = state.value;
+    if (current == null || index < 0 || index >= current.length) return;
+    final newList = [...current];
+    newList[index] = chapter;
+    state = AsyncData<List<ChapterDto>?>(newList);
   }
 }
 

--- a/lib/src/features/manga_book/presentation/upcoming/controller/upcoming_controller.dart
+++ b/lib/src/features/manga_book/presentation/upcoming/controller/upcoming_controller.dart
@@ -76,8 +76,10 @@ Future<List<MangaDto>> upcomingLibraryMangas(Ref ref) async {
 /// once. Reuses the same [predictNextUpdate] the manga-details estimate uses.
 @riverpod
 Future<UpcomingData> upcoming(Ref ref) async {
-  final mangas = await ref.watch(upcomingLibraryMangasProvider.future);
+  // Read before the await: this provider auto-disposes and touching ref after
+  // the async gap throws UnmountedRefException.
   final client = ref.watch(graphQlClientProvider);
+  final mangas = await ref.watch(upcomingLibraryMangasProvider.future);
   final now = DateTime.now();
 
   final entries = <({MangaDto manga, DateTime date})>[];

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -191,13 +191,16 @@ class OfflineServerMismatch {
 Future<OfflineServerMismatch?> offlineServerMismatch(Ref ref) async {
   if (!ref.watch(offlineEnabledProvider)) return null;
   final preferences = ref.watch(sharedPreferencesProvider);
+  // Read before the await: touching ref after the async gap throws if this
+  // provider was disposed mid-build.
+  final catalogDb = ref.watch(offlineDatabaseProvider);
   final stamp = preferences.getString(DBKeys.offlineCatalogServerId.name);
   final current = await ref.watch(serverInstanceIdProvider.future);
   if (stamp == null || stamp == current) return null;
-  if (!await ref.watch(offlineDatabaseProvider).hasCatalogData()) {
+  if (!await catalogDb.hasCatalogData()) {
     await preferences.setString(DBKeys.offlineCatalogServerId.name, current);
     await preferences.remove(DBKeys.offlineServerMismatchDismissedList.name);
-    ref.invalidate(offlineActiveProvider);
+    if (ref.mounted) ref.invalidate(offlineActiveProvider);
     return null;
   }
   final key = serverMismatchKey(stamp, current);

--- a/lib/src/features/tracking/presentation/hub/track_sheet.dart
+++ b/lib/src/features/tracking/presentation/hub/track_sheet.dart
@@ -70,8 +70,9 @@ class TrackSheetContent extends ConsumerWidget {
       );
     }
 
-    // Show a spinner while loading.
-    if (trackersAsync.isLoading || recordsAsync.isLoading) {
+    // Spinner only on the initial load (no data yet). A reload/retry keeps the
+    // current content visible instead of flashing a spinner over it.
+    if (!trackersAsync.hasValue || !recordsAsync.hasValue) {
       return const SizedBox(
         height: 200,
         child: Center(child: CircularProgressIndicator()),

--- a/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
@@ -77,6 +77,10 @@ extension AsyncValueExtensions<T> on AsyncValue<T> {
 
   AsyncValue<U> copyWithData<U>(U Function(T) data) => when(
         skipError: true,
+        // Keep showing mapped stale data while an upstream dependency reloads,
+        // instead of collapsing the whole derived chain to a full-screen spinner
+        // (stale-while-revalidate on Sources / Extensions / global search).
+        skipLoadingOnReload: true,
         data: (prev) => AsyncData(data(prev)),
         error: (error, stackTrace) => AsyncError<U>(error, stackTrace),
         loading: () => AsyncLoading<U>(),

--- a/lib/src/utils/hooks/debounced_hook.dart
+++ b/lib/src/utils/hooks/debounced_hook.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+/// Returns [value], but only propagates a change after [value] has stayed the
+/// same for [delay]. Initialized to the first [value] (unlike flutter_hooks'
+/// `useDebounced`, which starts null). While [value] keeps changing (e.g.
+/// dragging a desktop window resize), it holds the previous settled value — so a
+/// consumer keyed on it (like an image's decode resolution) doesn't churn every
+/// frame.
+T useSettled<T>(T value, Duration delay) {
+  final settled = useState<T>(value);
+  useEffect(() {
+    if (value == settled.value) return null;
+    final timer = Timer(delay, () => settled.value = value);
+    return timer.cancel;
+  }, [value]);
+  return settled.value;
+}

--- a/lib/src/widgets/server_image.dart
+++ b/lib/src/widgets/server_image.dart
@@ -25,6 +25,7 @@ import '../features/settings/presentation/server/widget/client/server_url_tile/s
 import '../features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
 import '../global_providers/global_providers.dart';
 import '../utils/extensions/custom_extensions.dart';
+import '../utils/hooks/debounced_hook.dart';
 import '../utils/misc/app_utils.dart';
 import 'custom_circular_progress_indicator.dart';
 
@@ -79,20 +80,30 @@ class ServerImage extends HookConsumerWidget {
   /// instead of the source's native resolution. Returns [base] unchanged when
   /// no cap is set. Used for the offline/crop provider paths; the network path
   /// takes memCache* directly on [CachedNetworkImage].
-  ImageProvider _capDecode(ImageProvider base) =>
-      (memCacheWidth == null && memCacheHeight == null)
+  ImageProvider _capDecode(ImageProvider base, int? width, int? height) =>
+      (width == null && height == null)
           ? base
-          : ResizeImage(base, width: memCacheWidth, height: memCacheHeight);
+          : ResizeImage(base, width: width, height: height);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final key = useState(UniqueKey());
+    // Debounce the decode resolution. Reader modes tie memCache* to the window
+    // size; a desktop window resize changes it every frame, which would evict
+    // and re-decode the page each frame — flashing its placeholder ("black")
+    // until the drag stops. Holding the last decode size lets the current bitmap
+    // stretch smoothly, then re-decodes once when the size settles. Static
+    // memCache* (thumbnails/covers) never changes, so this is a no-op there.
+    final int? cacheWidth =
+        useSettled(memCacheWidth, const Duration(milliseconds: 250));
+    final int? cacheHeight =
+        useSettled(memCacheHeight, const Duration(milliseconds: 250));
 
     // Renders a crop provider through the same imageBuilder/wrapper contract as
     // the normal paths (imageBuilder fires immediately with the provider, like
     // the offline branch; consumers show the frame once it decodes).
     Widget renderCrop(ImageProvider rawProvider) {
-      final provider = _capDecode(rawProvider);
+      final provider = _capDecode(rawProvider, cacheWidth, cacheHeight);
       if (imageBuilder != null) {
         return AppUtils.wrapOn(wrapper, imageBuilder!(context, provider));
       }
@@ -131,7 +142,8 @@ class ServerImage extends HookConsumerWidget {
           localPath: localPath,
         ));
       }
-      final ImageProvider provider = _capDecode(offlineImageProvider(localPath));
+      final ImageProvider provider =
+          _capDecode(offlineImageProvider(localPath), cacheWidth, cacheHeight);
       if (imageBuilder != null) {
         return AppUtils.wrapOn(wrapper, imageBuilder!(context, provider));
       }
@@ -304,7 +316,7 @@ class ServerImage extends HookConsumerWidget {
     final imageBuilderCapped = imageBuilder == null
         ? null
         : (BuildContext ctx, ImageProvider provider) =>
-            imageBuilder!(ctx, _capDecode(provider));
+            imageBuilder!(ctx, _capDecode(provider, cacheWidth, cacheHeight));
 
     return CachedNetworkImage(
       key: key.value,
@@ -315,8 +327,8 @@ class ServerImage extends HookConsumerWidget {
       httpHeaders: httpHeaders,
       width: size?.width,
       fit: fit ?? BoxFit.cover,
-      memCacheWidth: imageBuilder == null ? memCacheWidth : null,
-      memCacheHeight: imageBuilder == null ? memCacheHeight : null,
+      memCacheWidth: imageBuilder == null ? cacheWidth : null,
+      memCacheHeight: imageBuilder == null ? cacheHeight : null,
       imageRenderMethodForWeb: renderMethod,
       progressIndicatorBuilder: finalProgressIndicatorBuilder,
       imageBuilder: imageBuilderCapped,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 0.9.1+43
+version: 0.9.2+44
 
 environment:
   sdk: ">=3.9.0 <4.0.0"

--- a/test/library/category_controller_disposal_test.dart
+++ b/test/library/category_controller_disposal_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Regression guard for the "Cannot use the Ref of categoryControllerProvider
+// after it has been disposed" crash: opening a manga and adding it to the
+// library reads categoryControllerProvider.future, which starts an async build
+// that the auto-dispose then tears down mid-flight. If build() touches ref
+// after its await, Riverpod throws. This exercises the REAL build() (not an
+// overridden stub) with a disposal in the middle.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/library/data/category_repository.dart';
+import 'package:tsumiru/src/features/library/domain/category/category_model.dart';
+import 'package:tsumiru/src/features/library/presentation/category/controller/edit_category_controller.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+/// getCategoryList() completes only when the test says so, holding
+/// CategoryController.build() suspended at its await.
+class _PendingCategoryRepo extends CategoryRepository {
+  _PendingCategoryRepo(this.completer) : super(_dummyClient());
+  final Completer<List<CategoryDto>?> completer;
+  @override
+  Future<List<CategoryDto>?> getCategoryList() => completer.future;
+}
+
+void main() {
+  test('build() disposed mid-fetch does not use ref after disposal', () async {
+    final fetch = Completer<List<CategoryDto>?>();
+    final errors = <Object>[];
+
+    // The disposed-ref crash surfaces through Flutter's error handler (the red
+    // overlay), not as an uncaught async error — capture both to be safe.
+    final prevOnError = FlutterError.onError;
+    FlutterError.onError = (details) => errors.add(details.exception);
+    addTearDown(() => FlutterError.onError = prevOnError);
+
+    await runZonedGuarded(() async {
+      final container = ProviderContainer(overrides: [
+        categoryRepositoryProvider
+            .overrideWithValue(_PendingCategoryRepo(fetch)),
+        offlineReadDatabaseProvider.overrideWithValue(null),
+        offlineSyncProvider.overrideWithValue(null),
+      ]);
+      addTearDown(container.dispose);
+
+      // Mirror add-to-library: read .future with NO retained listener, so this
+      // auto-dispose provider can be torn down while its build is still pending.
+      final future = container.read(categoryControllerProvider.future);
+      await Future<void>.delayed(Duration.zero);
+      // Fully dispose the pending build (no listener → no rebuild).
+      container.invalidate(categoryControllerProvider);
+
+      // Resume the disposed build past its await. On the buggy version this is
+      // where ref.read(offlineSyncProvider) hits a dead ref and throws.
+      fetch.complete(const <CategoryDto>[]);
+      try {
+        await future;
+      } catch (e) {
+        errors.add(e);
+      }
+      await Future<void>.delayed(Duration.zero);
+    }, (error, _) => errors.add(error));
+
+    final disposedRefUse =
+        errors.where((e) => e.toString().contains('after it has been disposed'));
+    expect(disposedRefUse, isEmpty,
+        reason: 'build() used ref after the provider was disposed: $errors');
+  });
+}

--- a/test/utils/copy_with_data_stale_test.dart
+++ b/test/utils/copy_with_data_stale_test.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Regression guard for stale-while-revalidate: a derived provider built with
+// `.copyWithData` must keep showing the mapped previous value while its upstream
+// reloads, instead of collapsing to a bare loading (which blanked Sources /
+// Extensions / global search to a full-screen spinner on every reload).
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/utils/extensions/custom_extensions.dart';
+
+class _Source {
+  Completer<int> completer = Completer<int>();
+}
+
+class _Trigger extends Notifier<int> {
+  @override
+  int build() => 0;
+  void bump() => state++;
+}
+
+final _source = _Source();
+final _trigger = NotifierProvider<_Trigger, int>(_Trigger.new);
+final _upstream = FutureProvider.autoDispose<int>((ref) {
+  // Depend on _trigger so bumping it forces a RELOAD (isReloading) — the case
+  // skipLoadingOnReload governs, distinct from an invalidate-driven refresh.
+  ref.watch(_trigger);
+  return _source.completer.future;
+});
+final _derived = Provider.autoDispose<AsyncValue<String>>(
+    (ref) => ref.watch(_upstream).copyWithData((v) => 'mapped:$v'));
+
+void main() {
+  test('copyWithData keeps stale mapped data while the upstream reloads', () async {
+    _source.completer = Completer<int>();
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final sub = container.listen(_derived, (_, __) {});
+
+    // Initial load resolves to 1.
+    _source.completer.complete(1);
+    await container.read(_upstream.future);
+    expect(container.read(_derived).value, 'mapped:1');
+
+    // Reload via a DEPENDENCY change (not invalidate) with a fresh pending fetch.
+    _source.completer = Completer<int>();
+    container.read(_trigger.notifier).bump();
+    await Future<void>.delayed(Duration.zero);
+
+    // DURING the reload the derived value must still expose the stale mapped
+    // value — not a bare loading with no value (the bug).
+    final duringReload = container.read(_derived);
+    expect(duringReload.hasValue, isTrue,
+        reason: 'stale value must survive an upstream reload');
+    expect(duringReload.value, 'mapped:1');
+
+    // Reload completes with the new value.
+    _source.completer.complete(2);
+    await container.read(_upstream.future);
+    expect(container.read(_derived).value, 'mapped:2');
+    sub.close();
+  });
+}


### PR DESCRIPTION
## What
Fixes the "Cannot use the Ref of X after it has been disposed" (`UnmountedRefException`) crash — most visibly, the app crashing when adding a manga to the library — plus the same-class crashes in five more providers, a batch of silent post-migration render regressions, and a desktop reader resize glitch.

## Crashes (UnmountedRefException)
The Riverpod-3 migration left providers using `ref` after an `await` in an auto-dispose `build()`. When the provider is torn down mid-build, the resumed build touches a dead `ref` and throws. Fixed by hoisting `ref` reads before the await (or guarding post-await side effects with `ref.mounted`):
- `categoryControllerProvider` (add-to-library) — the reported crash
- library list, manga details (`MangaWithId` + `MangaChapterList`), upcoming, offline server-mismatch, history

## Render regressions (silent, from an audit sweep)
- **Stale-while-revalidate:** `copyWithData` dropped the previous value on reload, blanking Sources / Extensions / global search to a full spinner. Now keeps the mapped stale data (`skipLoadingOnReload`). History pull-to-refresh and the tracking sheet had the same local bug.
- **`MangaWithId`** is now `keepAlive` like its sibling, so revisiting details doesn't refetch.
- **`updateChapter`** swallowed a range error silently and used the internal `copyWithPrevious` API; now bounds-checked and public-API only.

## Reader resize flicker (desktop)
Pages decode at the window's on-screen width to cap GPU cost (#196); on desktop that width changes every frame while dragging a window resize, so the shared image widget re-decoded each frame and flashed its placeholder. Debounced the decode resolution in `ServerImage` — the one widget every reader mode renders through — so the current bitmap stretches smoothly during the drag, then re-decodes once when it settles. Covers webtoon, continuous, and paged; a no-op for static thumbnails/covers.

## Tests
Regression tests for the shapes the suite never exercised: provider **disposed mid-build** (reproduces the crash) and **reload preserves stale data**. Full suite green (989).