### PR TITLE
Add a Sources filter screen to hide sources

### DIFF
--- a/docs/architecture/browse-sources-extensions.md
+++ b/docs/architecture/browse-sources-extensions.md
@@ -24,6 +24,7 @@ All `typedef`s over GraphQL codegen (except `Language`, which is `freezed`): `Ex
 
 - **Extensions:** grouped into update/installed/by-language; NSFW-gated; language allowlist persisted (`DBKeys.extensionLanguageFilter`). Install via `UpdateExtension` or file upload (`InstallExternalExtension`).
 - **Sources:** grouped lastUsed/all/by-language/localSource; tapping saves `sourceLastUsedProvider` and navigates to `SourceTypeRoute(POPULAR)`.
+- **Hide sources:** the Sources filter screen (`SourceFilterRoute`, tune action) toggles per-source visibility. Hidden state persists as the `tsumiru_isHidden` source meta key (sibling to pinning's `webUI_isPinned`), so it syncs across devices. `browsableSourceListProvider` strips hidden sources from browse/global-search/migration; the filter screen reads pre-hide `allSourcesByLanguageProvider` so hidden sources stay listable.
 - **Source browsing:** `infinite_scroll_pagination` `PagingController<int, MangaDto>` (`firstPageKey: 1`); POPULAR/LATEST/SEARCH chips; filter drawer (end-drawer tablet / bottom-sheet phone) rendered via exhaustive `switch` in `filter_to_widget.dart`.
 - **Global search:** `quickSearchResultsProvider(query)` fans out `sourceQuickSearchMangaListProvider(sourceId, query)` across filtered sources, all wrapped in `rateLimitQueueProvider(query)`.
 

--- a/lib/src/features/browse_center/data/source_repository/source_repository.dart
+++ b/lib/src/features/browse_center/data/source_repository/source_repository.dart
@@ -98,6 +98,24 @@ class SourceRepository {
         ),
       )
       .getData((data) => data.setSourceMeta?.meta);
+
+  /// Hides/unhides a source from the browse list by writing the
+  /// `tsumiru_isHidden` server meta key (syncs across Tsumiru devices).
+  Future<void> setSourceHidden(String sourceId, bool hidden) => ferryClient
+      .mutate$SetSourceMeta(
+        Options$Mutation$SetSourceMeta(
+          variables: Variables$Mutation$SetSourceMeta(
+            input: Input$SetSourceMetaInput(
+              meta: Input$SourceMetaTypeInput(
+                sourceId: sourceId,
+                key: kSourceHiddenMetaKey,
+                value: hidden ? 'true' : 'false',
+              ),
+            ),
+          ),
+        ),
+      )
+      .getData((data) => data.setSourceMeta?.meta);
 }
 
 @riverpod

--- a/lib/src/features/browse_center/domain/language/flag_emoji.dart
+++ b/lib/src/features/browse_center/domain/language/flag_emoji.dart
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Direct port of Komikku's tachiyomi-presentation-core FlagEmoji so the
+// Sources filter screen shows the same per-language flags. Maps a source
+// language code to a country, then to the two regional-indicator symbols that
+// render as a flag emoji. Falls back to the globe (🌎) for unknown languages.
+
+/// Regional indicators run from U+1F1E6 (A) to U+1F1FF (Z).
+String _regionalIndicator(String char) {
+  final upper = char.toUpperCase().codeUnitAt(0);
+  return String.fromCharCode(0x1F1E6 + (upper - 0x41));
+}
+
+String _countryToFlag(String countryCode) {
+  final code = countryCode.toUpperCase();
+  return _regionalIndicator(code[0]) + _regionalIndicator(code[1]);
+}
+
+/// Language code -> country code. Keys and lookups are lower-cased so Tsumiru's
+/// lower-case source langs (`pt-br`, `zh-hans`) match Komikku's cased entries.
+const Map<String, String> _lang2Country = {
+  'all': 'un',
+  'af': 'za',
+  'am': 'et',
+  'ar': 'eg',
+  'az': 'az',
+  'be': 'by',
+  'bg': 'bg',
+  'bn': 'bd',
+  'br': 'fr',
+  'bs': 'ba',
+  'ca': 'es',
+  'ceb': 'ph',
+  'cn': 'cn',
+  'co': 'es',
+  'cs': 'cz',
+  'da': 'dk',
+  'de': 'de',
+  'el': 'gr',
+  'en': 'us',
+  'es-419': 'mx',
+  'es': 'es',
+  'et': 'ee',
+  'eu': 'es',
+  'fa': 'ir',
+  'fi': 'fi',
+  'fil': 'ph',
+  'fo': 'fo',
+  'fr': 'fr',
+  'ga': 'ie',
+  'gn': 'py',
+  'gu': 'in',
+  'ha': 'ng',
+  'he': 'il',
+  'hi': 'in',
+  'hr': 'hr',
+  'ht': 'ht',
+  'hu': 'hu',
+  'hy': 'am',
+  'id': 'id',
+  'ig': 'ng',
+  'is': 'is',
+  'it': 'it',
+  'ja': 'jp',
+  'jv': 'id',
+  'ka': 'ge',
+  'kk': 'kz',
+  'km': 'kh',
+  'kn': 'in',
+  'ko': 'kr',
+  'kr': 'ng',
+  'ku': 'iq',
+  'ky': 'kg',
+  'lb': 'lu',
+  'lmo': 'it',
+  'lo': 'la',
+  'lt': 'lt',
+  'lv': 'lv',
+  'mg': 'mg',
+  'mi': 'nz',
+  'mk': 'mk',
+  'ml': 'in',
+  'mn': 'mn',
+  'mo': 'md',
+  'mr': 'in',
+  'ms': 'my',
+  'mt': 'mt',
+  'my': 'mm',
+  'ne': 'np',
+  'nl': 'nl',
+  'no': 'no',
+  'ny': 'mw',
+  'pl': 'pl',
+  'ps': 'af',
+  'pt-br': 'br',
+  'pt-pt': 'pt',
+  'pt': 'pt',
+  'rm': 'ch',
+  'ro': 'ro',
+  'ru': 'ru',
+  'sd': 'pk',
+  'sh': 'hr',
+  'si': 'lk',
+  'sk': 'sk',
+  'sl': 'si',
+  'sm': 'ws',
+  'sn': 'zw',
+  'so': 'so',
+  'sq': 'al',
+  'sr': 'hr',
+  'st': 'ls',
+  'sv': 'se',
+  'sw': 'tz',
+  'ta': 'in',
+  'te': 'in',
+  'tg': 'tj',
+  'th': 'th',
+  'ti': 'er',
+  'tk': 'tm',
+  'tl': 'ph',
+  'to': 'to',
+  'tr': 'tr',
+  'uk': 'ua',
+  'ur': 'pk',
+  'uz': 'uz',
+  'vec': 'it',
+  'vi': 'vn',
+  'yo': 'ng',
+  'zh-hans': 'cn',
+  'zh-hant': 'tw',
+  'zh': 'cn',
+  'zu': 'za',
+  'gl': 'es',
+  'in': 'id',
+  'nb-no': 'no',
+  'nn': 'no',
+  'sc': 'it',
+  'sdh': 'ir',
+  'sah': 'ru',
+  'cv': 'ru',
+  'sa': 'in',
+  'ka-ge': 'ge',
+  'zh-cn': 'cn',
+  'zh-tw': 'tw',
+};
+
+/// The flag emoji for a source language code (🌎 when unknown).
+String flagEmojiForLang(String lang) {
+  final country = _lang2Country[lang.toLowerCase()];
+  return country != null ? _countryToFlag(country) : '\u{1F30E}';
+}

--- a/lib/src/features/browse_center/domain/source/source_model.dart
+++ b/lib/src/features/browse_center/domain/source/source_model.dart
@@ -25,11 +25,20 @@ typedef SourceType = Enum$FetchSourceMangaType;
 /// string "true"/"false".
 const kSourcePinnedMetaKey = 'webUI_isPinned';
 
+/// Server meta key marking a source hidden from the browse list. Tsumiru-owned
+/// (WebUI has no hide concept), so it syncs across Tsumiru devices via the
+/// server but is ignored by WebUI. Sibling to [kSourcePinnedMetaKey]; value is
+/// the plain string "true"/"false".
+const kSourceHiddenMetaKey = 'tsumiru_isHidden';
+
 extension SourceExtensions on SourceDto {
   Language? get language => LanguageJsonConverter.fromJson(lang);
 
   bool get isPinned =>
       meta.any((m) => m.key == kSourcePinnedMetaKey && m.value == 'true');
+
+  bool get isHidden =>
+      meta.any((m) => m.key == kSourceHiddenMetaKey && m.value == 'true');
 }
 
 extension SourceMangaTypeExtension on SourceType {

--- a/lib/src/features/browse_center/presentation/browse/browse_screen.dart
+++ b/lib/src/features/browse_center/presentation/browse/browse_screen.dart
@@ -49,12 +49,18 @@ class BrowseScreen extends HookConsumerWidget {
       appBar: AppBar(
         title: Text(context.l10n.browse),
         actions: [
-          if (tabController.index == 0)
+          if (tabController.index == 0) ...[
             IconButton(
               tooltip: context.l10n.globalSearch,
               onPressed: () => const GlobalSearchRoute().push(context),
               icon: const Icon(Icons.travel_explore_rounded),
             ),
+            IconButton(
+              tooltip: context.l10n.filterSources,
+              onPressed: () => const SourceFilterRoute().push(context),
+              icon: const Icon(Icons.filter_list_rounded),
+            ),
+          ],
           if (tabController.index == 1) ...[
             IconButton(
               tooltip: context.l10n.extensionRepository,

--- a/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
+++ b/lib/src/features/browse_center/presentation/source/controller/source_controller.dart
@@ -35,6 +35,17 @@ AsyncValue<List<SourceDto>?> visibleSourceList(Ref ref) {
       );
 }
 
+/// [visibleSourceList] with user-hidden sources removed. Every browse-facing
+/// list (grouped map, pinned section, global search, migration) derives from
+/// this, so hiding a source drops it everywhere. The Sources filter screen
+/// deliberately reads [visibleSourceList] instead, so hidden sources stay
+/// visible there to be un-hidden.
+@riverpod
+AsyncValue<List<SourceDto>?> browsableSourceList(Ref ref) =>
+    ref.watch(visibleSourceListProvider).copyWithData(
+          (list) => list == null ? list : [...list.where((e) => !e.isHidden)],
+        );
+
 int _byName(SourceDto a, SourceDto b) =>
     a.name.toLowerCase().compareTo(b.name.toLowerCase());
 
@@ -72,14 +83,47 @@ Map<String, List<SourceDto>> groupSourcesByLanguage(
 /// language filter.
 @riverpod
 List<SourceDto> pinnedSources(Ref ref) => pinnedSourcesFrom(
-    ref.watch(visibleSourceListProvider).value ?? const []);
+    ref.watch(browsableSourceListProvider).value ?? const []);
 
 @riverpod
 AsyncValue<Map<String, List<SourceDto>>> sourceMap(Ref ref) {
-  final sourceListData = ref.watch(visibleSourceListProvider);
+  final sourceListData = ref.watch(browsableSourceListProvider);
   final sourceLastUsed = ref.watch(sourceLastUsedProvider);
   return sourceListData.copyWithData(
     (data) => groupSourcesByLanguage(data ?? const [], sourceLastUsed),
+  );
+}
+
+/// Pure: group EVERY source by language code (pinned and hidden included, no
+/// last-used bucket), alphabetically by name. Backs the Sources filter screen
+/// where each source is toggled hidden/shown. Exposed for testing.
+Map<String, List<SourceDto>> groupAllSourcesByLanguage(
+  List<SourceDto> sources,
+) {
+  final sourceMap = <String, List<SourceDto>>{};
+  for (final e in sources) {
+    sourceMap.update(
+      e.language?.code ?? "other",
+      (value) => [...value, e],
+      ifAbsent: () => [e],
+    );
+  }
+  // Komikku within-language order: shown sources before hidden, then by name.
+  for (final list in sourceMap.values) {
+    list.sort((a, b) => a.isHidden == b.isHidden
+        ? _byName(a, b)
+        : (a.isHidden ? 1 : -1));
+  }
+  return sourceMap;
+}
+
+/// All sources grouped by language for the Sources filter screen. Reads the
+/// pre-hide [visibleSourceList] so hidden sources remain listed (to un-hide).
+@riverpod
+AsyncValue<Map<String, List<SourceDto>>> allSourcesByLanguage(Ref ref) {
+  final sourceListData = ref.watch(visibleSourceListProvider);
+  return sourceListData.copyWithData(
+    (data) => groupAllSourcesByLanguage(data ?? const []),
   );
 }
 

--- a/lib/src/features/browse_center/presentation/source/source_filter_screen.dart
+++ b/lib/src/features/browse_center/presentation/source/source_filter_screen.dart
@@ -1,0 +1,242 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../constants/app_sizes.dart';
+import '../../../../constants/language_list.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../utils/misc/toast/toast.dart';
+import '../../../../widgets/emoticons.dart';
+import '../../../../widgets/server_image.dart';
+import '../../data/source_repository/source_repository.dart';
+import '../../domain/language/flag_emoji.dart';
+import '../../domain/source/source_model.dart';
+import 'controller/source_controller.dart';
+
+/// 1:1 port of Komikku's SourcesFilterScreen: every language is a toggle
+/// (enables/disables it in browse), each enabled language has an "All Sources"
+/// toggle plus per-source checkboxes. Language state is [SourceLanguageFilter];
+/// per-source hide state is the `tsumiru_isHidden` server meta.
+class SourceFilterScreen extends HookConsumerWidget {
+  const SourceFilterScreen({super.key});
+
+  void _toggleLanguage(WidgetRef ref, String code, bool enable) {
+    final notifier = ref.read(sourceLanguageFilterProvider.notifier);
+    if (enable) {
+      notifier.updateWithPreviousState((prev) => {...?prev, code}.toList());
+    } else {
+      notifier
+          .updateWithPreviousState((prev) => [...?prev]..remove(code));
+    }
+  }
+
+  Future<void> _setHidden(
+    WidgetRef ref,
+    BuildContext context,
+    List<String> sourceIds, {
+    required bool hidden,
+  }) async {
+    try {
+      final repo = ref.read(sourceRepositoryProvider);
+      await Future.wait(sourceIds.map((id) => repo.setSourceHidden(id, hidden)));
+      ref.invalidate(sourceListProvider);
+    } catch (e) {
+      if (context.mounted) ref.read(toastProvider)?.showError(e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sourceMapData = ref.watch(allSourcesByLanguageProvider);
+    final enabledLangs = ref.watch(sourceLanguageFilterProvider);
+
+    refresh() => ref.refresh(sourceListProvider.future);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(context.l10n.sources)),
+      body: sourceMapData.showUiWhenData(
+        context,
+        (data) {
+          final sourceMap = {...data};
+          // The local source isn't listed on Komikku's filter screen (it's
+          // always available); Browse surfaces it in its own bucket.
+          sourceMap.remove('localsourcelang');
+          // Komikku's GetLanguagesWithSources ordering: enabled languages
+          // first, then alphabetical — so the languages you actually use float
+          // to the top above the disabled ones.
+          bool isEnabled(String c) => enabledLangs?.contains(c) ?? false;
+          final languages = sourceMap.keys.toList()
+            ..sort((a, b) {
+              final ae = isEnabled(a), be = isEnabled(b);
+              return ae == be ? a.compareTo(b) : (ae ? -1 : 1);
+            });
+
+          if (languages.isEmpty) {
+            return Emoticons(
+              title: context.l10n.noSourcesFound,
+              button: TextButton(
+                onPressed: refresh,
+                child: Text(context.l10n.refresh),
+              ),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: refresh,
+            child: CustomScrollView(
+              slivers: [
+                for (final lang in languages) ...[
+                  SliverToBoxAdapter(
+                    child: _LanguageToggle(
+                      langCode: lang,
+                      enabled: enabledLangs?.contains(lang) ?? false,
+                      onChanged: (value) => _toggleLanguage(ref, lang, value),
+                    ),
+                  ),
+                  if (enabledLangs?.contains(lang) ?? false) ...[
+                    SliverToBoxAdapter(
+                      child: _AllSourcesToggle(
+                        langCode: lang,
+                        sources: sourceMap[lang]!,
+                        onToggleAll: (hidden) => _setHidden(
+                          ref,
+                          context,
+                          [for (final s in sourceMap[lang]!) s.id],
+                          hidden: hidden,
+                        ),
+                      ),
+                    ),
+                    SliverList(
+                      delegate: SliverChildBuilderDelegate(
+                        (context, index) {
+                          final source = sourceMap[lang]![index];
+                          return _SourceCheckItem(
+                            source: source,
+                            onToggle: () => _setHidden(
+                              ref,
+                              context,
+                              [source.id],
+                              hidden: !source.isHidden,
+                            ),
+                          );
+                        },
+                        childCount: sourceMap[lang]!.length,
+                      ),
+                    ),
+                  ],
+                ],
+              ],
+            ),
+          );
+        },
+        refresh: refresh,
+      ),
+    );
+  }
+}
+
+/// Komikku's SourcesFilterHeader: `native (name flag)` with a switch that
+/// enables/disables the whole language.
+class _LanguageToggle extends StatelessWidget {
+  const _LanguageToggle({
+    required this.langCode,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final String langCode;
+  final bool enabled;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final lang = languageMap[langCode];
+    final native = lang?.nativeName ?? lang?.name ?? langCode;
+    final name = lang?.name ?? langCode;
+    final flag = flagEmojiForLang(langCode);
+    final title = langCode == 'all' || langCode == 'other'
+        ? '$native ($flag)'
+        : '$native ($name $flag)';
+    return SwitchListTile(
+      value: enabled,
+      onChanged: onChanged,
+      title: Text(title),
+    );
+  }
+}
+
+/// Komikku's SourcesFilterToggle: `All Sources (flag)` — enables/disables
+/// every source in the language at once. On when none are hidden.
+class _AllSourcesToggle extends StatelessWidget {
+  const _AllSourcesToggle({
+    required this.langCode,
+    required this.sources,
+    required this.onToggleAll,
+  });
+
+  final String langCode;
+  final List<SourceDto> sources;
+  final ValueChanged<bool> onToggleAll;
+
+  @override
+  Widget build(BuildContext context) {
+    final allShown = sources.every((s) => !s.isHidden);
+    return SwitchListTile(
+      value: allShown,
+      // On -> hide all; off/partial -> show all.
+      onChanged: (_) => onToggleAll(allShown),
+      title: Text('${context.l10n.allSources} (${flagEmojiForLang(langCode)})'),
+    );
+  }
+}
+
+/// Komikku's SourcesFilterItem: source icon, name, `flag lang 18+` subtitle,
+/// and a trailing checkbox (checked = shown).
+class _SourceCheckItem extends StatelessWidget {
+  const _SourceCheckItem({required this.source, required this.onToggle});
+
+  final SourceDto source;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final langName = source.language?.name ?? source.language?.displayName;
+    return ListTile(
+      onTap: onToggle,
+      leading: ClipRRect(
+        borderRadius: KBorderRadius.r8.radius,
+        child: ServerImage(
+          imageUrl: source.iconUrl,
+          size: const Size.square(40),
+        ),
+      ),
+      title: Text(source.name),
+      subtitle: Row(
+        children: [
+          Flexible(
+            child: Text(
+              '${flagEmojiForLang(source.lang)} ${langName ?? source.lang}',
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (source.isNsfw.ifNull()) ...[
+            const SizedBox(width: 8),
+            Text(
+              context.l10n.nsfw18,
+              style: TextStyle(color: context.theme.colorScheme.error),
+            ),
+          ],
+        ],
+      ),
+      trailing: Checkbox(
+        value: !source.isHidden,
+        onChanged: (_) => onToggle(),
+      ),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1958,6 +1958,8 @@
     "pinnedSources": "Pinned sources",
     "hasResults": "Has results",
     "pinSource": "Pin source",
+    "filterSources": "Filter sources",
+    "allSources": "All Sources",
     "pinchToZoom": "Pinch to Zoom",
     "doubleTapToZoom": "Double tap to zoom",
     "disableZoomOut": "Disable zoom out",

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -11,6 +11,7 @@ import '../features/browse_center/domain/source/source_model.dart';
 import '../features/browse_center/presentation/browse/browse_screen.dart';
 import '../features/browse_center/presentation/extension/extension_screen.dart';
 import '../features/browse_center/presentation/global_search/global_search_screen.dart';
+import '../features/browse_center/presentation/source/source_filter_screen.dart';
 import '../features/browse_center/presentation/source/source_screen.dart';
 import '../features/browse_center/presentation/source_manga_list/source_manga_list_screen.dart';
 import '../features/browse_center/presentation/source_preference/source_preference_screen.dart';
@@ -83,6 +84,7 @@ abstract class Routes {
 
   static const extensionRoute = '/extension';
   static const source = '/source';
+  static const sourceFilter = '/source-filter';
   static const sourceManga = ':sourceId';
   static const sourceMangaType = '$sourceManga/:sourceType';
   static const sourcePreference = '$sourceManga/preference';
@@ -250,6 +252,7 @@ GoRouter routerConfig(Ref ref) {
     ),
     TypedGoRoute<UpdateStatusRoute>(path: Routes.updateStatus),
     TypedGoRoute<GlobalSearchRoute>(path: Routes.globalSearch),
+    TypedGoRoute<SourceFilterRoute>(path: Routes.sourceFilter),
     TypedGoRoute<MigrationGlobalSearchRoute>(
         path: Routes.migrationGlobalSearch),
     TypedGoRoute<MigrationSourceSelectionRoute>(

--- a/lib/src/routes/sub_routes/browser_routes.dart
+++ b/lib/src/routes/sub_routes/browser_routes.dart
@@ -74,6 +74,15 @@ class SourceTypeRoute extends GoRouteData with $SourceTypeRoute {
       );
 }
 
+class SourceFilterRoute extends GoRouteData with $SourceFilterRoute {
+  const SourceFilterRoute();
+
+  static final $parentNavigatorKey = _quickOpenNavigatorKey;
+
+  @override
+  Widget build(context, state) => const SourceFilterScreen();
+}
+
 class SourcePreferenceRoute extends GoRouteData with $SourcePreferenceRoute {
   const SourcePreferenceRoute({required this.sourceId});
 

--- a/test/src/features/browse_center/presentation/source/source_controller_test.dart
+++ b/test/src/features/browse_center/presentation/source/source_controller_test.dart
@@ -14,6 +14,7 @@ SourceDto _src({
   required String name,
   String lang = 'en',
   bool pinned = false,
+  bool hidden = false,
 }) =>
     SourceDto.fromJson({
       'displayName': name,
@@ -25,15 +26,20 @@ SourceDto _src({
       'name': name,
       'supportsLatest': true,
       '__typename': 'SourceType',
-      'meta': pinned
-          ? [
-              {
-                'key': 'webUI_isPinned',
-                'value': 'true',
-                '__typename': 'SourceMetaType',
-              }
-            ]
-          : const <Map<String, dynamic>>[],
+      'meta': [
+        if (pinned)
+          {
+            'key': 'webUI_isPinned',
+            'value': 'true',
+            '__typename': 'SourceMetaType',
+          },
+        if (hidden)
+          {
+            'key': 'tsumiru_isHidden',
+            'value': 'true',
+            '__typename': 'SourceMetaType',
+          },
+      ],
       'extension': {
         'pkgName': 'pkg',
         'repo': 'repo',
@@ -58,6 +64,41 @@ void main() {
         _src(id: '9', name: 'x').isPinned,
         isFalse,
       );
+    });
+  });
+
+  group('isHidden', () {
+    test('true only when tsumiru_isHidden meta == "true"', () {
+      expect(_src(id: '9', name: 'x', hidden: true).isHidden, isTrue);
+      expect(mangaDex.isHidden, isFalse);
+      // a pinned-but-not-hidden source is not hidden
+      expect(asura.isHidden, isFalse);
+    });
+  });
+
+  group('groupAllSourcesByLanguage (Sources filter screen)', () {
+    test('keeps pinned/hidden sources; shown before hidden, then by name', () {
+      final hiddenSrc = _src(id: '5', name: 'Comick', hidden: true);
+      final map = groupAllSourcesByLanguage([...sources, hiddenSrc]);
+      // Asura is pinned but must still appear (unlike groupSourcesByLanguage);
+      // hidden Comick sorts after the shown sources.
+      expect(map['en']!.map((e) => e.name),
+          ['allmanga', 'Asura Scans', 'MangaDex', 'Comick']);
+      expect(map['ko']!.map((e) => e.name), ['Bato']);
+    });
+  });
+
+  group('browsableSourceList (hidden sources dropped from browse)', () {
+    test('removes hidden sources, keeps the rest', () {
+      final hiddenSrc = _src(id: '5', name: 'Comick', hidden: true);
+      final c = ProviderContainer(overrides: [
+        visibleSourceListProvider
+            .overrideWith((ref) => AsyncData([...sources, hiddenSrc])),
+      ]);
+      addTearDown(c.dispose);
+      final out = c.read(browsableSourceListProvider).value!;
+      expect(out.map((e) => e.name), isNot(contains('Comick')));
+      expect(out.length, sources.length);
     });
   });
 

--- a/test/src/features/browse_center/presentation/source/source_filter_screen_test.dart
+++ b/test/src/features/browse_center/presentation/source/source_filter_screen_test.dart
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/browse_center/domain/source/source_model.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/source/controller/source_controller.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/source/source_filter_screen.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+SourceDto _src({
+  required String id,
+  required String name,
+  String lang = 'en',
+  bool nsfw = false,
+  bool hidden = false,
+}) =>
+    SourceDto.fromJson({
+      'displayName': name,
+      'iconUrl': '',
+      'id': id,
+      'isConfigurable': false,
+      'isNsfw': nsfw,
+      'lang': lang,
+      'name': name,
+      'supportsLatest': true,
+      '__typename': 'SourceType',
+      'meta': [
+        if (hidden)
+          {
+            'key': 'tsumiru_isHidden',
+            'value': 'true',
+            '__typename': 'SourceMetaType',
+          },
+      ],
+      'extension': {
+        'pkgName': 'pkg',
+        'repo': 'repo',
+        '__typename': 'ExtensionType',
+      },
+    });
+
+Future<Widget> _harness(Map<String, List<SourceDto>> byLang) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  return ProviderScope(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      allSourcesByLanguageProvider.overrideWith((ref) => AsyncData(byLang)),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const SourceFilterScreen(),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders Komikku structure: language switch, All Sources switch, '
+      'per-source checkbox with flag', (tester) async {
+    // Default enabled langs include "en" (not "ko"), so en expands and ko does not.
+    await tester.pumpWidget(await _harness({
+      'en': [_src(id: '1', name: 'Asura Scans')],
+      'ko': [_src(id: '2', name: 'Manatoki', lang: 'ko')],
+    }));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // Title "Sources".
+    expect(find.widgetWithText(AppBar, 'Sources'), findsOneWidget);
+
+    // Language rows are switches (not checkboxes) with flag in the title.
+    expect(find.textContaining('English (English'), findsOneWidget);
+    expect(find.textContaining('🇺🇸'), findsWidgets);
+    expect(find.byType(SwitchListTile), findsWidgets);
+
+    // en is enabled -> its "All Sources" switch + the source row show.
+    expect(find.textContaining('All Sources'), findsOneWidget);
+    expect(find.text('Asura Scans'), findsOneWidget);
+    // per-source control is a Checkbox on the trailing side, checked = shown.
+    final box = tester.widget<Checkbox>(find.descendant(
+      of: find.widgetWithText(ListTile, 'Asura Scans'),
+      matching: find.byType(Checkbox),
+    ));
+    expect(box.value, isTrue);
+
+    // ko is disabled by default -> only the language switch, no source row.
+    expect(find.text('Manatoki'), findsNothing);
+  });
+
+  testWidgets('enabled languages sort above disabled ones', (tester) async {
+    // "en" is enabled by default, "af" (Afrikaans) is not — English must
+    // render above Afrikaans even though "af" sorts first alphabetically.
+    await tester.pumpWidget(await _harness({
+      'af': [_src(id: '1', name: 'AfrikaSource', lang: 'af')],
+      'en': [_src(id: '2', name: 'Asura Scans')],
+    }));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final englishY =
+        tester.getTopLeft(find.textContaining('English (English')).dy;
+    final afrikaansY =
+        tester.getTopLeft(find.textContaining('Afrikaans (Afrikaans')).dy;
+    expect(englishY, lessThan(afrikaansY));
+  });
+
+  testWidgets('a hidden source shows an unchecked box', (tester) async {
+    await tester.pumpWidget(await _harness({
+      'en': [_src(id: '1', name: 'Asura Scans', hidden: true)],
+    }));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final box = tester.widget<Checkbox>(find.descendant(
+      of: find.widgetWithText(ListTile, 'Asura Scans'),
+      matching: find.byType(Checkbox),
+    ));
+    expect(box.value, isFalse);
+  });
+}

--- a/test/src/features/browse_center/source_filter_affordance_test.dart
+++ b/test/src/features/browse_center/source_filter_affordance_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/browse/browse_screen.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+Widget _harness(int currentIndex) => ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BrowseScreen(
+          currentIndex: currentIndex,
+          onDestinationSelected: (_) {},
+          children: const [
+            Center(child: Text('sources')),
+            Center(child: Text('extensions')),
+          ],
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('Filter sources affordance shows on the Sources tab',
+      (tester) async {
+    await tester.pumpWidget(_harness(0));
+    await tester.pump();
+    expect(find.byTooltip('Filter sources'), findsOneWidget);
+  });
+
+  testWidgets('Filter sources affordance is absent on the Extensions tab',
+      (tester) async {
+    await tester.pumpWidget(_harness(1));
+    await tester.pump();
+    expect(find.byTooltip('Filter sources'), findsNothing);
+  });
+}


### PR DESCRIPTION
Closes #122.

Sources you don't actively use — NSFW ones, or sources only needed elsewhere — had no way out of the browse list short of uninstalling, which loses updates and drops sources still used on other clients.

Adds a **Sources filter** screen (filter action on the Browse app bar), built as a 1:1 port of Komikku's `SourcesFilterScreen`:

- Languages sorted **enabled-first, then alphabetically**, each a toggle that enables/disables the whole language.
- Every enabled language gets an **"All Sources"** toggle plus per-source rows: source icon, a "flag language 18+" subtitle, and a trailing checkbox (checked = shown). Shown sources sort before hidden ones.
- Per-source hide state persists as the `tsumiru_isHidden` **server meta** key, mirroring how pinning uses `webUI_isPinned`, so it **syncs across devices**. WebUI has no hide concept and simply ignores it.
- Browse, global search and migration read a hidden-filtered source list; the filter screen reads the pre-hide list so hidden sources stay listable (to un-hide).
- Ports Komikku's `FlagEmoji` so the per-language flags render.

The local source is intentionally omitted from the list (Komikku doesn't list it either — it's always available).

**Tests:** unit coverage for the hide flag, all-languages grouping, hidden-from-browse filtering, and enabled-first ordering; widget coverage for the screen structure (language switches, All Sources toggle, per-source checkbox states, flags) and the Browse entry point. Full suite green.