### PR TITLE
Credential redaction and safe-failure hardening

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ import 'src/features/tracking/domain/tracker_oauth_helpers.dart';
 import 'src/global_providers/global_providers.dart';
 import 'src/sorayomi.dart';
 import 'src/utils/crash/crash_log.dart';
+import 'src/utils/crash/redact_tokens.dart';
 import 'src/utils/desktop/desktop_window.dart';
 import 'src/utils/misc/toast/toast.dart';
 import 'src/utils/platform/is_android_native.dart';
@@ -287,18 +288,20 @@ Future<void> _setUpCrashReporting() async {
     _logCrash(error, stack);
     return true;
   };
-  ErrorWidget.builder = (details) =>
-      AppErrorApp(message: details.exceptionAsString(), logPath: _crashLogPath);
+  ErrorWidget.builder = (details) => AppErrorApp(
+        message: redactTokens(details.exceptionAsString()),
+        logPath: _crashLogPath,
+      );
 }
 
 void _logCrash(Object error, StackTrace? stack) {
   // Include the runtime type — some exceptions (e.g. wrapped GraphQL ones) have
   // an empty toString(), which would otherwise log a blank line.
-  final line = '${error.runtimeType}: $error';
-  debugPrint('Tsumiru error: $line\n$stack');
+  final body = redactTokens('${error.runtimeType}: $error\n$stack');
+  debugPrint('Tsumiru error: $body');
   writeCrashLog(
     _crashLogPath,
-    '[${DateTime.now().toIso8601String()}] $line\n$stack\n\n',
+    '[${DateTime.now().toIso8601String()}] $body\n\n',
   );
 }
 
@@ -311,7 +314,8 @@ void _onFatalError(Object error, StackTrace stack) {
   // running app with a "couldn't start" screen.
   if (_appRendered) return;
   try {
-    runApp(AppErrorApp(message: error.toString(), logPath: _crashLogPath));
+    runApp(AppErrorApp(
+        message: redactTokens(error.toString()), logPath: _crashLogPath));
   } catch (_) {}
 }
 

--- a/lib/src/features/migration/data/migration_repository.dart
+++ b/lib/src/features/migration/data/migration_repository.dart
@@ -51,7 +51,6 @@ class MigrationRepositoryImpl implements MigrationRepository {
       final sources = result.parsedData?.sources.nodes;
       if (sources == null) return null;
 
-      // Convert SourceDto to MigrationSource
       return sources
           .map((source) => MigrationSource(
                 id: source.id,
@@ -105,7 +104,6 @@ class MigrationRepositoryImpl implements MigrationRepository {
       int fromMangaId, int toMangaId, MigrationOption options,
       [BuildContext? context]) async {
     try {
-      // Get source manga information
       final sourceMangaResult = await client.query$GetManga(
         Options$Query$GetManga(
           variables: Variables$Query$GetManga(id: fromMangaId),
@@ -125,7 +123,6 @@ class MigrationRepositoryImpl implements MigrationRepository {
         throw Exception(errorMessage);
       }
 
-      // Get target manga information
       final targetMangaResult = await client.query$GetManga(
         Options$Query$GetManga(
           variables: Variables$Query$GetManga(id: toMangaId),
@@ -148,6 +145,9 @@ class MigrationRepositoryImpl implements MigrationRepository {
       List<String> warnings = [];
       int migratedChapters = 0;
       int migratedCategories = 0;
+      // Set on any hard failure below; blocks deleting the source so a partial
+      // migration can't lose data (better a visible duplicate than gone).
+      bool hardFailure = false;
 
       // Step 1: Add target manga to library if source manga is in library
       if (sourceManga.inLibrary) {
@@ -162,16 +162,17 @@ class MigrationRepositoryImpl implements MigrationRepository {
           ),
         );
 
-        if (updateLibraryResult.hasException) {
+        if (updateLibraryResult.hasException ||
+            updateLibraryResult.parsedData?.updateManga == null) {
           warnings.add(
-              'Failed to add target manga to library: ${updateLibraryResult.exception}');
+              'Failed to add target manga to library: ${updateLibraryResult.exception ?? 'no data'}');
+          hardFailure = true;
         }
       }
 
       // Step 2: Migrate categories if enabled
       if (options.migrateCategories && sourceManga.inLibrary) {
         try {
-          // Get source manga categories
           final sourceCategoriesResult = await client.query$GetMangaCategories(
             Options$Query$GetMangaCategories(
               variables: Variables$Query$GetMangaCategories(id: fromMangaId),
@@ -186,7 +187,6 @@ class MigrationRepositoryImpl implements MigrationRepository {
             if (categories.isNotEmpty) {
               List<int> categoryIds = categories.map((cat) => cat.id).toList();
 
-              // Apply the same categories to target manga
               final updateCategoriesResult =
                   await client.mutate$UpdateMangaCategories(
                 Options$Mutation$UpdateMangaCategories(
@@ -201,23 +201,32 @@ class MigrationRepositoryImpl implements MigrationRepository {
                 ),
               );
 
-              if (updateCategoriesResult.hasException) {
+              if (updateCategoriesResult.hasException ||
+                  updateCategoriesResult.parsedData?.updateMangaCategories ==
+                      null) {
                 warnings.add(
-                    'Failed to migrate categories: ${updateCategoriesResult.exception}');
+                    'Failed to migrate categories: ${updateCategoriesResult.exception ?? 'no data'}');
+                hardFailure = true;
               } else {
                 migratedCategories = categoryIds.length;
               }
             }
+          } else {
+            // The fetch itself failed — treat as a hard failure so we don't
+            // delete the source having migrated nothing.
+            warnings.add(
+                'Failed to read source categories: ${sourceCategoriesResult.exception ?? 'no data'}');
+            hardFailure = true;
           }
         } catch (e) {
           warnings.add('Category migration failed: $e');
+          hardFailure = true;
         }
       }
 
       // Step 3: Migrate reading progress if enabled
       if (options.migrateChapters) {
         try {
-          // Get source manga chapters using the correct API
           final sourceChaptersResult = await client.mutate$GetChaptersByMangaId(
             Options$Mutation$GetChaptersByMangaId(
               variables: Variables$Mutation$GetChaptersByMangaId(
@@ -226,7 +235,6 @@ class MigrationRepositoryImpl implements MigrationRepository {
             ),
           );
 
-          // Get target manga chapters using the correct API
           final targetChaptersResult = await client.mutate$GetChaptersByMangaId(
             Options$Mutation$GetChaptersByMangaId(
               variables: Variables$Mutation$GetChaptersByMangaId(
@@ -246,65 +254,106 @@ class MigrationRepositoryImpl implements MigrationRepository {
             final targetChapters =
                 targetChaptersResult.parsedData!.fetchChapters!.chapters;
 
-            // Create a list to batch update read chapters
             List<Input$UpdateChapterInput> chapterUpdates = [];
+            // Source chapters carrying state (read / bookmark / partial progress)
+            // that has no target match — that state can't migrate, so it must
+            // block deleting the source.
+            int unmatchedState = 0;
+            // Merge state per target id, seeded from the target's own state, so
+            // several source chapters matching one target (via the number
+            // tolerance or a name fallback) can't overwrite higher progress with
+            // lower: read/bookmark OR together, position takes the max.
+            final merged = <int, ({bool read, bool bookmark, int lastPage})>{};
 
-            // Try to match chapters by multiple criteria for better accuracy
             for (final sourceChapter in sourceChapters) {
-              if (sourceChapter.isRead) {
-                ChapterDto? matchingChapter;
+              // Migrate any chapter with state to carry over, not just read ones
+              // — a bookmarked or partially-read (unread) chapter counts too.
+              final hasState = sourceChapter.isRead ||
+                  sourceChapter.isBookmarked ||
+                  sourceChapter.lastPageRead > 0;
+              if (!hasState) continue;
 
-                // First, try exact chapter number match
+              ChapterDto? matchingChapter;
+
+              // First, try exact chapter number match
+              matchingChapter = targetChapters
+                  .where(
+                    (chapter) =>
+                        (chapter.chapterNumber - sourceChapter.chapterNumber)
+                            .abs() <
+                        0.01,
+                  )
+                  .firstOrNull;
+
+              // If no exact match, try name matching (case insensitive)
+              if (matchingChapter == null && sourceChapter.name.isNotEmpty) {
+                final sourceName = sourceChapter.name.toLowerCase().trim();
                 matchingChapter = targetChapters
                     .where(
                       (chapter) =>
-                          (chapter.chapterNumber - sourceChapter.chapterNumber)
-                              .abs() <
-                          0.01,
+                          chapter.name.toLowerCase().trim() == sourceName,
                     )
                     .firstOrNull;
+              }
 
-                // If no exact match, try name matching (case insensitive)
-                if (matchingChapter == null && sourceChapter.name.isNotEmpty) {
-                  final sourceName = sourceChapter.name.toLowerCase().trim();
-                  matchingChapter = targetChapters
-                      .where(
-                        (chapter) =>
-                            chapter.name.toLowerCase().trim() == sourceName,
-                      )
-                      .firstOrNull;
-                }
+              // If still no match, try partial name matching
+              if (matchingChapter == null && sourceChapter.name.isNotEmpty) {
+                final sourceName = sourceChapter.name.toLowerCase().trim();
+                matchingChapter = targetChapters.where(
+                  (chapter) {
+                    final targetName = chapter.name.toLowerCase().trim();
+                    return targetName.contains(sourceName) ||
+                        sourceName.contains(targetName);
+                  },
+                ).firstOrNull;
+              }
 
-                // If still no match, try partial name matching
-                if (matchingChapter == null && sourceChapter.name.isNotEmpty) {
-                  final sourceName = sourceChapter.name.toLowerCase().trim();
-                  matchingChapter = targetChapters.where(
-                    (chapter) {
-                      final targetName = chapter.name.toLowerCase().trim();
-                      return targetName.contains(sourceName) ||
-                          sourceName.contains(targetName);
-                    },
-                  ).firstOrNull;
-                }
+              if (matchingChapter == null) {
+                unmatchedState++;
+                continue;
+              }
 
-                // If we found a matching chapter and it's not already read
-                if (matchingChapter != null && !matchingChapter.isRead) {
-                  chapterUpdates.add(
-                    Input$UpdateChapterInput(
-                      id: matchingChapter.id,
-                      patch: Input$UpdateChapterPatchInput(
-                        isRead: true,
-                        lastPageRead: sourceChapter.lastPageRead,
-                        isBookmarked: sourceChapter
-                            .isBookmarked, // Also migrate bookmarks
-                      ),
-                    ),
+              final prev = merged[matchingChapter.id] ??
+                  (
+                    read: matchingChapter.isRead,
+                    bookmark: matchingChapter.isBookmarked,
+                    lastPage: matchingChapter.lastPageRead,
                   );
-                }
+              merged[matchingChapter.id] = (
+                read: prev.read || sourceChapter.isRead,
+                bookmark: prev.bookmark || sourceChapter.isBookmarked,
+                lastPage: sourceChapter.lastPageRead > prev.lastPage
+                    ? sourceChapter.lastPageRead
+                    : prev.lastPage,
+              );
+            }
+
+            // Emit an update per target only when the merged state ADDS something
+            // over the target's own state — never un-read, un-bookmark, or rewind.
+            for (final entry in merged.entries) {
+              final original =
+                  targetChapters.firstWhere((c) => c.id == entry.key);
+              final m = entry.value;
+              final setRead = m.read && !original.isRead;
+              final setBookmark = m.bookmark && !original.isBookmarked;
+              // Carry the furthest position independently of read state — a read
+              // chapter can still record where it was left off, and losing the
+              // merged max here would silently drop migrated progress.
+              final setPosition = m.lastPage > original.lastPageRead;
+              if (setRead || setBookmark || setPosition) {
+                chapterUpdates.add(
+                  Input$UpdateChapterInput(
+                    id: entry.key,
+                    patch: Input$UpdateChapterPatchInput(
+                      isRead: setRead ? true : null,
+                      isBookmarked: setBookmark ? true : null,
+                      lastPageRead: setPosition ? m.lastPage : null,
+                    ),
+                  ),
+                );
               }
             }
 
-            // Batch update chapters if we have any to update
             if (chapterUpdates.isNotEmpty) {
               // Update chapters one by one to avoid overwhelming the server
               for (final updateInput in chapterUpdates) {
@@ -315,27 +364,42 @@ class MigrationRepositoryImpl implements MigrationRepository {
                             input: updateInput)),
                   );
 
-                  if (!updateResult.hasException) {
+                  // A null payload (no exception, but the server applied
+                  // nothing) must not count as migrated, or the source could be
+                  // deleted with state unmoved.
+                  if (!updateResult.hasException &&
+                      updateResult.parsedData?.updateChapter != null) {
                     migratedChapters++;
                   } else {
                     warnings.add(
-                        'Failed to migrate chapter ${updateInput.id}: ${updateResult.exception}');
+                        'Failed to migrate chapter ${updateInput.id}: ${updateResult.exception ?? 'no data'}');
+                    hardFailure = true;
                   }
                 } catch (e) {
                   warnings
                       .add('Failed to migrate chapter ${updateInput.id}: $e');
+                  hardFailure = true;
                 }
               }
             }
 
-            if (migratedChapters == 0 &&
-                sourceChapters.any((ch) => ch.isRead)) {
+            // Any chapter with state and no target match means that state can't
+            // migrate — keep the source so that data isn't lost.
+            if (unmatchedState > 0) {
               warnings.add(
-                  'No matching chapters found for read status migration. This may be due to different chapter numbering between sources.');
+                  '$unmatchedState chapter(s) with read/bookmark/progress had no match on the target (likely different chapter numbering); kept the source so that data is not lost.');
+              hardFailure = true;
             }
+          } else {
+            // The fetch itself failed — treat as a hard failure so we don't
+            // delete the source having migrated no read progress.
+            warnings.add(
+                'Failed to read chapters for migration: ${sourceChaptersResult.exception ?? targetChaptersResult.exception ?? 'no data'}');
+            hardFailure = true;
           }
         } catch (e) {
           warnings.add('Chapter migration failed: $e');
+          hardFailure = true;
         }
       }
 
@@ -359,16 +423,30 @@ class MigrationRepositoryImpl implements MigrationRepository {
               } catch (e) {
                 warnings.add(
                     'Failed to migrate tracking record (tracker ${record.trackerId}): $e');
+                hardFailure = true;
               }
             }
+          } else {
+            // A null result (degraded/no data, no exception) means the tracking
+            // state was never read — treat as a hard failure so we don't delete
+            // a source whose tracking might not have migrated.
+            warnings.add('Failed to read source tracking records.');
+            hardFailure = true;
           }
         } catch (e) {
           warnings.add('Tracking migration failed: $e');
+          hardFailure = true;
         }
       }
 
-      // Step 5: Remove source manga from library if deleteSource is enabled
-      if (options.deleteSource && sourceManga.inLibrary) {
+      // Step 5: Remove the source from the library only if enabled AND nothing
+      // hard-failed above — otherwise deleting it would lose the data that
+      // didn't migrate. Leave the (visible) duplicate instead.
+      if (options.deleteSource && sourceManga.inLibrary && hardFailure) {
+        warnings.add(
+            'Kept the source in your library: parts of the migration failed, '
+            'so removing it would lose data.');
+      } else if (options.deleteSource && sourceManga.inLibrary) {
         final removeFromLibraryResult = await client.mutate$UpdateManga(
           Options$Mutation$UpdateManga(
             variables: Variables$Mutation$UpdateManga(
@@ -380,14 +458,17 @@ class MigrationRepositoryImpl implements MigrationRepository {
           ),
         );
 
-        if (removeFromLibraryResult.hasException) {
+        if (removeFromLibraryResult.hasException ||
+            removeFromLibraryResult.parsedData?.updateManga == null) {
           warnings.add(
-              'Failed to remove source manga from library: ${removeFromLibraryResult.exception}');
+              'Failed to remove source manga from library: ${removeFromLibraryResult.exception ?? 'no data'}');
+          hardFailure = true;
         }
       }
 
-      // Add completion message
-      warnings.add('Migration completed successfully! ✅');
+      warnings.add(hardFailure
+          ? 'Migration finished with some failures (see above).'
+          : 'Migration completed successfully! ✅');
       warnings.add('• Target manga: ${targetManga.title}');
       warnings.add('• Source: ${targetManga.sourceId}');
       if (migratedChapters > 0) {
@@ -401,7 +482,9 @@ class MigrationRepositoryImpl implements MigrationRepository {
       }
 
       return MigrationResult(
-        success: true,
+        // A hard failure means the migration didn't fully complete its intent
+        // (and the source was deliberately kept) — report that honestly.
+        success: !hardFailure,
         migratedChapters: migratedChapters,
         migratedCategories: migratedCategories,
         migratedTracking: migratedTracking,

--- a/lib/src/features/settings/presentation/settings/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../routes/router_config.dart';
+import '../../../../utils/crash/copy_crash_log.dart';
 import '../../../../utils/crash/crash_log.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
@@ -110,7 +111,7 @@ class _CopyCrashLogTile extends ConsumerWidget {
         },
       ),
       onTap: () async {
-        final log = readCrashLog(await initCrashLog());
+        final log = crashLogForClipboard(await initCrashLog());
         if (!context.mounted) return;
         final toast = ref.read(toastProvider);
         if (log == null) {

--- a/lib/src/features/tracking/data/tracker_repository.dart
+++ b/lib/src/features/tracking/data/tracker_repository.dart
@@ -83,19 +83,25 @@ class TrackerRepository {
     required int trackerId,
     required String remoteId,
     required bool private,
-  }) =>
-      client
-          .mutate$BindTrack(
-            Options$Mutation$BindTrack(
-              variables: Variables$Mutation$BindTrack(
-                mangaId: mangaId,
-                trackerId: trackerId,
-                remoteId: remoteId,
-                private: private,
-              ),
+  }) async {
+    final data = await client
+        .mutate$BindTrack(
+          Options$Mutation$BindTrack(
+            variables: Variables$Mutation$BindTrack(
+              mangaId: mangaId,
+              trackerId: trackerId,
+              remoteId: remoteId,
+              private: private,
             ),
-          )
-          .getData((d) => d);
+          ),
+        )
+        .getData((d) => d);
+    // A null payload (no exception, but nothing bound) must surface as an error
+    // so callers don't treat an unbound record as success.
+    if (data == null) {
+      throw Exception('Tracking bind returned no data');
+    }
+  }
 
   Future<void> update({
     required int recordId,

--- a/lib/src/utils/crash/copy_crash_log.dart
+++ b/lib/src/utils/crash/copy_crash_log.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'crash_log.dart';
+import 'redact_tokens.dart';
+
+/// Reads the crash log and redacts it — covers entries an older, pre-redaction
+/// version wrote. Use this instead of [readCrashLog] for anything user-copyable.
+String? crashLogForClipboard(String? path) {
+  final raw = readCrashLog(path);
+  return raw == null ? null : redactTokens(raw);
+}

--- a/lib/src/utils/crash/redact_tokens.dart
+++ b/lib/src/utils/crash/redact_tokens.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Matches token/accessToken/access_token/refreshToken/refresh_token query params
+// (case-insensitive) — values that must never end up in a copyable log.
+final _sensitiveParam = RegExp(
+  '([?&](?:token|access_?token|refresh_?token)=)[^&;\\s"\']+',
+  caseSensitive: false,
+);
+
+/// Replaces the value of any auth token carried in a URL query string with
+/// `<redacted>`, preserving the key so the log still reads sensibly.
+String redactTokens(String input) => input.replaceAllMapped(
+    _sensitiveParam, (m) => '${m.group(1)}<redacted>');

--- a/lib/src/utils/launch_url_in_web.dart
+++ b/lib/src/utils/launch_url_in_web.dart
@@ -13,11 +13,18 @@ import 'misc/toast/toast.dart';
 
 Future<void> launchUrlInWeb(BuildContext context, String url,
     [Toast? toast]) async {
-  if (!await launchUrl(
-    Uri.parse(url),
-    mode: LaunchMode.externalApplication,
-    webOnlyWindowName: "_blank",
-  )) {
+  final uri = Uri.tryParse(url);
+  // Restrict to http(s): these URLs come from server/source data, and a
+  // malicious source could otherwise trigger arbitrary intents (intent://, tel:, etc).
+  final scheme = uri?.scheme.toLowerCase();
+  final launched = uri != null &&
+      (scheme == 'http' || scheme == 'https') &&
+      await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+        webOnlyWindowName: "_blank",
+      );
+  if (!launched) {
     await Clipboard.setData(ClipboardData(text: url));
     if (context.mounted) toast?.showError(context.l10n.errorLaunchURL(url));
   }

--- a/lib/src/widgets/app_error_app.dart
+++ b/lib/src/widgets/app_error_app.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../utils/crash/crash_log.dart';
+import '../utils/crash/copy_crash_log.dart';
 
 /// A self-contained fallback screen shown when the app fails to start —
 /// instead of a blank white window with no clue. Kept dependency-light (its own
@@ -51,10 +51,8 @@ class AppErrorApp extends StatelessWidget {
                     const SizedBox(height: 20),
                     FilledButton.icon(
                       onPressed: () async {
-                        // The log lives in the app's private files dir, which a
-                        // user can't browse — copy it so they can paste it into
-                        // a bug report. Fall back to the message if unreadable.
-                        final log = readCrashLog(logPath) ?? message;
+                        // Fall back to the message if the log is unreadable.
+                        final log = crashLogForClipboard(logPath) ?? message;
                         await Clipboard.setData(ClipboardData(text: log));
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(

--- a/test/utils/redact_tokens_test.dart
+++ b/test/utils/redact_tokens_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/utils/crash/redact_tokens.dart';
+
+void main() {
+  group('redactTokens', () {
+    test('redacts token / accessToken / access_token / refresh variants', () {
+      expect(redactTokens('x?token=ABC.def'), 'x?token=<redacted>');
+      expect(redactTokens('x&accessToken=ABC'), 'x&accessToken=<redacted>');
+      expect(redactTokens('x?access_token=ABC'), 'x?access_token=<redacted>');
+      expect(redactTokens('x&refreshToken=ABC'), 'x&refreshToken=<redacted>');
+      expect(redactTokens('x?refresh_token=ABC'), 'x?refresh_token=<redacted>');
+    });
+
+    test('is case-insensitive on the key, preserving original casing', () {
+      expect(redactTokens('x?Token=ABC'), 'x?Token=<redacted>');
+      expect(redactTokens('x&AccessToken=ABC'), 'x&AccessToken=<redacted>');
+    });
+
+    test('stops at value delimiters and preserves the rest', () {
+      expect(redactTokens('a?token=ABC&width=100'),
+          'a?token=<redacted>&width=100');
+      expect(redactTokens('a?width=100&token=ABC'),
+          'a?width=100&token=<redacted>');
+      expect(redactTokens('a?token=ABC;b=2'), 'a?token=<redacted>;b=2');
+      expect(redactTokens('GET http://h/img?token=ey.J.Z failed'),
+          'GET http://h/img?token=<redacted> failed');
+    });
+
+    test('does not over-redact non-token params or plain text', () {
+      expect(redactTokens('a?width=100&height=200'), 'a?width=100&height=200');
+      expect(redactTokens('no tokens here'), 'no tokens here');
+      // Not a query param (no ? or & immediately before the key).
+      expect(redactTokens('the mytoken value'), 'the mytoken value');
+    });
+
+    test('redacts every occurrence', () {
+      expect(redactTokens('a?token=X then b?token=Y'),
+          'a?token=<redacted> then b?token=<redacted>');
+    });
+
+    test('redacts token-bearing entries in a multi-line historical log', () {
+      // Simulates a pre-redaction crash log entry still on disk.
+      const log = '[2026-01-01] Exception: http://h/img?token=OLD.secret x\n\n'
+          '[2026-02-01] StateError: unrelated failure\n\n';
+      final out = redactTokens(log);
+      expect(out.contains('OLD.secret'), isFalse);
+      expect(out.contains('token=<redacted>'), isTrue);
+      expect(out.contains('StateError: unrelated failure'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Credential-safety and safe-failure hardening.

- Redacts tokens from the persisted crash log and the fatal-error screen.
- Restricts external URL launches to http(s).
- Rejects null payloads from migration and tracking fetches so a no-op response isn't counted as a success.

Builds clean; 1006 tests pass.
