### PR TITLE
Reader, offline, and server-switch reliability

### DIFF
--- a/lib/src/features/about/presentation/about/about_screen.dart
+++ b/lib/src/features/about/presentation/about/about_screen.dart
@@ -39,6 +39,8 @@ class AboutScreen extends HookConsumerWidget {
     AsyncValue.guard(updateCallback).then(
       (value) {
         toast?.close();
+        // Left the About screen before the check resolved → context is dead.
+        if (!context.mounted) return;
         try {
           value.whenOrNull(
             data: (data) {

--- a/lib/src/features/auth/data/auth_coordinator.dart
+++ b/lib/src/features/auth/data/auth_coordinator.dart
@@ -69,7 +69,14 @@ TestConnectionFailure classifyAuthError(Object e) {
         TestConnectionFailureKind.unexpectedShape, e.message);
   }
   final msg = e.toString().toLowerCase();
-  if (msg.contains('unauthor') || msg.contains('forbidden')) {
+  if (msg.contains('unauthor') ||
+      msg.contains('forbidden') ||
+      // Suwayomi's UI-login rejection ("Incorrect username or password.")
+      // and Simple Login's variants — none contain "unauthorized", so match
+      // them explicitly rather than fall through to the scary "wrong URL?".
+      msg.contains('incorrect username or password') ||
+      msg.contains('invalid username or password') ||
+      msg.contains('invalid credentials')) {
     return const TestConnectionFailure(
         TestConnectionFailureKind.invalidCredentials);
   }
@@ -357,14 +364,16 @@ class AuthCoordinator extends _$AuthCoordinator {
     required String username,
     required String password,
   }) async {
+    final store = ref.read(authCredentialsStoreProvider.notifier);
+    // Capture before verify so a switch mid-login can't persist creds for the new host.
+    final epoch = store.serverEpoch;
     final cookie = await verifySimpleCredentials(
       serverBaseUrl: serverBaseUrl,
       username: username,
       password: password,
     );
-    final store = ref.read(authCredentialsStoreProvider.notifier);
-    await store.saveSimpleLoginCookie(cookie);
-    await store.savePassword(password);
+    await store.saveSimpleLoginCookie(cookie, forEpoch: epoch);
+    await store.savePassword(password, forEpoch: epoch);
     ref.read(needsReauthProvider.notifier).set(false);
   }
 
@@ -374,17 +383,19 @@ class AuthCoordinator extends _$AuthCoordinator {
     required String username,
     required String password,
   }) async {
+    final store = ref.read(authCredentialsStoreProvider.notifier);
+    final epoch = store.serverEpoch;
     final tokens = await verifyUiCredentials(
       gqlClient: gqlClient,
       username: username,
       password: password,
     );
-    final store = ref.read(authCredentialsStoreProvider.notifier);
     await store.saveUiLoginTokens(
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
+      forEpoch: epoch,
     );
-    await store.savePassword(password);
+    await store.savePassword(password, forEpoch: epoch);
     ref.read(needsReauthProvider.notifier).set(false);
   }
 
@@ -428,6 +439,8 @@ class AuthCoordinator extends _$AuthCoordinator {
   Future<RefreshOutcome> _refreshUiAccessTokenImpl(
       GraphQLClient gqlClient) async {
     final store = ref.read(authCredentialsStoreProvider.notifier);
+    // A switch bumping the epoch mid-refresh discards the write below.
+    final startEpoch = store.serverEpoch;
     final tokens = store.uiLoginTokens();
     if (tokens == null) {
       // No tokens to refresh = nothing more we can do. This is treated
@@ -509,7 +522,7 @@ class AuthCoordinator extends _$AuthCoordinator {
           Exception('auth mode changed during refresh'));
     }
 
-    await store.updateUiLoginAccessToken(newAccess);
+    await store.updateUiLoginAccessToken(newAccess, forEpoch: startEpoch);
     return RefreshOutcome.success(newAccess);
   }
 

--- a/lib/src/features/auth/data/auth_credentials_store.dart
+++ b/lib/src/features/auth/data/auth_credentials_store.dart
@@ -147,12 +147,21 @@ class AuthCredentialsStore extends _$AuthCredentialsStore {
   AuthCredentialsState get _current =>
       state.value ?? const AuthCredentialsState.empty();
 
+  // Bumped by [clearAllForServerSwitch]; a delayed write racing a switch
+  // captures a stale epoch and discards itself instead of writing.
+  int _serverEpoch = 0;
+  int get serverEpoch => _serverEpoch;
+
   // ---------- Password ----------
 
-  Future<void> savePassword(String password) async {
-    await ref
-        .read(secureStorageProvider)
-        .write(key: _kPasswordKey, value: password);
+  Future<void> savePassword(String password, {int? forEpoch}) async {
+    if (forEpoch != null && forEpoch != _serverEpoch) return;
+    final storage = ref.read(secureStorageProvider);
+    await storage.write(key: _kPasswordKey, value: password);
+    if (forEpoch != null && forEpoch != _serverEpoch) {
+      await storage.delete(key: _kPasswordKey);
+      return;
+    }
     state = AsyncData(_current.copyWith(password: password));
   }
 
@@ -163,11 +172,14 @@ class AuthCredentialsStore extends _$AuthCredentialsStore {
 
   // ---------- Simple Login ----------
 
-  Future<void> saveSimpleLoginCookie(String cookieValue) async {
-    await ref.read(secureStorageProvider).write(
-          key: _kSimpleCookieKey,
-          value: cookieValue,
-        );
+  Future<void> saveSimpleLoginCookie(String cookieValue, {int? forEpoch}) async {
+    if (forEpoch != null && forEpoch != _serverEpoch) return;
+    final storage = ref.read(secureStorageProvider);
+    await storage.write(key: _kSimpleCookieKey, value: cookieValue);
+    if (forEpoch != null && forEpoch != _serverEpoch) {
+      await storage.delete(key: _kSimpleCookieKey);
+      return;
+    }
     state = AsyncData(_current.copyWith(simpleLoginCookie: cookieValue));
   }
 
@@ -178,13 +190,22 @@ class AuthCredentialsStore extends _$AuthCredentialsStore {
 
   // ---------- UI Login ----------
 
+  /// [forEpoch]: discards (or undoes) the write if a switch bumps [serverEpoch]
+  /// before or during the storage write.
   Future<void> saveUiLoginTokens({
     required String accessToken,
     required String refreshToken,
+    int? forEpoch,
   }) async {
+    if (forEpoch != null && forEpoch != _serverEpoch) return;
     final storage = ref.read(secureStorageProvider);
     await storage.write(key: _kUiAccessKey, value: accessToken);
     await storage.write(key: _kUiRefreshKey, value: refreshToken);
+    if (forEpoch != null && forEpoch != _serverEpoch) {
+      await storage.delete(key: _kUiAccessKey);
+      await storage.delete(key: _kUiRefreshKey);
+      return;
+    }
     final expiresAt = decodeJwtExp(accessToken);
     state = AsyncData(_current.copyWith(
       uiAccessToken: accessToken,
@@ -197,11 +218,15 @@ class AuthCredentialsStore extends _$AuthCredentialsStore {
     ));
   }
 
-  Future<void> updateUiLoginAccessToken(String accessToken) async {
-    await ref.read(secureStorageProvider).write(
-          key: _kUiAccessKey,
-          value: accessToken,
-        );
+  Future<void> updateUiLoginAccessToken(String accessToken,
+      {int? forEpoch}) async {
+    if (forEpoch != null && forEpoch != _serverEpoch) return;
+    final storage = ref.read(secureStorageProvider);
+    await storage.write(key: _kUiAccessKey, value: accessToken);
+    if (forEpoch != null && forEpoch != _serverEpoch) {
+      await storage.delete(key: _kUiAccessKey);
+      return;
+    }
     final expiresAt = decodeJwtExp(accessToken);
     state = AsyncData(_current.copyWith(
       uiAccessToken: accessToken,
@@ -241,4 +266,19 @@ class AuthCredentialsStore extends _$AuthCredentialsStore {
   /// a way to clear that entry post-migration.
   Future<void> clearBasicCredentials() =>
       ref.read(secureStorageProvider).delete(key: _kBasicCredentialsKey);
+
+  /// Wipe every credential for a server switch. Clears in-memory state
+  /// synchronously so nothing reads a stale cookie/token mid-delete.
+  Future<void> clearAllForServerSwitch() async {
+    _serverEpoch++;
+    state = const AsyncData(AuthCredentialsState.empty());
+    final storage = ref.read(secureStorageProvider);
+    await Future.wait([
+      storage.delete(key: _kPasswordKey),
+      storage.delete(key: _kSimpleCookieKey),
+      storage.delete(key: _kUiAccessKey),
+      storage.delete(key: _kUiRefreshKey),
+      storage.delete(key: _kBasicCredentialsKey),
+    ]);
+  }
 }

--- a/lib/src/features/auth/data/suwayomi_auth_link.dart
+++ b/lib/src/features/auth/data/suwayomi_auth_link.dart
@@ -66,75 +66,109 @@ class SuwayomiAuthLink extends Link {
 
   @override
   Stream<Response> request(Request request, [NextLink? forward]) async* {
-    final headers = await getHeaders();
-    final withHeaders = headers == null
+    final next = forward!;
+    final Map<String, String>? headers;
+    try {
+      headers = await getHeaders();
+    } catch (error) {
+      // Header fetch failed before the request left. A thrown HTTP 401/403
+      // still belongs on the refresh path; anything else (e.g. a disposed-ref
+      // StateError from provider churn) is not an auth failure — rethrow so it
+      // surfaces as a normal error instead of vanishing.
+      if (_isThrownAuthError(error)) {
+        yield* _handle401(request, next, originalError: error);
+        return;
+      }
+      rethrow;
+    }
+    // Local copy so it promotes to non-null inside the capturing closure below.
+    final resolvedHeaders = headers;
+    final withHeaders = resolvedHeaders == null
         ? request
         : request.updateContextEntry<HttpLinkHeaders>(
             (HttpLinkHeaders? entry) => HttpLinkHeaders(
               headers: <String, String>{
                 ...?entry?.headers,
-                ...headers,
+                ...resolvedHeaders,
               },
             ),
           );
 
     // Iterate the forwarded stream. We inspect only the FIRST event to
     // decide whether we have a 401 → retry case; every other event flows
-    // through unchanged. Using `await forward!(withHeaders).first` would
+    // through unchanged. Using `await next(withHeaders).first` would
     // cancel the subscription after one event, silently killing any
     // GraphQL subscription that doesn't immediately fail.
     Response? first401;
-    var sawFirst = false;
-    await for (final response in forward!(withHeaders)) {
-      if (!sawFirst) {
-        sawFirst = true;
-        if (_is401(response)) {
-          // Cache the 401 and break out to handle refresh/retry below.
-          // We're cancelling the upstream stream here — that's fine for
-          // queries/mutations (they only emit one response anyway) and
-          // for subscriptions a 401 means the server rejected the
-          // connection, so there's nothing useful to keep streaming.
-          first401 = response;
-          break;
+    try {
+      var sawFirst = false;
+      await for (final response in next(withHeaders)) {
+        if (!sawFirst) {
+          sawFirst = true;
+          if (_is401(response)) {
+            // Cache the 401 and break out to handle refresh/retry below.
+            // We're cancelling the upstream stream here — that's fine for
+            // queries/mutations (they only emit one response anyway) and
+            // for subscriptions a 401 means the server rejected the
+            // connection, so there's nothing useful to keep streaming.
+            first401 = response;
+            break;
+          }
         }
+        yield response;
       }
-      yield response;
+    } catch (error) {
+      // HttpLink THROWS on a non-200 (a real HTTP 401/403), so that auth
+      // failure never reaches `_is401` (which only sees 200-with-errors
+      // bodies). Route a thrown 401/403 into the same refresh path; let any
+      // transient error (socket/timeout/5xx) escape unchanged.
+      if (_isThrownAuthError(error)) {
+        yield* _handle401(request, next, originalError: error);
+        return;
+      }
+      rethrow;
     }
 
-    if (first401 == null) {
-      // Success path: stream already drained and yielded. Done.
-      return;
+    if (first401 != null) {
+      yield* _handle401(request, next, originalResponse: first401);
     }
+  }
 
-    // 401 path.
+  /// Runs the ui_login refresh + single-retry state machine after a 401,
+  /// regardless of how the 401 arrived: as a 200-with-errors [Response]
+  /// (`originalResponse`) or as a thrown HTTP 401/403 (`originalError`). On a
+  /// dead session it surfaces the original failure in whichever form it came.
+  Stream<Response> _handle401(
+    Request request,
+    NextLink forward, {
+    Response? originalResponse,
+    Object? originalError,
+  }) async* {
+    // simple_login / basic have no refresh path.
     if (authType() != AuthType.uiLogin) {
-      // simple_login has no refresh path.
       onNeedsReauth();
-      yield first401;
+      yield* _surfaceOriginal(originalResponse, originalError);
       return;
     }
 
-    // ui_login: delegate refresh to AuthCoordinator. The coordinator
-    // owns the single-flight Completer (R2-3) so concurrent 401s in the
-    // query and subscription clients share one refresh.
+    // ui_login: delegate refresh to AuthCoordinator. The coordinator owns the
+    // single-flight Completer (R2-3) so concurrent 401s in the query and
+    // subscription clients share one refresh.
     final outcome = await refreshAccessToken();
     switch (outcome) {
       case RefreshAuthFailure():
-        // Refresh token rejected. Tokens already cleared by the
-        // coordinator. Surface the original 401.
+        // Refresh token rejected; tokens already cleared by the coordinator.
         onNeedsReauth();
-        yield first401;
+        yield* _surfaceOriginal(originalResponse, originalError);
         return;
       case RefreshTransientFailure():
-        // Network / server error — DON'T mark session as dead. Surface
-        // the original 401 so the UI shows a normal error; the next
-        // request will trigger another refresh attempt.
-        yield first401;
+        // Network / server error — DON'T mark the session dead. Surface the
+        // original failure; the next request retries the refresh.
+        yield* _surfaceOriginal(originalResponse, originalError);
         return;
       case RefreshSuccess(:final newAccessToken):
         // Retry once with the fresh token. R2-4: re-check the retried
-        // response for a second 401. If it's still 401, the new token
-        // didn't work either — treat as auth failure.
+        // response for a second 401 (either form) and treat that as dead.
         final retried = request.updateContextEntry<HttpLinkHeaders>(
           (HttpLinkHeaders? entry) => HttpLinkHeaders(
             headers: <String, String>{
@@ -144,26 +178,54 @@ class SuwayomiAuthLink extends Link {
           ),
         );
         Response? retryFirst401;
-        var sawRetryFirst = false;
-        await for (final response in forward(retried)) {
-          if (!sawRetryFirst) {
-            sawRetryFirst = true;
-            if (_is401(response)) {
-              retryFirst401 = response;
-              break;
+        try {
+          var sawRetryFirst = false;
+          await for (final response in forward(retried)) {
+            if (!sawRetryFirst) {
+              sawRetryFirst = true;
+              if (_is401(response)) {
+                retryFirst401 = response;
+                break;
+              }
             }
+            yield response;
           }
-          yield response;
+        } catch (error) {
+          if (!_isThrownAuthError(error)) rethrow;
+          // Second auth failure after a fresh token = dead session.
+          onNeedsReauth();
+          rethrow;
         }
         if (retryFirst401 != null) {
-          // Second 401 after a fresh token = something's off (server
-          // rotated mid-flight, fresh token rejected, etc). Clear and
-          // require re-auth.
           onNeedsReauth();
           yield retryFirst401;
         }
         return;
     }
+  }
+
+  /// Re-emits the original 401 to the caller: as a yielded [Response] when it
+  /// arrived that way, otherwise by rethrowing the original exception.
+  Stream<Response> _surfaceOriginal(
+    Response? originalResponse,
+    Object? originalError,
+  ) async* {
+    if (originalResponse != null) {
+      yield originalResponse;
+    } else {
+      throw originalError!;
+    }
+  }
+
+  /// True only for a THROWN HTTP 401/403 (HttpLink throws on non-200). A
+  /// socket/timeout/5xx is not auth and must propagate unchanged.
+  bool _isThrownAuthError(Object error) {
+    final ex = error is OperationException ? error.linkException : error;
+    if (ex is HttpLinkServerException) {
+      final status = ex.response.statusCode;
+      return status == 401 || status == 403;
+    }
+    return false;
   }
 
   bool _is401(Response response) {

--- a/lib/src/features/auth/presentation/sign_in_action.dart
+++ b/lib/src/features/auth/presentation/sign_in_action.dart
@@ -39,6 +39,8 @@ Future<void> performSignIn(
 }) async {
   ref.read(authUsernameProvider.notifier).update(username);
   final store = ref.read(authCredentialsStoreProvider.notifier);
+  // Guards every write below against a server switch racing this sign-in.
+  final epoch = store.serverEpoch;
   if (authType != AuthType.uiLogin) await store.clearUiLoginTokens();
   if (authType != AuthType.simpleLogin) await store.clearSimpleLoginCookie();
   if (authType != AuthType.basic) await store.clearBasicCredentials();
@@ -46,9 +48,9 @@ Future<void> performSignIn(
   final coordinator = ref.read(authCoordinatorProvider.notifier);
   switch (authType) {
     case AuthType.basic:
-      await ref
-          .read(credentialsProvider.notifier)
-          .set('Basic ${base64.encode(utf8.encode('$username:$password'))}');
+      await ref.read(credentialsProvider.notifier).set(
+          'Basic ${base64.encode(utf8.encode('$username:$password'))}',
+          forEpoch: epoch);
     case AuthType.simpleLogin:
       await coordinator.loginSimple(
         serverBaseUrl: serverBaseUrl,

--- a/lib/src/features/browse_center/presentation/global_search/controller/source_quick_search_controller.dart
+++ b/lib/src/features/browse_center/presentation/global_search/controller/source_quick_search_controller.dart
@@ -90,8 +90,10 @@ Future<List<MangaDto>> sourceQuickSearchMangaList(
   String? query,
 }) async {
   final rateLimiterQueue = ref.watch(rateLimitQueueProvider(query));
+  // Capture now — ref access after the gap may throw once disposed.
+  final sourceRepository = ref.watch(sourceRepositoryProvider);
   final mangaPage = await rateLimiterQueue
-      .add(() => ref.watch(sourceRepositoryProvider).fetchSourceManga(
+      .add(() => sourceRepository.fetchSourceManga(
             page: 1,
             sourceId: sourceId,
             sourceType: SourceType.SEARCH,

--- a/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
+++ b/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
@@ -279,6 +279,8 @@ class MangaBookRepository {
       .getData((data) => data.chapters.nodes);
 }
 
-@riverpod
+// keepAlive so a captured repository ref can't be disposed out from under an
+// in-flight progress write (pairs with the keepAlive graphQlClient).
+@Riverpod(keepAlive: true)
 MangaBookRepository mangaBookRepository(Ref ref) =>
     MangaBookRepository(ref.watch(graphQlClientProvider));

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -49,8 +49,14 @@ class DownloadsMap extends _$DownloadsMap {
 
   @override
   Map<int, DownloadDto> build() {
-    ref.listen(downloadUpdatesProvider,
-        (_, next) => updateDownloadStatus(next.value));
+    // The subscription can emit while any widget is mid-build; assigning state
+    // synchronously then trips the Riverpod-3 modify-during-build assert
+    // app-wide. Defer the write off the current frame.
+    ref.listen(downloadUpdatesProvider, (_, next) {
+      Future.microtask(() {
+        if (ref.mounted) updateDownloadStatus(next.value);
+      });
+    });
     final downloadStatusDto = ref.watch(downloadStatusProvider).value;
     return getStateFromUpdates(downloadStatusDto);
   }
@@ -68,6 +74,7 @@ class DownloadsMap extends _$DownloadsMap {
     final downloadStatusDto = await ref
         .read(downloadsRepositoryProvider)
         .reorderDownload(chapterId, to);
+    if (!ref.mounted) return;
     state = getStateFromUpdates(downloadStatusDto);
   }
 
@@ -79,6 +86,7 @@ class DownloadsMap extends _$DownloadsMap {
   /// from the cached snapshot.
   Future<void> clearAll() async {
     await ref.read(downloadsRepositoryProvider).clearDownloads();
+    if (!ref.mounted) return;
     state = {};
     ref.invalidate(downloadStatusProvider);
   }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -207,6 +207,7 @@ class MangaChapterFilterScanlator extends _$MangaChapterFilterScanlator {
             value: scanlator ?? MangaMetaKeys.scanlator.key,
           ),
     );
+    if (!ref.mounted) return;
     ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
     state = scanlator ?? MangaMetaKeys.scanlator.key;
   }
@@ -230,6 +231,7 @@ class MangaChapterListMode extends _$MangaChapterListMode {
             value: mode.name,
           ),
     );
+    if (!ref.mounted) return;
     ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
     state = mode;
   }
@@ -256,6 +258,7 @@ class MangaRating extends _$MangaRating {
             value: '$next',
           ),
     );
+    if (!ref.mounted) return;
     ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
     // Refresh the library list so rating sort/filter reflect the change without
     // waiting for the next full library fetch.
@@ -282,6 +285,7 @@ class MangaUserTags extends _$MangaUserTags {
             value: jsonEncode(tags),
           ),
     );
+    if (!ref.mounted) return;
     ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
     // Refresh the library list so the tag filter list picks up new/removed tags
     // without waiting for the next full library fetch.
@@ -404,6 +408,9 @@ ChapterDto? firstUnreadInFilteredChapterList(
   } else {
     final current =
         filteredList.indexWhere((element) => element.id == chapterId);
+    // Not in the filtered list (e.g. unread-only filter while re-reading):
+    // otherwise current == -1 would resolve nextChapter to filteredList[0].
+    if (current == -1) return (first: null, second: null);
     final prevChapter = current > 0 ? filteredList[current - 1] : null;
     final nextChapter =
         current < (filteredList.length - 1) ? filteredList[current + 1] : null;

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -38,7 +38,6 @@ class MangaDetailsScreen extends HookConsumerWidget {
   final int? categoryId;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Providers as Class for this screen
     final mangaProvider = mangaWithIdProvider(mangaId: mangaId);
     final chapterListProvider = mangaChapterListProvider(mangaId: mangaId);
     final chapterListFilteredProvider =
@@ -61,15 +60,21 @@ class MangaDetailsScreen extends HookConsumerWidget {
     useEffect(() => scrollPx.dispose, const []);
     final surface = context.theme.scaffoldBackgroundColor;
 
-    // Refresh manga
+    // Container (not the widget ref) so deferred invalidations below survive
+    // this screen being disposed mid-flight.
+    final providerContainer = ProviderScope.containerOf(context, listen: false);
+
     final mangaRefresh = useCallback(([bool onlineFetch = false]) async {
       await ref.read(mangaProvider.notifier).refresh();
       // Screen may be disposed during the refresh → don't invalidate a dead ref.
       if (!context.mounted) return;
-      ref.invalidate(categoryControllerProvider);
-    }, [mangaProvider]);
+      // Defer past the current frame — this resumes after an await and may land
+      // mid-build, which would trip the Riverpod-3 modify-during-build assert.
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => providerContainer.invalidate(categoryControllerProvider),
+      );
+    }, [mangaProvider, providerContainer]);
 
-    // Refresh chapter list
     final chapterListRefresh = useCallback(
         ([bool onlineFetch = false]) async =>
             await ref.read(chapterListProvider.notifier).refresh(onlineFetch),
@@ -110,11 +115,9 @@ class MangaDetailsScreen extends HookConsumerWidget {
       return;
     }, []);
 
-    // Migration function
     void startMigration(BuildContext context, int mangaId, dynamic manga) {
       if (manga == null) return;
 
-      // Navigate to migration source selection
       MigrationGlobalSearchRoute(
         $extra: MigrationRouteData(sourceManga: manga),
       ).push(context);
@@ -133,8 +136,12 @@ class MangaDetailsScreen extends HookConsumerWidget {
     return PopScope(
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop && categoryId != null) {
-          ref.invalidate(libraryMangaListProvider);
-          ref.invalidate(categoryMangaListProvider(categoryId!));
+          final id = categoryId!;
+          // Defer off the pop's build phase (Riverpod-3 modify-during-build).
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            providerContainer.invalidate(libraryMangaListProvider);
+            providerContainer.invalidate(categoryMangaListProvider(id));
+          });
         }
       },
       child: manga.showUiWhenData(

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -133,7 +133,7 @@ class ReaderScreen extends HookConsumerWidget {
 
       // Persist locally first (survives offline + app restart), then push to
       // the server; if offline it stays pending and up-syncs on reconnect.
-      await recordReadingProgressWithDependencies(
+      final progressResult = await recordReadingProgressWithDependencies(
         offlineEnabled: offlineEnabled,
         offlineDatabase: offlineDatabase,
         repository: mangaBookRepository,
@@ -141,6 +141,11 @@ class ReaderScreen extends HookConsumerWidget {
         lastPageRead: isReadingCompleted ? 0 : currentPage,
         isRead: isReadingCompleted,
       );
+      // An online-only user has no pending row to retry, so a failed push would
+      // otherwise vanish. Surface it instead of saving progress into a void.
+      if (progressResult.hasError && context.mounted) {
+        toast?.showError(context.l10n.errorSomethingWentWrong);
+      }
 
       // Delete the on-device copy once read, if the user opted in.
       // On a new read, auto-delete behind the reader — both the on-device copy
@@ -159,8 +164,13 @@ class ReaderScreen extends HookConsumerWidget {
         ));
       }
 
-      // Invalidate history to refresh the reading progress
-      providerContainer.invalidate(readingHistoryProvider);
+      // Invalidate history to refresh the reading progress. Defer past the
+      // current frame: this callback can resume inside a build (an upstream
+      // await doesn't guarantee otherwise), and invalidating mid-build throws
+      // the Riverpod-3 modify-during-build assert.
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => providerContainer.invalidate(readingHistoryProvider),
+      );
     }, [
       chapter.value,
       chapterPages.value,
@@ -316,15 +326,20 @@ class ReaderScreen extends HookConsumerWidget {
               await updateLastRead(latestPage.value);
             }
           } finally {
-            providerContainer.invalidate(chapterProviderWithIndex);
-            providerContainer
-                .invalidate(mangaChapterListProvider(mangaId: mangaId));
-            // Refresh the library's per-category lists so the unread badge updates
-            // even when the reader was opened directly (e.g. the continue-reading
-            // button), bypassing the manga-details screen that would otherwise do
-            // this on its own pop (#282).
-            providerContainer.invalidate(libraryMangaListProvider);
-            providerContainer.invalidate(categoryMangaListProvider);
+            // The write above lands first (awaited); defer the list refreshes
+            // past this frame — invalidating during the pop's build phase trips
+            // the Riverpod-3 modify-during-build assert.
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              providerContainer.invalidate(chapterProviderWithIndex);
+              providerContainer
+                  .invalidate(mangaChapterListProvider(mangaId: mangaId));
+              // Refresh the library's per-category lists so the unread badge
+              // updates even when the reader was opened directly (e.g. the
+              // continue-reading button), bypassing the manga-details screen
+              // that would otherwise do this on its own pop (#282).
+              providerContainer.invalidate(libraryMangaListProvider);
+              providerContainer.invalidate(categoryMangaListProvider);
+            });
           }
         }
       },

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
@@ -100,6 +100,8 @@ class ReaderBottomControls extends ConsumerWidget {
 
     return MeasureSize(
       onChange: (size) {
+        // Fires post-layout; guard against a teardown between frame and callback.
+        if (!context.mounted) return;
         final current = ref.read(chromeExtentsProvider);
         final next = ChromeExtents(
           topInset: current.topInset,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -17,6 +17,7 @@ import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import '../../../../../../../constants/db_keys.dart';
 import '../../../../../../../constants/enum.dart';
 import '../../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../../utils/misc/toast/toast.dart';
 import '../../../../../../../utils/misc/app_utils.dart';
 import '../../../../../../../widgets/server_image.dart';
 import '../../../../../../../widgets/zoom/scroll_offset_to_scroll_controller.dart';
@@ -239,7 +240,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           lc.chapter.lastPageRead.getValueOnNullOrNegative() >= rel) {
         return;
       }
-      await recordReadingProgress(
+      final progressResult = await recordReadingProgress(
         ref,
         chapterId: chapterId,
         lastPageRead: completed ? 0 : rel,
@@ -247,6 +248,11 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       );
       // Disposed during the await → the ref calls below would throw.
       if (!context.mounted) return;
+      // Online-only users have no dirty row to retry, so a failed push would
+      // vanish — surface it instead of losing progress silently.
+      if (progressResult.hasError) {
+        ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+      }
       if (completed && !completedChapterIds.value.contains(chapterId)) {
         completedChapterIds.value = {...completedChapterIds.value, chapterId};
         unawaited(maybeTrackProgressOnReadFetch(ref,
@@ -256,7 +262,11 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         unawaited(maybeDeleteOnReadServer(ref,
             mangaId: manga.id, readChapterId: chapterId));
       }
-      ref.invalidate(readingHistoryProvider);
+      // Fired off a scroll/visibility notification — defer past the frame or
+      // it trips the Riverpod-3 modify-during-build assert.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) ref.invalidate(readingHistoryProvider);
+      });
     }
 
     void scheduleVisibleProgress(int chapterId, int rel) {
@@ -276,7 +286,15 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       }
     }
 
+    // Skip the first run (on-mount restore, not a page turn) so opening a
+    // chapter already on its last page doesn't instantly fire delete-on-read/
+    // tracker. Matches the paged engine's guard.
+    final initialProgressConsumed = useRef<bool>(false);
     useEffect(() {
+      if (!initialProgressConsumed.value) {
+        initialProgressConsumed.value = true;
+        return null;
+      }
       scheduleVisibleProgress(
           currentVisibleChapter.value.id, currentChapterPageIndex.value);
       return null;
@@ -1156,8 +1174,12 @@ void _markChapterRead(
     chapterId: chapter.id,
     lastPageRead: 0,
     isRead: true,
-  ).then((_) {
+  ).then((progressResult) {
     if (!context.mounted) return;
+    // A failed boundary push has no dirty row to retry for online-only users.
+    if (progressResult.hasError) {
+      ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+    }
     // Push progress to external trackers (fire-and-forget).
     unawaited(maybeTrackProgressOnReadFetch(
       ref,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -13,6 +13,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../../../constants/db_keys.dart';
 import '../../../../../../constants/enum.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/misc/toast/toast.dart';
 import '../../../../../history/presentation/history_controller.dart';
 import '../../../../../offline/data/offline_download_providers.dart';
 import '../../../../../offline/data/offline_repository.dart';
@@ -187,21 +188,17 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // prepend shifts every index; committing mid-gesture would jump the page.
     final pending = useRef<List<_LoadedChapter>?>(null);
 
+    // watch, not a one-time read: on cold open the filtered list is still
+    // loading, so a read-once pinned both neighbours null for the session.
+    // Mirrored into a ref for the once-bound preload effect below.
     final nextPrevChapterPair =
-        useState<({ChapterDto? first, ChapterDto? second})?>(null);
-    useEffect(() {
-      try {
-        nextPrevChapterPair.value = ref.read(
-          getNextAndPreviousChaptersProvider(
-            mangaId: manga.id,
-            chapterId: currentVisibleChapter.value.id,
-          ),
-        );
-      } catch (_) {
-        nextPrevChapterPair.value = null;
-      }
-      return null;
-    }, [currentVisibleChapter.value.id]);
+        useRef<({ChapterDto? first, ChapterDto? second})?>(null);
+    nextPrevChapterPair.value = ref.watch(
+      getNextAndPreviousChaptersProvider(
+        mangaId: manga.id,
+        chapterId: currentVisibleChapter.value.id,
+      ),
+    );
 
     _LoadedChapter? loadedById(int id) {
       for (final c in loadedRef.value) {
@@ -230,12 +227,19 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           lc.chapter.lastPageRead.getValueOnNullOrNegative() >= rel) {
         return;
       }
-      await recordReadingProgress(
+      final progressResult = await recordReadingProgress(
         ref,
         chapterId: chapterId,
         lastPageRead: completed ? 0 : rel,
         isRead: completed,
       );
+      // Disposed during the await → the ref calls below would throw.
+      if (!context.mounted) return;
+      // Online-only users have no dirty row to retry, so a failed push would
+      // vanish — surface it instead of losing progress silently.
+      if (progressResult.hasError) {
+        ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+      }
       if (completed && !completedChapterIds.value.contains(chapterId)) {
         completedChapterIds.value = {...completedChapterIds.value, chapterId};
         unawaited(maybeTrackProgressOnReadFetch(ref,
@@ -245,7 +249,11 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         unawaited(maybeDeleteOnReadServer(ref,
             mangaId: manga.id, readChapterId: chapterId));
       }
-      ref.invalidate(readingHistoryProvider);
+      // Fired off a scroll/visibility notification — defer past the frame or
+      // it trips the Riverpod-3 modify-during-build assert.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) ref.invalidate(readingHistoryProvider);
+      });
     }
 
     void scheduleVisibleProgress(int chapterId, int rel) {
@@ -299,14 +307,16 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         // downloaded, otherwise the server repository — so leaving mid-chapter
         // saves the spot even with offline disabled (the single-chapter reader
         // did this via its PopScope flush; the offline-DB-only flush dropped it).
-        unawaited(recordReadingProgressWithDependencies(
+        // Fire-and-forget teardown flush; ignore() swallows any local-write
+        // throw (the server push is already guarded internally).
+        recordReadingProgressWithDependencies(
           offlineEnabled: offlineEnabledForFlush,
           offlineDatabase: offlineDbForFlush,
           repository: repoForFlush,
           chapterId: p.chapterId,
           lastPageRead: isCompletion ? 0 : p.rel,
           isRead: isCompletion,
-        ).catchError((_) {}));
+        ).ignore();
       };
     }, const []);
 
@@ -318,13 +328,27 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       final staged = pending.value;
       if (staged != null && staged.any((e) => e.chapterId == next.id)) return;
       loadingNext.value = true;
+      // Hold a listener: chapterPages is autoDispose with no other subscriber
+      // for the neighbour, so an unheld read gets disposed mid-fetch under
+      // Riverpod 3. Closed in finally so retries can't leak subscriptions.
+      final sub = ref.listenManual(
+          chapterPagesProvider(chapterId: next.id), (_, __) {});
       try {
         deferFeedback(() => InfinityContinuousFeedback
             .showLoadingNextChapterFeedback(context, next.name));
-        final pages =
-            await ref.read(chapterPagesProvider(chapterId: next.id).future);
+        final ChapterPagesDto? pages;
+        try {
+          pages = await ref
+              .read(chapterPagesProvider(chapterId: next.id).future)
+              .timeout(const Duration(seconds: 15));
+        } on TimeoutException {
+          return;
+        }
+        if (!context.mounted) return;
         if (pages == null) {
-          hasReachedEnd.value = true;
+          // No pages is a transient/empty result, not the end of the manga —
+          // drop the cached null so the next gesture refetches; don't latch.
+          ref.invalidate(chapterPagesProvider(chapterId: next.id));
           return;
         }
         if (loadedRef.value.any((e) => e.chapterId == next.id)) return;
@@ -336,9 +360,14 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         deferFeedback(() => InfinityContinuousFeedback
             .showNextChapterLoadedFeedback(context, next.name));
       } catch (_) {
-        hasReachedEnd.value = true;
+        // Transient failure — leave unlatched and refetchable so the next
+        // gesture retries instead of dead-ending the boundary for the session.
+        if (context.mounted) {
+          ref.invalidate(chapterPagesProvider(chapterId: next.id));
+        }
       } finally {
-        loadingNext.value = false;
+        sub.close();
+        if (context.mounted) loadingNext.value = false;
       }
     }
 
@@ -348,13 +377,23 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       final staged = pending.value;
       if (staged != null && staged.any((e) => e.chapterId == prev.id)) return;
       loadingPrevious.value = true;
+      // Same held-subscription + finally-close treatment as loadNextChapter.
+      final sub = ref.listenManual(
+          chapterPagesProvider(chapterId: prev.id), (_, __) {});
       try {
         deferFeedback(() => InfinityContinuousFeedback
             .showLoadingPreviousChapterFeedback(context, prev.name));
-        final pages =
-            await ref.read(chapterPagesProvider(chapterId: prev.id).future);
+        final ChapterPagesDto? pages;
+        try {
+          pages = await ref
+              .read(chapterPagesProvider(chapterId: prev.id).future)
+              .timeout(const Duration(seconds: 15));
+        } on TimeoutException {
+          return;
+        }
+        if (!context.mounted) return;
         if (pages == null) {
-          hasReachedStart.value = true;
+          ref.invalidate(chapterPagesProvider(chapterId: prev.id));
           return;
         }
         if (loadedRef.value.any((e) => e.chapterId == prev.id)) return;
@@ -366,9 +405,13 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         deferFeedback(() => InfinityContinuousFeedback
             .showPreviousChapterLoadedFeedback(context, prev.name));
       } catch (_) {
-        hasReachedStart.value = true;
+        // Transient failure — leave unlatched and refetchable.
+        if (context.mounted) {
+          ref.invalidate(chapterPagesProvider(chapterId: prev.id));
+        }
       } finally {
-        loadingPrevious.value = false;
+        sub.close();
+        if (context.mounted) loadingPrevious.value = false;
       }
     }
 
@@ -421,7 +464,14 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         unawaited(loadPreviousChapter(pair!.second!));
       }
       return null;
-    }, [currentChapterPageIndex.value, currentVisibleChapter.value.id]);
+      // Also keyed on neighbour ids: cold open has the pair null while the
+      // filtered list loads, so this reruns once it resolves.
+    }, [
+      currentChapterPageIndex.value,
+      currentVisibleChapter.value.id,
+      nextPrevChapterPair.value?.first?.id,
+      nextPrevChapterPair.value?.second?.id,
+    ]);
 
     // --- display window --------------------------------------------------
 
@@ -520,6 +570,17 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     }
 
     void onReachedEndEdge() {
+      // Explicit fallback trigger: the scroll-toward-edge preloader needs a
+      // forward movement tick, which openAtEnd / a one-page chapter never give.
+      final nextToLoad = tailAdjacency?.first;
+      if (nextToLoad != null && !hasReachedEnd.value) {
+        // onIdle already fired when the edge bounce settled, before the fetch
+        // finished — commit explicitly or the swap waits for the next swipe.
+        unawaited(loadNextChapter(nextToLoad).then((_) {
+          if (context.mounted) commitPendingIfAny();
+        }));
+        return;
+      }
       if (nextChapterExists) return; // more to load — no end feedback
       if (!context.mounted || !readerToastsEnabled()) return;
       InfinityContinuousFeedback.showEndOfMangaFeedback(
@@ -527,6 +588,16 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     }
 
     void onReachedStartEdge() {
+      // Explicit fallback trigger: opening at page 0 and paging back gives no
+      // backward tick for the preloader, so it would dead-end otherwise.
+      final prevToLoad = headAdjacency?.second;
+      if (prevToLoad != null && !hasReachedStart.value) {
+        // Commit once the fetch lands (see onReachedEndEdge).
+        unawaited(loadPreviousChapter(prevToLoad).then((_) {
+          if (context.mounted) commitPendingIfAny();
+        }));
+        return;
+      }
       if (prevChapterExists) return;
       if (!context.mounted || !readerToastsEnabled()) return;
       InfinityContinuousFeedback.showStartOfMangaFeedback(
@@ -673,8 +744,12 @@ void _markChapterRead(
     chapterId: chapter.id,
     lastPageRead: 0,
     isRead: true,
-  ).then((_) {
+  ).then((progressResult) {
     if (!context.mounted) return;
+    // A failed boundary push has no dirty row to retry for online-only users.
+    if (progressResult.hasError) {
+      ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+    }
     unawaited(maybeTrackProgressOnReadFetch(
       ref,
       mangaId: mangaId,

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -58,7 +58,7 @@ class MultiChaptersActionIcon extends ConsumerWidget {
             isRead: change.isRead!,
             resetPosition: change.lastPageRead == 0 && change.isRead == true,
           );
-          if (!ok && !ref.read(offlineActiveProvider) && context.mounted) {
+          if (!ok && context.mounted && !ref.read(offlineActiveProvider)) {
             ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
           }
         } else {

--- a/lib/src/features/manga_book/widgets/chapter_actions/single_chapter_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/single_chapter_action_icon.dart
@@ -49,7 +49,7 @@ class SingleChapterActionIcon extends ConsumerWidget {
             isRead: change.isRead!,
             resetPosition: change.lastPageRead == 0 && change.isRead == true,
           );
-          if (!ok && !ref.read(offlineActiveProvider) && context.mounted) {
+          if (!ok && context.mounted && !ref.read(offlineActiveProvider)) {
             ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
           }
         } else {

--- a/lib/src/features/migration/controller/migration_controller.dart
+++ b/lib/src/features/migration/controller/migration_controller.dart
@@ -67,11 +67,13 @@ class MigrationSearch extends _$MigrationSearch {
   Future<void> search(String sourceId, String query) async {
     state = const AsyncLoading();
 
-    state = await AsyncValue.guard(() async {
+    final result = await AsyncValue.guard(() async {
       return await ref
           .read(migrationRepositoryProvider)
           .searchMangaInSource(sourceId, query);
     });
+    if (!ref.mounted) return;
+    state = result;
   }
 
   void clearResults() {
@@ -92,8 +94,10 @@ Future<List<MangaDto>> migrationSourceQuickSearchMangaList(
   String? query,
 }) async {
   final rateLimiterQueue = ref.watch(rateLimitQueueProvider(query));
+  // Capture now — ref access after the gap may throw once disposed.
+  final sourceRepository = ref.watch(sourceRepositoryProvider);
   final mangaPage = await rateLimiterQueue
-      .add(() => ref.watch(sourceRepositoryProvider).fetchSourceManga(
+      .add(() => sourceRepository.fetchSourceManga(
             page: 1,
             sourceId: sourceId,
             sourceType: SourceType.SEARCH,
@@ -135,49 +139,40 @@ class MigrationExecution extends _$MigrationExecution {
     required MigrationOption options,
   }) async {
     try {
-      // Set initial progress
       state = const MigrationProgress(
         currentStep: MigrationStep.preparingMigration,
         percentage: 0.0,
         status: MigrationStatus.preparing,
       );
 
-      // Add a delay for visual feedback
       await Future.delayed(const Duration(milliseconds: 1000));
 
-      // Update progress to migrating chapters
       state = const MigrationProgress(
         currentStep: MigrationStep.migrateChapters,
         percentage: 25.0,
         status: MigrationStatus.migrating,
       );
 
-      // Add another delay
       await Future.delayed(const Duration(milliseconds: 800));
 
-      // Update progress to migrating categories
       state = const MigrationProgress(
         currentStep: MigrationStep.migrateCategories,
         percentage: 50.0,
         status: MigrationStatus.migrating,
       );
 
-      // Add another delay
       await Future.delayed(const Duration(milliseconds: 600));
 
-      // Update progress to finalizing
       state = const MigrationProgress(
         currentStep: MigrationStep.migrationInProgress,
         percentage: 75.0,
         status: MigrationStatus.migrating,
       );
 
-      // Now execute the actual migration
       final result = await ref
           .read(migrationRepositoryProvider)
           .migrateManga(fromMangaId, toMangaId, options);
 
-      // Update final progress based on result
       if (result?.success == true) {
         state = const MigrationProgress(
           currentStep: MigrationStep.migrationCompleted,
@@ -185,7 +180,6 @@ class MigrationExecution extends _$MigrationExecution {
           status: MigrationStatus.completed,
         );
 
-        // Invalidate caches to refresh UI data after successful migration
         await _invalidateCachesAfterMigration(fromMangaId, toMangaId);
       } else {
         state = MigrationProgress(
@@ -227,11 +221,9 @@ class MigrationExecution extends _$MigrationExecution {
     state = null;
   }
 
-  /// Invalidate caches after successful migration to refresh UI data
   Future<void> _invalidateCachesAfterMigration(
       int fromMangaId, int toMangaId) async {
     try {
-      // Invalidate manga details for both source and target manga
       ref.invalidate(mangaWithIdProvider(mangaId: fromMangaId));
       ref.invalidate(mangaWithIdProvider(mangaId: toMangaId));
 
@@ -242,7 +234,6 @@ class MigrationExecution extends _$MigrationExecution {
       // Invalidate the full library fetch (source of truth) then the
       // per-category slices so all reactive descendants re-partition.
       ref.invalidate(libraryMangaListProvider);
-      // Invalidate all category manga lists to refresh library
       final categories = ref.read(categoryControllerProvider).value ?? [];
       for (final category in categories) {
         ref.invalidate(categoryMangaListProvider(category.id));

--- a/lib/src/features/offline/data/background/background_completion_log.dart
+++ b/lib/src/features/offline/data/background/background_completion_log.dart
@@ -15,25 +15,34 @@ sealed class LogEntry {
 }
 
 class PageEntry extends LogEntry {
-  const PageEntry(this.chapterId, this.mangaId, this.pageIndex, this.relPath, this.bytes);
-  final int chapterId, mangaId, pageIndex, bytes;
+  const PageEntry(this.chapterId, this.mangaId, this.pageIndex, this.relPath,
+      this.bytes, this.generation);
+  final int chapterId, mangaId, pageIndex, bytes, generation;
   final String relPath;
 }
 
 class ChapterEntry extends LogEntry {
-  const ChapterEntry(this.chapterId, this.status, this.pages, this.bytes);
-  final int chapterId, pages, bytes;
+  const ChapterEntry(
+      this.chapterId, this.status, this.pages, this.bytes, this.generation);
+  final int chapterId, pages, bytes, generation;
   final String status; // downloaded | error | authFailed | offline
+}
+
+/// A chapter was deleted at the given (post-bump) generation; replay wipes
+/// prior accumulation for it, so even a stale entry appended after this is
+/// discarded rather than applied.
+class DeletedEntry extends LogEntry {
+  const DeletedEntry(this.chapterId, this.generation);
+  final int chapterId, generation;
 }
 
 class DrainedEntry extends LogEntry {
   const DrainedEntry();
 }
 
-/// Append-only JSONL record of background-download progress. The DURABLE source
-/// of truth the main isolate replays into drift on resume/launch. One JSON object
-/// per line, flushed. A torn final line (process killed mid-write) is silently
-/// discarded on parse; page files are independently crash-safe (atomic write).
+/// Append-only JSONL record of background-download progress — the durable
+/// source of truth replayed into drift on resume/launch. A torn final line
+/// (killed mid-write) is silently discarded on parse.
 class BackgroundCompletionLog {
   BackgroundCompletionLog(this.file);
   final File file;
@@ -50,16 +59,21 @@ class BackgroundCompletionLog {
     required int pageIndex,
     required String relPath,
     required int bytes,
+    int generation = 0,
   }) =>
-      _append({'t': 'page', 'c': chapterId, 'm': mangaId, 'i': pageIndex, 'p': relPath, 'b': bytes});
+      _append({'t': 'page', 'c': chapterId, 'm': mangaId, 'i': pageIndex, 'p': relPath, 'b': bytes, 'g': generation});
 
   Future<void> appendChapter({
     required int chapterId,
     required String status,
     required int pages,
     required int bytes,
+    int generation = 0,
   }) =>
-      _append({'t': 'chapter', 'c': chapterId, 's': status, 'pages': pages, 'bytes': bytes});
+      _append({'t': 'chapter', 'c': chapterId, 's': status, 'pages': pages, 'bytes': bytes, 'g': generation});
+
+  Future<void> appendDeleted(int chapterId, int generation) =>
+      _append({'t': 'deleted', 'c': chapterId, 'g': generation});
 
   Future<void> appendDrained() => _append({'t': 'drained'});
 
@@ -77,9 +91,11 @@ class BackgroundCompletionLog {
       }
       switch (j['t']) {
         case 'page':
-          out.add(PageEntry(j['c'] as int, j['m'] as int, j['i'] as int, j['p'] as String, j['b'] as int));
+          out.add(PageEntry(j['c'] as int, j['m'] as int, j['i'] as int, j['p'] as String, j['b'] as int, j['g'] as int? ?? 0));
         case 'chapter':
-          out.add(ChapterEntry(j['c'] as int, j['s'] as String, j['pages'] as int, j['bytes'] as int));
+          out.add(ChapterEntry(j['c'] as int, j['s'] as String, j['pages'] as int, j['bytes'] as int, j['g'] as int? ?? 0));
+        case 'deleted':
+          out.add(DeletedEntry(j['c'] as int, j['g'] as int? ?? 0));
         case 'drained':
           out.add(const DrainedEntry());
       }
@@ -94,6 +110,37 @@ class BackgroundCompletionLog {
 
 typedef ChapterBytesMeasurer = Future<int> Function(int mangaId, int chapterId);
 
+/// Apply a worker terminal event (chapterDone) to drift. `downloaded` is
+/// verified against page rows actually on disk, and [eventGeneration] older
+/// than the chapter's persisted `downloadGeneration` (bumped on each delete) is
+/// dropped — both guard against a stale event from a deleted/re-queued chapter.
+Future<void> applyBackgroundTerminalState({
+  required OfflineDatabase db,
+  required int chapterId,
+  required String status,
+  required int bytes,
+  int eventGeneration = 0,
+}) async {
+  await db.transaction(() async {
+    final c = await db.chapterById(chapterId);
+    if (c == null || c.deviceState == OfflineDeviceState.none) return;
+    if (eventGeneration < c.downloadGeneration) return; // stale generation
+    switch (status) {
+      case 'downloaded':
+        final pages = await db.downloadedPageCount(chapterId);
+        if (pages <= 0 || (c.pageCount > 0 && pages < c.pageCount)) return;
+        await db.setChapterDeviceState(chapterId, OfflineDeviceState.downloaded,
+            bytes: bytes, downloadedAt: DateTime.now());
+      case 'error':
+      case 'authFailed':
+        if (c.deviceState == OfflineDeviceState.downloading) {
+          await db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
+        }
+      // 'offline' / null: leave `downloading` so it resumes.
+    }
+  });
+}
+
 Future<void> replayCompletionLog({
   required OfflineDatabase db,
   required OfflinePaths paths,
@@ -103,16 +150,45 @@ Future<void> replayCompletionLog({
   final entries = await log.parse();
   if (entries.isEmpty) return;
 
-  // Which chapters were touched + their terminal status (last one wins).
+  // touched/terminal are scoped to the latest generation seen per chapter, so a
+  // stale entry (even one after the delete in file order) is discarded rather
+  // than applied to a re-queued chapter.
   final touched = <int, int>{}; // chapterId -> mangaId
   final terminal = <int, String>{};
+  final terminalPages = <int, int>{}; // expected page count from the entry
+  final gen = <int, int>{}; // highest generation seen per chapter
+
+  // Advance a chapter to a newer generation, wiping everything accumulated for
+  // older ones.
+  void advance(int chapterId, int g) {
+    if (g > (gen[chapterId] ?? 0)) {
+      gen[chapterId] = g;
+      touched.remove(chapterId);
+      terminal.remove(chapterId);
+      terminalPages.remove(chapterId);
+    }
+  }
+
   for (final e in entries) {
     switch (e) {
-      case PageEntry(:final chapterId, :final mangaId):
+      case PageEntry(:final chapterId, :final mangaId, :final generation):
+        advance(chapterId, generation);
+        if (generation < (gen[chapterId] ?? 0)) break; // stale generation
         touched[chapterId] = mangaId;
-      case ChapterEntry(:final chapterId, :final status):
+      case ChapterEntry(:final chapterId, :final status, :final pages,
+            :final generation):
+        advance(chapterId, generation);
+        if (generation < (gen[chapterId] ?? 0)) break; // stale generation
         terminal[chapterId] = status;
+        terminalPages[chapterId] = pages;
         // mangaId for a chapter-only entry comes from drift below
+      case DeletedEntry(:final chapterId, :final generation):
+        // Advance to the delete's new generation and wipe prior accumulation; a
+        // re-download at that generation re-accumulates on later iterations.
+        advance(chapterId, generation);
+        touched.remove(chapterId);
+        terminal.remove(chapterId);
+        terminalPages.remove(chapterId);
       case DrainedEntry():
         break;
     }
@@ -123,43 +199,70 @@ Future<void> replayCompletionLog({
     // Skip deleted/cleared chapters — never resurrect (design: filesystem is
     // subordinate to drift authority here).
     if (ch == null || ch.deviceState == OfflineDeviceState.none) continue;
+    // drift's persisted generation is authority: if it's advanced past
+    // everything in the log (e.g. tombstone truncated across a restart), the
+    // log is stale for this chapter.
+    if ((gen[chapterId] ?? 0) < ch.downloadGeneration) continue;
     final mangaId = touched[chapterId] ?? ch.mangaId;
 
-    // Filesystem is truth: upsert a row for every page file on disk.
-    final dir = Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
+    // Enumerate final on-disk pages (filesystem is truth) and measure bytes
+    // BEFORE the transaction, so the DB write stays atomic and serializes with
+    // a delete; `.part` staging files are excluded as incomplete.
+    final rowsByIndex = <int, String>{};
+    final dir =
+        Directory(paths.absolute(paths.chapterDirRel(mangaId, chapterId)));
     if (await dir.exists()) {
       await for (final f in dir.list()) {
         if (f is! File) continue;
         final name = f.uri.pathSegments.last; // e.g. 003.jpg
+        if (name.endsWith('.part')) continue; // atomic-write staging, not final
         final dot = name.indexOf('.');
         if (dot <= 0) continue;
         final idx = int.tryParse(name.substring(0, dot));
         if (idx == null) continue;
-        await db.into(db.offlinePages).insertOnConflictUpdate(
-              OfflinePagesCompanion.insert(
-                chapterId: chapterId,
-                pageIndex: idx,
-                relativePath: paths.pageRel(mangaId, chapterId, idx,
-                    name.substring(dot + 1)),
-              ),
-            );
+        rowsByIndex[idx] =
+            paths.pageRel(mangaId, chapterId, idx, name.substring(dot + 1));
       }
     }
+    final status = terminal[chapterId];
+    final bytes =
+        status == 'downloaded' ? await measureBytes(mangaId, chapterId) : 0;
 
-    // Apply terminal state.
-    switch (terminal[chapterId]) {
-      case 'downloaded':
-        final bytes = await measureBytes(mangaId, chapterId);
-        await db.setChapterDeviceState(chapterId, OfflineDeviceState.downloaded,
-            bytes: bytes, downloadedAt: DateTime.now());
-      case 'error':
-      case 'authFailed':
-        await db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
-      case 'offline':
-      case null:
-        // leave downloading — resumed later by the pump/worker
-        break;
-    }
+    // Recheck state, then upsert rows + apply terminal state atomically: a
+    // delete that commits after the check above must win, not be overwritten.
+    await db.transaction(() async {
+      final c = await db.chapterById(chapterId);
+      if (c == null || c.deviceState == OfflineDeviceState.none) return;
+      for (final entry in rowsByIndex.entries) {
+        await db.into(db.offlinePages).insertOnConflictUpdate(
+              OfflinePagesCompanion.insert(
+                  chapterId: chapterId,
+                  pageIndex: entry.key,
+                  relativePath: entry.value),
+            );
+      }
+      switch (status) {
+        case 'downloaded':
+          // Verify against files actually on disk, not log metadata: a stale
+          // `downloaded` racing a delete/re-queue finds too few pages and must
+          // not complete the chapter. Requires the full expected page set, not
+          // just a partial.
+          final expected = terminalPages[chapterId] ?? 0;
+          final complete = expected > 0
+              ? List.generate(expected, (i) => i).every(rowsByIndex.containsKey)
+              : rowsByIndex.isNotEmpty;
+          if (!complete) break;
+          await db.setChapterDeviceState(
+              chapterId, OfflineDeviceState.downloaded,
+              bytes: bytes, downloadedAt: DateTime.now());
+        case 'error':
+        case 'authFailed':
+          await db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
+        case 'offline':
+        case null:
+          break; // leave downloading — resumed later by the pump/worker
+      }
+    });
   }
 
   await log.truncate();

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -32,22 +32,22 @@ import 'background_token_record.dart';
 import 'background_work_order.dart';
 import 'download_task_handler.dart';
 
-/// Owns the Android foreground-service download worker from the MAIN isolate:
-/// starts/stops it at the right moments, mirrors drift into the worker via
-/// messages, applies the worker's events + the durable completion log back into
-/// drift, and recovers correctly after backgrounding / a kill.
-///
-/// Single-owner invariant: while the queue is non-empty on Android, exactly one
-/// background isolate downloads (foreground + background). The main-isolate
-/// file-writing pump must NOT run on Android — that gate lives in
-/// `initOfflineDownloads` (wired in a later task), not here.
-///
-/// This controller is a no-op on non-Android platforms; desktop/iOS keep the
-/// existing main-isolate pump.
+/// Owns the Android foreground-service download worker from the MAIN isolate —
+/// starts/stops it, mirrors drift into it, and applies its events + completion
+/// log back into drift. Single-owner invariant: exactly one isolate downloads
+/// while the queue is non-empty on Android, so the main-isolate pump must never
+/// run there; on other platforms this controller is a no-op and the
+/// main-isolate pump is used instead.
 class BackgroundDownloadController with WidgetsBindingObserver {
   BackgroundDownloadController(this._ref);
 
   final Ref _ref;
+
+  /// The chapter's persistent download generation (bumped on each delete),
+  /// stamped into every worker message so a terminal event from an older
+  /// generation is dropped. Persisted so it survives a restart — an in-memory
+  /// counter would let a re-queued download reuse a generation.
+  int _genOf(OfflineChapter c) => c.downloadGeneration;
 
   /// Registered as the FFT task-data callback; held so we can deregister.
   DataCallback? _workerEventCallback;
@@ -71,9 +71,9 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   // Lifecycle registration
   // ---------------------------------------------------------------------------
 
-  /// Wire up the worker-event callback + the Wi-Fi-only connectivity listener.
-  /// Call once at startup (after FFT.initCommunicationPort, before/at launch
-  /// replay). Idempotent.
+  /// Wire up the worker-event callback + Wi-Fi-only listener. Call once at
+  /// startup (after FFT.initCommunicationPort, before/at launch replay);
+  /// idempotent.
   void register() {
     if (!Platform.isAndroid) return;
     WidgetsBinding.instance.addObserver(this);
@@ -94,18 +94,16 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   // Service start (heart of single-owner)
   // ---------------------------------------------------------------------------
 
-  /// Ensure the foreground service owns the current queue. Idempotent: if it's
-  /// already running, the pending ids are messaged in (the worker merges them);
-  /// otherwise the service is started with a freshly-built work order.
-  ///
-  /// Wi-Fi-only is enforced HERE (main isolate): if the setting is on and the
-  /// active connection is metered, the service is not started.
+  /// Ensure the foreground service owns the current queue — idempotent: merges
+  /// pending ids into an already-running worker, else starts one with a fresh
+  /// work order. Wi-Fi-only is enforced here: won't start on a metered
+  /// connection when the setting is on.
   Future<void> ensureServiceRunning() async {
     if (!Platform.isAndroid) return;
     if (_suppressRestarts) return;
-    // PAUSE GATE — first line so EVERY restart path inherits it: the public
-    // start, onEnqueued, replayOnResume, replayAtLaunchAndMaybeStart, _onDrained,
-    // _onServiceStopped, and the connectivity-resume branch all funnel here.
+    // PAUSE GATE — first line so every restart path (start, onEnqueued,
+    // replayOnResume, launch replay, drain/stop handlers, connectivity-resume)
+    // inherits it.
     if (_isPaused()) return;
     if (_ensuring) return;
     _ensuring = true;
@@ -116,15 +114,19 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       if (await FlutterForegroundTask.isRunningService) {
         // Already owned — just merge the new ids into the worker's queue.
         for (final c in pending) {
-          FlutterForegroundTask.sendDataToTask(
-              {'op': 'add', 'chapterId': c.id, 'mangaId': c.mangaId});
+          FlutterForegroundTask.sendDataToTask({
+            'op': 'add',
+            'chapterId': c.id,
+            'mangaId': c.mangaId,
+            'gen': _genOf(c),
+          });
         }
         return;
       }
 
-      // Start gate: don't bring up the service on a metered connection when
-      // Wi-Fi-only is on. The queue stays in drift; a later Wi-Fi reconnect (or
-      // the next foreground) starts it.
+      // Start gate: don't bring up the service on metered + Wi-Fi-only; the
+      // queue stays in drift until a Wi-Fi reconnect or next foreground starts
+      // it.
       if (await _wifiOnlyBlocks()) {
         logger.i('Offline: Wi-Fi-only on + metered — deferring service start');
         return;
@@ -133,10 +135,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       await _ensureNotificationPermission();
       await _writeWorkOrder(pending);
       // Re-check the pause gate: a pause could have landed while we awaited the
-      // steps above (this call passed the gate at the top before the user
-      // paused). Without this, we'd start the service into a paused state, and
-      // pause() — which only messages a *running* service — would have skipped
-      // it because the service wasn't up yet.
+      // steps above, and pause() only messages a *running* service — without
+      // this recheck we'd start straight into a paused state.
       if (_isPaused()) return;
       final res = await FlutterForegroundTask.startService(
         serviceTypes: [ForegroundServiceTypes.dataSync],
@@ -178,14 +178,13 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       false;
 
   /// Pause all on-device downloads: tell the worker to park the in-flight
-  /// chapter and self-stop. The caller persists the flag first; the start gate
-  /// in [ensureServiceRunning] then prevents any restart until [resume].
+  /// chapter and self-stop. Caller persists the flag first; the start gate in
+  /// [ensureServiceRunning] then blocks restart until [resume].
   Future<void> pause() async {
     if (!Platform.isAndroid) return;
     if (await FlutterForegroundTask.isRunningService) {
-      // Graceful: the worker cancels the active chapter (left resumable) and
-      // self-stops. Never main-side stopService here — that would race the
-      // worker and could corrupt a half-written page.
+      // Graceful: the worker cancels + self-stops. Never main-side stopService
+      // here — it would race the worker and could corrupt a half-written page.
       FlutterForegroundTask.sendDataToTask({'op': 'pause'});
     }
   }
@@ -224,6 +223,14 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     }
   }
 
+  /// Record a delete tombstone at [newGeneration] (already bumped in drift) so
+  /// a stale entry from the previous generation can't complete the chapter
+  /// after it's re-queued.
+  Future<void> recordChapterDeleted(int chapterId, int newGeneration) async {
+    if (!Platform.isAndroid) return;
+    await _log.appendDeleted(chapterId, newGeneration);
+  }
+
   /// Push a Wi-Fi-only setting change to the worker, and enforce it from the
   /// main side: if it's now on + we're metered, stop the running service.
   Future<void> onWifiOnlyChanged(bool value) async {
@@ -255,11 +262,9 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// Replay the completion log into drift (live-UI catch-up on resume).
   Future<void> replayOnResume() async {
     await _replay();
-    // The foreground service may have been killed while we were backgrounded (OS
-    // memory pressure, the dataSync time cap, a swipe-away). If drift still has
-    // pending chapters, (re)start it — ensureServiceRunning is idempotent, so
-    // it's a no-op when the worker is still alive. Without this, downloads only
-    // resumed when the user reopened a manga's details (which calls it too).
+    // The FGS may have been killed while backgrounded (OOM, the dataSync time
+    // cap, a swipe-away); restart if pending work remains — ensureServiceRunning
+    // is idempotent/no-op if the worker's still alive.
     final pending = await _pendingChapters();
     if (pending.isNotEmpty) await ensureServiceRunning();
   }
@@ -287,34 +292,19 @@ class BackgroundDownloadController with WidgetsBindingObserver {
 
   void _onWorkerEvent(Object data) {
     if (data is! Map) return;
-    // During a catalog clear the worker is being torn down; a page/chapter event
-    // still in the SendPort queue would otherwise re-insert a row into the
-    // just-wiped catalog. Drop everything until the clear releases the flag.
+    // During a catalog clear the worker is being torn down; a page/chapter
+    // event still queued in the SendPort would otherwise re-insert a row into
+    // the just-wiped catalog — drop everything until the clear releases the flag.
     if (_suppressRestarts) return;
     switch (data['kind']) {
-      // Live foreground UI: mark the chapter downloading + accumulate page rows
-      // as the worker reports them, so the per-chapter progress arc animates.
-      // (Only meaningful while the app is foreground; the durable record is the
-      // completion log, replayed on resume.)
+      // Live foreground UI only — mark downloading + accumulate page rows so
+      // the progress arc animates; the durable record is the completion log,
+      // replayed on resume.
       case 'chapterStart':
-        final id = data['chapterId'] as int;
-        unawaited(
-            _db.setChapterDeviceState(id, OfflineDeviceState.downloading));
-        // Record the resolved page total so the progress arc can show a real
-        // fraction (only when known + currently unset/0, to avoid clobbering a
-        // good catalog value).
-        final total = data['total'] as int?;
-        if (total != null && total > 0) {
-          unawaited(_db.setChapterPageCount(id, total));
-        }
+        unawaited(_applyChapterStart(data['chapterId'] as int,
+            data['total'] as int?, data['gen'] as int? ?? 0));
       case 'page':
-        unawaited(_db.into(_db.offlinePages).insertOnConflictUpdate(
-              OfflinePagesCompanion.insert(
-                chapterId: data['chapterId'] as int,
-                pageIndex: data['pageIndex'] as int,
-                relativePath: data['relPath'] as String,
-              ),
-            ));
+        unawaited(_applyPageEvent(data));
       case 'chapterDone':
         unawaited(_onChapterDone(data));
       case 'drained':
@@ -322,11 +312,45 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     }
   }
 
-  /// The worker drained its queue and is self-stopping. Anything enqueued during
-  /// that shutdown window is in drift `queued` but stranded in the dying worker
-  /// (the "tap download, nothing happens until reopen" bug). So: wait for the
-  /// service to actually stop (stopService is async), then re-check the catalog
-  /// and restart if work remains. ensureServiceRunning is idempotent.
+  /// Apply a `chapterStart` inside a transaction that checks the chapter isn't
+  /// deleted first — a remove message can cross the isolate boundary after
+  /// already-queued worker events, so this guard (serialized with
+  /// deleteChapter) drops it instead of resurrecting a `none` chapter.
+  Future<void> _applyChapterStart(int id, int? total, int eventGen) async {
+    await _db.transaction(() async {
+      final c = await _db.chapterById(id);
+      if (c == null || c.deviceState == OfflineDeviceState.none) return;
+      if (eventGen < c.downloadGeneration) return; // stale generation
+      await _db.setChapterDeviceState(id, OfflineDeviceState.downloading);
+      // Only set a known total over an unset/0 one, to avoid clobbering a good
+      // catalog value.
+      if (total != null && total > 0) {
+        await _db.setChapterPageCount(id, total);
+      }
+    });
+  }
+
+  Future<void> _applyPageEvent(Map data) async {
+    final id = data['chapterId'] as int;
+    final eventGen = data['gen'] as int? ?? 0;
+    await _db.transaction(() async {
+      final c = await _db.chapterById(id);
+      if (c == null || c.deviceState == OfflineDeviceState.none) return;
+      if (eventGen < c.downloadGeneration) return; // stale generation
+      await _db.into(_db.offlinePages).insertOnConflictUpdate(
+            OfflinePagesCompanion.insert(
+              chapterId: id,
+              pageIndex: data['pageIndex'] as int,
+              relativePath: data['relPath'] as String,
+            ),
+          );
+    });
+  }
+
+  /// The worker drained and is self-stopping. Anything queued during that
+  /// shutdown window is stranded (the "tap download, nothing happens until
+  /// reopen" bug), so wait for the stop to actually complete, then recheck and
+  /// restart if work remains.
   Future<void> _onDrained() async {
     for (var i = 0; i < 20; i++) {
       if (!await FlutterForegroundTask.isRunningService) break;
@@ -340,27 +364,25 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     final chapterId = data['chapterId'] as int?;
     final status = data['status'] as String?;
     if (chapterId != null && status != null) {
-      // Foreground live UI: apply the terminal state immediately (the durable
-      // log is still the source of truth and is reconciled on the next replay).
-      switch (status) {
-        case 'downloaded':
-          final ch = await _db.chapterById(chapterId);
-          if (ch != null && ch.deviceState != OfflineDeviceState.none) {
-            final bytes = await _store.chapterBytes(ch.mangaId, chapterId);
-            await _db.setChapterDeviceState(
-                chapterId, OfflineDeviceState.downloaded,
-                bytes: bytes, downloadedAt: DateTime.now());
-          }
-        case 'error':
-        case 'authFailed':
-          await _db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
-        // 'offline' / null: leave `downloading` so it resumes.
+      // Measure bytes outside the transaction (filesystem read); the
+      // terminal-state apply rechecks so a chapterDone landing after a delete
+      // can't flip a `none` chapter back to downloaded/error.
+      int bytes = 0;
+      if (status == 'downloaded') {
+        final ch = await _db.chapterById(chapterId);
+        if (ch != null) bytes = await _store.chapterBytes(ch.mangaId, chapterId);
       }
+      await applyBackgroundTerminalState(
+          db: _db,
+          chapterId: chapterId,
+          status: status,
+          bytes: bytes,
+          eventGeneration: data['gen'] as int? ?? 0);
     }
 
-    // Drain handshake: if the worker just self-stopped (queue empty), do the
-    // post-stop reconciliation + a drift requery in case work was enqueued
-    // during the async stop window (CRITICAL-1).
+    // Drain handshake: if the worker just self-stopped, do post-stop
+    // reconciliation + a drift requery in case work was enqueued during the
+    // async stop window (CRITICAL-1).
     if (!await FlutterForegroundTask.isRunningService) {
       await _onServiceStopped();
     }
@@ -383,6 +405,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     final order = BackgroundWorkOrder(
       chapterIds: [for (final c in pending) c.id],
       mangaIdByChapter: {for (final c in pending) c.id: c.mangaId},
+      generationByChapter: {for (final c in pending) c.id: _genOf(c)},
       serverBase: _ref.read(serverUrlProvider) ?? '',
       port: _ref.read(serverPortProvider),
       addPort: _ref.read(serverPortToggleProvider).ifNull(),
@@ -407,6 +430,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     return BackgroundTokenRecord(
       gen: 0,
       authType: authType.name,
+      endpoint: _effectiveEndpoint(),
       accessToken: creds?.uiAccessToken,
       refreshToken: creds?.uiRefreshToken,
       basicCredential: basicToken,
@@ -414,9 +438,16 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     );
   }
 
-  /// After the worker stops, copy any rotated ui_login tokens it persisted back
-  /// into the app's [AuthCredentialsStore], then clear the FFT auth keys so a
-  /// stale token snapshot never lingers in plugin storage.
+  /// Endpoint identity (URL + custom port if enabled) the client talks to.
+  String _effectiveEndpoint() {
+    final usePort = _ref.read(serverPortToggleProvider).ifNull();
+    final port = usePort ? _ref.read(serverPortProvider) : null;
+    return '${_ref.read(serverUrlProvider)}|${port ?? '-'}';
+  }
+
+  /// After the worker stops, copy any rotated ui_login tokens back into
+  /// [AuthCredentialsStore], then clear the FFT auth keys so a stale snapshot
+  /// doesn't linger in plugin storage.
   Future<void> _wipeWorkOrderAuth() async {
     final raw =
         await FlutterForegroundTask.getData<String>(key: kTokenRecordKey);
@@ -424,18 +455,24 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       try {
         final record = BackgroundTokenRecord.fromJson(
             jsonDecode(raw) as Map<String, Object?>);
-        // gen > 0 means the worker rotated the token at least once.
+        // gen > 0 means the worker rotated the token at least once. Endpoint
+        // check skips writeback if the user switched servers meanwhile.
         if (record.gen > 0 &&
             record.authType == 'uiLogin' &&
-            record.accessToken != null) {
+            record.accessToken != null &&
+            record.endpoint == _effectiveEndpoint()) {
           final store = _ref.read(authCredentialsStoreProvider.notifier);
+          // Epoch guard covers a switch landing during the writeback itself.
+          final epoch = store.serverEpoch;
           if (record.refreshToken != null) {
             await store.saveUiLoginTokens(
               accessToken: record.accessToken!,
               refreshToken: record.refreshToken!,
+              forEpoch: epoch,
             );
           } else {
-            await store.updateUiLoginAccessToken(record.accessToken!);
+            await store.updateUiLoginAccessToken(record.accessToken!,
+                forEpoch: epoch);
           }
         }
       } catch (e) {
@@ -457,9 +494,9 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     return _isMetered();
   }
 
-  /// True when the active connection is metered (no Wi-Fi and no ethernet).
-  /// `connectivity_plus` returns a list; an empty/none list is treated as
-  /// metered-ish (no usable unmetered link), so we don't start a wifi-only batch.
+  /// True when the active connection is metered (no Wi-Fi/ethernet).
+  /// `connectivity_plus` returns a list; empty/none is treated as metered-ish
+  /// so a wifi-only batch doesn't start.
   Future<bool> _isMetered() async {
     final result = await Connectivity().checkConnectivity();
     final hasUnmetered = result.contains(ConnectivityResult.wifi) ||
@@ -467,30 +504,33 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     return !hasUnmetered;
   }
 
-  /// React to connectivity changes while the app is alive: if Wi-Fi-only is on
-  /// and we drop to metered, stop the running service (the chapters stay
-  /// `downloading` and resume on Wi-Fi). If we (re)gain Wi-Fi and there's
-  /// pending work, start it.
-  ///
-  /// v1 LIMITATION: a Wi-Fi→mobile switch that happens ENTIRELY while the app is
-  /// backgrounded isn't caught here (no listener runs) — it's only reconciled on
-  /// the next foreground/launch. The worker carries the wifiOnly flag for a
-  /// future in-worker gate but does not act on connection type today.
+  /// React to connectivity changes while the app is alive: stop the service on
+  /// a drop to metered under Wi-Fi-only (chapters stay `downloading`, resume on
+  /// Wi-Fi), or start it on a (re)gained connection with pending work.
+  /// LIMITATION: a switch entirely while backgrounded isn't caught here — only
+  /// reconciled on the next foreground/launch.
   void _onConnectivityChanged(List<ConnectivityResult> result) {
     if (!Platform.isAndroid) return;
     final wifiOnly = _ref.read(offlineWifiOnlyProvider) ?? true;
-    if (!wifiOnly) return;
     final hasUnmetered = result.contains(ConnectivityResult.wifi) ||
         result.contains(ConnectivityResult.ethernet);
+    final hasConnection =
+        result.any((r) => r != ConnectivityResult.none) && result.isNotEmpty;
     unawaited(() async {
-      if (!hasUnmetered) {
+      if (wifiOnly && !hasUnmetered) {
+        // Wi-Fi-only and dropped to metered: stop the running service (chapters
+        // stay `downloading` and resume on Wi-Fi).
         if (await FlutterForegroundTask.isRunningService) {
           logger
               .i('Offline: dropped to metered with Wi-Fi-only — stopping FGS');
           await FlutterForegroundTask.stopService();
         }
-      } else {
-        // Back on an unmetered link — resume any pending work.
+        return;
+      }
+      // A usable link returned — resume pending work; covers a queue parked by
+      // a resolve-time network drop that would otherwise strand until app
+      // resume.
+      if (hasConnection) {
         final pending = await _pendingChapters();
         if (pending.isNotEmpty) await ensureServiceRunning();
       }
@@ -502,8 +542,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   // ---------------------------------------------------------------------------
 
   /// Request POST_NOTIFICATIONS (Android 13+) before starting the service —
-  /// `startService` fails without it. Best-effort: a denial is logged; the start
-  /// attempt still proceeds (the OS will simply suppress the notification).
+  /// `startService` fails without it. Best-effort: a denial is only logged,
+  /// and the start still proceeds.
   Future<void> _ensureNotificationPermission() async {
     final current = await FlutterForegroundTask.checkNotificationPermission();
     if (current == NotificationPermission.granted) return;
@@ -517,10 +557,9 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   // TokenBroker adapter (main side)
   // ---------------------------------------------------------------------------
 
-  /// A [TokenBroker] backed by FFT storage for the main side, sharing the same
-  /// gen-versioned record the worker uses. Provided for callers/tests that need
-  /// to coordinate a refresh from the main isolate against the worker's record.
-  /// Only ui_login refreshes; the network refresh is delegated to [refreshFn].
+  /// A [TokenBroker] backed by FFT storage, sharing the worker's gen-versioned
+  /// record — for callers/tests coordinating a refresh from the main isolate.
+  /// Only ui_login refreshes; network refresh is delegated to [refreshFn].
   TokenBroker mainSideBroker({
     required Future<RefreshResult?> Function(String refreshToken) refreshFn,
   }) =>
@@ -540,11 +579,10 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       );
 }
 
-/// App-lifetime singleton driving the foreground-service downloads on Android.
-/// Read it at launch (to `register()` + replay) and from the enqueue/delete
-/// sites. Self-gates to Android; a no-op on iOS/desktop (main-isolate pump used
-/// there). On web this file is never compiled — the conditional-import shim
-/// (`background_download_controller_shim.dart`) swaps in a no-op stub.
+/// App-lifetime singleton driving the foreground-service downloads on
+/// Android; read at launch (register + replay) and from enqueue/delete sites.
+/// No-op on iOS/desktop; on web this file isn't compiled at all —
+/// `background_download_controller_shim.dart` swaps in a stub.
 final backgroundDownloadControllerProvider =
     Provider<BackgroundDownloadController>(
         (Ref ref) => BackgroundDownloadController(ref));

--- a/lib/src/features/offline/data/background/background_download_controller_stub.dart
+++ b/lib/src/features/offline/data/background/background_download_controller_stub.dart
@@ -23,6 +23,7 @@ class BackgroundDownloadController {
   Future<void> ensureServiceRunning() async {}
   Future<void> onEnqueued(List<int> chapterIds) async {}
   Future<void> onRemoved(int chapterId) async {}
+  Future<void> recordChapterDeleted(int chapterId, int newGeneration) async {}
   Future<void> onWifiOnlyChanged(bool value) async {}
   Future<void> pause() async {}
   Future<void> resume() async {}

--- a/lib/src/features/offline/data/background/background_token_record.dart
+++ b/lib/src/features/offline/data/background/background_token_record.dart
@@ -10,6 +10,7 @@ class BackgroundTokenRecord {
   const BackgroundTokenRecord({
     required this.gen,
     required this.authType,
+    this.endpoint,
     this.accessToken,
     this.refreshToken,
     this.password,
@@ -19,12 +20,15 @@ class BackgroundTokenRecord {
 
   final int gen;
   final String authType; // basic | simpleLogin | uiLogin | none
+  // Endpoint these creds belong to, checked before writeback after a switch.
+  final String? endpoint;
   final String? accessToken, refreshToken, password, basicCredential, simpleCookie;
 
   BackgroundTokenRecord copyWith({int? gen, String? accessToken, String? refreshToken}) =>
       BackgroundTokenRecord(
         gen: gen ?? this.gen,
         authType: authType,
+        endpoint: endpoint,
         accessToken: accessToken ?? this.accessToken,
         refreshToken: refreshToken ?? this.refreshToken,
         password: password,
@@ -33,15 +37,17 @@ class BackgroundTokenRecord {
       );
 
   Map<String, Object?> toJson() => {
-        'gen': gen, 'authType': authType, 'accessToken': accessToken,
-        'refreshToken': refreshToken, 'password': password,
-        'basicCredential': basicCredential, 'simpleCookie': simpleCookie,
+        'gen': gen, 'authType': authType, 'endpoint': endpoint,
+        'accessToken': accessToken, 'refreshToken': refreshToken,
+        'password': password, 'basicCredential': basicCredential,
+        'simpleCookie': simpleCookie,
       };
 
   factory BackgroundTokenRecord.fromJson(Map<String, Object?> j) =>
       BackgroundTokenRecord(
         gen: j['gen'] as int,
         authType: j['authType'] as String,
+        endpoint: j['endpoint'] as String?,
         accessToken: j['accessToken'] as String?,
         refreshToken: j['refreshToken'] as String?,
         password: j['password'] as String?,

--- a/lib/src/features/offline/data/background/background_work_order.dart
+++ b/lib/src/features/offline/data/background/background_work_order.dart
@@ -16,11 +16,16 @@ class BackgroundWorkOrder {
     required this.wifiOnly,
     required this.auth,
     required this.baseDir,
+    this.generationByChapter = const {},
     this.rootIsolateToken = 0,
   });
 
   final List<int> chapterIds;
   final Map<int, int> mangaIdByChapter;
+
+  /// Per-chapter download generation (bumped on delete). The worker echoes it on
+  /// every event so the main isolate can drop a stale generation's events.
+  final Map<int, int> generationByChapter;
   final String serverBase;
   final int? port;
   final bool addPort;
@@ -28,21 +33,22 @@ class BackgroundWorkOrder {
   final BackgroundTokenRecord auth;
 
   /// Absolute offline base directory (`<appSupport>/offline`), resolved by the
-  /// MAIN isolate via path_provider and handed to the worker so the worker
-  /// itself stays plugin-free: it builds [OfflinePaths]/[IoOfflinePageStore]
-  /// from this string with only dart:io.
+  /// MAIN isolate via path_provider and handed to the worker so it stays
+  /// plugin-free (builds [OfflinePaths]/[IoOfflinePageStore] from this string
+  /// with only dart:io).
   final String baseDir;
 
-  /// Vestigial — the plugin-free worker no longer reconstructs a
-  /// [RootIsolateToken] (it touches no platform channels), so this is unused.
-  /// Kept on the model so the JSON shape stays backward-compatible; defaults
-  /// to 0 and is ignored by the worker.
+  /// Vestigial — the plugin-free worker touches no platform channels so this
+  /// is unused. Kept only so the JSON shape stays backward-compatible;
+  /// defaults to 0 and is ignored.
   final int rootIsolateToken;
 
   Map<String, Object?> toJson() => {
         'chapterIds': chapterIds,
         'mangaIdByChapter':
             mangaIdByChapter.map((k, v) => MapEntry(k.toString(), v)),
+        'generationByChapter':
+            generationByChapter.map((k, v) => MapEntry(k.toString(), v)),
         'serverBase': serverBase,
         'port': port,
         'addPort': addPort,
@@ -57,6 +63,9 @@ class BackgroundWorkOrder {
         chapterIds: (j['chapterIds'] as List).cast<int>(),
         mangaIdByChapter: (j['mangaIdByChapter'] as Map)
             .map((k, v) => MapEntry(int.parse(k as String), v as int)),
+        generationByChapter: (j['generationByChapter'] as Map?)
+                ?.map((k, v) => MapEntry(int.parse(k as String), v as int)) ??
+            const {},
         serverBase: j['serverBase'] as String,
         port: j['port'] as int?,
         addPort: j['addPort'] as bool,

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -19,10 +19,9 @@ import 'background_completion_log.dart';
 import 'background_token_record.dart';
 import 'background_work_order.dart';
 
-/// Foreground-service entry point. MUST be a top-level function annotated
-/// `@pragma('vm:entry-point')` so the AOT compiler keeps it and the plugin can
-/// re-enter it in the background isolate. Registers the handler and returns;
-/// the actual work runs in [DownloadTaskHandler.onStart].
+/// Foreground-service entry point. Must be top-level +
+/// `@pragma('vm:entry-point')` so AOT keeps it and the plugin can re-enter it
+/// in the background isolate; actual work runs in [DownloadTaskHandler.onStart].
 @pragma('vm:entry-point')
 void backgroundDownloadCallback() {
   FlutterForegroundTask.setTaskHandler(DownloadTaskHandler());
@@ -37,23 +36,23 @@ const String kWorkOrderKey = 'work_order';
 /// rotation and is read back by the main side on stop).
 const String kTokenRecordKey = 'token_record';
 
-/// The background-download worker. Runs entirely inside the foreground-service
-/// isolate, which is PLUGIN-FREE by design: it uses only `dart:io`,
-/// `package:http`, and `flutter_foreground_task`'s own storage/messaging. It
-/// never touches path_provider / secure_storage / connectivity_plus, so it
-/// needs no [RootIsolateToken] / [BackgroundIsolateBinaryMessenger] init.
-///
-/// Single-owner model: while the queue is non-empty this isolate owns ALL
-/// downloading (foreground and background), reusing the pure-Dart
-/// [ChapterDownloadEngine]. Progress is appended to a durable JSONL log
-/// ([BackgroundCompletionLog]) — the real source of truth — while
-/// `sendDataToMain` events are foreground-only cosmetics.
+/// The background-download worker, running entirely in the foreground-service
+/// isolate — plugin-free by design (only `dart:io`, `package:http`, FFT
+/// storage/messaging), so it needs no isolate-binary-messenger init.
+/// Single-owner: while the queue is non-empty this isolate owns all
+/// downloading via the pure-Dart [ChapterDownloadEngine], appending progress
+/// to the durable [BackgroundCompletionLog]; `sendDataToMain` events are
+/// foreground-only cosmetics.
 class DownloadTaskHandler extends TaskHandler {
   /// chapterIds still to download, in order.
   final List<int> _queue = <int>[];
 
   /// chapterId -> mangaId, needed to build page paths.
   final Map<int, int> _mangaOf = <int, int>{};
+
+  /// chapterId -> download generation, echoed on every event so the main isolate
+  /// can drop events from a deleted (stale) generation.
+  final Map<int, int> _genOf = <int, int>{};
 
   /// chapters the main isolate asked to drop (delete/cancel).
   final Set<int> _cancelled = <int>{};
@@ -65,11 +64,9 @@ class DownloadTaskHandler extends TaskHandler {
   /// Chapters that reached a terminal state (for the notification counter).
   int _done = 0;
 
-  /// Wi-Fi-only flag carried from the main isolate. v1 LIMITATION: the worker
-  /// records and live-updates it but does NOT itself gate on connection type —
-  /// Wi-Fi-only is enforced by the MAIN isolate (it won't start/keep the service
-  /// on a metered connection). Kept here for a future in-worker connectivity
-  /// gate; currently informational only.
+  /// Wi-Fi-only flag carried from the main isolate. v1 LIMITATION: recorded/
+  /// live-updated here but not acted on — enforcement is done by the main
+  /// isolate; kept for a future in-worker gate.
   // ignore: unused_field
   var _wifiOnly = false;
 
@@ -77,13 +74,18 @@ class DownloadTaskHandler extends TaskHandler {
   /// chapters, so the drain loop re-checks before self-stopping.
   var _sawNewWork = false;
 
+  /// The chapter the drain loop is actively downloading — already pulled off
+  /// [_queue], so an `add` merge (which resends every `downloading` row on
+  /// resume) would otherwise re-queue and double-download it.
+  int? _inFlight;
+
   /// True once onDestroy fires (timeout / external stop) — the drain loop and
   /// the in-flight chapter observe it and unwind.
   var _stopping = false;
 
-  /// True once the main isolate sends `{op:'pause'}` (user paused downloads).
-  /// The in-flight chapter is cancelled (left resumable) and the worker
-  /// self-stops; drift retains queued/downloading so resume re-enqueues them.
+  /// True once the main isolate sends `{op:'pause'}`. The in-flight chapter is
+  /// cancelled (left resumable) and the worker self-stops; drift retains
+  /// queued/downloading so resume re-enqueues them.
   var _paused = false;
 
   BackgroundWorkOrder? _order;
@@ -117,6 +119,7 @@ class DownloadTaskHandler extends TaskHandler {
 
     _queue.addAll(order.chapterIds);
     _mangaOf.addAll(order.mangaIdByChapter);
+    _genOf.addAll(order.generationByChapter);
     _total = _queue.length;
 
     await _drain();
@@ -128,6 +131,10 @@ class DownloadTaskHandler extends TaskHandler {
     switch (data['op']) {
       case 'add':
         final id = data['chapterId'] as int;
+        if (id == _inFlight) break; // already downloading — don't double-queue
+        // A re-add after a delete carries a bumped generation; adopt it so this
+        // download's events outrank the deleted generation's stale ones.
+        _genOf[id] = data['gen'] as int? ?? 0;
         if (!_queue.contains(id) &&
             !_cancelled.contains(id) &&
             !_mangaOf.containsKey(id)) {
@@ -148,10 +155,9 @@ class DownloadTaskHandler extends TaskHandler {
       case 'setWifiOnly':
         _wifiOnly = data['value'] as bool;
       case 'pause':
-        // User paused all device downloads. The in-flight chapter's isCancelled
-        // picks this up and unwinds (left resumable); the drain loop then exits
-        // and the worker self-stops. The main side won't restart while the
-        // persisted pause flag is set.
+        // User paused: the in-flight chapter's isCancelled picks this up and
+        // unwinds (left resumable), the drain loop exits and self-stops; main
+        // won't restart while the persisted pause flag is set.
         _paused = true;
     }
   }
@@ -178,45 +184,65 @@ class DownloadTaskHandler extends TaskHandler {
           _sawNewWork = false;
           continue;
         }
-        // Queue genuinely empty — record the drain marker, tell the main isolate
-        // we're stopping (so it can re-check the catalog for anything enqueued
-        // during this shutdown window and restart us), then self-stop.
+        // Queue genuinely empty — record the drain marker, tell main we're
+        // stopping (so it can recheck for anything enqueued during this window
+        // and restart us), then self-stop.
         await _log.appendDrained();
         FlutterForegroundTask.sendDataToMain({'kind': 'drained'});
         await FlutterForegroundTask.stopService();
         return;
       }
       _queue.remove(next);
-      await _downloadChapter(next, _mangaOf[next]!);
+      _inFlight = next;
+      final parked = await _downloadChapter(next, _mangaOf[next]!);
+      _inFlight = null;
+      if (parked) {
+        // Server unreachable — stop with the queue still in drift so a reconnect
+        // (or relaunch) resumes it. No drained marker: it isn't drained, parked.
+        await FlutterForegroundTask.stopService();
+        return;
+      }
     }
-    // Exited because the user paused (not a stop/timeout): self-stop cleanly so
-    // the FGS notification clears. drift still has the queued/downloading rows
-    // (the in-flight chapter was cancelled, left resumable), so resume just
-    // re-enqueues from drift. Do NOT append a drained marker — the queue isn't
-    // drained, it's parked.
+    // Exited because the user paused (not a stop/timeout): self-stop cleanly to
+    // clear the FGS notification. drift still has queued/downloading rows, so
+    // resume just re-enqueues; do NOT append a drained marker — this is parked,
+    // not drained.
     if (_paused && !_stopping) {
       await FlutterForegroundTask.stopService();
     }
   }
 
-  Future<void> _downloadChapter(int chapterId, int mangaId) async {
+  /// Returns true when the chapter was parked (server unreachable) — the drain
+  /// should stop and leave the queue intact for a later resume.
+  Future<bool> _downloadChapter(int chapterId, int mangaId) async {
     final urls = await _resolvePageUrls(chapterId);
+    if (urls == null) {
+      // Server unreachable resolving pages: leave `downloading` (resumable) and
+      // park. Marking it error here poisoned the whole queue — one blip
+      // cascaded through every remaining chapter.
+      return true;
+    }
     if (urls.isEmpty) {
       // Could not resolve pages (terminal): a server with no pages or a hard
       // failure even after a token refresh. Mark error, keep draining.
       await _log.appendChapter(
-          chapterId: chapterId, status: 'error', pages: 0, bytes: 0);
+          chapterId: chapterId,
+          status: 'error',
+          pages: 0,
+          bytes: 0,
+          generation: _genOf[chapterId] ?? 0);
       _done++;
       _afterChapter(chapterId, 'error');
-      return;
+      return false;
     }
 
-    // Tell the UI this chapter is now downloading, so the live progress arc
-    // shows while the app is in the foreground (the main isolate applies it to
-    // the catalog; while backgrounded it's dropped and the log replay covers it).
+    // Tell the UI this chapter is downloading so the progress arc shows in
+    // foreground (the main isolate applies it to the catalog); while
+    // backgrounded it's dropped and covered by log replay.
     FlutterForegroundTask.sendDataToMain({
       'kind': 'chapterStart',
       'chapterId': chapterId,
+      'gen': _genOf[chapterId] ?? 0,
       // The resolved page count — lets the UI show a determinate progress arc
       // (webtoon chapters don't know their page total until resolved here).
       'total': urls.length,
@@ -237,6 +263,7 @@ class DownloadTaskHandler extends TaskHandler {
         FlutterForegroundTask.sendDataToMain({
           'kind': 'page',
           'chapterId': chapterId,
+          'gen': _genOf[chapterId] ?? 0,
           'pageIndex': i,
           'relPath': rel,
         });
@@ -246,6 +273,7 @@ class DownloadTaskHandler extends TaskHandler {
           pageIndex: i,
           relPath: rel,
           bytes: bytes,
+          generation: _genOf[chapterId] ?? 0,
         );
       },
     );
@@ -269,16 +297,24 @@ class DownloadTaskHandler extends TaskHandler {
         status: status,
         pages: urls.length,
         bytes: bytes,
+        generation: _genOf[chapterId] ?? 0,
       );
       _done++;
     }
     _afterChapter(chapterId, status);
+    // Network died mid-download: the chapter is recorded `offline` (resumable),
+    // so park rather than churn every remaining chapter through the same drop.
+    return status == 'offline';
   }
 
   /// Notification + main-isolate notification after each chapter settles.
   void _afterChapter(int chapterId, String? status) {
-    FlutterForegroundTask.sendDataToMain(
-        {'kind': 'chapterDone', 'chapterId': chapterId, 'status': status});
+    FlutterForegroundTask.sendDataToMain({
+      'kind': 'chapterDone',
+      'chapterId': chapterId,
+      'gen': _genOf[chapterId] ?? 0,
+      'status': status,
+    });
     FlutterForegroundTask.updateService(
       notificationTitle: 'Downloading chapters',
       notificationText: 'Downloading — $_done/$_total',
@@ -289,10 +325,10 @@ class DownloadTaskHandler extends TaskHandler {
   // Page-list resolution (hand-rolled GraphQL POST, pure http)
   // ---------------------------------------------------------------------------
 
-  /// Resolves a chapter's page URLs via the `fetchChapterPages` mutation. On a
-  /// 401/403 it runs the [TokenBroker] refresh once and retries; on any other
-  /// failure (or an empty result) it returns an empty list (terminal error).
-  Future<List<String>> _resolvePageUrls(int chapterId) async {
+  /// Resolves a chapter's page URLs: the list on success, empty on terminal
+  /// failure (no pages), or null when the server was unreachable (transient —
+  /// the caller parks, doesn't error).
+  Future<List<String>?> _resolvePageUrls(int chapterId) async {
     var result = await _postChapterPages(chapterId, _record.accessToken);
     if (result == _gqlAuthError && _record.authType == 'uiLogin') {
       final newAccess = await _broker.resolveAfter401(_record.accessToken ?? '');
@@ -301,12 +337,18 @@ class DownloadTaskHandler extends TaskHandler {
       }
     }
     if (result is List<String>) return result;
-    return const <String>[];
+    if (result == _gqlNetworkError) return null; // transient — park
+    return const <String>[]; // terminal
   }
 
   /// Sentinel returned by [_postChapterPages] to signal an auth (401/403)
   /// failure distinctly from "no pages / other error" (an empty list).
   static const Object _gqlAuthError = Object();
+
+  /// Sentinel: the page-list POST couldn't reach the server (transient),
+  /// distinct from an empty (terminal) result — so a network blip parks the
+  /// chapter instead of erroring and poisoning the queue.
+  static const Object _gqlNetworkError = Object();
 
   /// Returns the page-URL list on success, [_gqlAuthError] on 401/403, or an
   /// empty list on any other failure.
@@ -339,9 +381,7 @@ class DownloadTaskHandler extends TaskHandler {
       if (pages is List) return pages.cast<String>();
       return const <String>[];
     } on SocketException {
-      // No network for the page-list POST: treat as a transient empty so the
-      // batch isn't poisoned. (Per-page fetches surface offline via the engine.)
-      return const <String>[];
+      return _gqlNetworkError; // transient — park, don't error
     } catch (_) {
       return const <String>[];
     }
@@ -400,11 +440,10 @@ class DownloadTaskHandler extends TaskHandler {
         },
       );
 
-  /// Builds the page-image GET URL + headers — mirrors
-  /// `fetchOfflinePageBytes`: base API WITHOUT the `/api` suffix (page URLs
-  /// already carry `/api/...`); ui_login as a `?token=` query param;
-  /// basic/simpleLogin via headers. Reads the CURRENT in-isolate [_record]
-  /// (kept fresh by the broker), not Riverpod.
+  /// Builds the page-image GET URL + headers, mirroring
+  /// `fetchOfflinePageBytes`: base API without `/api` (page URLs already carry
+  /// it), ui_login as `?token=`, basic/simpleLogin via headers. Reads the
+  /// current in-isolate [_record] (kept fresh by the broker), not Riverpod.
   (String, Map<String, String>) _authedPageRequest(String pageUrl) {
     final order = _order!;
     final base = Endpoints.baseApi(

--- a/lib/src/features/offline/data/chapter_download_engine.dart
+++ b/lib/src/features/offline/data/chapter_download_engine.dart
@@ -70,18 +70,11 @@ class ChapterDownloadOutcome {
       error == null && !cancelled && !authFailed && !offline;
 }
 
-/// Downloads a single chapter's pages: up to
-/// [parallelPageLimit] pages in flight at once (default 5), each retried a few
-/// times with short backoff for transient blips, and auth refreshed once on a
-/// 401 before retrying. Pure Dart and dependency-injected so it runs the same
-/// on Android and the Linux desktop build and is testable without HTTP, dart:io
-/// or the real auth stack.
-///
-/// Deliberately does ONE chapter: with a single-source model, the
-/// orchestrator runs chapters one at a time (everything comes from our own
-/// server, so there's nothing to spread chapter-level load against). The win is
-/// page-level parallelism, which also hides the server's cold upstream-fetch
-/// latency for chapters it hasn't cached yet.
+/// Downloads a single chapter's pages with up to [parallelPageLimit] in flight
+/// (default 5), retrying blips and refreshing auth once on a 401. Deliberately
+/// does ONE chapter at a time (page-level parallelism is the real win, since
+/// everything comes from our own server); pure Dart + dependency-injected, so
+/// it's testable without HTTP, dart:io, or the real auth stack.
 class ChapterDownloadEngine {
   ChapterDownloadEngine({
     required this.fetchPage,
@@ -136,7 +129,7 @@ class ChapterDownloadEngine {
         }
         if (cursor >= queue.length) return;
         final page = queue[cursor++];
-        final result = await _downloadOne(mangaId, chapterId, page);
+        final result = await _downloadOne(mangaId, chapterId, page, isCancelled);
         switch (result) {
           case _PageOk(:final relPath, :final bytes):
             stored[page.index] = (relPath: relPath, bytes: bytes);
@@ -147,6 +140,8 @@ class ChapterDownloadEngine {
             authFailed = true;
           case _PageOffline():
             offline = true;
+          case _PageCancelled():
+            return; // cancel landed mid-fetch; the loop's guard also stops us
           case _PageError(:final error):
             fatalError ??= error;
         }
@@ -166,12 +161,16 @@ class ChapterDownloadEngine {
     );
   }
 
-  Future<_PageResult> _downloadOne(
-      int mangaId, int chapterId, PageRef page) async {
+  Future<_PageResult> _downloadOne(int mangaId, int chapterId, PageRef page,
+      bool Function() isCancelled) async {
     var refreshedForAuth = false;
     for (var attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
         final bytes = await fetchPage(page.url);
+        // The fetch can outlast a cancel (delete/pause landing mid-request);
+        // don't write a file for a chapter being deleted — the purge likely
+        // already ran, so the write would orphan on disk.
+        if (isCancelled()) return const _PageCancelled();
         final written = await writePage.writePage(
           mangaId,
           chapterId,
@@ -221,6 +220,10 @@ class _PageError extends _PageResult {
 
 class _PageAuthDead extends _PageResult {
   const _PageAuthDead();
+}
+
+class _PageCancelled extends _PageResult {
+  const _PageCancelled();
 }
 
 class _PageOffline extends _PageResult {

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -42,14 +42,11 @@ class OfflineMangas extends Table {
   Set<Column> get primaryKey => {id};
 }
 
-/// Chapter metadata + per-chapter device-download state. Keyed by the server's
-/// stable chapter id (NEVER chapterIndex/sourceOrder, which renumbers).
-///
-/// No FK to [OfflineMangas] by design: the server is canonical, and a chapter
-/// whose manga/chapter disappears server-side is reconciled in app logic via
-/// [OfflineDeviceState.orphaned] rather than cascade-deleted; `orphaned` is a
-/// transient reconciliation marker — server-gone chapters are evicted on the
-/// next reconcile pass, not kept indefinitely for explicit cleanup.
+/// Chapter metadata + per-chapter device-download state, keyed by the server's
+/// stable chapter id (never chapterIndex/sourceOrder, which renumbers). No FK
+/// to [OfflineMangas] by design — a chapter whose manga disappears
+/// server-side is reconciled via [OfflineDeviceState.orphaned] and evicted on
+/// the next reconcile pass, not cascade-deleted.
 @TableIndex(name: 'idx_offline_chapter_manga', columns: {#mangaId})
 class OfflineChapters extends Table {
   IntColumn get id => integer()();
@@ -76,24 +73,29 @@ class OfflineChapters extends Table {
   BoolColumn get progressDirty =>
       boolean().withDefault(const Constant(false))();
 
-  /// True when this chapter's bookmark was toggled locally but not yet pushed
-  /// to the server. Tracked separately from [progressDirty] so a read-progress
-  /// sync can't clobber a server bookmark that hasn't down-synced yet, and a
-  /// bookmark sync can't clobber un-synced read progress (#13/#33).
+  /// True when this chapter's bookmark was toggled locally but not yet pushed.
+  /// Tracked separately from [progressDirty] so a read-progress sync can't
+  /// clobber an un-synced bookmark, or vice versa (#13/#33).
   BoolColumn get bookmarkDirty =>
       boolean().withDefault(const Constant(false))();
 
-  /// True when this chapter's read-STATE (isRead) was changed locally but not
-  /// yet pushed. Tracked separately from [progressDirty] so a position-only
-  /// write can never push a stale isRead (the ch-99 un-read loop), mirroring
-  /// [bookmarkDirty] (#13).
+  /// True when this chapter's read-STATE (isRead) changed locally but not yet
+  /// pushed — separate from [progressDirty] so a position-only write can't
+  /// push a stale isRead (the ch-99 loop), mirroring [bookmarkDirty] (#13).
   BoolColumn get readStateDirty =>
       boolean().withDefault(const Constant(false))();
 
-  /// The server's last-read timestamp (epoch millis as a string, matching the
-  /// server's LongString) — synced down so the offline library can sort by
-  /// "Last Read". Server is the source of truth; this is never the device clock.
+  /// The server's last-read timestamp (epoch millis as a string) synced down
+  /// so the offline library can sort by "Last Read" — server is the source of
+  /// truth, never the device clock.
   TextColumn get lastReadAt => text().nullable()();
+
+  /// Monotonic download generation, bumped on every delete and persisted so a
+  /// restart can't let a re-queued download reuse one. Background events carry
+  /// their starting generation; anything below the current value is dropped so
+  /// a stale event can't corrupt a re-queued download.
+  IntColumn get downloadGeneration =>
+      integer().withDefault(const Constant(0))();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -141,7 +143,7 @@ class OfflineDatabase extends _$OfflineDatabase {
   OfflineDatabase(super.e);
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -207,12 +209,16 @@ class OfflineDatabase extends _$OfflineDatabase {
                 'UPDATE offline_chapters SET read_state_dirty = 1 '
                 'WHERE progress_dirty = 1 AND is_read = 1');
           }
+          if (from < 8) {
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.downloadGeneration);
+          }
         },
       );
 
-  /// drift's [Migrator.addColumn] throws if the column already exists. A device
-  /// migrated by an intermediate/dev build can have a column present while still
-  /// recording an older schema version, so guard each add to stay idempotent.
+  /// drift's [Migrator.addColumn] throws if the column already exists — a
+  /// device migrated by an intermediate/dev build can have it present at an
+  /// older recorded schema version, so guard each add to stay idempotent.
   Future<void> _addColumnIfMissing(
       Migrator m, TableInfo table, GeneratedColumn column) async {
     final info =
@@ -224,8 +230,7 @@ class OfflineDatabase extends _$OfflineDatabase {
 
   // --- metadata down-sync upserts -------------------------------------------
   // These set ONLY server-sourced columns, so device-managed columns
-  // (deviceState, bytes, thumbnailRelPath) are preserved on conflict and never
-  // clobbered by a metadata refresh.
+  // (deviceState, bytes, thumbnailRelPath) survive a metadata refresh untouched.
 
   Future<void> upsertMangaMetadata({
     required int id,
@@ -366,9 +371,9 @@ class OfflineDatabase extends _$OfflineDatabase {
       (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
           .write(OfflineChaptersCompanion(pinned: Value(pinned)));
 
-  /// Set a chapter's resolved page count (used to drive the determinate
-  /// download progress arc for chapters whose total wasn't known until the
-  /// downloader resolved their pages — e.g. webtoon chapters).
+  /// Set a chapter's resolved page count — drives the determinate download
+  /// progress arc for chapters (e.g. webtoon) whose total wasn't known until
+  /// the downloader resolved their pages.
   Future<void> setChapterPageCount(int chapterId, int pageCount) =>
       (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
           .write(OfflineChaptersCompanion(pageCount: Value(pageCount)));
@@ -388,6 +393,17 @@ class OfflineDatabase extends _$OfflineDatabase {
         ),
       );
 
+  /// Bump a chapter's persistent download generation and return the new
+  /// value — called on every delete so a re-queued download outranks any
+  /// still-in-flight event, and persisted so it survives a restart.
+  Future<int> bumpChapterGeneration(int chapterId) => transaction(() async {
+        final current = await chapterById(chapterId);
+        final next = (current?.downloadGeneration ?? 0) + 1;
+        await (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
+            .write(OfflineChaptersCompanion(downloadGeneration: Value(next)));
+        return next;
+      });
+
   /// Record local reading progress (read offline / always). Marks it
   /// `progressDirty` so it's pushed to the server on the next online sync.
   Future<void> setChapterProgress(
@@ -399,9 +415,9 @@ class OfflineDatabase extends _$OfflineDatabase {
         OfflineChaptersCompanion(
           lastPageRead: Value(lastPageRead),
           progressDirty: const Value(true),
-          // null → leave read-state untouched (a partial write must not un-read).
-          // A read-state change rides its OWN flag so a position-only write can
-          // never push a stale isRead (the ch-99 un-read loop).
+          // null → leave read-state untouched (a partial write must not
+          // un-read); a read-state change rides its OWN flag so position-only
+          // writes can't push a stale isRead (the ch-99 loop).
           isRead: isRead == null ? const Value.absent() : Value(isRead),
           readStateDirty:
               isRead == null ? const Value.absent() : const Value(true),
@@ -428,10 +444,9 @@ class OfflineDatabase extends _$OfflineDatabase {
       (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
           .write(const OfflineChaptersCompanion(bookmarkDirty: Value(false)));
 
-  /// Clear progressDirty only if the row still holds the exact values that were
-  /// pushed — so a newer local write that landed during the push isn't marked
-  /// clean and lost (the snapshot-then-clear race). A non-matching row keeps its
-  /// flag and re-syncs on the next pass.
+  /// Clear progressDirty only if the row still holds the exact pushed values —
+  /// so a newer local write landing mid-push isn't marked clean and lost (the
+  /// snapshot-then-clear race); a non-matching row keeps its flag and re-syncs.
   Future<void> clearProgressDirtyIfUnchanged(int chapterId,
           {required int lastPageRead}) =>
       (update(offlineChapters)
@@ -457,9 +472,9 @@ class OfflineDatabase extends _$OfflineDatabase {
                 t.id.equals(chapterId) & t.isBookmarked.equals(isBookmarked)))
           .write(const OfflineChaptersCompanion(bookmarkDirty: Value(false)));
 
-  /// Record a local bookmark change. Marks `bookmarkDirty` (separate from
-  /// `progressDirty`) so the bookmark is pushed on the next online sync without
-  /// dragging stale read progress with it, and vice versa (#13/#33).
+  /// Record a local bookmark change, marking `bookmarkDirty` (separate from
+  /// `progressDirty`) so the bookmark pushes without dragging stale read
+  /// progress along, and vice versa (#13/#33).
   Future<void> setChapterBookmark(int chapterId, bool isBookmarked) =>
       (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
         OfflineChaptersCompanion(
@@ -508,8 +523,8 @@ class OfflineDatabase extends _$OfflineDatabase {
       });
 
   /// Sweep browsed-not-added manga a past bug wrote here: no library timestamp
-  /// (null/'0') and nothing downloaded. Never touches downloads; a stray library
-  /// row swept here just re-mirrors on the next online load.
+  /// and nothing downloaded. Never touches downloads — a swept stray row just
+  /// re-mirrors on the next online load.
   Future<int> purgeNonLibraryManga() {
     final withDeviceContent = selectOnly(offlineChapters)
       ..addColumns([offlineChapters.mangaId])
@@ -523,10 +538,9 @@ class OfflineDatabase extends _$OfflineDatabase {
         .go();
   }
 
-  /// Most-recent read timestamp per manga (the max chapter `lastReadAt`), for
-  /// the offline library's "Last Read" sort. Mangas with no read chapter are
-  /// absent from the map. Values are the server's epoch-millis strings, so the
-  /// max is taken numerically to match how the sort parses them.
+  /// Most-recent read timestamp per manga (max chapter `lastReadAt`), for the
+  /// offline library's "Last Read" sort — absent for mangas with no read
+  /// chapter. Values are epoch-millis strings, so the max is taken numerically.
   Future<Map<int, String>> lastReadAtByManga() async {
     final maxExpr = offlineChapters.lastReadAt.cast<int>().max();
     final query = selectOnly(offlineChapters)
@@ -544,11 +558,10 @@ class OfflineDatabase extends _$OfflineDatabase {
     return result;
   }
 
-  /// The next unread chapter that is downloaded on this device, per manga — the
-  /// lowest `chapterIndex` row with `isRead = false` and
-  /// `deviceState = downloaded`. Drives the offline "continue reading" button:
-  /// offline you can only open a chapter that's actually on the device, so a
-  /// manga with no downloaded unread chapter is simply absent from the map.
+  /// The next unread downloaded chapter per manga (lowest `chapterIndex` with
+  /// `isRead = false` and `deviceState = downloaded`) — drives the offline
+  /// "continue reading" button; a manga with none downloaded is absent from
+  /// the map.
   Future<Map<int, OfflineChapter>> firstUnreadDownloadedChapterByManga() async {
     final rows = await (select(offlineChapters)
           ..where((t) =>
@@ -589,9 +602,9 @@ class OfflineDatabase extends _$OfflineDatabase {
       (select(offlineChapters)..where((t) => t.mangaId.equals(mangaId)))
           .watch();
 
-  /// Live stream of every chapter that's downloaded OR actively
-  /// downloading/queued on this device — drives the Downloads → Offline files
-  /// tab (so it shows in-progress downloads, not just finished ones).
+  /// Live stream of every chapter downloaded OR actively downloading/queued —
+  /// drives the Downloads → Offline files tab, so in-progress downloads show
+  /// too, not just finished ones.
   Stream<List<OfflineChapter>> watchOfflineChapters() =>
       (select(offlineChapters)
             ..where((t) => t.deviceState.isIn([
@@ -601,13 +614,11 @@ class OfflineDatabase extends _$OfflineDatabase {
                 ])))
           .watch();
 
-  /// Live list of every series with an offline footprint on this device —
-  /// either chapters present (downloaded / in-flight) OR an active keep-rule
-  /// (`keepRule != off`) — with per-series aggregates and the manga row (which
-  /// carries `keepRule` / `keepUnreadCount`). The union is what makes the
-  /// Downloads → On device tab the single surface: a rule with nothing
-  /// downloaded yet still appears, and hand-saved chapters with no rule still
-  /// appear. Updates on either table changing.
+  /// Live list of every series with an offline footprint — chapters present
+  /// OR an active keep-rule — with per-series aggregates and the manga row.
+  /// The union makes Downloads → On device the single surface: a rule with
+  /// nothing downloaded yet still appears, and hand-saved chapters with no
+  /// rule still appear.
   Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
       watchOfflineSeries() {
     final downloaded = offlineChapters.id.count(

--- a/lib/src/features/offline/data/offline_download_coordinator.dart
+++ b/lib/src/features/offline/data/offline_download_coordinator.dart
@@ -15,15 +15,12 @@ typedef PageUrlsResolver = Future<List<String>> Function(int chapterId);
 /// Measures the total on-disk bytes of a downloaded chapter's pages.
 typedef ChapterBytesMeasurer = Future<int> Function(int mangaId, int chapterId);
 
-/// Orchestrates background chapter downloads on top of [ChapterDownloadEngine].
-///
-/// Download ONE chapter at a time (everything comes from our
-/// own server, so there's nothing to spread chapter-level load against), with
-/// page-level parallelism inside the engine. Auth is resolved at request time
-/// by the engine's fetcher and refreshed on a 401 — nothing is baked at enqueue,
-/// which is what stranded the old `background_downloader` tasks with expired
-/// tokens. Deps are injected so the flow is testable without GraphQL, HTTP or
-/// dart:io.
+/// Orchestrates background chapter downloads on top of [ChapterDownloadEngine],
+/// one chapter at a time (page-level parallelism lives in the engine) since
+/// everything comes from our own server. Auth is resolved fresh per request
+/// and refreshed on a 401 — nothing baked at enqueue, which is what stranded
+/// the old `background_downloader` tasks with expired tokens; deps are
+/// injected so the flow is testable without GraphQL/HTTP/dart:io.
 class OfflineDownloadCoordinator {
   OfflineDownloadCoordinator({
     required this.db,
@@ -38,33 +35,53 @@ class OfflineDownloadCoordinator {
   final ChapterDownloadEngine engine;
   final ChapterBytesMeasurer measureChapterBytes;
 
-  /// Reads the persisted "downloads paused" flag (injected so the pump survives
-  /// a restart with the pause intact, without the coordinator depending on
-  /// SharedPreferences directly). Null in tests = never persistently paused.
+  /// Reads the persisted "downloads paused" flag (injected so a restart
+  /// survives with the pause intact, without depending on SharedPreferences
+  /// directly). Null in tests = never persistently paused.
   final bool Function()? persistedPaused;
 
-  /// In-session pause, set by [pause]/[resume] for an immediate brake. The gate
-  /// is the OR of this and the persisted flag, so a restart honours a saved
-  /// pause even though this resets to false.
+  /// In-session pause, set by [pause]/[resume] for an immediate brake — the
+  /// gate is the OR of this and the persisted flag, so a restart still honours
+  /// a saved pause even though this resets to false.
   bool _paused = false;
 
   /// True when on-device downloads are paused (in-session or persisted).
   bool get isPaused => _paused || (persistedPaused?.call() ?? false);
 
-  /// Chapter currently being downloaded by the engine (in-memory). One at a
-  /// time, so at most one entry.
-  final Set<int> _active = {};
+  // These three and [_pumping] are PROCESS-WIDE (static): a keep-alive provider
+  // rebuild mid-drain can leave an old coordinator's pump running while deletes
+  // route through the new instance, so instance-local guards would let it
+  // resurrect a just-deleted chapter — sharing state keeps a delete claim
+  // visible across generations.
+
+  /// Chapter currently being downloaded by the engine. One at a time, so at most
+  /// one entry.
+  static final Set<int> _active = {};
 
   /// Chapters asked to stop mid-download (delete / pause). Cleared once the
   /// in-flight download observes it and unwinds.
-  final Set<int> _cancelled = {};
+  static final Set<int> _cancelled = {};
 
-  /// True while a pump loop is draining the queue. PROCESS-WIDE (static) so that
-  /// even if the provider rebuilds mid-drain (e.g. the concurrency setting
-  /// settles) and a second coordinator instance is created, only ONE loop ever
-  /// drains the shared DB queue — otherwise both race and re-download every
-  /// chapter. Mirrors the auth refresh single-flight.
+  /// Chapters mid-delete, reference-counted by claimant (a user delete and a
+  /// reconcile eviction can overlap). Pump/[enqueueChapter] skip any key
+  /// present; the claim releases only when the last claimant calls [endDelete],
+  /// so one finishing early can't unguard a chapter another is still
+  /// deleting — `_cancelled` alone isn't enough since `enqueueChapter`'s
+  /// `finally` clears it.
+  static final Map<int, int> _deleting = {};
+
+  /// True while a pump loop is draining the queue — only ONE loop ever drains
+  /// the shared DB queue even across a mid-drain rebuild.
   static bool _pumping = false;
+
+  /// Reset all process-wide state. Test-only: tests share one process, so a
+  /// coordinator built in one test would otherwise inherit another's claims.
+  static void resetSharedStateForTest() {
+    _active.clear();
+    _cancelled.clear();
+    _deleting.clear();
+    _pumping = false;
+  }
 
   /// True if this chapter is actively downloading right now.
   bool isActive(int chapterId) => _active.contains(chapterId);
@@ -75,6 +92,32 @@ class OfflineDownloadCoordinator {
     if (_active.contains(chapterId)) _cancelled.add(chapterId);
   }
 
+  /// Claim a chapter for deletion, cancelling it and waiting (bounded) for the
+  /// engine to stop writing. Call before deleting files/rows; pair with
+  /// [endDelete] in a `finally`.
+  Future<void> beginDelete(int chapterId,
+      {Duration timeout = const Duration(seconds: 3)}) async {
+    _deleting.update(chapterId, (n) => n + 1, ifAbsent: () => 1);
+    _cancelled.add(chapterId);
+    final deadline = DateTime.now().add(timeout);
+    while (_active.contains(chapterId) && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+  }
+
+  /// Release a chapter claimed by [beginDelete] once its files/rows are gone.
+  /// Drops the cancel only when the LAST claimant exits, so an overlapping
+  /// delete keeps it guarded.
+  void endDelete(int chapterId) {
+    final remaining = (_deleting[chapterId] ?? 0) - 1;
+    if (remaining <= 0) {
+      _deleting.remove(chapterId);
+      _cancelled.remove(chapterId);
+    } else {
+      _deleting[chapterId] = remaining;
+    }
+  }
+
   /// Pause all on-device downloading: stop starting new chapters and cancel the
   /// in-flight one (left `downloading` = resumable). The persisted flag is set
   /// by the caller; this is the immediate in-session brake.
@@ -83,11 +126,10 @@ class OfflineDownloadCoordinator {
     _cancelled.addAll(_active);
   }
 
-  /// Wait until nothing is actively downloading and the pump loop has exited, so
-  /// a catalog clear can be sure no `onPageStored` write lands after it wipes the
-  /// DB/files. Call after [pause]. Bounded so it can never hang the clear — the
-  /// clear proceeds even if a stubborn page fetch hasn't observed the cancel yet
-  /// (rare, and the worst case is one orphan row, which a later clear removes).
+  /// Wait until nothing is downloading and the pump has exited, so a catalog
+  /// clear is sure no `onPageStored` write lands after it wipes the DB/files.
+  /// Bounded so it never hangs the clear — worst case is one orphan row,
+  /// cleaned up later.
   Future<void> awaitIdle(
       {Duration timeout = const Duration(seconds: 3)}) async {
     final deadline = DateTime.now().add(timeout);
@@ -108,37 +150,53 @@ class OfflineDownloadCoordinator {
   /// starts it when it reaches the front. Skips chapters already downloaded or
   /// in flight.
   Future<void> queueChapter(int chapterId) async {
-    final c = await db.chapterById(chapterId);
-    if (c == null) return;
-    if (c.deviceState == OfflineDeviceState.downloaded ||
-        c.deviceState == OfflineDeviceState.downloading ||
-        c.deviceState == OfflineDeviceState.queued) {
-      return;
-    }
-    await db.setChapterDeviceState(chapterId, OfflineDeviceState.queued);
+    if (_deleting.containsKey(chapterId)) return;
+    await db.transaction(() async {
+      // Recheck inside the transaction (serialized with deleteChapter): `none`
+      // is itself queueable, so without the _deleting guard a racing queue
+      // request would re-queue a chapter the user just removed.
+      if (_deleting.containsKey(chapterId)) return;
+      final c = await db.chapterById(chapterId);
+      if (c == null) return;
+      if (c.deviceState == OfflineDeviceState.downloaded ||
+          c.deviceState == OfflineDeviceState.downloading ||
+          c.deviceState == OfflineDeviceState.queued) {
+        return;
+      }
+      await db.setChapterDeviceState(chapterId, OfflineDeviceState.queued);
+    });
   }
 
   /// Resolve + download a single chapter immediately (used by the pump and for
-  /// a direct save). Idempotent + resumable: an already-`downloaded` chapter is
-  /// skipped, pages already on disk are not re-fetched, and a chapter left
-  /// `downloading` by a previous run (e.g. an app kill) simply resumes.
+  /// a direct save). Idempotent + resumable: skips an already-`downloaded`
+  /// chapter, doesn't re-fetch pages already on disk, and simply resumes a
+  /// chapter left `downloading` by a prior run.
   Future<void> enqueueChapter(OfflineChapter chapter) async {
+    if (_deleting.containsKey(chapter.id)) return;
     if (chapter.deviceState == OfflineDeviceState.downloaded) return;
-    // Paused: don't start (or re-start a stranded) chapter. Guarded here too —
-    // not just in pumpDownloads — because enqueueChapter's `finally` clears the
-    // chapter from `_cancelled`, so a stray pump could otherwise re-select a
-    // stranded `downloading` chapter and restart it while paused.
+    // Paused: don't start (or re-start a stranded) chapter. Guarded here too,
+    // not just in pumpDownloads — enqueueChapter's `finally` clears
+    // `_cancelled`, so a stray pump could otherwise re-select and restart a
+    // stranded chapter while paused.
     if (isPaused) return;
     if (_active.contains(chapter.id)) return;
     _active.add(chapter.id);
     try {
-      await db.setChapterDeviceState(
-          chapter.id, OfflineDeviceState.downloading);
+      // Recheck _deleting and mark downloading atomically (serialized with
+      // deleteChapter) — a mid-flight delete claim must win; `none` is itself
+      // a valid fresh-download start, so only an active delete blocks it.
+      final started = await db.transaction(() async {
+        if (_deleting.containsKey(chapter.id)) return false;
+        await db.setChapterDeviceState(
+            chapter.id, OfflineDeviceState.downloading);
+        return true;
+      });
+      if (!started) return;
       final urls = await resolvePages(chapter.id);
       if (urls.isEmpty) {
         logger.e('Offline: no pages resolved for chapter ${chapter.id}; '
             'marking error');
-        await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+        await _applyTerminalError(chapter.id);
         return;
       }
       final stored = (await (db.select(db.offlinePages)
@@ -157,13 +215,21 @@ class OfflineDownloadCoordinator {
         pages: pages,
         isCancelled: () => _cancelled.contains(chapter.id),
         onPageStored: (pageIndex, relPath, bytes) async {
-          await db.into(db.offlinePages).insertOnConflictUpdate(
-                OfflinePagesCompanion.insert(
-                  chapterId: chapter.id,
-                  pageIndex: pageIndex,
-                  relativePath: relPath,
-                ),
-              );
+          if (_deleting.containsKey(chapter.id)) return;
+          // Atomic state-check + insert: deleteChapter flips state=none and
+          // drops rows in one transaction, so this either commits first (and
+          // gets deleted there) or reads none and skips — no orphan row survives.
+          await db.transaction(() async {
+            final c = await db.chapterById(chapter.id);
+            if (c == null || c.deviceState == OfflineDeviceState.none) return;
+            await db.into(db.offlinePages).insertOnConflictUpdate(
+                  OfflinePagesCompanion.insert(
+                    chapterId: chapter.id,
+                    pageIndex: pageIndex,
+                    relativePath: relPath,
+                  ),
+                );
+          });
         },
       );
 
@@ -177,12 +243,12 @@ class OfflineDownloadCoordinator {
       }
       if (outcome.authFailed) {
         logger.e('Offline: chapter ${chapter.id} auth failed (token dead)');
-        await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+        await _applyTerminalError(chapter.id);
         return;
       }
       if (outcome.error != null) {
         logger.e('Offline: chapter ${chapter.id} failed: ${outcome.error}');
-        await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+        await _applyTerminalError(chapter.id);
         return;
       }
       logger.i('Offline: enqueued ${pages.length} page tasks for chapter '
@@ -190,11 +256,25 @@ class OfflineDownloadCoordinator {
       await _finalizeIfComplete(chapter.mangaId, chapter.id, urls.length);
     } catch (e) {
       logger.e('Offline: chapter ${chapter.id} download error: $e');
-      await db.setChapterDeviceState(chapter.id, OfflineDeviceState.error);
+      await _applyTerminalError(chapter.id);
     } finally {
       _active.remove(chapter.id);
-      _cancelled.remove(chapter.id);
+      // Keep the cancel set while a delete still holds a claim — endDelete owns
+      // clearing it once the last claimant exits.
+      if (!_deleting.containsKey(chapter.id)) _cancelled.remove(chapter.id);
     }
+  }
+
+  /// Write a terminal error state only if the chapter is still ours. beginDelete
+  /// waits only briefly for the engine to stop, so a slow fetch can outlive a
+  /// delete that already committed `none` — a late error must not resurrect it.
+  Future<void> _applyTerminalError(int chapterId) async {
+    if (_deleting.containsKey(chapterId)) return;
+    await db.transaction(() async {
+      final c = await db.chapterById(chapterId);
+      if (c == null || c.deviceState == OfflineDeviceState.none) return;
+      await db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
+    });
   }
 
   /// Mark a chapter `downloaded` (with measured bytes) once all its pages are on
@@ -205,15 +285,32 @@ class OfflineDownloadCoordinator {
     final chapter = await db.chapterById(chapterId);
     if (chapter == null) return false;
     if (chapter.deviceState == OfflineDeviceState.downloaded) return true;
+    // Deleted mid-download: never resurrect as `downloaded`.
+    if (chapter.deviceState == OfflineDeviceState.none ||
+        _deleting.containsKey(chapterId)) {
+      return false;
+    }
     final target = expectedPages ?? chapter.pageCount;
     if (target <= 0) return false;
     if (await db.downloadedPageCount(chapterId) < target) return false;
     final bytes = await measureChapterBytes(mangaId, chapterId);
-    await db.setChapterDeviceState(chapterId, OfflineDeviceState.downloaded,
-        bytes: bytes, downloadedAt: DateTime.now());
-    logger.i('Offline: chapter $chapterId downloaded ($target pages, '
-        '$bytes bytes)');
-    return true;
+    // Re-check and write atomically (serialized with deleteChapter): a delete
+    // that landed during the async count/measure must win over this completion.
+    final finalized = await db.transaction(() async {
+      if (_deleting.containsKey(chapterId)) return false;
+      final fresh = await db.chapterById(chapterId);
+      if (fresh == null || fresh.deviceState == OfflineDeviceState.none) {
+        return false;
+      }
+      await db.setChapterDeviceState(chapterId, OfflineDeviceState.downloaded,
+          bytes: bytes, downloadedAt: DateTime.now());
+      return true;
+    });
+    if (finalized) {
+      logger.i('Offline: chapter $chapterId downloaded ($target pages, '
+          '$bytes bytes)');
+    }
+    return finalized;
   }
 
   /// Drain the queue one chapter at a time: resume any chapter left
@@ -221,10 +318,10 @@ class OfflineDownloadCoordinator {
   /// `queued` backlog. Single-flight — a second call while running is a no-op;
   /// the running loop picks up anything newly queued.
   Future<void> pumpDownloads() async {
-    // CORRUPTION GATE: on Android the foreground-service worker isolate is the
-    // sole downloader; the main-isolate pump must NEVER write page files there
-    // (two isolates writing the same files/catalog corrupts it). Downloads on
-    // Android are driven by BackgroundDownloadController instead.
+    // CORRUPTION GATE: on Android the foreground-service worker is the sole
+    // downloader — two isolates writing the same files/catalog corrupts it, so
+    // this pump must never run there; BackgroundDownloadController drives
+    // Android instead.
     if (isAndroidNative) return;
     if (isPaused) return;
     if (_pumping) return;
@@ -253,11 +350,14 @@ class OfflineDownloadCoordinator {
         stranded++;
       }
     }
-    final firstStranded =
-        downloading.where((c) => !_active.contains(c.id)).firstOrNull;
+    final firstStranded = downloading
+        .where((c) => !_active.contains(c.id) && !_deleting.containsKey(c.id))
+        .firstOrNull;
     logger.i('Offline pump: downloading=${downloading.length} '
         'active=${_active.length} stranded=$stranded');
     if (firstStranded != null) return firstStranded;
-    return db.nextQueuedChapter();
+    // Skip a queue head mid-deletion so it doesn't stall the rest of the backlog.
+    final queued = await db.chaptersInState(OfflineDeviceState.queued);
+    return queued.where((c) => !_deleting.containsKey(c.id)).firstOrNull;
   }
 }

--- a/lib/src/features/offline/data/offline_download_manager.dart
+++ b/lib/src/features/offline/data/offline_download_manager.dart
@@ -14,12 +14,10 @@ typedef PageUrlsFetcher = Future<List<String>> Function(int chapterId);
 /// Fetches one page URL's bytes + extension (wraps the auth'd HTTP GET).
 typedef PageBytesFetcher = Future<PageBytes> Function(String url);
 
-/// Orchestrates saving a chapter's pages to the device.
-///
-/// Platform-agnostic: the page-URL resolver, the byte fetcher, and the file
-/// store are injected, so the download flow is hermetically testable. The
-/// runtime wiring (GraphQL page URLs, auth'd HTTP, dart:io store, free-space
-/// guard) is provided on native platforms.
+/// Orchestrates saving a chapter's pages to the device. Platform-agnostic —
+/// the page-URL resolver, byte fetcher, and file store are injected so the
+/// flow is hermetically testable; real wiring (GraphQL, auth'd HTTP, dart:io,
+/// free-space guard) is provided on native platforms.
 class OfflineDownloadManager {
   OfflineDownloadManager({
     required this.db,
@@ -33,10 +31,10 @@ class OfflineDownloadManager {
   final PageUrlsFetcher fetchPageUrls;
   final PageBytesFetcher fetchBytes;
 
-  /// Download every page of [chapter] to the device. Requires the chapter to be
-  /// server-downloaded (product policy). On any failure, partial files + page
-  /// rows are removed and the chapter is marked `error`, then the error
-  /// rethrows so the queue/UI can surface it.
+  /// Download every page of [chapter] to the device. Requires it to be
+  /// server-downloaded (product policy); on any failure, partial files/rows
+  /// are removed, the chapter is marked `error`, and the error rethrows so
+  /// the queue/UI can surface it.
   Future<void> downloadChapter(OfflineChapter chapter, {bool force = false}) async {
     if (!force && !chapter.serverIsDownloaded) {
       throw StateError(
@@ -83,8 +81,18 @@ class OfflineDownloadManager {
 
   /// Remove a chapter's device copy entirely and reset its state.
   Future<void> deleteChapter(OfflineChapter chapter) async {
-    await _purge(chapter);
-    await db.setChapterDeviceState(chapter.id, OfflineDeviceState.none, bytes: 0);
+    // Flip state and drop page rows in one transaction so it serializes with
+    // the coordinator's onPageStored insert: that insert either commits first
+    // and is deleted here, or reads state=none and skips. Files come after —
+    // reconcile sweeps an orphan file, not an orphan row.
+    await db.transaction(() async {
+      await db.setChapterDeviceState(chapter.id, OfflineDeviceState.none,
+          bytes: 0);
+      await (db.delete(db.offlinePages)
+            ..where((t) => t.chapterId.equals(chapter.id)))
+          .go();
+    });
+    await store.deleteChapter(chapter.mangaId, chapter.id);
   }
 
   /// On launch, reset chapters left mid-download (app killed) so they can be

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -49,9 +49,8 @@ part 'offline_download_providers.g.dart';
 /// downloads (web-safe + correct in unit tests — see [isAndroidNative]).
 bool get _useBgService => isAndroidNative;
 
-/// THE single entry point that kicks off downloading after chapters have been
-/// queued into drift. EVERY download trigger must call this — on Android it
-/// starts the foreground-service worker, elsewhere it drains via the
+/// THE single entry point that kicks off downloading after chapters are
+/// queued into drift — starts the FGS worker on Android, else drains via the
 /// main-isolate pump. Centralised (and overridable in tests) so no trigger can
 /// ever again silently rely on the Android-disabled pump.
 final downloadStarterProvider = Provider<Future<void> Function()>((Ref ref) {
@@ -67,11 +66,10 @@ final downloadStarterProvider = Provider<Future<void> Function()>((Ref ref) {
   };
 });
 
-/// Pause or resume ALL on-device downloads. Persists the flag (so it survives a
-/// restart) and acts immediately on the active pipeline: the FGS worker on
-/// Android, the main-isolate pump elsewhere. The persisted flag is what the
-/// download starters gate on, so no enqueue/connectivity/launch path can restart
-/// downloads while paused.
+/// Pause or resume ALL on-device downloads. Persists the flag (survives a
+/// restart) and acts immediately on the active pipeline (FGS on Android,
+/// main-isolate pump elsewhere) — the persisted flag is what every download
+/// starter gates on, so no path can restart downloads while paused.
 Future<void> setOfflineDownloadsPaused(WidgetRef ref, bool paused) async {
   ref.read(offlineDownloadsPausedProvider.notifier).update(paused);
   if (isAndroidNative) {
@@ -105,9 +103,9 @@ Future<void> clearOfflineCatalog(WidgetRef ref) async {
       await coordinator?.awaitIdle();
     },
     clearDatabase: ref.read(offlineDatabaseProvider).clearAll,
-    // Best-effort: a file-delete failure (a locked file, permissions) must not
-    // abort the clear before the identity stamp is reset — the DB is already
-    // wiped, and leftover bytes are only dead weight, not stale content.
+    // Best-effort: a file-delete failure (locked file, permissions) must not
+    // abort the clear before the identity stamp resets — the DB is already
+    // wiped, so leftover bytes are just dead weight, not stale content.
     clearFiles: () async {
       try {
         await ref.read(offlinePageStoreProvider).clearAll();
@@ -134,9 +132,9 @@ Future<void> clearOfflineCatalogWithDependencies({
   required Future<void> Function() clearIdentity,
   required void Function() finish,
 }) async {
-  // stopBackground sets the restart-suppression flag; keep it INSIDE the try so
-  // finish() always clears it even if teardown throws — otherwise a leaked flag
-  // would silently drop every background-worker event for the rest of the session.
+  // stopBackground sets the restart-suppression flag; keep it inside the try
+  // so finish() always clears it, or a leaked flag would silently drop every
+  // background-worker event for the rest of the session.
   try {
     await stopBackground();
     await stopMainPump();
@@ -180,24 +178,20 @@ Stream<double?> offlineChapterProgress(Ref ref, int chapterId) {
     return Stream.value(null);
   }
   final repo = ref.watch(offlineRepositoryProvider);
-  // Re-read the page total on every downloaded-page tick (instead of once up
-  // front) so the arc flips from indeterminate to a real fraction the moment the
-  // total becomes known — webtoon chapters only learn their page count when the
-  // downloader resolves their pages mid-download.
+  // Re-read the page total on every tick (not once up front) so the arc flips
+  // from indeterminate to real the moment it's known — webtoon chapters only
+  // learn their count once the downloader resolves pages mid-download.
   return repo.watchChapterDownloadedPages(chapterId).asyncMap((done) async {
     final total = (await repo.db.chapterById(chapterId))?.pageCount ?? 0;
     return total <= 0 ? null : (done / total).clamp(0.0, 1.0);
   }).distinct();
 }
 
-/// Save a chapter's pages to the device. Looks up the synced catalog row and
-/// hands it to the download manager. No-op if offline is unavailable or the
-/// chapter hasn't been synced (browse it online once first).
-///
-/// Manual save is sticky (pinned). If the chapter is not yet server-downloaded,
-/// enqueues a server download first so Suwayomi fetches the source pages, then
-/// pulls them immediately with `force: true` so the device copy is available as
-/// soon as the server completes its own fetch.
+/// Save a chapter's pages to the device from the synced catalog row; no-op if
+/// offline is unavailable or the chapter hasn't been synced yet. Manual save
+/// is sticky (pinned) — if not yet server-downloaded, enqueues a server
+/// download first, then pulls immediately so the device copy is available as
+/// soon as the server's own fetch completes.
 Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
   final coordinator = ref.read(offlineDownloadCoordinatorProvider);
   if (coordinator == null) return;
@@ -206,11 +200,10 @@ Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
   if (chapter == null) return;
   // Manual save is sticky.
   await ref.read(offlineDatabaseProvider).setChapterPinned(chapterId, true);
-  // Ensure the SERVER also has the chapter (device ⊆ server). The cached
-  // `serverIsDownloaded` flag can be stale (e.g. it isn't reset when a chapter is
-  // deleted), so when it claims the server already has the chapter, verify
-  // against the server before skipping — otherwise the device keeps a copy the
-  // server never saved. A failed/offline check falls back to the cached value.
+  // Ensure the SERVER also has the chapter (device ⊆ server): the cached
+  // `serverIsDownloaded` flag can be stale (not reset on delete), so verify
+  // against the server before trusting it — a failed/offline check falls back
+  // to the cached value.
   var serverHasIt = chapter.serverIsDownloaded;
   if (serverHasIt) {
     final fresh = await AsyncValue.guard(() =>
@@ -235,14 +228,14 @@ Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
 /// FIRST (so it survives offline + app restart — the bug where progress was
 /// lost reading offline), then pushes to the server; on a successful push the
 /// dirty flag is cleared, otherwise it stays pending for the next online sync.
-Future<void> recordReadingProgress(
+Future<AsyncValue<void>> recordReadingProgress(
   WidgetRef ref, {
   required int chapterId,
   required int lastPageRead,
   required bool isRead,
 }) async {
   final offline = ref.read(offlineActiveProvider);
-  await recordReadingProgressWithDependencies(
+  return recordReadingProgressWithDependencies(
     offlineEnabled: offline,
     offlineDatabase: offline ? ref.read(offlineDatabaseProvider) : null,
     repository: ref.read(mangaBookRepositoryProvider),
@@ -252,7 +245,10 @@ Future<void> recordReadingProgress(
   );
 }
 
-Future<void> recordReadingProgressWithDependencies({
+/// Returns the server-push outcome so callers aren't blind to a failed write.
+/// For an online-only user there's no pending row to retry, so a swallowed
+/// error means the progress is lost silently — the reader surfaces this.
+Future<AsyncValue<void>> recordReadingProgressWithDependencies({
   required bool offlineEnabled,
   required OfflineDatabase? offlineDatabase,
   required MangaBookRepository repository,
@@ -289,12 +285,12 @@ Future<void> recordReadingProgressWithDependencies({
       await db.clearReadStateDirtyIfUnchanged(chapterId, isRead: markRead);
     }
   }
+  return result;
 }
 
 /// Toggle a chapter's bookmark, offline-aware. Writes it to the on-device
-/// catalog first (so it survives offline + restart) and marks it dirty, then
-/// pushes to the server; on a failed push it stays pending for the next online
-/// sync (#33). Best-effort — the local write is authoritative.
+/// catalog first (survives offline + restart) and marks it dirty, then pushes
+/// to the server — a failed push stays pending for the next sync (#33).
 Future<void> recordBookmark(
   WidgetRef ref, {
   required int chapterId,
@@ -307,8 +303,8 @@ Future<void> recordBookmark(
         .setChapterBookmark(chapterId, isBookmarked);
   }
   // Bookmark dirtiness is tracked separately from read progress, so push only
-  // the bookmark and clear only its flag — any pending offline read stays dirty
-  // and is flushed independently by pushPendingProgress.
+  // the bookmark and clear only its flag — any pending offline read stays
+  // dirty and flushes independently via pushPendingProgress.
   final result = await AsyncValue.guard(
     () => ref.read(mangaBookRepositoryProvider).putChapter(
           chapterId: chapterId,
@@ -322,14 +318,12 @@ Future<void> recordBookmark(
   }
 }
 
-/// Mark chapters read/unread, offline-aware. Writes the local row FIRST (so the
-/// change survives offline + restart and keeps Resume and the offline UI
-/// truthful — the root of the ch-99 loop was that list mark-read never touched
-/// the local row), then the server bulk write; on failure the change stays
-/// dirty and up-syncs on reconnect. [resetPosition] mirrors the mark-read
-/// action's `lastPageRead: 0` reset (recorded locally as a deliberate position
-/// write); mark-unread leaves position alone. Returns the server write's
-/// success, so callers keep firing trackers / delete-on-manual online only.
+/// Mark chapters read/unread, offline-aware. Writes the local row FIRST (the
+/// ch-99 loop's root cause was list mark-read never touching it), then the
+/// server bulk write; on failure the change stays dirty and up-syncs on
+/// reconnect. [resetPosition] mirrors the mark-read action's `lastPageRead: 0`
+/// reset; returns the server write's success so callers gate trackers/
+/// delete-on-manual on being online.
 Future<bool> recordReadStateWithDependencies({
   required bool offlineEnabled,
   required OfflineDatabase? offlineDatabase,
@@ -389,13 +383,12 @@ Future<bool> recordReadState(
 }
 
 // === Delete-on-read =========================================================
-// Two INDEPENDENT features, each with its own settings (see
-// delete_chapters_settings_repository): the on-device set (local prefs) deletes
-// THIS phone's copy; the server set (global meta, shared with the WebUI) deletes
-// the server's copy, which then cascades to the device (device ⊆ server). On a
-// read we fire both; each no-ops if its own setting is off. The N-behind target
-// only ever lands on a chapter already behind the reader, so the continuous
-// reader never loses pages it still needs.
+// Two INDEPENDENT features (see delete_chapters_settings_repository):
+// on-device (local prefs) deletes THIS phone's copy; server (shared with the
+// WebUI) deletes the server's copy, which cascades to the device (device ⊆
+// server). Each no-ops if its own setting is off, and the N-behind target only
+// ever lands on a chapter already behind the reader, so the continuous reader
+// never loses pages it still needs.
 
 /// Resolve the chapter to delete `slots` behind [readChapterId] in the manga's
 /// reading order (1 = the just-read chapter). Null if out of range or the list
@@ -449,10 +442,10 @@ Future<void> maybeDeleteOnManualLocal(
   await _deleteDeviceCopyIfDeletable(ref, chapterId, s.deleteWithBookmark);
 }
 
-/// Delete a chapter's device copy iff it's downloaded on the device and the
-/// bookmark gate allows it. A manually-saved (pinned) chapter IS deleted on a
-/// new read — and un-pinned (via [deleteChapterFromDevice]) so the reconciler
-/// doesn't simply re-download it. The server copy is untouched.
+/// Delete a chapter's device copy iff it's downloaded and the bookmark gate
+/// allows it. A manually-saved (pinned) chapter IS deleted on a new read and
+/// un-pinned (via [deleteChapterFromDevice]) so the reconciler doesn't just
+/// re-download it; the server copy is untouched.
 Future<void> _deleteDeviceCopyIfDeletable(
   WidgetRef ref,
   int chapterId,
@@ -502,13 +495,11 @@ Future<void> maybeDeleteOnManualServer(
       ref, mangaId, chapterId, s.deleteWithBookmark);
 }
 
-/// Delete a chapter's SERVER copy iff it's downloaded on the server and the
-/// bookmark gate allows it, then cascade to drop the device copy.
-///
-/// Gates off the UNFILTERED chapter list (id lookup — order is irrelevant), so
-/// an active "hide read" filter can't make this silently miss. The bookmark gate
-/// also honours a bookmark made offline that hasn't reached the server yet (the
-/// server DTO would still read false), via the on-device catalog.
+/// Delete a chapter's SERVER copy iff downloaded and the bookmark gate allows
+/// it, then cascade to drop the device copy. Gates off the UNFILTERED chapter
+/// list so an active "hide read" filter can't cause a silent miss, and the
+/// bookmark gate also honours a bookmark made offline that hasn't reached the
+/// server yet.
 Future<void> _deleteServerCopyIfDeletable(
   WidgetRef ref,
   int mangaId,
@@ -537,13 +528,10 @@ Future<void> _deleteServerCopyIfDeletable(
   }
 }
 
-/// Push any locally-recorded read progress that hasn't reached the server yet
-/// (e.g. read while offline). Run at launch + after a manga's chapters sync, so
-/// progress made offline syncs up once the connection returns.
-///
-/// After a successful server push, also nudges the manga's external trackers
-/// for any chapter that was marked read — so trackers stay in sync even when
-/// progress was recorded while the device was offline.
+/// Push any locally-recorded read progress that hasn't reached the server yet.
+/// Run at launch + after a manga's chapters sync; after a successful push also
+/// nudges the manga's external trackers for any chapter marked read, so
+/// trackers stay in sync too.
 Future<void> pushPendingProgress(ProviderContainer container) async {
   if (!container.read(offlineActiveProvider)) return;
   final db = container.read(offlineDatabaseProvider);
@@ -554,25 +542,60 @@ Future<void> pushPendingProgress(ProviderContainer container) async {
   final syncedReadMangaIds = <int>{};
 
   for (final c in await db.dirtyChapters()) {
+    var pushProgress = c.progressDirty;
+    var pushReadState = c.readStateDirty;
+    // Never-regress: if another device already read further (or finished it),
+    // don't push our lesser offline position — drop the dirty flags and adopt
+    // the server's state on the next down-sync. Furthest read wins; bookmarks
+    // are independent and still sync.
+    if (pushProgress || pushReadState) {
+      final server =
+          (await AsyncValue.guard(() => repo.getChapter(chapterId: c.id)))
+              .asData
+              ?.value;
+      if (server != null) {
+        final serverRead = server.isRead.ifNull();
+        final serverAhead = serverRead
+            ? !c.isRead // server finished it; our push would un-finish it
+            : c.isRead
+                // We finished it; a server partial position never outranks a
+                // completion (marking read leaves lastPageRead low).
+                ? false
+                : server.lastPageRead.getValueOnNullOrNegative() >
+                    c.lastPageRead;
+        if (serverAhead) {
+          pushProgress = false;
+          pushReadState = false;
+          if (c.progressDirty) {
+            await db.clearProgressDirtyIfUnchanged(c.id,
+                lastPageRead: c.lastPageRead);
+          }
+          if (c.readStateDirty) {
+            await db.clearReadStateDirtyIfUnchanged(c.id, isRead: c.isRead);
+          }
+        }
+      }
+    }
+    if (!pushProgress && !pushReadState && !c.bookmarkDirty) continue;
     final result = await AsyncValue.guard(
       () => repo.putChapter(
         chapterId: c.id,
         patch: ChapterChange(
-          // Send only the locally-changed fields (null = omitted from the
-          // patch), each gated on its OWN dirty flag. isRead rides
-          // readStateDirty — NOT progressDirty — so a position-only write can
-          // never push a stale isRead (the ch-99 un-read loop), just as a
-          // bookmark sync never overwrites pending read progress (#13).
-          lastPageRead: c.progressDirty ? c.lastPageRead : null,
-          isRead: c.readStateDirty ? c.isRead : null,
+          // Send only locally-changed fields (null = omitted), each gated on
+          // its OWN dirty flag: isRead rides readStateDirty (not
+          // progressDirty) so a position-only write can't push a stale isRead
+          // (ch-99), just as a bookmark sync can't overwrite pending read
+          // progress (#13).
+          lastPageRead: pushProgress ? c.lastPageRead : null,
+          isRead: pushReadState ? c.isRead : null,
           isBookmarked: c.bookmarkDirty ? c.isBookmarked : null,
         ),
       ),
     );
     if (!result.hasError) {
       // Clear each flag only if the row still holds what we just pushed — a
-      // newer local write that arrived during the push keeps its flag and
-      // re-syncs on the next pass (no silent data loss).
+      // newer local write that arrived mid-push keeps its flag and re-syncs
+      // on the next pass.
       if (c.progressDirty) {
         await db.clearProgressDirtyIfUnchanged(c.id,
             lastPageRead: c.lastPageRead);
@@ -588,9 +611,9 @@ Future<void> pushPendingProgress(ProviderContainer container) async {
     }
   }
 
-  // Push tracker progress for each manga that had read chapters synced.
-  // Gate on the "update after reading" toggle and whether the manga has any
-  // tracker bindings. A tracker failure must never break the progress sync.
+  // Push tracker progress for mangas with read chapters synced, gated on the
+  // "update after reading" toggle and tracker bindings — a tracker failure
+  // must never break the progress sync.
   if (syncedReadMangaIds.isEmpty) return;
   final enabledAfterReading =
       container.read(updateProgressAfterReadingProvider).ifNull();
@@ -639,31 +662,46 @@ Future<void> cascadeServerDeleteToDevice(
 Future<void> deleteChapterFromDevice(WidgetRef ref, int chapterId) async {
   final manager = ref.read(offlineDownloadManagerProvider);
   if (manager == null) return;
-  // If the FGS worker is mid-download of this chapter, stop it first so it can't
-  // resurrect files we're about to delete (the worker honours `remove` via the
-  // engine's per-chapter cancel).
+  // Stop any in-flight download first so it can't resurrect the files we're
+  // about to delete — Android routes through the FGS worker, elsewhere claim
+  // the main-isolate coordinator.
+  final coordinator =
+      _useBgService ? null : ref.read(offlineDownloadCoordinatorProvider);
+  // Bump the persistent download generation first so a re-queued download
+  // outranks any still-in-flight event from the deleted one (survives restart).
+  final newGen =
+      await ref.read(offlineDatabaseProvider).bumpChapterGeneration(chapterId);
   if (_useBgService) {
-    await ref.read(backgroundDownloadControllerProvider).onRemoved(chapterId);
+    final controller = ref.read(backgroundDownloadControllerProvider);
+    await controller.onRemoved(chapterId);
+    // Tombstone the completion log at the new generation so a stale terminal
+    // entry can't complete a later re-queued generation of this chapter.
+    await controller.recordChapterDeleted(chapterId, newGen);
+  } else {
+    await coordinator?.beginDelete(chapterId);
   }
-  final chapter =
-      await ref.read(offlineRepositoryProvider).chapterById(chapterId);
-  if (chapter != null) await manager.deleteChapter(chapter);
-  await ref.read(offlineDatabaseProvider).setChapterPinned(chapterId, false);
+  try {
+    final chapter =
+        await ref.read(offlineRepositoryProvider).chapterById(chapterId);
+    if (chapter != null) await manager.deleteChapter(chapter);
+    await ref.read(offlineDatabaseProvider).setChapterPinned(chapterId, false);
+  } finally {
+    coordinator?.endDelete(chapterId);
+  }
 }
 
 /// Remove a series from the library AND clean up its on-device downloads, so
-/// they aren't left orphaned (the offline catalog is library-scoped). Clears
-/// the keep-rule and deletes every device copy. The SERVER's own download is
-/// left alone — it isn't tied to library membership (see #34, #36).
+/// they aren't left orphaned. Clears the keep-rule and deletes every device
+/// copy; the SERVER's own download is left alone (see #34, #36).
 Future<void> removeMangaFromLibraryAndPurge(WidgetRef ref, int mangaId) async {
   await ref.read(mangaBookRepositoryProvider).removeMangaFromLibrary(mangaId);
   if (!ref.read(offlineActiveProvider)) return;
   final db = ref.read(offlineDatabaseProvider);
   await db.setKeepRule(mangaId, OfflineKeepRule.off, 3);
-  // Purge every chapter that has any on-device footprint — not just the fully
-  // downloaded ones. Queued / downloading / errored chapters must also be
-  // cancelled and cleaned up, or an in-flight download could finish (and leave
-  // files) after the series has already left the library.
+  // Purge every chapter with any on-device footprint, not just fully
+  // downloaded ones — queued/downloading/errored must also be cancelled, or an
+  // in-flight download could finish and leave files after the series left the
+  // library.
   for (final c in await db.chaptersForManga(mangaId)) {
     if (c.deviceState != OfflineDeviceState.none) {
       await deleteChapterFromDevice(ref, c.id);
@@ -672,9 +710,9 @@ Future<void> removeMangaFromLibraryAndPurge(WidgetRef ref, int mangaId) async {
 }
 
 /// The offline download orchestrator, wired with real network dependencies:
-/// `fetchChapterPages` for the page URL list and an auth'd HTTP GET for each
-/// page's bytes. Null on web / when offline storage is unavailable, so callers
-/// can `ref.read(offlineDownloadManagerProvider)?.downloadChapter(c)`.
+/// `fetchChapterPages` for URLs and an auth'd HTTP GET for page bytes. Null on
+/// web / when offline storage is unavailable, so callers use
+/// `?.downloadChapter(c)`.
 @riverpod
 OfflineDownloadManager? offlineDownloadManager(Ref ref) {
   if (!ref.watch(offlineActiveProvider)) return null;
@@ -689,12 +727,11 @@ OfflineDownloadManager? offlineDownloadManager(Ref ref) {
   );
 }
 
-/// Fetch one page image's bytes with the active auth, resolved at CALL time
-/// (never baked) — mirrors `ServerImage`'s request building: base API WITHOUT
-/// the `/api` suffix (page URLs already carry `/api/...`), ui_login token as a
-/// `?token=` query param, basic / simple_login via headers. Throws
-/// [PageAuthException] on 401 so the download engine refreshes the token and
-/// retries; any other non-200 is a plain (transient) exception.
+/// Fetch one page image's bytes with the active auth, resolved at call time
+/// (never baked) — mirrors `ServerImage`'s request building (base API without
+/// `/api`, ui_login `?token=`, basic/simple_login via headers). Throws
+/// [PageAuthException] on 401 so the engine refreshes and retries; any other
+/// non-200 is a plain transient exception.
 Future<PageBytes> fetchOfflinePageBytes(Ref ref, String pageUrl) async {
   final authType = ref.read(authTypeKeyProvider);
   final basicToken = ref.read(credentialsProvider).value;
@@ -733,9 +770,9 @@ Future<PageBytes> fetchOfflinePageBytes(Ref ref, String pageUrl) async {
   );
 }
 
-/// Manga ids that have at least one chapter downloaded on this device — used
-/// by the "On device" library filter. Returns an empty set when offline is
-/// unavailable so the filter is a no-op.
+/// Manga ids with at least one chapter downloaded on this device — used by
+/// the "On device" library filter. Empty set when offline is unavailable, so
+/// the filter is a no-op.
 @riverpod
 Future<Set<int>> offlineDeviceMangaIds(Ref ref) async {
   if (!ref.watch(offlineActiveProvider)) return const {};
@@ -798,11 +835,10 @@ Stream<({int downloaded, int inFlight})> mangaOfflineProgress(
   }).distinct(); // only rebuild the button when the counts actually change
 }
 
-/// Every series with an offline footprint on this device — chapters present
-/// (downloaded / in-flight) OR an active keep-rule — with per-series counts,
-/// byte size, and the manga row (carrying the rule). The single source for the
-/// Downloads → On device tab, which both shows what's downloaded AND manages the
-/// keep-rules. Sorted active-first, then biggest, then strongest rule.
+/// Every series with an offline footprint — chapters present OR an active
+/// keep-rule — with per-series counts, bytes, and the manga row. Single source
+/// for the Downloads → On device tab (shows downloads AND manages keep-rules);
+/// sorted active-first, then biggest, then strongest rule.
 @riverpod
 Stream<List<OfflineSeriesEntry>> offlineSeries(Ref ref) {
   if (!ref.watch(offlineActiveProvider)) return Stream.value(const []);
@@ -825,18 +861,11 @@ Stream<List<OfflineSeriesEntry>> offlineSeries(Ref ref) {
   });
 }
 
-/// Stop auto-keeping [mangaId] offline but KEEP the chapters already fully
-/// downloaded on the device. Unfinished (queued / partially-downloaded)
-/// chapters are dropped — "keep what I already have", not "finish the rest".
-///
-/// Order is load-bearing (see the design's interleaving analysis):
-/// 1. Quiesce the series' pipeline (cancel its queued/downloading chapters) so
-///    the downloaded set can't grow underneath us.
-/// 2. Pin every still-downloaded chapter — pinned is immune to reconcile
-///    eviction. Done BEFORE clearing the rule, so any reconcile that interleaves
-///    while we pin still sees the rule active (and so evicts nothing).
-/// 3. Clear the rule (count is dormant while off; preserve it).
-/// 4. Reconcile — now eviction-safe: desired set = pinned = all downloaded.
+/// Stop auto-keeping [mangaId] offline but KEEP chapters already downloaded;
+/// unfinished ones are dropped ("keep what I have", not "finish the rest").
+/// Order matters: pin every still-downloaded chapter BEFORE clearing the rule,
+/// so a reconcile racing this can't evict anything before the pin lands —
+/// only then is it safe to reconcile.
 Future<void> detachKeepRule(WidgetRef ref, int mangaId) async {
   if (!ref.read(offlineActiveProvider)) return;
   final db = ref.read(offlineDatabaseProvider);
@@ -848,13 +877,11 @@ Future<void> detachKeepRule(WidgetRef ref, int mangaId) async {
   }
   final cfg = await ref.read(offlineRepositoryProvider).keepConfigFor(mangaId);
   // Pin the downloaded set and clear the rule ATOMICALLY: the cancel above is
-  // async on Android (the FGS worker may finish a chapter slightly later), so
-  // re-read the downloaded set HERE and pin it inside the same transaction that
-  // flips the rule off. That guarantees that the instant the rule is off, every
-  // chapter the catalog shows as downloaded is already pinned (immune to
-  // eviction) — so neither this call's reconcile nor a concurrent one can evict
-  // a downloaded chapter. A chapter still finishing after this was in-flight at
-  // detach time and is intentionally dropped.
+  // async on Android, so re-read the downloaded set HERE inside the same
+  // transaction that flips the rule off — guaranteeing every downloaded
+  // chapter is already pinned the instant the rule clears, so no reconcile can
+  // evict it. A chapter still finishing after this was in-flight at detach
+  // time and is intentionally dropped.
   await db.transaction(() async {
     for (final c in await db.downloadedChaptersForManga(mangaId)) {
       await db.setChapterPinned(c.id, true);
@@ -913,15 +940,15 @@ Future<void> reconcileMangaCore({
   required SafetyNetConfig nets,
   required int mangaId,
   Future<void> Function(List<int> chapterIds)? enqueueServerDownload,
+  Future<void> Function(int chapterId)? removeFromWorker,
 }) {
   return OfflineReconciler(
     db: db,
     nets: nets,
     now: DateTime.now(),
-    // Only QUEUE chapters here (mark them in the persistent backlog). Starting
-    // the download is the caller's job (via downloadStarterProvider) — this core
-    // must NOT start anything itself, so the Ref-less launch path and tests stay
-    // in control. One failed queue-mark must NOT abort the rest.
+    // Only QUEUE chapters here; starting the download is the caller's job (via
+    // downloadStarterProvider) so the Ref-less launch path and tests stay in
+    // control. One failed queue-mark must not abort the rest.
     onDownload: (id) async {
       try {
         await coordinator.queueChapter(id);
@@ -931,10 +958,19 @@ Future<void> reconcileMangaCore({
     },
     onEvict: (id) async {
       try {
+        // Cancel the active downloader before removing files, or an in-flight
+        // download re-writes the chapter after the purge. beginDelete claims
+        // the desktop engine; removeFromWorker stops the Android FGS worker
+        // (null in the launch/test core, where the coordinator is the only
+        // downloader).
+        await coordinator.beginDelete(id);
+        if (removeFromWorker != null) await removeFromWorker(id);
         final c = await repo.chapterById(id);
         if (c != null) await manager.deleteChapter(c);
       } catch (e) {
         logger.e('Offline: reconcile evict skipped for chapter $id: $e');
+      } finally {
+        coordinator.endDelete(id);
       }
     },
     onServerDownload: enqueueServerDownload == null
@@ -966,6 +1002,13 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
     enqueueServerDownload: (ids) => ref
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),
+    removeFromWorker: (id) async {
+      final ctrl = ref.read(backgroundDownloadControllerProvider);
+      await ctrl.onRemoved(id);
+      final gen = await ref.read(offlineDatabaseProvider)
+          .bumpChapterGeneration(id);
+      await ctrl.recordChapterDeleted(id, gen);
+    },
   );
   // Keep-rule sync queued any missing chapters; now start downloading them.
   await ref.read(downloadStarterProvider)();
@@ -987,6 +1030,13 @@ Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
     enqueueServerDownload: (ids) => ref
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),
+    removeFromWorker: (id) async {
+      final ctrl = ref.read(backgroundDownloadControllerProvider);
+      await ctrl.onRemoved(id);
+      final gen = await ref.read(offlineDatabaseProvider)
+          .bumpChapterGeneration(id);
+      await ctrl.recordChapterDeleted(id, gen);
+    },
   );
   // Start downloading the freshly-queued chapters. THIS was the missing wire
   // that made "Download all / unread" silently do nothing on Android.
@@ -1012,7 +1062,15 @@ Future<void> reconcileAllAtLaunch(ProviderContainer container) async {
         mangaId: m.id,
         enqueueServerDownload: (ids) => container
             .read(downloadsRepositoryProvider)
-            .addChaptersBatchToDownloadQueue(ids));
+            .addChaptersBatchToDownloadQueue(ids),
+        removeFromWorker: (id) async {
+          final ctrl = container.read(backgroundDownloadControllerProvider);
+          await ctrl.onRemoved(id);
+          final gen = await container
+              .read(offlineDatabaseProvider)
+              .bumpChapterGeneration(id);
+          await ctrl.recordChapterDeleted(id, gen);
+        });
   }
 }
 

--- a/lib/src/features/settings/controller/server_controller.dart
+++ b/lib/src/features/settings/controller/server_controller.dart
@@ -1,6 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../utils/extensions/custom_extensions.dart';
 import '../data/settings_repository.dart';
 import '../domain/settings/settings.dart';
 
@@ -12,6 +11,7 @@ class Settings extends _$Settings {
   Future<SettingsDto?> build() =>
       ref.watch(settingsRepositoryProvider).getServerSettings();
 
-  void updateState(SettingsDto value) =>
-      state = state.copyWithData((_) => value);
+  // Set directly: copyWithData only touches the data branch, so an update
+  // landing while loading/errored was silently dropped.
+  void updateState(SettingsDto value) => state = AsyncValue.data(value);
 }

--- a/lib/src/features/settings/presentation/backup/widgets/automatic_backup/automatic_backup_section.dart
+++ b/lib/src/features/settings/presentation/backup/widgets/automatic_backup/automatic_backup_section.dart
@@ -58,7 +58,7 @@ class AutomaticBackupSection extends ConsumerWidget {
                   final result = await AppUtils.guard(
                       () => repository.updateBackupTime(backupTime),
                       ref.read(toastProvider));
-                  if (result != null) {
+                  if (result != null && context.mounted) {
                     ref.read(settingsProvider.notifier).updateState(result);
                   }
                 } else {

--- a/lib/src/features/settings/presentation/browse/widgets/extension_repository/extension_repository_screen.dart
+++ b/lib/src/features/settings/presentation/browse/widgets/extension_repository/extension_repository_screen.dart
@@ -38,7 +38,7 @@ class ExtensionRepositoryScreen extends ConsumerWidget {
               () => repository.updateExtensionRepos({...repoList, newUrl!}),
               ref.read(toastProvider),
             );
-            if (result != null) {
+            if (result != null && context.mounted) {
               ref.read(settingsProvider.notifier).updateState(result);
             }
           } else if (context.mounted) {
@@ -87,7 +87,7 @@ class ExtensionRepositoryScreen extends ConsumerWidget {
                                   () =>
                                       repository.updateExtensionRepos(newList),
                                   ref.read(toastProvider));
-                              if (result != null) {
+                              if (result != null && context.mounted) {
                                 ref
                                     .read(settingsProvider.notifier)
                                     .updateState(result);

--- a/lib/src/features/settings/presentation/library/library_settings_screen.dart
+++ b/lib/src/features/settings/presentation/library/library_settings_screen.dart
@@ -79,7 +79,7 @@ class LibrarySettingsScreen extends ConsumerWidget {
                     () =>
                         repository.updateGlobalUpdateInterval(value.toDouble()),
                     ref.read(toastProvider));
-                if (result != null) {
+                if (result != null && context.mounted) {
                   ref.read(settingsProvider.notifier).updateState(result);
                 }
               }
@@ -154,7 +154,7 @@ class LibrarySettingsScreen extends ConsumerWidget {
                         final result = await AppUtils.guard(
                             () => repository.updateMangaMetaData(value),
                             ref.read(toastProvider));
-                        if (result != null) {
+                        if (result != null && context.mounted) {
                           ref
                               .read(settingsProvider.notifier)
                               .updateState(result);

--- a/lib/src/features/settings/presentation/library/widgets/skip_updating_entries_popup.dart
+++ b/lib/src/features/settings/presentation/library/widgets/skip_updating_entries_popup.dart
@@ -34,7 +34,7 @@ class SkipUpdatingEntriesPopup extends ConsumerWidget {
                   () => repository.toggleExcludeCompleted(value.ifNull()),
                   ref.read(toastProvider),
                 );
-                if (result != null) {
+                if (result != null && context.mounted) {
                   ref.read(settingsProvider.notifier).updateState(result);
                 }
               },
@@ -49,7 +49,7 @@ class SkipUpdatingEntriesPopup extends ConsumerWidget {
                   () => repository.toggleExcludeNotStarted(value.ifNull()),
                   ref.read(toastProvider),
                 );
-                if (result != null) {
+                if (result != null && context.mounted) {
                   ref.read(settingsProvider.notifier).updateState(result);
                 }
               },
@@ -64,7 +64,7 @@ class SkipUpdatingEntriesPopup extends ConsumerWidget {
                   () => repository.toggleExcludeUnreadChapters(value.ifNull()),
                   ref.read(toastProvider),
                 );
-                if (result != null) {
+                if (result != null && context.mounted) {
                   ref.read(settingsProvider.notifier).updateState(result);
                 }
               },

--- a/lib/src/features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart
+++ b/lib/src/features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart
@@ -14,6 +14,7 @@ import '../../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../../../../widgets/input_popup/domain/settings_prop_type.dart';
 import '../../../../../../../widgets/input_popup/settings_prop_tile.dart';
+import '../server_url_tile/server_url_tile.dart' show clearCredentialsForServerChange;
 
 part 'server_port_tile.g.dart';
 
@@ -21,6 +22,13 @@ part 'server_port_tile.g.dart';
 class ServerPort extends _$ServerPort with SharedPreferenceClientMixin<int> {
   @override
   int? build() => initialize(DBKeys.serverPort);
+
+  @override
+  void update(int? value) {
+    // Port is part of the effective endpoint, same as ServerUrl.
+    if (value != state) clearCredentialsForServerChange(ref);
+    super.update(value);
+  }
 }
 
 @riverpod
@@ -31,6 +39,13 @@ class ServerPortToggle extends _$ServerPortToggle
         DBKeys.serverPortToggle,
         initial: kIsWeb ? false : DBKeys.serverPortToggle.initial,
       );
+
+  @override
+  void update(bool? value) {
+    // Toggling the custom port on/off changes the effective endpoint too.
+    if (value != state) clearCredentialsForServerChange(ref);
+    super.update(value);
+  }
 }
 
 class ServerPortTile extends ConsumerWidget {

--- a/lib/src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart
+++ b/lib/src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart
@@ -10,10 +10,12 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../../../../constants/db_keys.dart';
+import '../../../../../../../features/auth/data/auth_credentials_store.dart';
 import '../../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../../../../widgets/input_popup/domain/settings_prop_type.dart';
 import '../../../../../../../widgets/input_popup/settings_prop_tile.dart';
+import '../../credential_popup/credentials_popup.dart';
 import 'server_search_button.dart';
 
 part 'server_url_tile.g.dart';
@@ -25,6 +27,29 @@ class ServerUrl extends _$ServerUrl with SharedPreferenceClientMixin<String> {
         DBKeys.serverUrl,
         initial: kIsWeb ? Uri.base.origin : DBKeys.serverUrl.initial,
       );
+
+  @override
+  void update(String? value) {
+    final previous = state;
+    // Clear before publishing so the rebuild it triggers can't send A's creds to B.
+    if (_isDifferentHost(previous, value)) clearCredentialsForServerChange(ref);
+    super.update(value);
+  }
+}
+
+bool _isDifferentHost(String? a, String? b) {
+  if (a == null || b == null || a == b) return false;
+  final ua = Uri.tryParse(a);
+  final ub = Uri.tryParse(b);
+  if (ua == null || ub == null) return true;
+  return ua.scheme != ub.scheme || ua.host != ub.host || ua.port != ub.port;
+}
+
+/// Wipe credentials and bump the epoch on an endpoint change (URL, port, or
+/// port toggle) so the old server's creds can't reach the new one.
+void clearCredentialsForServerChange(Ref ref) {
+  ref.read(credentialsProvider.notifier).set(null);
+  ref.read(authCredentialsStoreProvider.notifier).clearAllForServerSwitch();
 }
 
 class ServerUrlTile extends ConsumerWidget {

--- a/lib/src/features/settings/presentation/server/widget/cloud_flare/cloud_flare_section.dart
+++ b/lib/src/features/settings/presentation/server/widget/cloud_flare/cloud_flare_section.dart
@@ -40,7 +40,7 @@ class CloudFlareSection extends ConsumerWidget {
               final value = await AppUtils.guard(
                   () => repository.toggleFlareSolverr(isEnabled),
                   ref.read(toastProvider));
-              if (value != null) {
+              if (value != null && context.mounted) {
                 ref.read(settingsProvider.notifier).updateState(value);
               }
             },

--- a/lib/src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart
+++ b/lib/src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart
@@ -12,6 +12,7 @@ import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../../../../features/auth/data/auth_credentials_store.dart';
 import '../../../../../../features/auth/data/basic_auth_migration.dart';
 import '../../../../../../features/auth/data/secure_credentials_provider.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
@@ -25,14 +26,25 @@ class Credentials extends _$Credentials {
   Future<String?> build() async =>
       ref.read(secureStorageProvider).read(key: kBasicCredentialsSecureKey);
 
-  Future<void> set(String? value) async {
-    state = AsyncData(value);
+  /// [forEpoch]: discards/undoes the write if a switch bumps [AuthCredentialsStore.serverEpoch]
+  /// meanwhile. Omit for a clear (set null).
+  Future<void> set(String? value, {int? forEpoch}) async {
     final storage = ref.read(secureStorageProvider);
     if (value == null) {
+      state = const AsyncData(null);
       await storage.delete(key: kBasicCredentialsSecureKey);
-    } else {
-      await storage.write(key: kBasicCredentialsSecureKey, value: value);
+      return;
     }
+    bool stale() =>
+        forEpoch != null &&
+        forEpoch != ref.read(authCredentialsStoreProvider.notifier).serverEpoch;
+    if (stale()) return;
+    await storage.write(key: kBasicCredentialsSecureKey, value: value);
+    if (stale()) {
+      await storage.delete(key: kBasicCredentialsSecureKey);
+      return;
+    }
+    state = AsyncData(value);
   }
 }
 
@@ -93,6 +105,8 @@ class CredentialsPopup extends HookConsumerWidget {
                       userName: username.text,
                       password: password.text,
                     ),
+                    forEpoch:
+                        ref.read(authCredentialsStoreProvider.notifier).serverEpoch,
                   );
               Navigator.pop(context);
             }

--- a/lib/src/features/settings/presentation/server/widget/misc_settings/misc_settings_section.dart
+++ b/lib/src/features/settings/presentation/server/widget/misc_settings/misc_settings_section.dart
@@ -26,7 +26,7 @@ class MiscSettingsSection extends ConsumerWidget {
             final value = await AppUtils.guard(
                 () => repository.toggleDebugLogs(isEnabled),
                 ref.read(toastProvider));
-            if (value != null) {
+            if (value != null && context.mounted) {
               ref.read(settingsProvider.notifier).updateState(value);
             }
           },
@@ -39,7 +39,7 @@ class MiscSettingsSection extends ConsumerWidget {
             final value = await AppUtils.guard(
                 () => repository.toggleSystemTrayEnabled(isEnabled),
                 ref.read(toastProvider));
-            if (value != null) {
+            if (value != null && context.mounted) {
               ref.read(settingsProvider.notifier).updateState(value);
             }
           },

--- a/lib/src/features/tracking/presentation/hub/widgets/track_editor.dart
+++ b/lib/src/features/tracking/presentation/hub/widgets/track_editor.dart
@@ -43,15 +43,15 @@ class TrackEditor extends ConsumerWidget {
     Future<void> Function() mutation,
   ) async {
     final result = await AsyncValue.guard(mutation);
+    // Both branches touch ref; bail if the sheet was dismissed mid-flight.
+    if (!context.mounted) return;
     if (result.hasError) {
       result.showToastOnError(ref.read(toastProvider));
       // Revert: re-read from server.
       ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
       return;
     }
-    if (context.mounted) {
-      ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
-    }
+    ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
   }
 
   // ------------------------------------------------------------------

--- a/lib/src/features/tracking/presentation/hub/widgets/tracker_search.dart
+++ b/lib/src/features/tracking/presentation/hub/widgets/tracker_search.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/hooks/debounced_hook.dart';
 import '../../../../../utils/misc/toast/toast.dart';
 import '../../../../../widgets/search_field.dart';
 import '../../../controller/manga_track_records_controller.dart';
@@ -33,33 +34,46 @@ class TrackerSearch extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final query = useState(mangaTitle);
+    final rawInput = useState(mangaTitle);
+    // Debounce searchTracker calls or AniList/MAL rate-limits (429) and search looks broken.
+    final query = useSettled(rawInput.value, const Duration(milliseconds: 400));
     final selected = useState<Fragment$TrackSearchDto?>(null);
+    // Blocks selection/binding until results catch up with the typed query.
+    final searchPending = rawInput.value != query;
 
-    final resultsAsync = ref.watch(
-      searchTrackerProvider(trackerId: tracker.id, query: query.value),
-    );
+    void onInput(String? value) {
+      rawInput.value = value ?? '';
+      // Drop any selection from the previous query so it can't get bound.
+      selected.value = null;
+    }
+
+    // Don't fire a search for an empty query (e.g. the field was cleared).
+    final resultsAsync = query.isEmpty
+        ? null
+        : ref.watch(searchTrackerProvider(trackerId: tracker.id, query: query));
 
     Future<void> bind({required bool private}) async {
       final entry = selected.value;
       if (entry == null) return;
       final result = await AsyncValue.guard(
-        () => ref.read(trackerRepositoryProvider).bind(
+        () => ref
+            .read(trackerRepositoryProvider)
+            .bind(
               mangaId: mangaId,
               trackerId: tracker.id,
               remoteId: entry.remoteId,
               private: private,
             ),
       );
+      // Both branches touch ref; bail if the sheet was dismissed mid-flight.
+      if (!context.mounted) return;
       if (result.hasError) {
         result.showToastOnError(ref.read(toastProvider));
         return;
       }
-      if (context.mounted) {
-        ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
-        ref.read(toastProvider)?.show(context.l10n.trackBindSuccess(tracker.name));
-        onBound();
-      }
+      ref.invalidate(mangaTrackRecordsProvider(mangaId: mangaId));
+      ref.read(toastProvider)?.show(context.l10n.trackBindSuccess(tracker.name));
+      onBound();
     }
 
     return Padding(
@@ -85,22 +99,13 @@ class TrackerSearch extends HookConsumerWidget {
             initialText: mangaTitle,
             hintText: context.l10n.search,
             autofocus: false,
-            onSubmitted: (value) {
-              if (value != null && value.isNotEmpty) {
-                query.value = value;
-                selected.value = null;
-              }
-            },
-            onChanged: (value) {
-              if (value != null && value.isNotEmpty) {
-                query.value = value;
-                selected.value = null;
-              }
-            },
+            onSubmitted: onInput,
+            onChanged: onInput,
           ),
 
-          // Track / Track privately buttons (shown when a result is selected).
-          if (selected.value != null)
+          // Track / Track privately buttons (shown once a result is selected
+          // and the search has settled).
+          if (!searchPending && selected.value != null)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
               child: Row(
@@ -124,36 +129,43 @@ class TrackerSearch extends HookConsumerWidget {
               ),
             ),
 
-          // Results list.
+          // Results list. Spinner while pending so nothing stale can be tapped.
           Flexible(
-            child: resultsAsync.showUiWhenData(
-              context,
-              (results) {
-                if (results.isEmpty) {
-                  return Center(
+            child: query.isEmpty
+                ? const SizedBox.shrink()
+                : searchPending
+                ? const Center(
                     child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Text(context.l10n.noSearchResults),
+                      padding: EdgeInsets.all(24),
+                      child: CircularProgressIndicator(),
                     ),
-                  );
-                }
-                return ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: results.length,
-                  itemBuilder: (context, index) {
-                    final result = results[index];
-                    final isSelected = selected.value?.remoteId == result.remoteId;
-                    return _TrackSearchResultTile(
-                      result: result,
-                      isSelected: isSelected,
-                      onTap: () {
-                        selected.value = isSelected ? null : result;
+                  )
+                : resultsAsync!.showUiWhenData(context, (results) {
+                    if (results.isEmpty) {
+                      return Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(24),
+                          child: Text(context.l10n.noSearchResults),
+                        ),
+                      );
+                    }
+                    return ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: results.length,
+                      itemBuilder: (context, index) {
+                        final result = results[index];
+                        final isSelected =
+                            selected.value?.remoteId == result.remoteId;
+                        return _TrackSearchResultTile(
+                          result: result,
+                          isSelected: isSelected,
+                          onTap: () {
+                            selected.value = isSelected ? null : result;
+                          },
+                        );
                       },
                     );
-                  },
-                );
-              },
-            ),
+                  }),
           ),
         ],
       ),

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -33,7 +33,11 @@ import '../utils/network/timeout_http_client.dart';
 
 part 'global_providers.g.dart';
 
-@riverpod
+// keepAlive: the reader captures this client (and its ref) once and issues
+// progress writes through it. Under autoDispose the ref could die mid-write
+// during provider churn, throwing a disposed-ref StateError inside
+// SuwayomiAuthLink.getHeaders — the silent online-progress-loss root cause.
+@Riverpod(keepAlive: true)
 GraphQLClient graphQlClient(Ref ref) {
   final authType = ref.watch(authTypeKeyProvider) ?? DBKeys.authType.initial;
   final credentials = ref.watch(credentialsProvider).value;
@@ -232,10 +236,8 @@ GraphQLClient graphQlSubscriptionClient(Ref ref) {
 @riverpod
 ValueNotifier<GraphQLClient> graphQlClientHolder(Ref ref) {
   final notifier = ValueNotifier(ref.watch(graphQlClientProvider));
-  // Dispose of the notifier when the provider is destroyed
   ref.onDispose(notifier.dispose);
 
-  // Notify listeners of this provider whenever the ValueNotifier updates.
   notifier.addListener(ref.notifyListeners);
 
   return notifier;

--- a/test/offline/background/background_completion_log_replay_test.dart
+++ b/test/offline/background/background_completion_log_replay_test.dart
@@ -75,6 +75,224 @@ void main() {
     expect(ch!.deviceState, OfflineDeviceState.none);
   });
 
+  test('a delete committing mid-replay wins (recheck inside the transaction)',
+      () async {
+    await writePageFile(1, 5, 0);
+    await log.appendPage(
+        chapterId: 5,
+        mangaId: 1,
+        pageIndex: 0,
+        relPath: paths.pageRel(1, 5, 0, 'jpg'),
+        bytes: 10);
+    await log.appendChapter(chapterId: 5, status: 'downloaded', pages: 1, bytes: 10);
+
+    // measureBytes fires after replay's initial state check but before its write
+    // transaction — the seam where a concurrent delete commits.
+    await replayCompletionLog(
+        db: db,
+        paths: paths,
+        log: log,
+        measureBytes: (m, c) async {
+          await db.setChapterDeviceState(5, OfflineDeviceState.none);
+          return 10;
+        });
+
+    expect(await db.downloadedPageCount(5), 0, reason: 'no rows resurrected');
+    expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.none,
+        reason: 'the delete wins over the replay');
+  });
+
+  test('a delete tombstone stops a stale entry completing a re-queued chapter',
+      () async {
+    // Generation 1: the chapter finished (log has downloaded), not yet replayed.
+    await writePageFile(1, 5, 0);
+    await log.appendPage(
+        chapterId: 5,
+        mangaId: 1,
+        pageIndex: 0,
+        relPath: paths.pageRel(1, 5, 0, 'jpg'),
+        bytes: 10);
+    await log.appendChapter(chapterId: 5, status: 'downloaded', pages: 1, bytes: 10);
+    // The user deletes it (tombstone bumps to generation 1), its files go, then
+    // re-queues it.
+    await log.appendDeleted(5, 1);
+    await File(paths.absolute(paths.pageRel(1, 5, 0, 'jpg'))).delete();
+    await db.setChapterDeviceState(5, OfflineDeviceState.none);
+    await db.setChapterDeviceState(5, OfflineDeviceState.queued);
+
+    await replayCompletionLog(
+        db: db, paths: paths, log: log, measureBytes: (m, c) async => 10);
+
+    final ch = await db.chapterById(5);
+    expect(ch!.deviceState, OfflineDeviceState.queued,
+        reason: 'the stale downloaded entry must not complete the new generation');
+    expect(await db.downloadedPageCount(5), 0, reason: 'no stale rows applied');
+  });
+
+  test('a late downloaded entry after the tombstone cannot complete with no files',
+      () async {
+    // The worker was paused between its final page write and its terminal append,
+    // so the log order is pages -> tombstone -> stale downloaded. The files were
+    // deleted, so the filesystem check must reject the stale completion.
+    await log.appendPage(
+        chapterId: 5,
+        mangaId: 1,
+        pageIndex: 0,
+        relPath: paths.pageRel(1, 5, 0, 'jpg'),
+        bytes: 10);
+    await log.appendDeleted(5, 1);
+    // A current-generation downloaded whose files aren't actually on disk (a
+    // torn/partial download) — the filesystem check must still reject it.
+    await log.appendChapter(
+        chapterId: 5, status: 'downloaded', pages: 1, bytes: 10, generation: 1);
+    // Files gone (deleted), chapter re-queued.
+    await db.setChapterDeviceState(5, OfflineDeviceState.none);
+    await db.setChapterDeviceState(5, OfflineDeviceState.queued);
+
+    await replayCompletionLog(
+        db: db, paths: paths, log: log, measureBytes: (m, c) async => 10);
+
+    expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.queued,
+        reason: 'no files on disk — a stale downloaded must not complete it');
+    expect(await db.downloadedPageCount(5), 0);
+  });
+
+  test('a .part staging file does not count as a completed page', () async {
+    // Only an in-flight atomic-write staging file exists; a stale downloaded
+    // entry must not complete the chapter off it.
+    final part = File('${paths.absolute(paths.pageRel(1, 5, 0, 'jpg'))}.part');
+    await part.parent.create(recursive: true);
+    await part.writeAsBytes(List.filled(10, 0));
+    await log.appendChapter(chapterId: 5, status: 'downloaded', pages: 1, bytes: 10);
+
+    await replayCompletionLog(
+        db: db, paths: paths, log: log, measureBytes: (m, c) async => 10);
+
+    expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.downloading,
+        reason: 'a .part file is not a completed page');
+    expect(await db.downloadedPageCount(5), 0);
+  });
+
+  test('a re-download after a tombstone still completes normally', () async {
+    await log.appendChapter(chapterId: 5, status: 'downloaded', pages: 1, bytes: 10);
+    await log.appendDeleted(5, 1);
+    // Generation 1: re-downloaded after the delete, tagged with the new gen.
+    await writePageFile(1, 5, 0);
+    await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+    await log.appendChapter(
+        chapterId: 5, status: 'downloaded', pages: 1, bytes: 10, generation: 1);
+
+    await replayCompletionLog(
+        db: db, paths: paths, log: log, measureBytes: (m, c) async => 10);
+
+    expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.downloaded,
+        reason: 'entries logged after the tombstone still apply');
+    expect(await db.downloadedPageCount(5), 1);
+  });
+
+  test('a stale error appended after the tombstone is dropped on replay',
+      () async {
+    // The exact durable ordering: generation-0 activity, tombstone(gen 1), then
+    // the worker's late generation-0 error, then generation-1 activity.
+    await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+    await log.appendDeleted(5, 1);
+    await log.appendChapter(
+        chapterId: 5, status: 'error', pages: 0, bytes: 0, generation: 0);
+    // Generation 1 re-download completes with its page on disk.
+    await writePageFile(1, 5, 0);
+    await log.appendChapter(
+        chapterId: 5, status: 'downloaded', pages: 1, bytes: 10, generation: 1);
+
+    await replayCompletionLog(
+        db: db, paths: paths, log: log, measureBytes: (m, c) async => 10);
+
+    expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.downloaded,
+        reason: 'the stale generation-0 error must not override the new download');
+  });
+
+  group('applyBackgroundTerminalState (live worker events)', () {
+    test('a stale downloaded event cannot complete a re-queued chapter with too '
+        'few pages', () async {
+      // Chapter 5 exists with pageCount 2 but no page rows (deleted + re-queued).
+      await db.setChapterDeviceState(5, OfflineDeviceState.queued);
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'downloaded', bytes: 10);
+      expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.queued,
+          reason: 'no pages present — a stale downloaded must not complete it');
+    });
+
+    test('a downloaded event completes when all pages are present', () async {
+      await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+      await db.into(db.offlinePages).insert(OfflinePagesCompanion.insert(
+          chapterId: 5, pageIndex: 0, relativePath: '1/5/0.jpg'));
+      await db.into(db.offlinePages).insert(OfflinePagesCompanion.insert(
+          chapterId: 5, pageIndex: 1, relativePath: '1/5/1.jpg'));
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'downloaded', bytes: 20);
+      expect((await db.chapterById(5))!.deviceState,
+          OfflineDeviceState.downloaded);
+    });
+
+    test('a stale error event does not error a freshly queued chapter', () async {
+      await db.setChapterDeviceState(5, OfflineDeviceState.queued);
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'error', bytes: 0);
+      expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.queued,
+          reason: 'error applies only to a chapter actually mid-download');
+    });
+
+    test('an error event fails a chapter that is downloading', () async {
+      await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'error', bytes: 0);
+      expect(
+          (await db.chapterById(5))!.deviceState, OfflineDeviceState.error);
+    });
+
+    test('a downloaded event never resurrects a deleted chapter', () async {
+      await db.setChapterDeviceState(5, OfflineDeviceState.none);
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'downloaded', bytes: 10);
+      expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.none);
+    });
+
+    test('a stale-generation error is dropped even for a downloading chapter',
+        () async {
+      // Generation 0's error arrives after a delete bumped drift to generation 1
+      // and a new download reached downloading.
+      await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+      await db.bumpChapterGeneration(5); // now generation 1
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'error', bytes: 0, eventGeneration: 0);
+      expect((await db.chapterById(5))!.deviceState,
+          OfflineDeviceState.downloading,
+          reason: 'a deleted generation event must not touch the new one');
+    });
+
+    test('a current-generation error still applies', () async {
+      await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+      await db.bumpChapterGeneration(5); // now generation 1
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'error', bytes: 0, eventGeneration: 1);
+      expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.error);
+    });
+
+    test('the persisted generation increments monotonically (no restart reuse)',
+        () async {
+      // The generation lives in drift, so a restart (which would reset an
+      // in-memory counter) can't make a second delete reuse a generation.
+      expect(await db.bumpChapterGeneration(5), 1); // first delete
+      expect(await db.bumpChapterGeneration(5), 2); // second delete, not reused
+      // A late generation-1 event is now stale against the persisted 2.
+      await db.setChapterDeviceState(5, OfflineDeviceState.downloading);
+      await applyBackgroundTerminalState(
+          db: db, chapterId: 5, status: 'error', bytes: 0, eventGeneration: 1);
+      expect((await db.chapterById(5))!.deviceState,
+          OfflineDeviceState.downloading,
+          reason: 'a superseded generation event stays stale after a restart');
+    });
+  });
+
   test('double-replay is idempotent', () async {
     await writePageFile(1, 5, 0);
     await writePageFile(1, 5, 1);

--- a/test/offline/background/background_work_order_test.dart
+++ b/test/offline/background/background_work_order_test.dart
@@ -14,12 +14,15 @@ void main() {
       auth: const BackgroundTokenRecord(
           gen: 3, authType: 'uiLogin', accessToken: 'A', refreshToken: 'R'),
       baseDir: '/data/app/offline',
+      generationByChapter: const {5: 0, 6: 2, 7: 1},
       rootIsolateToken: 99887766,
     );
     final restored = BackgroundWorkOrder.fromJson(order.toJson());
     expect(restored.chapterIds, [5, 6, 7]);
     expect(restored.mangaIdByChapter[6], 1);
     expect(restored.mangaIdByChapter[7], 2);
+    expect(restored.generationByChapter[6], 2);
+    expect(restored.generationByChapter[7], 1);
     expect(restored.wifiOnly, isTrue);
     expect(restored.auth.gen, 3);
     expect(restored.auth.accessToken, 'A');
@@ -38,9 +41,12 @@ void main() {
       auth: const BackgroundTokenRecord(gen: 0, authType: 'none'),
       baseDir: '/x',
     );
-    final json = order.toJson()..remove('baseDir');
+    final json = order.toJson()
+      ..remove('baseDir')
+      ..remove('generationByChapter');
     final restored = BackgroundWorkOrder.fromJson(json);
     expect(restored.baseDir, '');
     expect(restored.rootIsolateToken, 0);
+    expect(restored.generationByChapter, isEmpty);
   });
 }

--- a/test/src/features/manga_book/next_prev_chapter_test.dart
+++ b/test/src/features/manga_book/next_prev_chapter_test.dart
@@ -1,0 +1,94 @@
+// Regression tests: a chapter absent from the filtered list (e.g. unread-only
+// filter while re-reading) must resolve to NO neighbours, not an arbitrary one.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+ChapterDto _chapter({required int id, required String name, int sourceOrder = 0}) =>
+    Fragment$ChapterDto(
+      chapterNumber: 0,
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: name,
+      pageCount: 0,
+      sourceOrder: sourceOrder,
+      uploadDate: '0',
+      url: '',
+      meta: const [],
+    );
+
+class _FakeChapterList extends MangaChapterList {
+  _FakeChapterList(this.chapters);
+  final List<ChapterDto> chapters;
+
+  @override
+  Future<List<ChapterDto>?> build({required int mangaId}) async => chapters;
+}
+
+Future<ProviderContainer> _container(List<ChapterDto> chapters) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final c = ProviderContainer(
+    overrides: [
+      sharedPreferencesProvider.overrideWithValue(prefs),
+      mangaChapterListProvider(mangaId: 1)
+          .overrideWith(() => _FakeChapterList(chapters)),
+    ],
+  );
+  addTearDown(c.dispose);
+  await c.read(mangaChapterListProvider(mangaId: 1).future);
+  return c;
+}
+
+void main() {
+  final chapters = [
+    _chapter(id: 1, name: 'One', sourceOrder: 1),
+    _chapter(id: 2, name: 'Two', sourceOrder: 2),
+    _chapter(id: 3, name: 'Three', sourceOrder: 3),
+  ];
+
+  test('a chapter absent from the filtered list has NO neighbours', () async {
+    final c = await _container(chapters);
+    final pair = c.read(getNextAndPreviousChaptersProvider(
+      mangaId: 1,
+      chapterId: 9999,
+    ));
+    expect(pair, isNotNull);
+    // Before the fix, indexWhere == -1 resolved one side to filteredList[0].
+    expect(pair!.first, isNull);
+    expect(pair.second, isNull);
+  });
+
+  test('a middle chapter resolves both neighbours', () async {
+    final c = await _container(chapters);
+    final pair = c.read(getNextAndPreviousChaptersProvider(
+      mangaId: 1,
+      chapterId: 2,
+    ));
+    expect(pair, isNotNull);
+    expect(pair!.first, isNotNull);
+    expect(pair.second, isNotNull);
+  });
+
+  test('an edge chapter resolves exactly one neighbour', () async {
+    final c = await _container(chapters);
+    final pair = c.read(getNextAndPreviousChaptersProvider(
+      mangaId: 1,
+      chapterId: 3,
+    ));
+    expect(pair, isNotNull);
+    // One side present, one absent — never two, never zero for an in-list edge.
+    expect([pair!.first, pair.second].where((e) => e != null).length, 1);
+  });
+}

--- a/test/src/features/manga_book/progress_save_silent_loss_regression_test.dart
+++ b/test/src/features/manga_book/progress_save_silent_loss_regression_test.dart
@@ -1,0 +1,86 @@
+// Regression coverage for the silent online-progress-loss bug.
+//
+// Root cause was: graphQlClient + mangaBookRepository were autoDispose, so the
+// reader's captured client ref could be torn down mid-write, throwing inside the
+// auth link; the throw was then swallowed (no surface, no retry). These tests
+// lock the two guarantees the fix restored:
+//   1. graphQlClient + mangaBookRepository stay keepAlive (can't be disposed
+//      out from under an in-flight write) — the ROOT-CAUSE trip wire.
+//   2. A failed online progress push is SURFACED to the caller, never swallowed
+//      silently (there is no offline dirty row to retry for an online-only user).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+/// putChapter throws exactly like the disposed-ref / 401 failure did — the case
+/// that used to vanish silently.
+class _ThrowingRepository extends MangaBookRepository {
+  _ThrowingRepository() : super(_dummyClient());
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {
+    throw StateError('server component was disposed mid-write');
+  }
+}
+
+class _OkRepository extends MangaBookRepository {
+  _OkRepository() : super(_dummyClient());
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {}
+}
+
+void main() {
+  group('root cause: the write path providers must stay keepAlive', () {
+    test('graphQlClient is NOT autoDispose', () {
+      // If this flips back to @riverpod (autoDispose), the reader can lose its
+      // captured client ref mid-write again — the exact regression.
+      expect(graphQlClientProvider.isAutoDispose, isFalse);
+    });
+
+    test('mangaBookRepository is NOT autoDispose', () {
+      expect(mangaBookRepositoryProvider.isAutoDispose, isFalse);
+    });
+  });
+
+  group('a failed online progress push is surfaced, not swallowed', () {
+    test('online-only + failing push -> returns an error (not silently lost)',
+        () async {
+      final result = await recordReadingProgressWithDependencies(
+        offlineEnabled: false, // no dirty row to retry — the online-only case
+        offlineDatabase: null,
+        repository: _ThrowingRepository(),
+        chapterId: 42,
+        lastPageRead: 7,
+        isRead: false,
+      );
+      expect(result.hasError, isTrue,
+          reason: 'a failed online push must reach the caller so the reader can '
+              'show it, instead of vanishing');
+    });
+
+    test('online-only + successful push -> no error', () async {
+      final result = await recordReadingProgressWithDependencies(
+        offlineEnabled: false,
+        offlineDatabase: null,
+        repository: _OkRepository(),
+        chapterId: 42,
+        lastPageRead: 7,
+        isRead: false,
+      );
+      expect(result.hasError, isFalse);
+    });
+  });
+}

--- a/test/src/features/offline/chapter_download_engine_test.dart
+++ b/test/src/features/offline/chapter_download_engine_test.dart
@@ -57,6 +57,29 @@ void main() {
     expect(store.written.length, 10);
   });
 
+  test('a cancel landing during the fetch prevents the page write', () async {
+    final store = _FakeStore();
+    var cancelled = false;
+    final engine = ChapterDownloadEngine(
+      fetchPage: (url) async {
+        cancelled = true; // a delete/pause lands while this request was in flight
+        return (bytes: [1, 2, 3], ext: 'jpg');
+      },
+      writePage: store,
+      refreshAuth: () async => true,
+      backoff: (_) => noBackoff,
+    );
+    final out = await engine.download(
+      mangaId: 1,
+      chapterId: 2,
+      pages: _pages(1),
+      isCancelled: () => cancelled,
+    );
+    expect(store.written, isEmpty,
+        reason: 'no file may be written for a chapter cancelled mid-fetch');
+    expect(out.cancelled, isTrue);
+  });
+
   test('refreshes auth once on 401 then succeeds', () async {
     var refreshes = 0;
     var firstTry = true;

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -16,8 +16,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 7', () {
-    expect(db.schemaVersion, 7);
+  test('opens at schema version 8', () {
+    expect(db.schemaVersion, 8);
   });
 
   test('inserts and reads a manga', () async {

--- a/test/src/features/offline/data/offline_download_coordinator_test.dart
+++ b/test/src/features/offline/data/offline_download_coordinator_test.dart
@@ -8,7 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tsumiru/src/features/offline/data/chapter_download_engine.dart';
 import 'package:tsumiru/src/features/offline/data/offline_database.dart';
 import 'package:tsumiru/src/features/offline/data/offline_download_coordinator.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_manager.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
 import 'package:tsumiru/src/features/offline/data/offline_page_store.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_types.dart';
 
 import '../../../../helpers/offline_test_db.dart';
 
@@ -44,6 +49,7 @@ void main() {
   late OfflineDatabase db;
   late _FakeStore store;
   setUp(() {
+    OfflineDownloadCoordinator.resetSharedStateForTest();
     db = testOfflineDatabase();
     store = _FakeStore();
   });
@@ -69,6 +75,8 @@ void main() {
     bool auth401 = false,
     bool refreshOk = false,
     bool Function()? persistedPaused,
+    Future<void> Function()? onFetch,
+    Future<int> Function(int, int)? measureOverride,
   }) {
     final engine = ChapterDownloadEngine(
       writePage: store,
@@ -76,6 +84,7 @@ void main() {
       backoff: (_) => Duration.zero,
       refreshAuth: () async => refreshOk,
       fetchPage: (url) async {
+        if (onFetch != null) await onFetch();
         if (auth401) throw const PageAuthException();
         if (fail) throw Exception('boom');
         return (bytes: [1, 2, 3], ext: 'jpg');
@@ -85,7 +94,7 @@ void main() {
       db: db,
       engine: engine,
       resolvePages: (_) async => pages,
-      measureChapterBytes: store.chapterBytes,
+      measureChapterBytes: measureOverride ?? store.chapterBytes,
       persistedPaused: persistedPaused,
     );
   }
@@ -190,6 +199,165 @@ void main() {
     await c.resume();
     expect(
         (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+  });
+
+  test('a chapter claimed by beginDelete is not (re)started by the pump',
+      () async {
+    await seedChapter(1, 7, 2);
+    // Stranded downloading, as an in-flight delete leaves it after cancelling.
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloading);
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    await c.beginDelete(1); // not active → returns immediately
+    await c.pumpDownloads();
+    // Must not resurrect it while the delete is in progress.
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloading);
+    expect(store.pages, isEmpty);
+    // Once the delete releases it, normal draining resumes.
+    c.endDelete(1);
+    await c.pumpDownloads();
+    expect(
+        (await db.chapterById(1))!.deviceState, OfflineDeviceState.downloaded);
+  });
+
+  test('reconcile eviction cancels the worker before deleting the copy',
+      () async {
+    // An orphaned (server-gone) chapter is always evicted. The eviction must
+    // cancel the active downloader first, or an in-flight download re-writes the
+    // whole chapter after the purge.
+    await db.upsertMangaMetadata(id: 7, title: 'M', updatedAt: DateTime(2026));
+    await seedChapter(9, 7, 1);
+    await db.setChapterDeviceState(9, OfflineDeviceState.orphaned, bytes: 10);
+
+    final manager = OfflineDownloadManager(
+      db: db,
+      store: store,
+      fetchPageUrls: (_) async => ['u'],
+      fetchBytes: (_) async => (bytes: [1], ext: 'jpg'),
+    );
+    final removed = <int>[];
+    await reconcileMangaCore(
+      db: db,
+      repo: OfflineRepository(db: db, paths: OfflinePaths('/tmp/x')),
+      manager: manager,
+      coordinator: coord(),
+      nets: SafetyNetConfig.off,
+      mangaId: 7,
+      removeFromWorker: (id) async => removed.add(id),
+    );
+
+    expect(removed, [9],
+        reason: 'the Android worker must be told to cancel before eviction');
+    expect((await db.chapterById(9))!.deviceState, OfflineDeviceState.none,
+        reason: 'the orphaned copy is removed');
+  });
+
+  test('a delete on a new coordinator blocks the old instance from resurrecting',
+      () async {
+    // The keep-alive provider can rebuild mid-drain: an old coordinator lingers
+    // while deletes route through the replacement. The delete claim must be
+    // visible across instances, or the old pump re-marks the chapter.
+    await seedChapter(1, 7, 2);
+    final oldCoord = coord(pages: const ['/p/0', '/p/1']);
+    final newCoord = coord(pages: const ['/p/0', '/p/1']);
+
+    await newCoord.beginDelete(1); // delete claimed on the replacement
+    await db.setChapterDeviceState(1, OfflineDeviceState.none); // delete commits
+
+    // The stale instance tries to (re)start the chapter it never knew was gone.
+    await oldCoord.enqueueChapter((await db.chapterById(1))!);
+
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.none,
+        reason: 'the cross-instance delete claim must block the old pump');
+    newCoord.endDelete(1);
+  });
+
+  test('overlapping deletes: the claim holds until the last one ends',
+      () async {
+    await seedChapter(1, 7, 2);
+    await db.setChapterDeviceState(1, OfflineDeviceState.none); // deleted
+    final c = coord(pages: const ['/p/0', '/p/1']);
+
+    // A user delete and a reconcile eviction both claim the same chapter.
+    await c.beginDelete(1);
+    await c.beginDelete(1);
+
+    // The first finishes and releases — the second is still deleting.
+    c.endDelete(1);
+    await c.queueChapter(1); // must still be blocked
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.none,
+        reason: 'a surviving delete claim must keep the chapter guarded');
+
+    c.endDelete(1); // last claimant — now the guard releases
+  });
+
+  test('queueChapter refuses a chapter being deleted (no resurrection)',
+      () async {
+    await seedChapter(1, 7, 2);
+    await db.setChapterDeviceState(1, OfflineDeviceState.none); // just deleted
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    await c.beginDelete(1); // delete in progress
+    await c.queueChapter(1);
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.none,
+        reason: 'a queue request during a delete must not re-queue it');
+    c.endDelete(1);
+  });
+
+  test('enqueueChapter refuses a chapter being deleted', () async {
+    await seedChapter(1, 7, 2);
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    await c.beginDelete(1);
+    await c.enqueueChapter((await db.chapterById(1))!);
+    expect(store.pages, isEmpty);
+    expect((await db.chapterById(1))!.deviceState,
+        isNot(OfflineDeviceState.downloaded));
+  });
+
+  test('deleting the queued head does not stall the rest of the backlog',
+      () async {
+    await seedChapter(1, 7, 2); // queue head, being deleted
+    await seedChapter(2, 8, 2); // must still download
+    final c = coord(pages: const ['/p/0', '/p/1']);
+    await c.queueChapter(1);
+    await c.queueChapter(2);
+    await c.beginDelete(1);
+    await c.pumpDownloads();
+    expect(
+        (await db.chapterById(2))!.deviceState, OfflineDeviceState.downloaded);
+    c.endDelete(1);
+  });
+
+  test('a delete committing during finalize measurement is not overwritten',
+      () async {
+    await seedChapter(1, 7, 2);
+    // measureChapterBytes fires inside _finalizeIfComplete, after the pages are
+    // stored but before the downloaded write — the seam where a delete commits.
+    final c = coord(
+      pages: const ['/p/0', '/p/1'],
+      measureOverride: (m, ch) async {
+        await db.setChapterDeviceState(1, OfflineDeviceState.none);
+        return 6;
+      },
+    );
+    await c.enqueueChapter((await db.chapterById(1))!);
+
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.none,
+        reason: 'the delete wins — the completion does not resurrect it');
+  });
+
+  test('a delete committing mid-download is not overwritten by a late error',
+      () async {
+    await seedChapter(1, 7, 2);
+    // The fetch fails, but a delete commits deviceState=none first (beginDelete
+    // timed out and the engine kept running). The late error must not resurrect.
+    final c = coord(
+      fail: true,
+      onFetch: () => db.setChapterDeviceState(1, OfflineDeviceState.none),
+    );
+    await c.enqueueChapter((await db.chapterById(1))!);
+
+    expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.none,
+        reason: 'the delete wins — a late error write is dropped');
   });
 
   test('persisted pause flag gates the pump even on a fresh coordinator',

--- a/test/src/features/offline/data/offline_download_manager_force_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_force_test.dart
@@ -47,6 +47,7 @@ void main() {
         bookmarkDirty: false,
         readStateDirty: false,
         updatedAt: DateTime(2026),
+        downloadGeneration: 0,
       );
 
   OfflineDownloadManager manager() => OfflineDownloadManager(

--- a/test/src/features/offline/data/offline_download_manager_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_test.dart
@@ -138,6 +138,55 @@ void main() {
     expect(pages, isEmpty);
   });
 
+  // Mirrors the coordinator's onPageStored guard: check device state and insert
+  // the page row in one transaction, so it serializes with deleteChapter.
+  Future<void> storePageIfLive(int chapterId, int pageIndex, String rel) =>
+      db.transaction(() async {
+        final c = await db.chapterById(chapterId);
+        if (c == null || c.deviceState == OfflineDeviceState.none) return;
+        await db.into(db.offlinePages).insertOnConflictUpdate(
+              OfflinePagesCompanion.insert(
+                  chapterId: chapterId,
+                  pageIndex: pageIndex,
+                  relativePath: rel),
+            );
+      });
+
+  test('a page stored after deleteChapter is rejected (state is none)',
+      () async {
+    final chapter = await seedChapter();
+    await managerWith().downloadChapter(chapter);
+
+    await managerWith().deleteChapter((await db.chaptersForManga(552)).single);
+    // A page callback that fired just before the delete finally lands.
+    await storePageIfLive(2000, 5, '552/2000/005.jpg');
+
+    final rows = await (db.select(db.offlinePages)
+          ..where((t) => t.chapterId.equals(2000)))
+        .get();
+    expect(rows, isEmpty,
+        reason: 'the insert reads state=none and skips — no resurrected row');
+  });
+
+  test('a page store racing deleteChapter leaves no orphan row', () async {
+    final chapter = await seedChapter();
+    await db.setChapterDeviceState(chapter.id, OfflineDeviceState.downloading);
+    final downloading = (await db.chaptersForManga(552)).single;
+
+    await Future.wait([
+      managerWith().deleteChapter(downloading),
+      storePageIfLive(2000, 5, '552/2000/005.jpg'),
+    ]);
+
+    expect((await db.chaptersForManga(552)).single.deviceState,
+        OfflineDeviceState.none);
+    final rows = await (db.select(db.offlinePages)
+          ..where((t) => t.chapterId.equals(2000)))
+        .get();
+    expect(rows, isEmpty,
+        reason: 'state=none + row purge is one transaction — nothing survives');
+  });
+
   test('sweepInterrupted resets chapters stuck downloading', () async {
     final chapter = await seedChapter();
     await db.setChapterDeviceState(chapter.id, OfflineDeviceState.downloading);

--- a/test/src/features/offline/data/offline_download_triggers_test.dart
+++ b/test/src/features/offline/data/offline_download_triggers_test.dart
@@ -43,7 +43,10 @@ void main() {
   late OfflineDatabase db;
   final store = _FakeStore();
 
-  setUp(() => db = testOfflineDatabase());
+  setUp(() {
+    OfflineDownloadCoordinator.resetSharedStateForTest();
+    db = testOfflineDatabase();
+  });
   tearDown(() => db.close());
 
   // Minimal non-null deps so the triggers reach the start step instead of

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 7', () {
-    expect(db.schemaVersion, 7);
+  test('opens at schema version 8', () {
+    expect(db.schemaVersion, 8);
   });
 
   test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',

--- a/test/src/features/offline/data/reconcile_desired_set_test.dart
+++ b/test/src/features/offline/data/reconcile_desired_set_test.dart
@@ -9,6 +9,7 @@ OfflineChapter ch(int id, int idx, {bool read = false, bool pinned = false}) =>
       deviceState: OfflineDeviceState.none, pageCount: 1, bytes: 0,
       pinned: pinned, downloadedAt: null, progressDirty: false,
       bookmarkDirty: false, readStateDirty: false, updatedAt: DateTime(2026),
+      downloadGeneration: 0,
     );
 
 void main() {

--- a/test/src/features/offline/data/reconcile_eviction_test.dart
+++ b/test/src/features/offline/data/reconcile_eviction_test.dart
@@ -16,7 +16,7 @@ OfflineChapter dl(int id, {int bytes = 100, DateTime? at, bool pinned = false}) 
       deviceState: OfflineDeviceState.downloaded, pageCount: 1, bytes: bytes,
       pinned: pinned, downloadedAt: at ?? DateTime(2026, 1, id),
       progressDirty: false, bookmarkDirty: false, readStateDirty: false,
-      updatedAt: DateTime(2026),
+      updatedAt: DateTime(2026), downloadGeneration: 0,
     );
 
 void main() {

--- a/test/src/features/offline/push_pending_progress_tracking_test.dart
+++ b/test/src/features/offline/push_pending_progress_tracking_test.dart
@@ -9,6 +9,7 @@ import 'package:graphql/client.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
 import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import 'package:tsumiru/src/features/offline/data/offline_database.dart';
 import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
@@ -90,6 +91,48 @@ class _FailingMangaBookRepository extends MangaBookRepository {
     throw Exception('offline — mutation failed');
   }
 }
+
+/// Captures pushed patches AND returns a fixed server chapter from getChapter,
+/// so the never-regress guard (cross-device) can be exercised.
+class _ServerStateRepository extends MangaBookRepository {
+  _ServerStateRepository(this._server) : super(_dummyClient());
+  final ChapterDto _server;
+  final List<ChapterChange> patches = [];
+
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {
+    patches.add(patch);
+  }
+
+  @override
+  Future<ChapterDto?> getChapter({required int chapterId}) async => _server;
+}
+
+ChapterDto _serverChapter({
+  required int id,
+  required bool isRead,
+  required int lastPageRead,
+}) =>
+    ChapterDto(
+      chapterNumber: id.toDouble(),
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: true,
+      isRead: isRead,
+      lastPageRead: lastPageRead,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: 'c$id',
+      pageCount: 10,
+      sourceOrder: id,
+      uploadDate: '0',
+      url: 'u$id',
+      meta: const [],
+    );
 
 /// Notifier subclass that returns a fixed bool? without touching SharedPreferences.
 class _FixedToggle extends UpdateProgressAfterReading {
@@ -407,6 +450,89 @@ void main() {
       expect(c.isRead, isTrue);
       expect(c.progressDirty, isFalse);
       expect(c.readStateDirty, isFalse);
+    });
+  });
+
+  group('pushPendingProgress → cross-device never-regress', () {
+    test('local completion beats a server partial (marked-read, low position)',
+        () async {
+      // The reported failure: mark-read leaves lastPageRead low, a server
+      // partial sits at a higher page — the guard used to drop the completion.
+      final repo = _ServerStateRepository(
+          _serverChapter(id: 10, isRead: false, lastPageRead: 7));
+      final (:container, :db, :tracker) =
+          await _build(mangaIds: [1], repository: repo);
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await db.setChapterReadState(10, true); // local complete, position 0
+
+      await pushPendingProgress(container);
+
+      expect(repo.patches.single.isRead, isTrue,
+          reason: 'a finished local chapter must still push over a server partial');
+      expect((await db.chapterById(10))!.readStateDirty, isFalse);
+    });
+
+    test('server completion is not un-finished by a local partial', () async {
+      final repo = _ServerStateRepository(
+          _serverChapter(id: 10, isRead: true, lastPageRead: 0));
+      final (:container, :db, :tracker) =
+          await _build(mangaIds: [1], repository: repo);
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await db.setChapterProgress(10, lastPageRead: 3, isRead: null);
+
+      await pushPendingProgress(container);
+
+      expect(repo.patches, isEmpty,
+          reason: 'the server already finished it — no lesser push');
+      expect((await db.chapterById(10))!.progressDirty, isFalse);
+    });
+
+    test('a further server position wins over a lesser local one', () async {
+      final repo = _ServerStateRepository(
+          _serverChapter(id: 10, isRead: false, lastPageRead: 8));
+      final (:container, :db, :tracker) =
+          await _build(mangaIds: [1], repository: repo);
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await db.setChapterProgress(10, lastPageRead: 3, isRead: null);
+
+      await pushPendingProgress(container);
+
+      expect(repo.patches, isEmpty);
+      expect((await db.chapterById(10))!.progressDirty, isFalse);
+    });
+
+    test('a further local position wins over a lesser server one', () async {
+      final repo = _ServerStateRepository(
+          _serverChapter(id: 10, isRead: false, lastPageRead: 3));
+      final (:container, :db, :tracker) =
+          await _build(mangaIds: [1], repository: repo);
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await db.setChapterProgress(10, lastPageRead: 8, isRead: null);
+
+      await pushPendingProgress(container);
+
+      expect(repo.patches.single.lastPageRead, 8);
+      expect((await db.chapterById(10))!.progressDirty, isFalse);
     });
   });
 }

--- a/test/src/features/settings/server_url_credential_clear_test.dart
+++ b/test/src/features/settings/server_url_credential_clear_test.dart
@@ -1,0 +1,124 @@
+// A server switch must clear stored credentials so A's secrets never reach B.
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/auth/data/auth_credentials_store.dart';
+import 'package:tsumiru/src/features/auth/data/secure_credentials_provider.dart';
+import 'package:tsumiru/src/features/settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import 'package:tsumiru/src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+import 'package:tsumiru/src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+class _InMemorySecureStorage implements FlutterSecureStorage {
+  final _store = <String, String>{};
+  @override
+  Future<void> write({required String key, required String? value, iOptions,
+      aOptions, lOptions, webOptions, mOptions, wOptions}) async {
+    value == null ? _store.remove(key) : _store[key] = value;
+  }
+
+  @override
+  Future<String?> read({required String key, iOptions, aOptions, lOptions,
+          webOptions, mOptions, wOptions}) async =>
+      _store[key];
+
+  @override
+  Future<void> delete({required String key, iOptions, aOptions, lOptions,
+      webOptions, mOptions, wOptions}) async {
+    _store.remove(key);
+  }
+
+  @override
+  noSuchMethod(Invocation i) =>
+      throw UnimplementedError('${i.memberName} not stubbed');
+}
+
+Future<ProviderContainer> _container() async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final c = ProviderContainer(overrides: [
+    secureStorageProvider.overrideWithValue(_InMemorySecureStorage()),
+    sharedPreferencesProvider.overrideWithValue(prefs),
+  ]);
+  addTearDown(c.dispose);
+  await c.read(authCredentialsStoreProvider.future);
+  return c;
+}
+
+void main() {
+  test('switching host clears credentials; same-host edits keep them',
+      () async {
+    final c = await _container();
+    // Keep providers alive across updates (real watchers would in the app).
+    c.listen(serverUrlProvider, (_, __) {}, fireImmediately: true);
+    c.listen(credentialsProvider, (_, __) {}, fireImmediately: true);
+    final store = c.read(authCredentialsStoreProvider.notifier);
+    final serverUrl = c.read(serverUrlProvider.notifier);
+
+    // Establish host A, then seed credentials against it.
+    serverUrl.update('http://192.168.1.10:4567');
+    await store.savePassword('hunter2');
+    await store.saveSimpleLoginCookie('JSESSIONID=abc');
+    await c.read(credentialsProvider.notifier).set('Basic abc123');
+
+    // Same host (trailing slash / path change) — credentials survive.
+    serverUrl.update('http://192.168.1.10:4567/manga');
+    await Future<void>.delayed(Duration.zero);
+    var state = await c.read(authCredentialsStoreProvider.future);
+    expect(state.password, 'hunter2');
+    expect(state.simpleLoginCookie, 'JSESSIONID=abc');
+    expect(await c.read(credentialsProvider.future), 'Basic abc123');
+
+    // Different host — every credential cleared, including the Basic header.
+    serverUrl.update('http://10.0.0.5:4567');
+    await Future<void>.delayed(Duration.zero);
+    state = await c.read(authCredentialsStoreProvider.future);
+    expect(state.password, isNull);
+    expect(state.simpleLoginCookie, isNull);
+    expect(await c.read(credentialsProvider.future), isNull);
+  });
+
+  test('changing the server port clears credentials too', () async {
+    final c = await _container();
+    c.listen(serverPortProvider, (_, __) {}, fireImmediately: true);
+    final store = c.read(authCredentialsStoreProvider.notifier);
+    final port = c.read(serverPortProvider.notifier);
+
+    port.update(4567);
+    await store.savePassword('pw');
+    port.update(4568); // effective endpoint changed
+    await Future<void>.delayed(Duration.zero);
+    expect((await c.read(authCredentialsStoreProvider.future)).password, isNull);
+  });
+
+  test('a delayed token write with a stale epoch is discarded', () async {
+    final c = await _container();
+    final store = c.read(authCredentialsStoreProvider.notifier);
+
+    final epochBefore = store.serverEpoch;
+    await store.clearAllForServerSwitch(); // simulates a server switch
+    // A refresh/worker that started before the switch tries to write back.
+    await store.updateUiLoginAccessToken('tokenFromOldServer',
+        forEpoch: epochBefore);
+
+    final state = await c.read(authCredentialsStoreProvider.future);
+    expect(state.uiAccessToken, isNull);
+  });
+
+  test('different port counts as a different host', () async {
+    final c = await _container();
+    // Keep serverUrlProvider alive across updates (a real watcher would in the app).
+    c.listen(serverUrlProvider, (_, __) {}, fireImmediately: true);
+    final store = c.read(authCredentialsStoreProvider.notifier);
+    final serverUrl = c.read(serverUrlProvider.notifier);
+
+    serverUrl.update('http://host.local:4567');
+    await store.savePassword('pw');
+    serverUrl.update('http://host.local:4568');
+    await Future<void>.delayed(Duration.zero);
+    final state = await c.read(authCredentialsStoreProvider.future);
+    expect(state.password, isNull);
+  });
+}


### PR DESCRIPTION
Reliability pass over the reader, offline downloads, and server switching.

- **Progress saving:** keeps the reader's write-path providers (GraphQL client, manga repository) alive so an in-flight progress write can't be torn down mid-flight, and surfaces a failed online push instead of swallowing it. This fixes silent loss of reading progress after an upgrade, where progress stopped saving with no visible error and no re-auth prompt.
- **Riverpod-3 lifecycle:** guards ref-after-dispose and modify-provider-during-build crashes across the reader-exit, manga-details, downloads, and tracking flows.
- **Paged reader:** fixes chapter-boundary dead-ends and wrong-neighbour page jumps.
- **Offline downloads:** hardens against delete/store races, deleted chapters resurrecting mid-download, and stale background events; keeps the queue alive through network drops.
- **Server switch:** clears stored and in-memory credentials and rebinds background worker tokens when the server host or port changes.

Builds clean; 1041 tests pass, including a new regression test that fails if a failed online progress write is ever swallowed again.
