### PR TITLE
Settings, history, library, and backup fixes

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -67,6 +67,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Verify tag matches pubspec version
+        if: startsWith(github.ref, 'refs/tags/v')
+        # Stops a release built from a commit whose pubspec version doesn't match
+        # the tag (e.g. tagging v0.9.2 while pubspec still says 0.9.1); the
+        # artifacts would report the wrong in-app version.
+        run: |
+          tag_ver="${GITHUB_REF_NAME#v}"
+          pubspec_ver="$(grep -m1 '^version:' pubspec.yaml | sed -E 's/version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+          if [ "$tag_ver" != "$pubspec_ver" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (version $tag_ver) does not match pubspec.yaml version $pubspec_ver"
+            exit 1
+          fi
+          echo "Tag matches pubspec version: $pubspec_ver"
+
       - uses: subosito/flutter-action@v2
         with:
           flutter-version-file: .fvmrc
@@ -158,6 +172,14 @@ jobs:
           export PATH="$PATH:$HOME/.pub-cache/bin"
           # Builds `flutter build linux --release` + packages an AppImage.
           fastforge package --platform linux --targets appimage
+          # Guard: the SQLite native lib must be bundled, or the app crashes on
+          # DB open (the error-126 class we shipped on Windows in 0.9.0/0.9.1).
+          sqlite="$(find build/linux -iname 'libsqlite3*.so' | head -1)"
+          if [ -z "$sqlite" ]; then
+            echo "::error::sqlite3 native library missing from the Linux build"
+            find build/linux -iname '*.so' 2>/dev/null | head; exit 1
+          fi
+          echo "Bundled SQLite: $sqlite"
           # Collect the AppImage into dist/ with our release naming.
           mkdir -p dist
           built="$(find dist -name '*.AppImage' | head -1)"

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -51,7 +51,10 @@ enum DBKeys {
   // (show the category picker), 0 = Default/uncategorized, >0 = a specific
   // category id. Mirrors Komikku's Default category preference.
   libraryDefaultCategory(-1),
-  l10n(Locale('en')),
+  // null = follow the device locale (MaterialApp resolves it against the
+  // supported set, falling back to English). A hardcoded default forced every
+  // fresh install to English regardless of the device language.
+  l10n(null),
   mangaFilterDownloaded(null),
   mangaFilterOffline(null),
   mangaFilterUnread(null),

--- a/lib/src/features/browse_center/presentation/source_manga_list/controller/source_manga_controller.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/controller/source_manga_controller.dart
@@ -28,8 +28,10 @@ Future<List<Filter>?> baseSourceMangaFilterList(Ref ref, String sourceId) =>
 class SourceDisplayMode extends _$SourceDisplayMode
     with SharedPreferenceEnumClientMixin<DisplayMode> {
   @override
+  // Persist against DisplayMode.values, not the curated sourceDisplayList —
+  // the latter would be a second, reorderable wire format for the same index.
   DisplayMode? build() => initialize(
         DBKeys.sourceDisplayMode,
-        enumList: DisplayMode.sourceDisplayList,
+        enumList: DisplayMode.values,
       );
 }

--- a/lib/src/features/history/data/history_repository.dart
+++ b/lib/src/features/history/data/history_repository.dart
@@ -13,7 +13,6 @@ import '../../../graphql/__generated__/schema.graphql.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
-import '../../manga_book/domain/chapter_page/chapter_page_model.dart';
 import '../domain/history_item.dart';
 import 'graphql/__generated__/query.graphql.dart';
 
@@ -24,39 +23,33 @@ class HistoryRepository {
   final GraphQLClient client;
   final MangaBookRepository mangaBookRepository;
 
-  /// Fetch reading history with pagination and filtering
-  Future<ChapterPageWithMangaDto?> getReadingHistory({
-    int pageSize = 50,
-    int pageNo = 0,
+  /// Most-recently-read chapter per manga, newest first.
+  ///
+  /// Fetches one bounded window (not paginated) — per-manga dedup over a
+  /// chapter-ordered, live-mutable server result doesn't paginate cleanly.
+  Future<List<HistoryItemDto>> getReadingHistory({
+    int maxChapters = 2000,
     String? searchQuery,
     DateTime? fromDate,
     DateTime? toDate,
   }) async {
-    // Build filter for chapters with actual reading progress
     final filter = Input$ChapterFilterInput(
-      // Only get chapters from library manga
       inLibrary: Input$BooleanFilterInput(equalTo: true),
-      // Only get chapters that have been read (lastReadAt is not null/empty)
       lastReadAt: Input$LongFilterInput(
         isNull: false,
         greaterThan:
             "0", // Ensure lastReadAt is actually set to a real timestamp
       ),
-      // Only show chapters that have actual reading progress:
-      // Either fully read OR have made progress beyond the first page
+      // Chapters with actual reading progress: fully read, or past the first page.
       or: [
-        // Fully completed chapters
         Input$ChapterFilterInput(
           isRead: Input$BooleanFilterInput(equalTo: true),
         ),
-        // Chapters with meaningful reading progress (at least 1 page read)
         Input$ChapterFilterInput(
           lastPageRead: Input$IntFilterInput(greaterThan: 0),
         ),
       ],
-      // Additional filters
       and: [
-        // Add date range filtering if provided
         if (fromDate != null)
           Input$ChapterFilterInput(
             lastReadAt: Input$LongFilterInput(
@@ -69,11 +62,9 @@ class HistoryRepository {
               lessThanOrEqualTo: toDate.millisecondsSinceEpoch.toString(),
             ),
           ),
-        // Add search filtering if provided
         if (searchQuery.isNotBlank)
           Input$ChapterFilterInput(
             or: [
-              // Search in chapter name
               Input$ChapterFilterInput(
                 name: Input$StringFilterInput(
                   includesInsensitive: searchQuery,
@@ -86,25 +77,23 @@ class HistoryRepository {
       ],
     );
 
-    // Order by lastReadAt descending (most recent first)
     final order = [
       Input$ChapterOrderInput(
         by: Enum$ChapterOrderBy.LAST_READ_AT,
         byType: Enum$SortOrder.DESC,
       ),
-      // Secondary sort by source order for consistency
       Input$ChapterOrderInput(
         by: Enum$ChapterOrderBy.SOURCE_ORDER,
         byType: Enum$SortOrder.DESC,
       ),
     ];
 
-    final result = await client
+    final chapters = await client
         .query$GetReadingHistory(
           Options$Query$GetReadingHistory(
             variables: Variables$Query$GetReadingHistory(
-              first: pageSize * 10, // Get more results to filter duplicates
-              offset: pageNo * pageSize,
+              first: maxChapters,
+              offset: 0,
               filter: filter,
               order: order,
             ),
@@ -112,54 +101,15 @@ class HistoryRepository {
         )
         .getData((data) => data.chapters);
 
-    // Filter to only show the most recent chapter per manga
-    if (result?.nodes != null) {
-      // First, apply client-side filtering to ensure removed chapters are excluded
-      final validChapters = result!.nodes.where((chapter) {
-        // Only include chapters with actual reading progress:
-        // 1. Fully read chapters (isRead: true), OR
-        // 2. Chapters with meaningful progress (lastPageRead > 0)
-        // This excludes chapters that were removed from history (isRead: false AND lastPageRead: 0)
-        final isFullyRead = chapter.isRead;
-        final hasProgress = chapter.lastPageRead > 0;
-
-        return isFullyRead || hasProgress;
-      }).toList();
-
-      final Map<int, HistoryItemDto> latestChapterPerManga = {};
-
-      for (final chapter in validChapters) {
-        final mangaId = chapter.mangaId;
-
-        // Only keep the first (most recent) chapter for each manga
-        if (!latestChapterPerManga.containsKey(mangaId)) {
-          latestChapterPerManga[mangaId] = chapter;
-        }
-      }
-
-      // Take only the requested page size from the filtered results
-      final filteredChapters = latestChapterPerManga.values.toList()
-        ..sort((a, b) {
-          final aTime = a.readAt?.millisecondsSinceEpoch ?? 0;
-          final bTime = b.readAt?.millisecondsSinceEpoch ?? 0;
-          return bTime.compareTo(aTime); // Most recent first
-        });
-
-      final startIndex = pageNo * pageSize;
-      final endIndex =
-          (startIndex + pageSize).clamp(0, filteredChapters.length);
-      final pageChapters = startIndex < filteredChapters.length
-          ? filteredChapters.sublist(startIndex, endIndex)
-          : <HistoryItemDto>[];
-
-      return ChapterPageWithMangaDto(
-        nodes: pageChapters,
-        pageInfo: result.pageInfo,
-        totalCount: latestChapterPerManga.length,
-      );
+    final seen = <int>{};
+    final items = <HistoryItemDto>[];
+    for (final chapter in chapters?.nodes ?? const <HistoryItemDto>[]) {
+      // Skip no-progress rows left behind by "remove from history".
+      if (!chapter.isRead && chapter.lastPageRead <= 0) continue;
+      // First-seen per manga wins (server order is already newest-first).
+      if (seen.add(chapter.mangaId)) items.add(chapter);
     }
-
-    return result;
+    return items;
   }
 
   /// Get reading history for a specific manga
@@ -194,14 +144,13 @@ class HistoryRepository {
 
   /// Clear reading history for a specific chapter
   Future<void> removeChapterFromHistory(int chapterId) async {
-    // Mark the chapter as unread and reset progress
-    // This should remove it from history queries since our filter requires:
+    // This removes it from history queries since our filter requires:
     // either isRead: true OR lastPageRead > 0
     await mangaBookRepository.putChapter(
       chapterId: chapterId,
       patch: ChapterChange(
-        isRead: false, // Set to false (not fully read)
-        lastPageRead: 0, // Reset to 0 (no progress)
+        isRead: false,
+        lastPageRead: 0,
         // Note: lastReadAt cannot be cleared via this API
         // Some chapters may still appear until server is restarted
       ),
@@ -211,8 +160,6 @@ class HistoryRepository {
   /// Clear all reading history (mark all chapters as unread)
   /// This is a destructive operation and should be used with caution
   Future<void> clearAllHistory() async {
-    // This would require a server-side bulk operation
-    // For now, this is a placeholder that would need server support
     throw UnimplementedError(
       'Clearing all history requires server-side support. '
       'Please use individual chapter removal instead.',

--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -9,6 +9,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../constants/db_keys.dart';
 import '../../../utils/extensions/custom_extensions.dart';
+import '../../../utils/misc/toast/toast.dart';
 import '../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import '../data/history_repository.dart';
@@ -21,12 +22,12 @@ part 'history_controller.g.dart';
 class ReadingHistory extends _$ReadingHistory {
   @override
   Future<List<HistoryItemDto>?> build() async {
-    final result =
+    final items =
         await ref.watch(historyRepositoryProvider).getReadingHistory();
     // Guard the post-await ref use: the provider may have been disposed during
     // the fetch, and keepAlive() on a dead ref throws UnmountedRefException.
     if (ref.mounted) ref.keepAlive();
-    return result?.nodes;
+    return items;
   }
 
   Future<void> refresh() async {
@@ -36,67 +37,38 @@ class ReadingHistory extends _$ReadingHistory {
     final result = await AsyncValue.guard(
       () => ref.read(historyRepositoryProvider).getReadingHistory(),
     );
-    if (ref.mounted) state = result.whenData((data) => data?.nodes);
+    if (!ref.mounted) return;
+    final items = result.asData?.value;
+    if (items != null) state = AsyncData(items);
+    // On error keep the current list (the pull spinner has dismissed).
   }
 
-  Future<void> loadMore() async {
-    final currentItems = state.value ?? [];
-    final pageNo = (currentItems.length / 50).floor() + 1;
-
+  /// Remove a chapter from reading history.
+  Future<void> removeFromHistory(int chapterId) async {
+    final current = state.value ?? const <HistoryItemDto>[];
+    HistoryItemDto? removed;
+    for (final item in current) {
+      if (item.id == chapterId) {
+        removed = item;
+        break;
+      }
+    }
     final result = await AsyncValue.guard(
       () =>
-          ref.read(historyRepositoryProvider).getReadingHistory(pageNo: pageNo),
+          ref.read(historyRepositoryProvider).removeChapterFromHistory(chapterId),
     );
-
-    state = result.when(
-      data: (data) {
-        if (data?.nodes != null) {
-          final newItems = data?.nodes ?? [];
-          final updatedItems = [...currentItems, ...newItems];
-          return AsyncData(updatedItems);
-        }
-        return state; // Keep current state if no new data
-      },
-      error: (error, stackTrace) => AsyncError(error, stackTrace),
-      loading: () => state, // Keep current state while loading more
-    );
-  }
-
-  /// Remove a chapter from reading history
-  Future<void> removeFromHistory(int chapterId) async {
-    state = await AsyncValue.guard(() async {
-      // First get the chapter to extract mangaId for cache invalidation
-      final currentItems = state.value ?? [];
-      HistoryItemDto? chapterToRemove;
-
-      try {
-        chapterToRemove =
-            currentItems.firstWhere((item) => item.id == chapterId);
-      } catch (e) {
-        // Chapter not found in current list, continue anyway
-      }
-
-      // Remove the chapter from history on the server
-      await ref
-          .read(historyRepositoryProvider)
-          .removeChapterFromHistory(chapterId);
-
-      // Invalidate all related caches to ensure fresh data
-      if (chapterToRemove != null) {
-        final mangaId = chapterToRemove.mangaId;
-        // Invalidate the specific manga's chapter list so it shows as unread immediately
-        ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
-        ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
-      }
-
-      // Also invalidate the history provider itself to force a fresh query
-      ref.invalidateSelf();
-
-      // Refresh the history data from server to get updated state
-      final result =
-          await ref.read(historyRepositoryProvider).getReadingHistory();
-      return result?.nodes;
-    });
+    if (!ref.mounted) return;
+    if (result.hasError) {
+      // Don't invalidate as though it succeeded — item would just reappear.
+      ref.read(toastProvider)?.showError(result.error.toString());
+      return;
+    }
+    if (removed != null) {
+      ref.invalidate(mangaChapterListProvider(mangaId: removed.mangaId));
+      ref.invalidate(mangaWithIdProvider(mangaId: removed.mangaId));
+    }
+    // Rebuild from the top so the removed chapter drops out.
+    ref.invalidateSelf();
   }
 }
 
@@ -125,7 +97,6 @@ List<HistoryGroup> historyGroupedByDate(Ref ref) {
 
   if (historyItems.isEmpty) return [];
 
-  // Group items by their read date using a simple key
   final Map<String, List<HistoryItemDto>> groupedItems = {};
 
   for (final item in historyItems) {
@@ -133,7 +104,6 @@ List<HistoryGroup> historyGroupedByDate(Ref ref) {
     groupedItems.putIfAbsent(groupKey, () => []).add(item);
   }
 
-  // Convert to HistoryGroup objects and sort by most recent
   final groups = groupedItems.entries.map((entry) {
     return HistoryGroup(
       title: entry.key,
@@ -141,7 +111,6 @@ List<HistoryGroup> historyGroupedByDate(Ref ref) {
     );
   }).toList();
 
-  // Sort groups by most recent read date
   groups.sort((a, b) {
     final aDate = a.mostRecentReadDate;
     final bDate = b.mostRecentReadDate;
@@ -163,7 +132,6 @@ List<HistoryGroup> filteredHistoryGroups(Ref ref) {
 
   if (searchQuery.isBlank) return groups;
 
-  // Filter each group and remove empty groups
   final filteredGroups = groups
       .map((group) => group.filterByQuery(searchQuery))
       .where((group) => group.isNotEmpty)

--- a/lib/src/features/history/presentation/history_screen.dart
+++ b/lib/src/features/history/presentation/history_screen.dart
@@ -63,9 +63,9 @@ class HistoryScreen extends ConsumerWidget {
                   return const HistoryNoSearchResults();
                 }
 
+                final notifier = ref.read(readingHistoryProvider.notifier);
                 return RefreshIndicator(
-                  onRefresh: () =>
-                      ref.read(readingHistoryProvider.notifier).refresh(),
+                  onRefresh: notifier.refresh,
                   child: ListView.builder(
                     padding: const EdgeInsets.all(8),
                     itemCount: historyGroups.length,
@@ -73,9 +73,8 @@ class HistoryScreen extends ConsumerWidget {
                       final group = historyGroups[index];
                       return HistoryGroupWidget(
                         group: group,
-                        onRemoveItem: (chapterId) => ref
-                            .read(readingHistoryProvider.notifier)
-                            .removeFromHistory(chapterId),
+                        onRemoveItem: (chapterId) =>
+                            notifier.removeFromHistory(chapterId),
                       );
                     },
                   ),

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -137,6 +137,8 @@ class CategoryMangaList extends HookConsumerWidget {
           }
         }
       }
+      // refresh() only re-buckets cached DTOs; unreadCount needs a real refetch.
+      ref.invalidate(libraryMangaListProvider);
       refresh();
       if (!context.mounted) return;
       // A server failure with offline inactive means nothing was persisted, so

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -155,7 +155,7 @@ List<MangaDto> applyLibraryFilterSort(
     return true;
   }
 
-  int sort(MangaDto m1, MangaDto m2) {
+  int sortPrimary(MangaDto m1, MangaDto m2) {
     final sortDirToggle = (sortedDirection ? 1 : -1);
     // Random sort: direction is pinned (always ascending by key) so that the
     // direction toggle button doesn't fight the re-roll affordance.
@@ -217,6 +217,12 @@ List<MangaDto> applyLibraryFilterSort(
           MangaSort.trackerScore => 0,
         }) *
         sortDirToggle;
+  }
+
+  int sort(MangaDto m1, MangaDto m2) {
+    final p = sortPrimary(m1, m2);
+    // List.sort is unstable, so tie-break on id to stop equal keys shuffling on refresh.
+    return p != 0 ? p : m1.id.compareTo(m2.id);
   }
 
   return input.where(filter).toList()..sort(sort);

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -220,6 +220,10 @@ class _DefaultLibraryScreen extends HookConsumerWidget {
                         child: TabBarView(
                           children: data
                               .map((e) => CategoryMangaList(
+                                    // Keyed so element reuse can't leak one
+                                    // category's multi-select into another.
+                                    key: ValueKey(
+                                        e.id.getValueOnNullOrNegative()),
                                     categoryId:
                                         e.id.getValueOnNullOrNegative(),
                                   ))
@@ -350,8 +354,10 @@ class _GroupedLibraryScreen extends HookConsumerWidget {
               Padding(
                 padding: KEdgeInsets.h8.size,
                 child: TabBarView(
-                  children:
-                      tabs.map((t) => _GroupedMangaList(tabId: t.id)).toList(),
+                  children: tabs
+                      .map((t) =>
+                          _GroupedMangaList(key: ValueKey(t.id), tabId: t.id))
+                      .toList(),
                 ),
               ),
             ),
@@ -399,7 +405,7 @@ class _CategoryTab extends ConsumerWidget {
 /// A manga grid/list for a non-default group tab (BY_SOURCE, BY_STATUS,
 /// UNGROUPED), fed from [groupedMangaListWithQueryAndFilterProvider].
 class _GroupedMangaList extends ConsumerWidget {
-  const _GroupedMangaList({required this.tabId});
+  const _GroupedMangaList({super.key, required this.tabId});
   final int tabId;
 
   @override

--- a/lib/src/features/migration/presentation/screens/migration_search_screen.dart
+++ b/lib/src/features/migration/presentation/screens/migration_search_screen.dart
@@ -11,6 +11,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../routes/router_config.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../utils/hooks/debounced_hook.dart';
 import '../../../../widgets/server_image.dart';
 import '../../../browse_center/domain/source/source_model.dart';
 import '../../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
@@ -33,6 +34,13 @@ class MigrationSearchScreen extends HookConsumerWidget {
     final l10n = context.l10n;
     final searchController = useTextEditingController();
     final searchQuery = ref.watch(migrationSearchQueryProvider);
+    // Debounce the source fetch, not the UI: raw searchQuery still drives clear/empty state.
+    final debouncedQuery = useSettled(
+      searchQuery,
+      const Duration(milliseconds: 400),
+    );
+    // Grid still shows the previous query's results until this settles.
+    final searchPending = searchQuery != debouncedQuery;
 
     // Auto-search with source manga title on screen load
     useEffect(() {
@@ -40,25 +48,19 @@ class MigrationSearchScreen extends HookConsumerWidget {
       if (initialQuery.isNotEmpty) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           searchController.text = initialQuery;
+          // Just update the query; reading the provider here raced a second fetch.
           ref.read(migrationSearchQueryProvider.notifier).update(initialQuery);
-          ref.read(migrationSearchProvider(
-            sourceId: targetSource.id,
-            query: initialQuery,
-          ).future);
         });
       }
       return null;
     }, []);
 
-    final searchResultsAsync = ref.watch(migrationSearchProvider(
-      sourceId: targetSource.id,
-      query: searchQuery,
-    ));
+    final searchResultsAsync = ref.watch(
+      migrationSearchProvider(sourceId: targetSource.id, query: debouncedQuery),
+    );
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text('Search in ${targetSource.displayName}'),
-      ),
+      appBar: AppBar(title: Text('Search in ${targetSource.displayName}')),
       body: Column(
         children: [
           // Search bar
@@ -82,11 +84,11 @@ class MigrationSearchScreen extends HookConsumerWidget {
                 ref.read(migrationSearchQueryProvider.notifier).update(query);
               },
               onSubmitted: (query) {
+                // Same as above: update, don't read, or it races a second fetch.
                 if (query.trim().isNotEmpty) {
-                  ref.read(migrationSearchProvider(
-                    sourceId: targetSource.id,
-                    query: query.trim(),
-                  ).future);
+                  ref
+                      .read(migrationSearchQueryProvider.notifier)
+                      .update(query.trim());
                 }
               },
             ),
@@ -123,125 +125,126 @@ class MigrationSearchScreen extends HookConsumerWidget {
 
           const SizedBox(height: 16),
 
-          // Search results
+          // Spinner while pending so a stale result can't be tapped.
           Expanded(
-            child: searchResultsAsync.when(
-              data: (results) {
-                if (searchQuery.isEmpty) {
-                  return Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.search,
-                          size: 64,
-                          color: Colors.grey.shade400,
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          l10n.searchForManga,
-                          style: context.theme.textTheme.titleMedium?.copyWith(
-                            color: Colors.grey.shade600,
+            child: searchPending
+                ? const Center(child: CircularProgressIndicator())
+                : searchResultsAsync.when(
+                    data: (results) {
+                      if (searchQuery.isEmpty) {
+                        return Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.search,
+                                size: 64,
+                                color: Colors.grey.shade400,
+                              ),
+                              const SizedBox(height: 16),
+                              Text(
+                                l10n.searchForManga,
+                                style: context.theme.textTheme.titleMedium
+                                    ?.copyWith(color: Colors.grey.shade600),
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                l10n.enterSearchTerm,
+                                style: context.theme.textTheme.bodyMedium
+                                    ?.copyWith(color: Colors.grey.shade500),
+                              ),
+                            ],
                           ),
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          l10n.enterSearchTerm,
-                          style: context.theme.textTheme.bodyMedium?.copyWith(
-                            color: Colors.grey.shade500,
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                }
+                        );
+                      }
 
-                if (results == null || results.isEmpty) {
-                  return Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.search_off,
-                          size: 64,
-                          color: Colors.grey.shade400,
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          l10n.noResultsFound,
-                          style: context.theme.textTheme.titleMedium,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          l10n.tryDifferentSearch,
-                          style: context.theme.textTheme.bodyMedium?.copyWith(
-                            color: Colors.grey.shade600,
+                      if (results == null || results.isEmpty) {
+                        return Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.search_off,
+                                size: 64,
+                                color: Colors.grey.shade400,
+                              ),
+                              const SizedBox(height: 16),
+                              Text(
+                                l10n.noResultsFound,
+                                style: context.theme.textTheme.titleMedium,
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                l10n.tryDifferentSearch,
+                                style: context.theme.textTheme.bodyMedium
+                                    ?.copyWith(color: Colors.grey.shade600),
+                              ),
+                            ],
                           ),
-                        ),
-                      ],
-                    ),
-                  );
-                }
+                        );
+                      }
 
-                return GridView.builder(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    childAspectRatio: 0.7,
-                    crossAxisSpacing: 12,
-                    mainAxisSpacing: 12,
-                  ),
-                  itemCount: results.length,
-                  itemBuilder: (context, index) {
-                    final manga = results[index];
-                    return _MangaSearchResultCard(
-                      manga: manga,
-                      onTap: () => _onMangaSelected(context, ref, manga),
-                    );
-                  },
-                );
-              },
-              loading: () => const Center(
-                child: CircularProgressIndicator(),
-              ),
-              error: (error, stackTrace) => Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      Icons.error_outline,
-                      size: 64,
-                      color: Colors.red.shade400,
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n.searchError,
-                      style: context.theme.textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      error.toString(),
-                      style: context.theme.textTheme.bodyMedium?.copyWith(
-                        color: Colors.grey.shade600,
+                      return GridView.builder(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        gridDelegate:
+                            const SliverGridDelegateWithFixedCrossAxisCount(
+                              crossAxisCount: 2,
+                              childAspectRatio: 0.7,
+                              crossAxisSpacing: 12,
+                              mainAxisSpacing: 12,
+                            ),
+                        itemCount: results.length,
+                        itemBuilder: (context, index) {
+                          final manga = results[index];
+                          return _MangaSearchResultCard(
+                            manga: manga,
+                            onTap: () => _onMangaSelected(context, ref, manga),
+                          );
+                        },
+                      );
+                    },
+                    loading: () =>
+                        const Center(child: CircularProgressIndicator()),
+                    error: (error, stackTrace) => Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.error_outline,
+                            size: 64,
+                            color: Colors.red.shade400,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            l10n.searchError,
+                            style: context.theme.textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            error.toString(),
+                            style: context.theme.textTheme.bodyMedium?.copyWith(
+                              color: Colors.grey.shade600,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 16),
+                          ElevatedButton(
+                            onPressed: () {
+                              if (searchQuery.isNotEmpty) {
+                                ref.read(
+                                  migrationSearchProvider(
+                                    sourceId: targetSource.id,
+                                    query: searchQuery,
+                                  ).future,
+                                );
+                              }
+                            },
+                            child: Text(l10n.retry),
+                          ),
+                        ],
                       ),
-                      textAlign: TextAlign.center,
                     ),
-                    const SizedBox(height: 16),
-                    ElevatedButton(
-                      onPressed: () {
-                        if (searchQuery.isNotEmpty) {
-                          ref.read(migrationSearchProvider(
-                            sourceId: targetSource.id,
-                            query: searchQuery,
-                          ).future);
-                        }
-                      },
-                      child: Text(l10n.retry),
-                    ),
-                  ],
-                ),
-              ),
-            ),
+                  ),
           ),
         ],
       ),
@@ -253,10 +256,8 @@ class MigrationSearchScreen extends HookConsumerWidget {
     WidgetRef ref,
     Fragment$MangaDto targetManga,
   ) {
-    // Select the target manga
     ref.read(selectedTargetMangaProvider.notifier).select(targetManga);
 
-    // Navigate to migration preview screen with proper data class
     MigrationPreviewRoute(
       $extra: MigrationPreviewRouteData(
         sourceManga: sourceManga,
@@ -268,10 +269,7 @@ class MigrationSearchScreen extends HookConsumerWidget {
 }
 
 class _MangaSearchResultCard extends StatelessWidget {
-  const _MangaSearchResultCard({
-    required this.manga,
-    required this.onTap,
-  });
+  const _MangaSearchResultCard({required this.manga, required this.onTap});
 
   final Fragment$MangaDto manga;
   final VoidCallback onTap;
@@ -288,9 +286,7 @@ class _MangaSearchResultCard extends StatelessWidget {
             // Manga cover
             Expanded(
               flex: 3,
-              child: ServerImage(
-                imageUrl: manga.thumbnailUrl ?? '',
-              ),
+              child: ServerImage(imageUrl: manga.thumbnailUrl ?? ''),
             ),
 
             // Manga info

--- a/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/backup_and_restore_section.dart
+++ b/lib/src/features/settings/presentation/backup/widgets/backup_and_restore/backup_and_restore_section.dart
@@ -45,9 +45,9 @@ class BackupAndRestoreSection extends HookConsumerWidget {
     final asyncBackupFile = await AsyncValue.guard(
         () => FilePickerUtils.convertToMultipartFile(pickedFile, "backup"));
 
-    if (context.mounted &&
-        (asyncBackupFile.hasError || asyncBackupFile.value == null)) {
-      asyncBackupFile.showToastOnError(toast);
+    if (asyncBackupFile.hasError || asyncBackupFile.value == null) {
+      // Bail unconditionally — mounted only gates the toast, not the null-assertion below.
+      if (context.mounted) asyncBackupFile.showToastOnError(toast);
       return null;
     }
 
@@ -57,14 +57,17 @@ class BackupAndRestoreSection extends HookConsumerWidget {
     final validateResult = await AsyncValue.guard(() =>
         ref.read(backupSettingsRepositoryProvider).validateBackup(backupFile));
 
-    if (context.mounted && validateResult.hasError) {
-      validateResult.showToastOnError(toast);
+    if (validateResult.hasError) {
+      // Bail unconditionally — don't let an unmounted validation failure proceed to restore.
+      if (context.mounted) validateResult.showToastOnError(toast);
       return null;
     }
 
     String? backupId;
     bool restoreBackup = true;
-    if (validateResult.value.isNotBlank && context.mounted) {
+    if (validateResult.value.isNotBlank) {
+      // Can't confirm missing sources without a context to show the dialog in.
+      if (!context.mounted) return null;
       restoreBackup = (await showDialog<bool>(
         context: context,
         builder: (context) =>
@@ -77,9 +80,9 @@ class BackupAndRestoreSection extends HookConsumerWidget {
       final asyncBackupFile = await AsyncValue.guard(
           () => FilePickerUtils.convertToMultipartFile(pickedFile, "backup"));
 
-      if (context.mounted &&
-          (asyncBackupFile.hasError || asyncBackupFile.value == null)) {
-        asyncBackupFile.showToastOnError(toast);
+      if (asyncBackupFile.hasError || asyncBackupFile.value == null) {
+        // Same unconditional bail as the first conversion.
+        if (context.mounted) asyncBackupFile.showToastOnError(toast);
         return null;
       }
       final backupResponse = (await AsyncValue.guard(() => ref

--- a/lib/src/utils/hooks/polling_hook.dart
+++ b/lib/src/utils/hooks/polling_hook.dart
@@ -10,12 +10,16 @@ T? usePolling<T>({
   final data = useState<T?>(null);
 
   useEffect(() {
+    bool cancelled = false;
+
     Future<void> poll() async {
-      while (true) {
+      while (!cancelled) {
         if (delayedStart) {
           await Future.delayed(pollingInterval);
         }
+        if (cancelled) return;
         final result = await pollFunction();
+        if (cancelled) return;
         data.value = result;
         if (!delayedStart) {
           await Future.delayed(pollingInterval);
@@ -25,10 +29,7 @@ T? usePolling<T>({
 
     poll();
 
-    // Cleanup function
-    return () {
-      // No cleanup needed for this simple example
-    };
+    return () => cancelled = true;
   }, []);
 
   return data.value;

--- a/lib/src/utils/network/timeout_http_client.dart
+++ b/lib/src/utils/network/timeout_http_client.dart
@@ -8,21 +8,19 @@ class TimeoutHttpClient extends http.BaseClient {
     this.timeout, {
     this.retries = 0,
     this.retryDelay = const Duration(seconds: 1),
-  });
+    http.Client? inner,
+  }) : _inner = inner ?? http.Client();
 
   /// The timeout duration for each request.
   final Duration timeout;
   final int retries;
   final Duration retryDelay;
 
-  final http.Client _inner = http.Client();
+  final http.Client _inner;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     int attempt = 0;
-
-    // Keep an immutable template to clone for each retry
-    final template = _cloneRequest(request);
     http.BaseRequest current = request;
 
     while (true) {
@@ -30,9 +28,12 @@ class TimeoutHttpClient extends http.BaseClient {
         return await _inner.send(current).timeout(timeout);
       } on TimeoutException {
         if (attempt >= retries) rethrow;
+        // Streamed/multipart bodies are single-use and can't be safely retried.
+        final retryClone = _cloneRequest(request);
+        if (retryClone == null) rethrow;
         attempt++;
         await Future.delayed(retryDelay);
-        current = _cloneRequest(template);
+        current = retryClone;
       }
     }
   }
@@ -43,8 +44,8 @@ class TimeoutHttpClient extends http.BaseClient {
     super.close();
   }
 
-  // Creates a fresh copy of an [http.BaseRequest] to reuse across retries.
-  http.BaseRequest _cloneRequest(http.BaseRequest original) {
+  // Clones a plain [http.Request] for retry; null for streamed/multipart bodies.
+  http.BaseRequest? _cloneRequest(http.BaseRequest original) {
     if (original is http.Request) {
       final clone = http.Request(original.method, original.url)
         ..headers.addAll(original.headers)
@@ -56,6 +57,6 @@ class TimeoutHttpClient extends http.BaseClient {
       }
       return clone;
     }
-    throw UnsupportedError('Unsupported request type for retry');
+    return null;
   }
 }

--- a/test/settings/enum_persistence_order_test.dart
+++ b/test/settings/enum_persistence_order_test.dart
@@ -1,0 +1,99 @@
+// Enums persisted via SharedPreferenceEnumClientMixin store an index into
+// Enum.values, so declaration order is a wire format — append new values at
+// the end, don't reorder or insert, or you'll silently remap saved settings.
+
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/app_theme.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+
+void main() {
+  // Expected declaration order (by name) for each index-persisted enum.
+  const expected = <String, List<String>>{
+    'AppTheme': [
+      'indigoNight', 'carbon', 'plum', 'custom', 'regression', 'ember',
+      'synthwave', 'terminal', 'catppuccin', 'nord', 'gruvbox', 'dracula',
+      'mono', 'royal'
+    ],
+    'AuthType': ['none', 'basic', 'simpleLogin', 'uiLogin'],
+    'CenterMarginType': ['none', 'doublePage', 'widePage', 'doubleAndWide'],
+    'ChapterDisplay': ['sourceTitle', 'chapterNumber'],
+    'ChapterSort': [
+      'source', 'uploadDate', 'fetchedDate', 'chapterNumber', 'alphabetical'
+    ],
+    'ColorFilterBlendMode': [
+      'defaultBlend', 'multiply', 'screen', 'overlay', 'lighten', 'darken'
+    ],
+    'DisplayMode': [
+      'grid', 'list', 'descriptiveList', 'coverOnly', 'comfortableGrid'
+    ],
+    'FlashColor': ['black', 'white', 'whiteBlack'],
+    'GlobalSearchSourceFilter': ['pinned', 'all'],
+    'ImageScaleType': [
+      'fitScreen', 'stretch', 'fitWidth', 'fitHeight', 'originalSize', 'smartFit'
+    ],
+    'MangaSort': [
+      'alphabetical', 'dateAdded', 'unread', 'lastUpdated', 'lastChapterDate',
+      'totalChapters', 'lastRead', 'random', 'trackerScore', 'lastUpdate',
+      'rating'
+    ],
+    'PageLayout': ['singlePage', 'doublePages', 'automatic'],
+    'ReaderBackgroundColor': ['white', 'black', 'gray', 'automatic'],
+    'ReaderMode': [
+      'defaultReader', 'continuousVertical', 'singleHorizontalLTR',
+      'singleHorizontalRTL', 'continuousHorizontalLTR',
+      'continuousHorizontalRTL', 'singleVertical', 'webtoon'
+    ],
+    'ReaderNavigationLayout': [
+      'defaultNavigation', 'lShaped', 'rightAndLeft', 'edge', 'kindlish',
+      'disabled'
+    ],
+    'ReaderOrientation': [
+      'defaultRotation', 'free', 'portrait', 'landscape', 'lockedPortrait',
+      'lockedLandscape', 'reversePortrait'
+    ],
+    'ReaderScrollAmount': ['tiny', 'small', 'medium', 'large'],
+    'TapInvert': ['none', 'horizontal', 'vertical', 'both'],
+    'ThemeMode': ['system', 'light', 'dark'],
+    'WebtoonScaleType': [
+      'fitScreen', 'ratio4to3', 'ratio3to2', 'ratio16to9', 'ratio20to9'
+    ],
+    'ZoomStart': ['automatic', 'left', 'right', 'center'],
+  };
+
+  final actual = <String, List<String>>{
+    'AppTheme': AppTheme.values.map((e) => e.name).toList(),
+    'AuthType': AuthType.values.map((e) => e.name).toList(),
+    'CenterMarginType': CenterMarginType.values.map((e) => e.name).toList(),
+    'ChapterDisplay': ChapterDisplay.values.map((e) => e.name).toList(),
+    'ChapterSort': ChapterSort.values.map((e) => e.name).toList(),
+    'ColorFilterBlendMode':
+        ColorFilterBlendMode.values.map((e) => e.name).toList(),
+    'DisplayMode': DisplayMode.values.map((e) => e.name).toList(),
+    'FlashColor': FlashColor.values.map((e) => e.name).toList(),
+    'GlobalSearchSourceFilter':
+        GlobalSearchSourceFilter.values.map((e) => e.name).toList(),
+    'ImageScaleType': ImageScaleType.values.map((e) => e.name).toList(),
+    'MangaSort': MangaSort.values.map((e) => e.name).toList(),
+    'PageLayout': PageLayout.values.map((e) => e.name).toList(),
+    'ReaderBackgroundColor':
+        ReaderBackgroundColor.values.map((e) => e.name).toList(),
+    'ReaderMode': ReaderMode.values.map((e) => e.name).toList(),
+    'ReaderNavigationLayout':
+        ReaderNavigationLayout.values.map((e) => e.name).toList(),
+    'ReaderOrientation': ReaderOrientation.values.map((e) => e.name).toList(),
+    'ReaderScrollAmount': ReaderScrollAmount.values.map((e) => e.name).toList(),
+    'TapInvert': TapInvert.values.map((e) => e.name).toList(),
+    'ThemeMode': ThemeMode.values.map((e) => e.name).toList(),
+    'WebtoonScaleType': WebtoonScaleType.values.map((e) => e.name).toList(),
+    'ZoomStart': ZoomStart.values.map((e) => e.name).toList(),
+  };
+
+  for (final name in expected.keys) {
+    test('$name index-persistence order is unchanged (append-only)', () {
+      expect(actual[name], expected[name],
+          reason: 'Reordering/inserting a value in $name remaps every saved '
+              'preference. Append new values at the end instead.');
+    });
+  }
+}

--- a/test/utils/timeout_http_client_test.dart
+++ b/test/utils/timeout_http_client_test.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:tsumiru/src/utils/network/timeout_http_client.dart';
+
+void main() {
+  group('TimeoutHttpClient', () {
+    test('sends a MultipartRequest without throwing (backup/extension upload)',
+        () async {
+      final mock = MockClient.streaming((request, bodyStream) async {
+        await bodyStream.drain<void>();
+        return http.StreamedResponse(
+          Stream.value(<int>[]),
+          200,
+          request: request,
+        );
+      });
+      final client = TimeoutHttpClient(
+        const Duration(seconds: 5),
+        retries: 2,
+        inner: mock,
+      );
+
+      final req = http.MultipartRequest('POST', Uri.parse('http://x/api'))
+        ..files.add(http.MultipartFile.fromString('backup', 'data'));
+
+      final res = await client.send(req);
+      expect(res.statusCode, 200);
+    });
+
+    test('retries a plain http.Request on timeout', () async {
+      var attempts = 0;
+      final mock = MockClient.streaming((request, bodyStream) async {
+        attempts++;
+        if (attempts == 1) throw TimeoutException('slow');
+        return http.StreamedResponse(Stream.value(<int>[]), 200,
+            request: request);
+      });
+      final client = TimeoutHttpClient(
+        const Duration(seconds: 5),
+        retries: 2,
+        retryDelay: Duration.zero,
+        inner: mock,
+      );
+
+      final res =
+          await client.send(http.Request('GET', Uri.parse('http://x/api')));
+      expect(res.statusCode, 200);
+      expect(attempts, 2);
+    });
+
+    test('does not retry a multipart body on timeout (single-use stream)',
+        () async {
+      var attempts = 0;
+      final mock = MockClient.streaming((request, bodyStream) async {
+        attempts++;
+        await bodyStream.drain<void>();
+        throw TimeoutException('slow');
+      });
+      final client = TimeoutHttpClient(
+        const Duration(seconds: 5),
+        retries: 2,
+        retryDelay: Duration.zero,
+        inner: mock,
+      );
+
+      final req = http.MultipartRequest('POST', Uri.parse('http://x/api'))
+        ..fields['k'] = 'v';
+
+      await expectLater(client.send(req), throwsA(isA<TimeoutException>()));
+      expect(attempts, 1);
+    });
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -51,7 +51,6 @@
   <link rel="manifest" href="manifest.json">
 
   <!-- This script adds the flutter initialization JS code -->
-  <script src="coi-serviceworker.min.js"></script>
   <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
 
 


### PR DESCRIPTION
Fixes across settings persistence, history, library, and backup.

- Rewrites reading-history pagination with a bounded keyset cursor (no double-offset, refresh-race guarded).
- Hardens preference persistence: enum wire-format, stable sorts, and backup-restore guards.
- Fixes library bulk-op staleness, a multi-select tab leak, and per-keystroke search.
- Fixes multipart uploads crashing backup restore and extension install.
- Follows the device language on a fresh install; guards the release tag against a pubspec version mismatch.

Builds clean; 1024 tests pass.
