### PR TITLE
Respect the Default Reading Mode; ship right-to-left as the default

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -24,7 +24,7 @@ enum DBKeys {
   authType(AuthType.none),
   basicCredentials(null),
   authUsername(null),
-  readerMode(ReaderMode.webtoon),
+  readerMode(ReaderMode.singleHorizontalRTL),
   readerPadding(0.0),
   readerMagnifierSize(1.0),
   readerNavigationLayout(ReaderNavigationLayout.disabled),

--- a/lib/src/features/manga_book/presentation/reader/controller/auto_webtoon.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/auto_webtoon.dart
@@ -12,32 +12,27 @@ import '../../../../../constants/enum.dart';
 enum _MangaType { manga, manhwa, manhua, comic, webtoon }
 
 /// The reader mode a Default-mode series should open in, from its type — or
-/// null when the type carries no reliable signal (fall through to the user's
-/// global default).
+/// null when the type carries no opinion (fall through to the user's default).
 ///
-/// - webtoon / manhwa / manhua → continuous webtoon (Komikku parity).
-/// - manga → single-page right-to-left, but **only on a positive `manga` tag**.
-///   `_MangaType.manga` is also the classifier's fallback for untagged /
-///   unrecognised series, and most modern manhwa land there — e.g. Asura Scans,
-///   whose source isn't in Komikku's lists and whose entries carry only content
-///   genres (Action/Fantasy/…). Mapping the whole bucket to RTL flipped every
-///   such webtoon to right-to-left (and fit-to-screen zoomed the tall pages
-///   out). So we trust only an explicit manga tag; the untagged fallback stays
-///   null → the user's default (Komikku likewise leaves this bucket at default).
-/// - comic → null (western comics vary; fall through to the default).
+/// Verbatim parity with Komikku's `defaultReaderType`: auto-detect only ever
+/// rescues long-strip content to the webtoon viewer (reading a tall strip as
+/// fixed pages is broken, not a taste call). It never picks a page *direction*
+/// — LTR vs RTL is pure preference and stays with the user's default.
+///
+/// - webtoon / manhwa / manhua → continuous webtoon.
+/// - manga / comic → null → the user's global (or per-series) default. Manga
+///   opens right-to-left by shipping RTL as the factory default, not by a
+///   detection rule that would override anyone who set LTR.
 ReaderMode? autoReaderModeFor({
   required List<String>? genres,
   String? sourceName,
 }) {
-  final tags = genres ?? const [];
-  return switch (_mangaType(tags, sourceName)) {
+  return switch (_mangaType(genres ?? const [], sourceName)) {
     _MangaType.webtoon ||
     _MangaType.manhwa ||
     _MangaType.manhua =>
       ReaderMode.webtoon,
-    _MangaType.manga =>
-      tags.any(_isMangaTag) ? ReaderMode.singleHorizontalRTL : null,
-    _MangaType.comic => null,
+    _MangaType.manga || _MangaType.comic => null,
   };
 }
 

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -69,11 +69,11 @@ class ReaderScreen extends HookConsumerWidget {
         offlineEnabled ? ref.watch(offlineDatabaseProvider) : null;
     final mangaBookRepository = ref.watch(mangaBookRepositoryProvider);
 
-    // Auto reading mode: a Default-mode series opens in the reader its type
-    // implies (webtoon scroll for manhwa/webtoon, right-to-left paged for
-    // manga) THIS session; never written to meta. Null when auto-detect is off,
-    // the series has an explicit per-series mode, or the type carries no
-    // opinion — in which case the per-series/global default takes over below.
+    // Auto reading mode: a Default-mode long-strip series (manhwa/manhua/
+    // webtoon) opens in webtoon scroll THIS session; never written to meta.
+    // Null when auto-detect is off, the series has an explicit per-series mode,
+    // or it isn't long-strip — in which case the per-series/global default
+    // takes over below. Auto never picks a page direction (LTR/RTL).
     final mangaData = manga.value;
     final autoReaderMode = (ref.watch(autoWebtoonModeProvider).ifNull(true) &&
             mangaData != null &&
@@ -403,7 +403,7 @@ class ReaderScreen extends HookConsumerWidget {
                             openAtEnd: openAtEnd,
                           ),
                         ReaderMode.defaultReader || null => switch (
-                              defaultReaderMode ?? ReaderMode.webtoon) {
+                              defaultReaderMode ?? ReaderMode.singleHorizontalRTL) {
                             ReaderMode.singleHorizontalLTR ||
                             ReaderMode.continuousHorizontalLTR =>
                               MultiChapterPagedReaderMode(

--- a/lib/src/features/manga_book/presentation/reader/utils/last_page_swipe_utils.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/last_page_swipe_utils.dart
@@ -54,7 +54,7 @@ class LastPageSwipeUtils {
   }) {
     if (mangaReaderMode == null ||
         mangaReaderMode == ReaderMode.defaultReader) {
-      return defaultReaderMode ?? ReaderMode.webtoon;
+      return defaultReaderMode ?? ReaderMode.singleHorizontalRTL;
     }
     return mangaReaderMode;
   }

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/reading_mode_tab.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/reading_mode_tab.dart
@@ -41,7 +41,7 @@ class ReadingModeTab extends ConsumerWidget {
     final model = ref.read(readerSettingsModelProvider(mangaId).notifier);
     // "Default" dereferences the app-wide mode, mirroring reader_screen.
     final resolvedMode = settings.readerMode == ReaderMode.defaultReader
-        ? (ref.watch(readerModeKeyProvider) ?? ReaderMode.webtoon)
+        ? (ref.watch(readerModeKeyProvider) ?? ReaderMode.singleHorizontalRTL)
         : settings.readerMode;
     final isLongStrip = switch (resolvedMode) {
       ReaderMode.webtoon ||

--- a/lib/src/features/settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart
@@ -40,7 +40,7 @@ class ReaderModeTile extends ConsumerWidget {
           title: context.l10n.readerMode,
           optionList: ReaderMode.values.sublist(1),
           getOptionTitle: (value) => value.toLocale(context),
-          value: readerMode ?? ReaderMode.webtoon,
+          value: readerMode ?? ReaderMode.singleHorizontalRTL,
           onChange: (enumValue) async {
             ref.read(readerModeKeyProvider.notifier).update(enumValue);
             if (context.mounted) Navigator.pop(context);

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1406,7 +1406,7 @@
     "splitWidePages": "Split wide pages",
     "alwaysShowChapterTransition": "Always show chapter transition",
     "autoWebtoonMode": "Auto reading mode",
-    "autoWebtoonModeSubtitle": "Pick the reading mode from the series type — webtoon scroll for manhwa/webtoons, right-to-left paged for manga",
+    "autoWebtoonModeSubtitle": "Open manhwa, manhua, and webtoons in webtoon scroll mode. Everything else keeps your default reading mode.",
     "backgroundColorAuto": "Auto",
     "backgroundColorBlack": "Black",
     "backgroundColorGray": "Gray",

--- a/test/manga_book/reader/auto_reader_mode_test.dart
+++ b/test/manga_book/reader/auto_reader_mode_test.dart
@@ -10,14 +10,14 @@ import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/a
 
 // Pins both the reader-mode mapping AND the underlying manga-type detection
 // (tag precedence, source-name lists, Cyrillic variants, substring matching).
-// Mapping: webtoon-family → webtoon; manga (incl. the fallback bucket) → RTL;
-// comic → null (fall through to the user's default).
+// Mapping (Komikku `defaultReaderType` parity): webtoon-family → webtoon;
+// manga and comic → null (fall through to the user's default). Auto-detect
+// never picks a page direction — RTL for manga comes from the factory default.
 void main() {
   group('autoReaderModeFor', () {
     ReaderMode? resolve({List<String>? genres, String? sourceName}) =>
         autoReaderModeFor(genres: genres, sourceName: sourceName);
 
-    const rtl = ReaderMode.singleHorizontalRTL;
     const webtoon = ReaderMode.webtoon;
 
     group('webtoon family → webtoon (scroll)', () {
@@ -59,22 +59,27 @@ void main() {
       });
     });
 
-    group('manga → single-page right-to-left, only on a positive manga tag', () {
-      test('explicit manga tag', () {
-        expect(resolve(genres: ['Manga']), rtl);
+    group('manga → null (never forces a direction; user default wins)', () {
+      // A manga tag is still a manga tag — but auto-detect deliberately has no
+      // opinion on LTR vs RTL. It returns null so the user's Default Reading
+      // Mode is honoured (RTL by default, LTR if they chose it).
+      test('explicit manga tag → null', () {
+        expect(resolve(genres: ['Manga']), isNull);
       });
 
-      test('manga tag beats a manhwa tag / webtoon source (precedence)', () {
-        expect(resolve(genres: ['Manhwa', 'Manga']), rtl);
-        expect(resolve(genres: ['Manga'], sourceName: 'Toonily'), rtl);
+      test('manga tag beats a manhwa tag / webtoon source, still → null', () {
+        // Precedence still lands on the manga bucket (not webtoon), so no
+        // webtoon override — it just falls through to the default.
+        expect(resolve(genres: ['Manhwa', 'Manga']), isNull);
+        expect(resolve(genres: ['Manga'], sourceName: 'Toonily'), isNull);
       });
 
-      test('Cyrillic манга tag wins precedence', () {
-        expect(resolve(genres: ['Манга', 'Манхва']), rtl);
+      test('Cyrillic манга tag → null', () {
+        expect(resolve(genres: ['Манга', 'Манхва']), isNull);
       });
     });
 
-    group('no reliable signal → null (respect the user default, not RTL)', () {
+    group('no reliable signal → null (respect the user default)', () {
       test('untagged / null genres', () {
         expect(resolve(genres: null), isNull);
         expect(resolve(genres: const [], sourceName: null), isNull);
@@ -82,7 +87,7 @@ void main() {
 
       test('content genres only, genuinely unknown source → null', () {
         // A source we don't recognise, with no type tag, has no reliable
-        // signal — it must fall to the user's default, NOT be forced to RTL.
+        // signal — it must fall to the user's default.
         expect(
           resolve(
             genres: ['Action', 'Adventure', 'Fantasy'],


### PR DESCRIPTION
Fixes the reader always opening manga right-to-left even when the Default Reading Mode is set to left-to-right.

## The problem

"Auto reading mode" (on by default) was forcing any `manga`-tagged series to `singleHorizontalRTL`, overriding the user's Default Reading Mode. A reader who set left-to-right still had their manga open right-to-left.

## The fix

Match Komikku's `defaultReaderType` exactly: auto-detect only switches long-strip content (manhwa, manhua, webtoon) into webtoon scroll, and never picks a page direction. Manga and comics fall through to the user's default. Page direction now comes from one place only — the global Default Reading Mode.

Ship that default as single-page right-to-left out of the box, matching Mihon/Komikku, so manga opens RTL through the honest default rather than an override that fights anyone who prefers LTR. The Asura Scans source detection is kept.

## Compatibility

Existing users are unaffected: reader-mode preferences persist by enum index and only the default *value* changed, so any saved choice is preserved. Only installs that never set a Default Reading Mode see the new right-to-left default (previously webtoon).

## Verification

- Matches the reference behavior 1:1 (Komikku `MangaType.kt` / `ReaderViewModel.getMangaReadingMode`).
- Full test suite passes (989); `autoReaderModeFor` unit tests updated to pin the new mapping.
- Verified end-to-end against a live server: with the default set to LTR a manga opens paged left-to-right; with no saved default it opens right-to-left.

Closes #234
