### PR TITLE
Bulk-select add-to-library from source browse

### DIFF
--- a/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_display_view.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_display_view.dart
@@ -5,21 +5,23 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
 import '../../../../../constants/db_keys.dart';
 import '../../../../../constants/enum.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../widgets/selection_action_bar.dart';
 import '../../../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
-import '../../../../offline/data/offline_download_providers.dart';
 import '../../../domain/source/source_model.dart';
 import '../controller/source_manga_controller.dart';
 import 'source_manga_grid_view.dart';
 import 'source_manga_list_view.dart';
 
-class SourceMangaDisplayView extends ConsumerWidget {
+class SourceMangaDisplayView extends HookConsumerWidget {
   const SourceMangaDisplayView({
     super.key,
     required this.controller,
@@ -32,58 +34,64 @@ class SourceMangaDisplayView extends ConsumerWidget {
   final SourceDto? source;
   final String sourceId;
   final SourceType sourceType;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final DisplayMode displayMode = ref.watch(sourceDisplayModeProvider) ??
         DBKeys.sourceDisplayMode.initial;
-    toggleFavorite(MangaDto item) async {
-      if (item.inLibrary.ifNull()) {
-        bool removeManga = false;
-        await showDialog(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: item.title.isNotBlank ? Text(item.title) : null,
-            content: Text(
-              context.l10n.removeFromLibrary,
-              style: context.textTheme.bodyLarge,
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: Text(context.l10n.cancel),
-              ),
-              ElevatedButton(
-                onPressed: () async {
-                  Navigator.pop(context);
-                  removeManga = true;
-                },
-                child: Text(context.l10n.remove),
-              ),
-            ],
-          ),
-        );
-        return removeManga
-            ? await AsyncValue.guard(
-                () => removeMangaFromLibraryAndPurge(ref, item.id))
-            : null;
-      } else {
-        return AsyncValue.guard(() =>
-            ref.read(mangaBookRepositoryProvider).addMangaToLibrary(item.id));
+
+    // Multi-select: long-press a cover to start selecting, tap to add/remove,
+    // then bulk-add the whole selection to the library. Mirrors the library
+    // grid's selection model.
+    final selection = useState<Set<int>>(const {});
+    final selecting = selection.value.isNotEmpty;
+
+    void toggleSelection(int id) {
+      final next = {...selection.value};
+      next.contains(id) ? next.remove(id) : next.add(id);
+      selection.value = next;
+    }
+
+    Future<void> addSelectionToLibrary() async {
+      final ids = selection.value.toList();
+      if (ids.isEmpty) return;
+      selection.value = const {};
+      final result = await AsyncValue.guard(
+        () => ref.read(mangaBookRepositoryProvider).addMangasToLibrary(ids),
+      );
+      if (result is AsyncError) return;
+      // Reflect the new library membership on the already-loaded covers.
+      final items = [...?controller.itemList];
+      final idSet = ids.toSet();
+      for (var i = 0; i < items.length; i++) {
+        if (idSet.contains(items[i].id)) {
+          items[i] = items[i].copyWith(inLibrary: true);
+        }
+      }
+      controller.itemList = items;
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text('Added ${ids.length} to library'),
+        ));
       }
     }
 
-    return switch (displayMode) {
+    final display = switch (displayMode) {
       DisplayMode.grid => SourceMangaGridView(
           sourceId: sourceId,
           sourceType: sourceType,
           controller: controller,
           source: source,
-          toggleFavorite: toggleFavorite,
+          selectedIds: selection.value,
+          selecting: selecting,
+          onToggleSelection: toggleSelection,
         ),
       DisplayMode.list || DisplayMode.descriptiveList => SourceMangaListView(
           controller: controller,
           source: source,
-          toggleFavorite: toggleFavorite,
+          selectedIds: selection.value,
+          selecting: selecting,
+          onToggleSelection: toggleSelection,
         ),
       // comfortableGrid isn't offered in the source display picker; map it to
       // the grid so the exhaustive switch stays safe.
@@ -94,8 +102,57 @@ class SourceMangaDisplayView extends ConsumerWidget {
           sourceType: sourceType,
           controller: controller,
           source: source,
-          toggleFavorite: toggleFavorite,
+          selectedIds: selection.value,
+          selecting: selecting,
+          onToggleSelection: toggleSelection,
         ),
     };
+
+    // While selecting, swallow the system back to clear the selection first,
+    // and float the action bar over the grid.
+    return PopScope(
+      canPop: !selecting,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) selection.value = const {};
+      },
+      child: Stack(
+        children: [
+          display,
+          if (selecting)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: SelectionActionBar(
+                clearsSystemNav: true,
+                leading: [
+                  IconButton(
+                    tooltip: 'Clear',
+                    icon: const Icon(Icons.close_rounded),
+                    onPressed: () => selection.value = const {},
+                  ),
+                  Text('${selection.value.length}',
+                      style: context.textTheme.titleMedium),
+                ],
+                actions: [
+                  IconButton(
+                    tooltip: 'Select all',
+                    icon: const Icon(Icons.select_all_rounded),
+                    onPressed: () => selection.value = {
+                      for (final m in controller.itemList ?? const <MangaDto>[])
+                        m.id,
+                    },
+                  ),
+                  IconButton(
+                    tooltip: context.l10n.addToLibrary,
+                    icon: const Icon(Icons.favorite_rounded),
+                    onPressed: addSelectionToLibrary,
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_grid_view.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_grid_view.dart
@@ -14,7 +14,6 @@ import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../widgets/custom_circular_progress_indicator.dart';
 import '../../../../../widgets/emoticons.dart';
 import '../../../../../widgets/manga_cover/grid/manga_cover_grid_tile.dart';
-import '../../../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
 import '../../../../settings/presentation/appearance/widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
 import '../../../domain/source/source_model.dart';
@@ -22,17 +21,21 @@ import '../../../domain/source/source_model.dart';
 class SourceMangaGridView extends ConsumerWidget {
   const SourceMangaGridView({
     super.key,
-    required this.toggleFavorite,
     required this.controller,
     required this.sourceId,
     required this.sourceType,
+    required this.selectedIds,
+    required this.selecting,
+    required this.onToggleSelection,
     this.source,
   });
-  final Future<AsyncValue?> Function(MangaDto) toggleFavorite;
   final PagingController<int, MangaDto> controller;
   final SourceDto? source;
   final String sourceId;
   final SourceType sourceType;
+  final Set<int> selectedIds;
+  final bool selecting;
+  final void Function(int mangaId) onToggleSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -59,17 +62,12 @@ class SourceMangaGridView extends ConsumerWidget {
         ),
         itemBuilder: (context, item, index) => MangaCoverGridTile(
           manga: item,
+          selected: selectedIds.contains(item.id),
           showDarkOverlay: item.inLibrary.ifNull(),
-          onLongPress: () async {
-            final value = await toggleFavorite(item);
-            if (value == null) return;
-            if (value is! AsyncError) {
-              final items = [...?controller.itemList];
-              items[index] = item.copyWith(inLibrary: !item.inLibrary.ifNull());
-              controller.itemList = items;
-            }
-          },
-          onPressed: () => MangaRoute(mangaId: item.id).push(context),
+          onLongPress: () => onToggleSelection(item.id),
+          onPressed: () => selecting
+              ? onToggleSelection(item.id)
+              : MangaRoute(mangaId: item.id).push(context),
         ),
       ),
       gridDelegate: mangaCoverGridDelegate(ref.watch(gridMinWidthProvider)),

--- a/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_list_view.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_list_view.dart
@@ -15,20 +15,23 @@ import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../widgets/custom_circular_progress_indicator.dart';
 import '../../../../../widgets/emoticons.dart';
 import '../../../../../widgets/manga_cover/list/manga_cover_list_tile.dart';
-import '../../../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
 import '../../../domain/source/source_model.dart';
 
 class SourceMangaListView extends ConsumerWidget {
   const SourceMangaListView({
     super.key,
-    required this.toggleFavorite,
     required this.controller,
+    required this.selectedIds,
+    required this.selecting,
+    required this.onToggleSelection,
     this.source,
   });
-  final Future<AsyncValue?> Function(MangaDto) toggleFavorite;
   final PagingController<int, MangaDto> controller;
   final SourceDto? source;
+  final Set<int> selectedIds;
+  final bool selecting;
+  final void Function(int mangaId) onToggleSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -81,19 +84,13 @@ class SourceMangaListView extends ConsumerWidget {
         ),
         itemBuilder: (context, item, index) => MangaCoverListTile(
           manga: item,
-          onLongPress: () async {
-            final value = await toggleFavorite(item);
-            if (value == null) return;
-            if (value is! AsyncError) {
-              final items = [...?controller.itemList];
-              items[index] = item.copyWith(inLibrary: !item.inLibrary.ifNull());
-              controller.itemList = items;
-            }
-          },
-          onPressed: () {
-            MangaRoute(mangaId: item.id).push(context);
-          },
+          selected: selectedIds.contains(item.id),
+          onLongPress: () => onToggleSelection(item.id),
+          onPressed: () => selecting
+              ? onToggleSelection(item.id)
+              : MangaRoute(mangaId: item.id).push(context),
         ),
+
       ),
     );
   }

--- a/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
+++ b/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
@@ -37,6 +37,20 @@ class MangaBookRepository {
       )
       .getData((data) => data.updateManga?.manga);
 
+  /// Add many series to the library in one request (bulk favorite from browse).
+  Future<void> addMangasToLibrary(List<int> mangaIds) => client
+      .mutate$UpdateMangas(
+        Options$Mutation$UpdateMangas(
+          variables: Variables$Mutation$UpdateMangas(
+            input: Input$UpdateMangasInput(
+              ids: mangaIds,
+              patch: Input$UpdateMangaPatchInput(inLibrary: true),
+            ),
+          ),
+        ),
+      )
+      .getData((data) => null);
+
   Future<void> removeMangaFromLibrary(int mangaId) => client
       .mutate$UpdateManga(
         Options$Mutation$UpdateManga(

--- a/lib/src/features/manga_book/data/manga_book/query.graphql
+++ b/lib/src/features/manga_book/data/manga_book/query.graphql
@@ -40,6 +40,14 @@ mutation UpdateMangasCategories($input: UpdateMangasCategoriesInput!) {
   }
 }
 
+mutation UpdateMangas($input: UpdateMangasInput!) {
+  updateMangas(input: $input) {
+    mangas {
+      id
+    }
+  }
+}
+
 query GetChapter($id: Int!) {
   chapter(id: $id) {
     ...ChapterDto


### PR DESCRIPTION
Browsing a source you could only add series one at a time.

Add a selection mode to the source grid and list — long-press to start, tap to add or remove — with a floating bar to add the whole selection to the library in one batched request (wires the server's `updateMangas(inLibrary)` mutation). It mirrors the library's existing multi-select model, so long-press now enters selection instead of toggling a single favorite.

Scope is the source browse screen (and in-source search, which shares the same grid). Verified end-to-end against a live server — selecting several and adding committed them to the library in one call; full suite green.

Closes #127
