### PR TITLE
Notifications: new chapters, downloads, updates, and error alerts

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -33,6 +33,8 @@ android {
     ndkVersion "27.0.12077973"
     namespace "io.github.aaronbamblett.tsumiru"
     compileOptions {
+        // Required by flutter_local_notifications (uses java.time on older APIs).
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -85,4 +87,6 @@ flutter {
     source '../..'
 }
 
-dependencies {}
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:workmanager/workmanager.dart';
 
 import 'src/constants/enum.dart';
 import 'src/constants/timeout_constants.dart';
@@ -24,6 +25,8 @@ import 'src/features/auth/data/auth_credentials_store.dart';
 import 'src/features/auth/data/basic_auth_migration.dart';
 import 'src/features/auth/data/secure_credentials_provider.dart';
 import 'src/features/migration/controller/bulk_migration_providers.dart';
+import 'src/features/notifications/controller/notifications_controller.dart';
+import 'src/features/notifications/data/background/notification_background_entry.dart';
 import 'src/features/offline/data/background/background_download_controller_shim.dart';
 import 'src/features/offline/data/offline_background_downloads.dart';
 import 'src/features/offline/data/offline_bootstrap.dart';
@@ -68,6 +71,12 @@ Future<void> _startApp() async {
   // Initialise the foreground-task plugin (Android-only; no-op elsewhere) before
   // any download service is started. Must run after the binding is ready.
   initForegroundTaskService();
+  // Register the background notification scheduler's isolate entry point
+  // (Android only). The periodic job itself is (re)scheduled from the launch
+  // sync below once settings are available.
+  if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+    Workmanager().initialize(notificationCallbackDispatcher);
+  }
   final packageInfo = await PackageInfo.fromPlatform();
   final sharedPreferences = await SharedPreferences.getInstance();
   // Desktop: hide the OS title bar + restore saved window size before first
@@ -242,6 +251,11 @@ Future<void> _startApp() async {
       // Drain any bulk-migration journal left by a mid-batch crash. Independent
       // of the offline feature, so it runs before that guard.
       await recoverBulkMigrationsAtLaunch(container);
+      // Reconcile the notification schedule + write the worker's endpoint-bound
+      // config now that auth is ready. Best-effort — never blocks launch.
+      try {
+        await container.read(notificationsControllerProvider).sync();
+      } catch (_) {}
       if (!container.read(offlineActiveProvider)) return;
       await pushPendingProgress(container);
       await reconcileAllAtLaunch(container);

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -131,6 +131,18 @@ enum DBKeys {
   offlineLastServerId(null),
   offlineLastServerAddress(null),
   offlineServerMismatchDismissedList(null),
+  // Notifications (background new-chapter + download-done checks). Interval is
+  // hours; WorkManager's real floor is ~15 min, so we never offer below 1h.
+  notificationsNewChaptersEnabled(false),
+  notificationsDownloadsEnabled(true),
+  notificationsCheckIntervalHours(6),
+  notificationsWifiOnly(true),
+  notificationsChargingOnly(false),
+  notificationsHideContent(false),
+  notificationsCategoriesInclude(null),
+  notificationsCategoriesExclude(null),
+  notificationsAppUpdatesEnabled(false),
+  notificationsExtensionUpdatesEnabled(false),
   // ON-DEVICE delete-on-read settings (frees device space; the server copy is
   // untouched). Independent of the server's "Delete chapters" settings.
   // whileReading: 0 = off, 1 = the just-read chapter, 2..5 = the Nth behind it.

--- a/lib/src/features/notifications/controller/notification_settings_providers.dart
+++ b/lib/src/features/notifications/controller/notification_settings_providers.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'notification_settings_providers.g.dart';
+
+@riverpod
+class NotificationsNewChaptersEnabled extends _$NotificationsNewChaptersEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.notificationsNewChaptersEnabled);
+}
+
+@riverpod
+class NotificationsDownloadsEnabled extends _$NotificationsDownloadsEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.notificationsDownloadsEnabled);
+}
+
+@riverpod
+class NotificationsCheckIntervalHours extends _$NotificationsCheckIntervalHours
+    with SharedPreferenceClientMixin<int> {
+  @override
+  int? build() => initialize(DBKeys.notificationsCheckIntervalHours);
+}
+
+@riverpod
+class NotificationsWifiOnly extends _$NotificationsWifiOnly
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.notificationsWifiOnly);
+}
+
+@riverpod
+class NotificationsChargingOnly extends _$NotificationsChargingOnly
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.notificationsChargingOnly);
+}
+
+@riverpod
+class NotificationsHideContent extends _$NotificationsHideContent
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.notificationsHideContent);
+}
+
+@riverpod
+class NotificationsCategoriesInclude extends _$NotificationsCategoriesInclude
+    with SharedPreferenceClientMixin<List<String>> {
+  @override
+  List<String>? build() => initialize(DBKeys.notificationsCategoriesInclude);
+}
+
+@riverpod
+class NotificationsCategoriesExclude extends _$NotificationsCategoriesExclude
+    with SharedPreferenceClientMixin<List<String>> {
+  @override
+  List<String>? build() => initialize(DBKeys.notificationsCategoriesExclude);
+}
+
+@riverpod
+class NotificationsAppUpdatesEnabled extends _$NotificationsAppUpdatesEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.notificationsAppUpdatesEnabled);
+}
+
+@riverpod
+class NotificationsExtensionUpdatesEnabled
+    extends _$NotificationsExtensionUpdatesEnabled
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.notificationsExtensionUpdatesEnabled);
+}

--- a/lib/src/features/notifications/controller/notifications_controller.dart
+++ b/lib/src/features/notifications/controller/notifications_controller.dart
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:workmanager/workmanager.dart';
+
+import '../../../constants/enum.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../auth/data/auth_credentials_store.dart';
+import '../../offline/data/background/background_token_record.dart';
+import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
+import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+import '../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
+import '../data/background/notification_background_client.dart';
+import '../data/background/notification_background_entry.dart';
+import '../data/local_notification_service.dart';
+import '../data/notification_state_store.dart';
+import 'notification_settings_providers.dart';
+
+/// Bridges app state → the background worker: writes the durable config + token
+/// record the headless isolate reads, and (re)schedules or cancels the periodic
+/// WorkManager job. Call [sync] on launch, on settings change, and on auth
+/// change so the worker always has a fresh, endpoint-bound configuration.
+class NotificationsController {
+  NotificationsController(this._ref);
+  final Ref _ref;
+
+  String _serverId() {
+    final usePort = _ref.read(serverPortToggleProvider).ifNull();
+    final port = usePort ? _ref.read(serverPortProvider) : null;
+    return '${_ref.read(serverUrlProvider)}|${port ?? '-'}';
+  }
+
+  NotificationEndpoint _endpoint() => NotificationEndpoint(
+        baseUrl: _ref.read(serverUrlProvider) ?? '',
+        port: _ref.read(serverPortProvider),
+        addPort: _ref.read(serverPortToggleProvider).ifNull(),
+      );
+
+  BackgroundTokenRecord _tokenRecord() {
+    final authType = _ref.read(authTypeKeyProvider) ?? AuthType.none;
+    final basicToken = _ref.read(credentialsProvider).value;
+    final creds = _ref.read(authCredentialsStoreProvider).value;
+    return BackgroundTokenRecord(
+      gen: 0,
+      authType: authType.name,
+      endpoint: _serverId(),
+      accessToken: creds?.uiAccessToken,
+      refreshToken: creds?.uiRefreshToken,
+      basicCredential: basicToken,
+      simpleCookie: creds?.simpleLoginCookie,
+    );
+  }
+
+  /// Persist config + token and reconcile the schedule with current settings.
+  Future<void> sync() async {
+    final newChapters =
+        _ref.read(notificationsNewChaptersEnabledProvider).ifNull();
+    final appUpdates =
+        _ref.read(notificationsAppUpdatesEnabledProvider).ifNull();
+    final extUpdates =
+        _ref.read(notificationsExtensionUpdatesEnabledProvider).ifNull();
+    final store = await NotificationStateStore.open();
+
+    await store.writeTokenRecord(_tokenRecord());
+    final config = NotificationWorkerConfig(
+      serverId: _serverId(),
+      endpoint: _endpoint(),
+      newChaptersEnabled: newChapters,
+      includedCategoryIds: _ids(_ref.read(notificationsCategoriesIncludeProvider)),
+      excludedCategoryIds: _ids(_ref.read(notificationsCategoriesExcludeProvider)),
+      hideContent: _ref.read(notificationsHideContentProvider).ifNull(),
+      appUpdatesEnabled: appUpdates,
+      extensionUpdatesEnabled: extUpdates,
+      appVersion: (await PackageInfo.fromPlatform()).version,
+    );
+    await store.writeConfig(config);
+
+    // The periodic job runs when ANY check is on; if the new-chapter check went
+    // off, drop its detection state.
+    if (!newChapters) await store.clearState();
+    if (!config.anyEnabled) {
+      await Workmanager().cancelByUniqueName(kNewChapterPeriodicName);
+      return;
+    }
+    await _schedule();
+  }
+
+  Future<void> _schedule() async {
+    final hours = _ref.read(notificationsCheckIntervalHoursProvider) ?? 6;
+    final wifiOnly = _ref.read(notificationsWifiOnlyProvider).ifNull(true);
+    final charging = _ref.read(notificationsChargingOnlyProvider).ifNull();
+    await Workmanager().registerPeriodicTask(
+      kNewChapterPeriodicName,
+      kNewChapterCheckTask,
+      frequency: Duration(hours: hours < 1 ? 1 : hours),
+      constraints: Constraints(
+        networkType: wifiOnly ? NetworkType.unmetered : NetworkType.connected,
+        requiresCharging: charging,
+        requiresBatteryNotLow: true,
+      ),
+      existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
+    );
+  }
+
+  /// Create the channels and request the Android 13+ POST_NOTIFICATIONS
+  /// permission before enabling, then reconcile the schedule.
+  Future<void> requestPermissionAndSync() async {
+    final service = LocalNotificationService();
+    await service.init();
+    await service.requestPermission();
+    await sync();
+  }
+
+  /// Manual "check now" — a one-off job under its OWN unique name so it can't
+  /// collide with or suppress the periodic schedule.
+  Future<void> checkNow() async {
+    await sync();
+    await Workmanager().registerOneOffTask(
+      kNewChapterCheckNowName,
+      kNewChapterCheckTask,
+      constraints: Constraints(networkType: NetworkType.connected),
+      existingWorkPolicy: ExistingWorkPolicy.replace,
+    );
+  }
+
+  Set<int> _ids(List<String>? raw) =>
+      {for (final s in raw ?? const <String>[]) int.parse(s)};
+}
+
+final notificationsControllerProvider = Provider<NotificationsController>(
+  (ref) => NotificationsController(ref),
+);

--- a/lib/src/features/notifications/data/background/notification_background_client.dart
+++ b/lib/src/features/notifications/data/background/notification_background_client.dart
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+import '../../../../constants/endpoints.dart';
+import '../../../offline/data/background/background_token_record.dart';
+
+/// Where + how the background worker reaches the server. Persisted so the
+/// WorkManager isolate (no Riverpod, no widget tree) can rebuild it.
+class NotificationEndpoint {
+  const NotificationEndpoint({
+    required this.baseUrl,
+    this.port,
+    this.addPort = true,
+  });
+
+  final String baseUrl;
+  final int? port;
+  final bool addPort;
+
+  String get graphqlUrl => Endpoints.baseApi(
+        baseUrl: baseUrl,
+        port: port,
+        addPort: addPort,
+        isGraphQl: true,
+      );
+
+  Map<String, Object?> toJson() =>
+      {'baseUrl': baseUrl, 'port': port, 'addPort': addPort};
+
+  factory NotificationEndpoint.fromJson(Map<String, Object?> j) =>
+      NotificationEndpoint(
+        baseUrl: j['baseUrl'] as String,
+        port: (j['port'] as num?)?.toInt(),
+        addPort: (j['addPort'] as bool?) ?? true,
+      );
+}
+
+/// A new chapter as the notifier needs it (detection fields + display fields).
+typedef NotifChapter = ({
+  int id,
+  int mangaId,
+  double chapterNumber,
+  String name,
+  int fetchedAt,
+  String mangaTitle,
+  String? thumbnailUrl,
+  Set<int> categoryIds,
+});
+
+typedef NewChaptersPage = ({
+  List<NotifChapter> nodes,
+  bool hasNextPage,
+  String? endCursor,
+});
+
+/// Provider-free authenticated GraphQL for the background notification worker.
+/// Reuses the download worker's proven [BackgroundTokenRecord] + [TokenBroker]
+/// (auth modes + gen-versioned 401 refresh), so nothing here touches Riverpod.
+class NotificationBackgroundClient {
+  NotificationBackgroundClient({
+    required this.endpoint,
+    required BackgroundTokenRecord record,
+    required this.broker,
+    http.Client? httpClient,
+  })  : _record = record,
+        _http = httpClient ?? http.Client();
+
+  final NotificationEndpoint endpoint;
+  final TokenBroker broker;
+  final http.Client _http;
+  BackgroundTokenRecord _record;
+
+  static const Object _authError = Object();
+  static const Object _networkError = Object();
+
+  /// One raw GraphQL POST, retrying once through the broker on a ui_login 401.
+  /// Returns the `data` map, or null on auth-dead / network / server error.
+  Future<Map<String, Object?>?> _post(
+      String query, Map<String, Object?> variables) async {
+    var res = await _raw(query, variables, _record.accessToken);
+    if (identical(res, _authError) && _record.authType == 'uiLogin') {
+      final fresh = await broker.resolveAfter401(_record.accessToken ?? '');
+      if (fresh != null) {
+        _record = await broker.read();
+        res = await _raw(query, variables, fresh);
+      }
+    }
+    return res is Map<String, Object?> ? res : null;
+  }
+
+  Future<Object?> _raw(
+      String query, Map<String, Object?> variables, String? accessToken) async {
+    final headers = <String, String>{'Content-Type': 'application/json'};
+    _applyAuth(headers, accessToken);
+    try {
+      final res = await _http.post(
+        Uri.parse(endpoint.graphqlUrl),
+        headers: headers,
+        body: jsonEncode({'query': query, 'variables': variables}),
+      );
+      if (res.statusCode == 401 || res.statusCode == 403) return _authError;
+      if (res.statusCode != 200) return _networkError;
+      final decoded = jsonDecode(res.body) as Map<String, Object?>;
+      return decoded['data'] as Map<String, Object?>?;
+    } on SocketException {
+      return _networkError;
+    } catch (_) {
+      return _networkError;
+    }
+  }
+
+  void _applyAuth(Map<String, String> headers, String? accessToken) {
+    switch (_record.authType) {
+      case 'uiLogin':
+        if (accessToken != null && accessToken.isNotEmpty) {
+          headers['Authorization'] = 'Bearer $accessToken';
+        }
+      case 'basic':
+        final cred = _record.basicCredential;
+        if (cred != null && cred.isNotEmpty) headers['Authorization'] = cred;
+      case 'simpleLogin':
+        final cookie = _record.simpleCookie;
+        if (cookie != null && cookie.isNotEmpty) headers['Cookie'] = cookie;
+    }
+  }
+
+  static const _newChaptersQuery = r'''
+query NotifNewChapters($f: LongString!, $after: Cursor) {
+  chapters(
+    filter: { inLibrary: { equalTo: true }, isRead: { equalTo: false }, fetchedAt: { greaterThanOrEqualTo: $f } }
+    order: [{ by: FETCHED_AT, byType: ASC }, { by: ID, byType: ASC }]
+    first: 200
+    after: $after
+  ) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      mangaId
+      chapterNumber
+      name
+      fetchedAt
+      manga { title thumbnailUrl categories { nodes { id } } }
+    }
+  }
+}''';
+
+  /// One page of unread, in-library chapters fetched at/after [fetchedAtGte]
+  /// (a LongString epoch), ascending by (fetchedAt, id). Null on failure.
+  Future<NewChaptersPage?> fetchNewChaptersPage({
+    required String fetchedAtGte,
+    String? after,
+  }) async {
+    final data = await _post(
+        _newChaptersQuery, {'f': fetchedAtGte, 'after': after});
+    final chapters = data?['chapters'] as Map<String, Object?>?;
+    if (chapters == null) return null;
+    final pageInfo = chapters['pageInfo'] as Map<String, Object?>?;
+    final nodes = (chapters['nodes'] as List? ?? const []).cast<Object?>();
+    return (
+      nodes: [for (final n in nodes) _parseChapter(n as Map<String, Object?>)],
+      hasNextPage: (pageInfo?['hasNextPage'] as bool?) ?? false,
+      endCursor: pageInfo?['endCursor'] as String?,
+    );
+  }
+
+  NotifChapter _parseChapter(Map<String, Object?> n) {
+    final manga = n['manga'] as Map<String, Object?>?;
+    final cats = ((manga?['categories'] as Map<String, Object?>?)?['nodes']
+                as List? ??
+            const [])
+        .cast<Object?>();
+    return (
+      id: (n['id'] as num).toInt(),
+      mangaId: (n['mangaId'] as num).toInt(),
+      chapterNumber: (n['chapterNumber'] as num?)?.toDouble() ?? -1,
+      name: (n['name'] as String?) ?? '',
+      fetchedAt: int.tryParse('${n['fetchedAt']}') ?? 0,
+      mangaTitle: (manga?['title'] as String?) ?? '',
+      thumbnailUrl: manga?['thumbnailUrl'] as String?,
+      categoryIds: {
+        for (final c in cats) ((c as Map<String, Object?>)['id'] as num).toInt(),
+      },
+    );
+  }
+
+  static const _maxFetchedQuery = r'''
+query NotifMaxFetched {
+  chapters(
+    filter: { inLibrary: { equalTo: true } }
+    order: [{ by: FETCHED_AT, byType: DESC }, { by: ID, byType: DESC }]
+    first: 1
+  ) { nodes { fetchedAt } }
+}''';
+
+  /// The server's current highest in-library `fetchedAt` (LongString), for
+  /// first-enable initialization — so we neither dump the backlog nor miss the
+  /// next fetch. 0 when the library has no chapters yet.
+  Future<int> serverMaxFetchedAt() async {
+    final data = await _post(_maxFetchedQuery, const {});
+    final nodes =
+        ((data?['chapters'] as Map<String, Object?>?)?['nodes'] as List? ??
+                const [])
+            .cast<Object?>();
+    if (nodes.isEmpty) return 0;
+    return int.tryParse(
+            '${(nodes.first as Map<String, Object?>)['fetchedAt']}') ??
+        0;
+  }
+
+  static const _markReadMutation = r'''
+mutation NotifMarkRead($ids: [Int!]!) {
+  updateChapters(input: { ids: $ids, patch: { isRead: true } }) { clientMutationId }
+}''';
+
+  Future<bool> markRead(List<int> chapterIds) async {
+    if (chapterIds.isEmpty) return true;
+    final data = await _post(_markReadMutation, {'ids': chapterIds});
+    return data != null;
+  }
+
+  static const _enqueueMutation = r'''
+mutation NotifEnqueue($ids: [Int!]!) {
+  enqueueChapterDownloads(input: { ids: $ids }) { clientMutationId }
+}''';
+
+  Future<bool> enqueueDownloads(List<int> chapterIds) async {
+    if (chapterIds.isEmpty) return true;
+    final data = await _post(_enqueueMutation, {'ids': chapterIds});
+    return data != null;
+  }
+
+  /// Fetch a manga cover's bytes for the per-series notification, mirroring
+  /// `fetchOfflinePageBytes`: base API without `/api` (the thumbnail path carries
+  /// it), ui_login as `?token=`, basic/simpleLogin via headers. Best-effort — a
+  /// failed cover just falls back to a text notification, so no 401 retry.
+  Future<List<int>?> fetchCover(String thumbnailUrl) async {
+    final base = Endpoints.baseApi(
+      baseUrl: endpoint.baseUrl,
+      port: endpoint.port,
+      addPort: endpoint.addPort,
+      appendApiToUrl: false,
+    );
+    var url = '$base$thumbnailUrl';
+    final headers = <String, String>{};
+    switch (_record.authType) {
+      case 'uiLogin':
+        final token = _record.accessToken;
+        if (token != null && token.isNotEmpty) {
+          final sep = url.contains('?') ? '&' : '?';
+          url = '$url${sep}token=${Uri.encodeQueryComponent(token)}';
+        }
+      case 'basic':
+        final cred = _record.basicCredential;
+        if (cred != null && cred.isNotEmpty) headers['Authorization'] = cred;
+      case 'simpleLogin':
+        final cookie = _record.simpleCookie;
+        if (cookie != null && cookie.isNotEmpty) headers['Cookie'] = cookie;
+    }
+    try {
+      final res = await _http.get(Uri.parse(url), headers: headers);
+      return res.statusCode == 200 ? res.bodyBytes : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static const _extensionUpdatesQuery =
+      'query { extensions(condition: { hasUpdate: true, isInstalled: true }) { totalCount } }';
+
+  /// How many installed extensions have an update available (server-tracked).
+  Future<int> countExtensionUpdates() async {
+    final data = await _post(_extensionUpdatesQuery, const {});
+    return ((data?['extensions'] as Map<String, Object?>?)?['totalCount']
+                as num?)
+            ?.toInt() ??
+        0;
+  }
+
+  /// The latest Tsumiru release tag + its page, from the public GitHub API (no
+  /// auth, no server). Null on any failure.
+  Future<({String version, String url})?> fetchLatestRelease() async {
+    try {
+      final res = await _http.get(
+        Uri.parse(
+            'https://api.github.com/repos/Suwayomi/Suwayomi-Tsumiru/releases/latest'),
+        headers: const {'Accept': 'application/vnd.github+json'},
+      );
+      if (res.statusCode != 200) return null;
+      final j = jsonDecode(res.body) as Map<String, Object?>;
+      final tag = (j['tag_name'] as String?)?.replaceFirst('v', '');
+      if (tag == null || tag.isEmpty) return null;
+      return (version: tag, url: (j['html_url'] as String?) ?? '');
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/src/features/notifications/data/background/notification_background_entry.dart
+++ b/lib/src/features/notifications/data/background/notification_background_entry.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:workmanager/workmanager.dart';
+
+import 'notification_worker.dart';
+
+/// WorkManager task name for the periodic new-chapter check.
+const kNewChapterCheckTask = 'tsumiru.newChapterCheck';
+
+/// Unique-work names. The manual "check now" uses a SEPARATE name from the
+/// periodic job — enqueuing manual work under the periodic identity can replace
+/// or suppress the schedule.
+const kNewChapterPeriodicName = 'tsumiru.newChapterCheck.periodic';
+const kNewChapterCheckNowName = 'tsumiru.newChapterCheck.now';
+
+/// The isolate entry point registered with `Workmanager().initialize`. Must be a
+/// top-level `vm:entry-point` function — the OS spawns a fresh isolate here.
+@pragma('vm:entry-point')
+void notificationCallbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    switch (task) {
+      case kNewChapterCheckTask:
+        return runNewChapterCheck();
+      default:
+        return true;
+    }
+  });
+}

--- a/lib/src/features/notifications/data/background/notification_worker.dart
+++ b/lib/src/features/notifications/data/background/notification_worker.dart
@@ -1,0 +1,339 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+import '../../../../constants/endpoints.dart';
+import '../../../../l10n/generated/app_localizations.dart';
+import '../../../offline/data/background/background_token_record.dart';
+import '../../domain/new_chapter_detection.dart';
+import '../local_notification_service.dart';
+import '../notification_state_store.dart';
+import 'notification_background_client.dart';
+
+/// The headless new-chapter check: read config + cursor, paginate the server's
+/// unread/in-library delta, detect what's new, write a durable outbox, publish,
+/// then advance the cursor. Returns false only on a transient failure so the
+/// scheduler retries (a cursor is never advanced past unseen chapters).
+///
+/// Runs in the WorkManager isolate — no Riverpod, no BuildContext.
+Future<bool> runNewChapterCheck() async {
+  final store = await NotificationStateStore.open();
+  final config = store.readConfig();
+  final token = store.readTokenRecord();
+  if (config == null || token == null) return true;
+
+  final l10n = lookupAppLocalizations(_deviceLocale());
+  final notifier = LocalNotificationService();
+  await notifier.init(onBackgroundTap: notificationActionCallback);
+  final client = NotificationBackgroundClient(
+    endpoint: config.endpoint,
+    record: token,
+    broker: _brokerFor(store, config.endpoint),
+  );
+
+  var ok = true;
+  if (config.newChaptersEnabled) {
+    ok = await _runNewChapters(store, config, client, notifier, l10n);
+  }
+  if (config.appUpdatesEnabled) {
+    await _checkAppUpdate(store, config, client, notifier, l10n);
+  }
+  if (config.extensionUpdatesEnabled) {
+    await _checkExtensionUpdates(store, client, notifier, l10n);
+  }
+  return ok;
+}
+
+/// App-update check — compares the latest GitHub release to the installed
+/// version, notifying once per new version.
+Future<void> _checkAppUpdate(
+  NotificationStateStore store,
+  NotificationWorkerConfig config,
+  NotificationBackgroundClient client,
+  LocalNotificationService notifier,
+  AppLocalizations l10n,
+) async {
+  final release = await client.fetchLatestRelease();
+  if (release == null) return;
+  if (release.version == config.appVersion) return; // up to date
+  if (release.version == store.lastNotifiedAppVersion) return; // already told
+  await store.setLastNotifiedAppVersion(release.version);
+  await notifier.showAppUpdate(
+    l10n.notificationAppUpdateTitle,
+    l10n.notificationAppUpdateBody(release.version),
+    release.url.isEmpty ? null : release.url,
+  );
+}
+
+/// Extension-update check — notifies when the count of installed extensions with
+/// an update rises (server-tracked).
+Future<void> _checkExtensionUpdates(
+  NotificationStateStore store,
+  NotificationBackgroundClient client,
+  LocalNotificationService notifier,
+  AppLocalizations l10n,
+) async {
+  final count = await client.countExtensionUpdates();
+  if (count <= store.lastExtensionUpdateCount) {
+    // Fewer/equal — user updated some or nothing new; just record.
+    await store.setLastExtensionUpdateCount(count);
+    return;
+  }
+  await store.setLastExtensionUpdateCount(count);
+  await notifier.showExtensionUpdates(
+    l10n.notificationExtensionUpdateTitle,
+    l10n.notificationExtensionUpdateBody(count),
+  );
+}
+
+Future<bool> _runNewChapters(
+  NotificationStateStore store,
+  NotificationWorkerConfig config,
+  NotificationBackgroundClient client,
+  LocalNotificationService notifier,
+  AppLocalizations l10n,
+) async {
+  // 0. Crash recovery — an outbox present means a prior run posted (or died
+  // mid-post) without advancing the cursor. Re-publish (stable ids → replace,
+  // not re-buzz), advance, clear.
+  final stranded = store.readOutbox();
+  if (stranded != null) {
+    await _publish(notifier, client, l10n, config, stranded.pending);
+    await store.writeWatermark(config.serverId, stranded.nextWatermark);
+    await store.clearOutbox();
+  }
+
+  var watermark = store.readWatermark(config.serverId);
+
+  // 1. First enable: seed the cursor to the server's current max fetch time and
+  // notify nothing, so we don't dump the backlog.
+  if (watermark.fetchedAt == 0 && watermark.recent.isEmpty) {
+    final maxFetched = await client.serverMaxFetchedAt();
+    await store.writeWatermark(
+        config.serverId, NewChapterWatermark(fetchedAt: maxFetched));
+    return true;
+  }
+
+  // 2. Paginate the overlap window to exhaustion.
+  final gte =
+      (watermark.fetchedAt - kDefaultOverlapMs).clamp(0, watermark.fetchedAt);
+  final all = <NotifChapter>[];
+  final mangaCategories = <int, Set<int>>{};
+  String? after;
+  while (true) {
+    final page =
+        await client.fetchNewChaptersPage(fetchedAtGte: '$gte', after: after);
+    if (page == null) return false; // transient — retry next wake
+    all.addAll(page.nodes);
+    for (final n in page.nodes) {
+      mangaCategories[n.mangaId] = n.categoryIds;
+    }
+    if (!page.hasNextPage || page.endCursor == null) break;
+    after = page.endCursor;
+  }
+
+  // 3. Detect.
+  final result = detectNewChapters(
+    candidates: [
+      for (final n in all)
+        (
+          id: n.id,
+          mangaId: n.mangaId,
+          chapterNumber: n.chapterNumber,
+          fetchedAt: n.fetchedAt
+        ),
+    ],
+    watermark: watermark,
+    allowedMangaIds: config.allowedMangaIds(mangaCategories),
+  );
+
+  if (result.groups.isEmpty) {
+    await store.writeWatermark(config.serverId, result.watermark);
+    return true;
+  }
+
+  // 4. Durable outbox BEFORE publishing.
+  final byId = {for (final n in all) n.id: n};
+  final pending = [
+    for (final g in result.groups) _toPending(g, byId),
+  ];
+  await store.writeOutbox(
+      NotificationOutbox(pending: pending, nextWatermark: result.watermark));
+
+  // 5. Publish, then mark delivered (advance cursor + clear outbox).
+  await _publish(notifier, client, l10n, config, pending);
+  await store.writeWatermark(config.serverId, result.watermark);
+  await store.clearOutbox();
+  return true;
+}
+
+PendingSeriesNotification _toPending(
+    MangaNewChapters group, Map<int, NotifChapter> byId) {
+  final first = byId[group.chapters.first.id]!;
+  return PendingSeriesNotification(
+    mangaId: group.mangaId,
+    mangaTitle: first.mangaTitle,
+    thumbnailUrl: first.thumbnailUrl,
+    chapterIds: [for (final c in group.chapters) c.id],
+    chapterNumbers: [for (final c in group.chapters) c.chapterNumber],
+    firstChapterId: group.chapters.first.id,
+    totalCount: group.chapters.length,
+  );
+}
+
+Future<void> _publish(
+  LocalNotificationService notifier,
+  NotificationBackgroundClient client,
+  AppLocalizations l10n,
+  NotificationWorkerConfig config,
+  List<PendingSeriesNotification> pending,
+) async {
+  final summaryTitle = l10n.notificationNewChaptersTitle;
+  final summaryText = pending.length == 1 && !config.hideContent
+      ? pending.first.mangaTitle
+      : l10n.notificationNewChaptersSummary(pending.length);
+  final series = <SeriesNotificationContent>[];
+  for (final p in pending) {
+    series.add(SeriesNotificationContent(
+      mangaId: p.mangaId,
+      title: p.mangaTitle,
+      body: _describe(l10n, p),
+      firstChapterId: p.firstChapterId,
+      chapterIds: p.chapterIds,
+      coverPath: config.hideContent ? null : await _fetchCover(client, p),
+    ));
+  }
+  await notifier.showNewChapters(
+    summaryTitle: summaryTitle,
+    summaryText: summaryText,
+    summaryLines: [for (final p in pending) p.mangaTitle],
+    hideContent: config.hideContent,
+    markReadLabel: l10n.notificationActionMarkRead,
+    viewLabel: l10n.notificationActionView,
+    downloadLabel: l10n.notificationActionDownload,
+    series: series,
+  );
+}
+
+/// Isolate entry point for a Mark-read / Download action fired while the app is
+/// dead. Top-level + `vm:entry-point` so the OS can spawn it.
+@pragma('vm:entry-point')
+void notificationActionCallback(NotificationResponse response) {
+  handleNotificationAction(response.actionId, response.payload);
+}
+
+/// Handles a Mark-read / Download notification action headlessly (the app may be
+/// dead): reads config + token, builds a client, fires the mutation. View is a
+/// UI action, routed by the foreground handler instead.
+Future<void> handleNotificationAction(
+    String? actionId, String? payload) async {
+  if (actionId != kNotifActionMarkRead && actionId != kNotifActionDownload) {
+    return;
+  }
+  final p = NotificationPayload.decode(payload);
+  if (p.chapterIds.isEmpty) return;
+  final store = await NotificationStateStore.open();
+  final config = store.readConfig();
+  final token = store.readTokenRecord();
+  if (config == null || token == null) return;
+  final client = NotificationBackgroundClient(
+    endpoint: config.endpoint,
+    record: token,
+    broker: _brokerFor(store, config.endpoint),
+  );
+  if (actionId == kNotifActionMarkRead) {
+    await client.markRead(p.chapterIds);
+  } else {
+    await client.enqueueDownloads(p.chapterIds);
+  }
+}
+
+/// Fetch + cache a series cover to a temp file for the notification's
+/// BigPicture. Best-effort — null on any failure falls back to text.
+Future<String?> _fetchCover(
+    NotificationBackgroundClient client, PendingSeriesNotification p) async {
+  final url = p.thumbnailUrl;
+  if (url == null || url.isEmpty) return null;
+  try {
+    final bytes = await client.fetchCover(url);
+    if (bytes == null) return null;
+    final dir = await getTemporaryDirectory();
+    final file = File('${dir.path}/notif_cover_${p.mangaId}.jpg');
+    await file.writeAsBytes(bytes, flush: true);
+    return file.path;
+  } catch (_) {
+    return null;
+  }
+}
+
+String _describe(AppLocalizations l10n, PendingSeriesNotification p) {
+  final label = newChaptersLabel(p.chapterNumbers, p.totalCount);
+  return switch (label) {
+    GenericNewChapters(:final count) =>
+      l10n.notificationChaptersGeneric(count),
+    SingleNewChapter(:final number, :final more) => more == 0
+        ? l10n.notificationChapterSingle(number)
+        : l10n.notificationChapterSingleAndMore(number, more),
+    MultipleNewChapters(:final numbers, :final more) => more == 0
+        ? l10n.notificationChaptersMultiple(numbers.join(', '))
+        : l10n.notificationChaptersMultipleAndMore(numbers.join(', '), more),
+  };
+}
+
+/// A [TokenBroker] backed by the persistent store, so a ui_login refresh in the
+/// worker isolate rotates the shared record (same gen-versioned scheme the
+/// download worker uses).
+TokenBroker _brokerFor(NotificationStateStore store, NotificationEndpoint ep) =>
+    TokenBroker(
+      read: () async =>
+          store.readTokenRecord() ??
+          const BackgroundTokenRecord(gen: 0, authType: 'none'),
+      write: (r) => store.writeTokenRecord(r),
+      refreshFn: (refreshToken) async {
+        final endpoint = Endpoints.baseApi(
+          baseUrl: ep.baseUrl,
+          port: ep.port,
+          addPort: ep.addPort,
+          isGraphQl: true,
+        );
+        try {
+          final res = await http.post(
+            Uri.parse(endpoint),
+            headers: const {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'query':
+                  r'mutation RefreshToken($input: RefreshTokenInput!){ refreshToken(input: $input){ accessToken } }',
+              'variables': {
+                'input': {'refreshToken': refreshToken},
+              },
+            }),
+          );
+          if (res.statusCode != 200) return null;
+          final data = (jsonDecode(res.body) as Map<String, Object?>)['data']
+              as Map<String, Object?>?;
+          final access =
+              (data?['refreshToken'] as Map<String, Object?>?)?['accessToken']
+                  as String?;
+          if (access == null || access.isEmpty) return null;
+          // Suwayomi doesn't rotate the refresh token — reuse it.
+          return (access: access, refresh: refreshToken);
+        } catch (_) {
+          return null;
+        }
+      },
+    );
+
+Locale _deviceLocale() {
+  final locales = PlatformDispatcher.instance.locales;
+  return locales.isNotEmpty ? locales.first : const Locale('en');
+}

--- a/lib/src/features/notifications/data/local_notification_service.dart
+++ b/lib/src/features/notifications/data/local_notification_service.dart
@@ -1,0 +1,365 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+/// Action ids on a per-series notification (Komikku parity).
+const kNotifActionMarkRead = 'markRead';
+const kNotifActionDownload = 'download';
+const kNotifActionView = 'view';
+
+/// Payload carried by a notification tap/action, so the (foreground or
+/// headless) handler can route/act without any object graph.
+class NotificationPayload {
+  const NotificationPayload.updates()
+      : mangaId = null,
+        chapterId = null,
+        chapterIds = const [];
+  const NotificationPayload.chapter({
+    required this.mangaId,
+    required this.chapterId,
+    this.chapterIds = const [],
+  });
+
+  final int? mangaId;
+
+  /// The first new chapter — the tap target.
+  final int? chapterId;
+
+  /// Every new chapter in this series' notification — the Mark-read / Download
+  /// action targets.
+  final List<int> chapterIds;
+
+  String encode() => jsonEncode({
+        if (mangaId != null) 'm': mangaId,
+        if (chapterId != null) 'c': chapterId,
+        if (chapterIds.isNotEmpty) 'cs': chapterIds,
+      });
+
+  static NotificationPayload decode(String? raw) {
+    if (raw == null || raw.isEmpty) return const NotificationPayload.updates();
+    try {
+      final j = jsonDecode(raw) as Map<String, Object?>;
+      final m = (j['m'] as num?)?.toInt();
+      if (m == null) return const NotificationPayload.updates();
+      return NotificationPayload.chapter(
+        mangaId: m,
+        chapterId: (j['c'] as num?)?.toInt(),
+        chapterIds: [
+          for (final id in (j['cs'] as List? ?? const [])) (id as num).toInt()
+        ],
+      );
+    } catch (_) {
+      return const NotificationPayload.updates();
+    }
+  }
+}
+
+/// One series' rendered notification content (formatted by the worker, so this
+/// service stays free of localization/BuildContext and works in any isolate).
+class SeriesNotificationContent {
+  const SeriesNotificationContent({
+    required this.mangaId,
+    required this.title,
+    required this.body,
+    required this.firstChapterId,
+    required this.chapterIds,
+    this.coverPath,
+  });
+  final int mangaId;
+  final String title;
+  final String body;
+  final int firstChapterId;
+
+  /// Every new chapter id — the Mark-read / Download action targets.
+  final List<int> chapterIds;
+
+  /// Local file path of the fetched cover, or null → text-only fallback.
+  final String? coverPath;
+}
+
+/// Thin wrapper over `flutter_local_notifications`: channels, a grouped summary
+/// + per-series children (Mihon/Komikku shape), and download-complete. Usable
+/// from the UI isolate and the headless worker isolate alike.
+class LocalNotificationService {
+  LocalNotificationService([FlutterLocalNotificationsPlugin? plugin])
+      : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  static const newChaptersChannelId = 'new_chapters';
+  static const downloadsChannelId = 'downloads_complete';
+  static const libraryErrorChannelId = 'library_errors';
+  static const downloadErrorChannelId = 'download_errors';
+  static const backupChannelId = 'backup_restore';
+  static const appUpdateChannelId = 'app_update';
+  static const extensionUpdateChannelId = 'extension_update';
+  static const incognitoChannelId = 'incognito';
+  static const _newChaptersGroup = 'com.tsumiru.NEW_CHAPTERS';
+
+  // Stable ids: one summary, per-series keyed on manga id (kept in a band well
+  // clear of the summary), so a re-publish REPLACES rather than re-buzzes.
+  static const _summaryId = 1;
+  static const _downloadsCompleteId = 2;
+  static const _libraryErrorId = 3;
+  static const _downloadErrorId = 4;
+  static const _backupId = 5;
+  static const _appUpdateId = 6;
+  static const _extensionUpdateId = 7;
+  static const _incognitoId = 8;
+  int _seriesId(int mangaId) => 100000 + (mangaId % 1000000);
+
+  Future<void> init({
+    void Function(NotificationResponse)? onTap,
+    DidReceiveBackgroundNotificationResponseCallback? onBackgroundTap,
+  }) async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const settings = InitializationSettings(android: android);
+    await _plugin.initialize(
+      settings: settings,
+      onDidReceiveNotificationResponse: onTap,
+      onDidReceiveBackgroundNotificationResponse: onBackgroundTap,
+    );
+
+    final android_ = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    await android_?.createNotificationChannel(const AndroidNotificationChannel(
+      newChaptersChannelId,
+      'New chapters',
+      description: 'Notifies when followed series get new chapters',
+      importance: Importance.high,
+    ));
+    await android_?.createNotificationChannel(const AndroidNotificationChannel(
+      downloadsChannelId,
+      'Downloads',
+      description: 'Notifies when downloads finish',
+      importance: Importance.low,
+    ));
+    for (final c in const [
+      (libraryErrorChannelId, 'Library update errors'),
+      (downloadErrorChannelId, 'Download errors'),
+      (backupChannelId, 'Backup & restore'),
+      (appUpdateChannelId, 'App updates'),
+      (extensionUpdateChannelId, 'Extension updates'),
+    ]) {
+      await android_?.createNotificationChannel(
+        AndroidNotificationChannel(c.$1, c.$2, importance: Importance.defaultImportance),
+      );
+    }
+    await android_?.createNotificationChannel(const AndroidNotificationChannel(
+      incognitoChannelId,
+      'Incognito mode',
+      description: 'Persistent reminder while incognito mode is on',
+      importance: Importance.low,
+    ));
+  }
+
+  Future<bool> requestPermission() async {
+    final android = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    return await android?.requestNotificationsPermission() ?? true;
+  }
+
+  /// Posts the grouped summary + one notification per series. [summaryTitle]
+  /// and [summaryLines] are pre-localized; [hideContent] suppresses the
+  /// per-series children and the title list (privacy).
+  /// Komikku only offers the one-tap Download action when the new-chapter count
+  /// is at/below its queue-warning threshold, to avoid a mass enqueue.
+  static const _downloadActionMax = 10;
+
+  Future<void> showNewChapters({
+    required String summaryTitle,
+    required String summaryText,
+    required List<String> summaryLines,
+    required List<SeriesNotificationContent> series,
+    required bool hideContent,
+    required String markReadLabel,
+    required String viewLabel,
+    required String downloadLabel,
+  }) async {
+    final summaryDetails = AndroidNotificationDetails(
+      newChaptersChannelId,
+      'New chapters',
+      groupKey: _newChaptersGroup,
+      setAsGroupSummary: true,
+      // Only the summary alerts — children stay silent, so N new series is one
+      // buzz, not N (Komikku `setGroupAlertBehavior(GROUP_ALERT_SUMMARY)`).
+      groupAlertBehavior: GroupAlertBehavior.summary,
+      onlyAlertOnce: true,
+      autoCancel: true,
+      importance: Importance.high,
+      priority: Priority.high,
+      styleInformation: hideContent
+          ? null
+          : InboxStyleInformation(summaryLines, contentTitle: summaryTitle),
+    );
+    await _plugin.show(
+        id: _summaryId,
+        title: summaryTitle,
+        body: summaryText,
+        notificationDetails: NotificationDetails(android: summaryDetails),
+        payload: const NotificationPayload.updates().encode());
+
+    if (hideContent) return;
+    for (final s in series) {
+      // Komikku shows the cover via BigPicture (LibraryUpdateNotifier.kt:249);
+      // fall back to big-text when the cover fetch failed.
+      final cover = s.coverPath;
+      final StyleInformation style = cover != null
+          ? BigPictureStyleInformation(
+              FilePathAndroidBitmap(cover),
+              largeIcon: FilePathAndroidBitmap(cover),
+              contentTitle: s.title,
+              summaryText: s.body,
+            )
+          : BigTextStyleInformation(s.body, contentTitle: s.title);
+      final details = AndroidNotificationDetails(
+        newChaptersChannelId,
+        'New chapters',
+        groupKey: _newChaptersGroup,
+        groupAlertBehavior: GroupAlertBehavior.summary,
+        onlyAlertOnce: true,
+        autoCancel: true,
+        importance: Importance.high,
+        priority: Priority.high,
+        largeIcon: cover != null ? FilePathAndroidBitmap(cover) : null,
+        styleInformation: style,
+        actions: [
+          // Mark-read / Download act headlessly (no UI); View opens the app.
+          AndroidNotificationAction(kNotifActionMarkRead, markReadLabel),
+          AndroidNotificationAction(kNotifActionView, viewLabel,
+              showsUserInterface: true),
+          if (s.chapterIds.length <= _downloadActionMax)
+            AndroidNotificationAction(kNotifActionDownload, downloadLabel,
+                cancelNotification: false),
+        ],
+      );
+      await _plugin.show(
+          id: _seriesId(s.mangaId),
+          title: s.title,
+          body: s.body,
+          notificationDetails: NotificationDetails(android: details),
+          payload: NotificationPayload.chapter(
+            mangaId: s.mangaId,
+            chapterId: s.firstChapterId,
+            chapterIds: s.chapterIds,
+          ).encode());
+    }
+  }
+
+  Future<void> showDownloadsComplete({
+    required String title,
+    required String body,
+  }) async {
+    const details = AndroidNotificationDetails(
+      downloadsChannelId,
+      'Downloads',
+      importance: Importance.low,
+      priority: Priority.low,
+      autoCancel: true,
+    );
+    await _plugin.show(
+        id: _downloadsCompleteId,
+        title: title,
+        body: body,
+        notificationDetails: const NotificationDetails(android: details));
+  }
+
+  Future<void> _showSimple({
+    required int id,
+    required String channelId,
+    required String channelName,
+    required String title,
+    required String body,
+    String? payload,
+    Importance importance = Importance.defaultImportance,
+    bool ongoing = false,
+  }) =>
+      _plugin.show(
+        id: id,
+        title: title,
+        body: body,
+        notificationDetails: NotificationDetails(
+          android: AndroidNotificationDetails(
+            channelId,
+            channelName,
+            importance: importance,
+            priority: importance == Importance.high
+                ? Priority.high
+                : Priority.defaultPriority,
+            styleInformation: BigTextStyleInformation(body, contentTitle: title),
+            ongoing: ongoing,
+            autoCancel: !ongoing,
+          ),
+        ),
+        payload: payload,
+      );
+
+  Future<void> showLibraryUpdateError(String title, String body) => _showSimple(
+        id: _libraryErrorId,
+        channelId: libraryErrorChannelId,
+        channelName: 'Library update errors',
+        title: title,
+        body: body,
+      );
+
+  Future<void> showDownloadError(String title, String body) => _showSimple(
+        id: _downloadErrorId,
+        channelId: downloadErrorChannelId,
+        channelName: 'Download errors',
+        title: title,
+        body: body,
+      );
+
+  Future<void> showBackupResult(String title, String body) => _showSimple(
+        id: _backupId,
+        channelId: backupChannelId,
+        channelName: 'Backup & restore',
+        title: title,
+        body: body,
+      );
+
+  /// Tapping opens the release page (payload = a URL the launch handler routes).
+  Future<void> showAppUpdate(String title, String body, String? url) =>
+      _showSimple(
+        id: _appUpdateId,
+        channelId: appUpdateChannelId,
+        channelName: 'App updates',
+        title: title,
+        body: body,
+        payload: url == null ? null : 'url:$url',
+        importance: Importance.high,
+      );
+
+  Future<void> showExtensionUpdates(String title, String body) => _showSimple(
+        id: _extensionUpdateId,
+        channelId: extensionUpdateChannelId,
+        channelName: 'Extension updates',
+        title: title,
+        body: body,
+      );
+
+  /// Persistent, non-dismissible while incognito mode is on (Komikku parity).
+  Future<void> showIncognito(String title, String body) => _showSimple(
+        id: _incognitoId,
+        channelId: incognitoChannelId,
+        channelName: 'Incognito mode',
+        title: title,
+        body: body,
+        importance: Importance.low,
+        ongoing: true,
+      );
+
+  Future<void> cancelIncognito() => _plugin.cancel(id: _incognitoId);
+
+  Future<NotificationPayload?> launchPayload() async {
+    final details = await _plugin.getNotificationAppLaunchDetails();
+    if (details?.didNotificationLaunchApp != true) return null;
+    return NotificationPayload.decode(details?.notificationResponse?.payload);
+  }
+}

--- a/lib/src/features/notifications/data/notification_state_store.dart
+++ b/lib/src/features/notifications/data/notification_state_store.dart
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../offline/data/background/background_token_record.dart';
+import '../domain/new_chapter_detection.dart';
+import 'background/notification_background_client.dart';
+
+/// Everything the headless worker needs to reach the server and decide what to
+/// notify. Written by the app (on enable / settings change / auth rotation);
+/// read fresh by the WorkManager isolate. `serverId` scopes the cursor so a
+/// server switch can't replay or skip chapters.
+class NotificationWorkerConfig {
+  const NotificationWorkerConfig({
+    required this.serverId,
+    required this.endpoint,
+    required this.newChaptersEnabled,
+    required this.includedCategoryIds,
+    required this.excludedCategoryIds,
+    required this.hideContent,
+    this.appUpdatesEnabled = false,
+    this.extensionUpdatesEnabled = false,
+    this.appVersion = '',
+  });
+
+  final String serverId;
+  final NotificationEndpoint endpoint;
+  final bool newChaptersEnabled;
+  final bool appUpdatesEnabled;
+  final bool extensionUpdatesEnabled;
+
+  /// The installed app version, so the worker can compare against the latest
+  /// release without a plugin call in the isolate.
+  final String appVersion;
+
+  /// The periodic job runs when ANY check is on.
+  bool get anyEnabled =>
+      newChaptersEnabled || appUpdatesEnabled || extensionUpdatesEnabled;
+
+  /// Empty include = all categories; anything in exclude is dropped.
+  final Set<int> includedCategoryIds;
+  final Set<int> excludedCategoryIds;
+  final bool hideContent;
+
+  Map<String, Object?> toJson() => {
+        'serverId': serverId,
+        'endpoint': endpoint.toJson(),
+        'newChaptersEnabled': newChaptersEnabled,
+        'includedCategoryIds': includedCategoryIds.toList(),
+        'excludedCategoryIds': excludedCategoryIds.toList(),
+        'hideContent': hideContent,
+        'appUpdatesEnabled': appUpdatesEnabled,
+        'extensionUpdatesEnabled': extensionUpdatesEnabled,
+        'appVersion': appVersion,
+      };
+
+  factory NotificationWorkerConfig.fromJson(Map<String, Object?> j) =>
+      NotificationWorkerConfig(
+        serverId: j['serverId'] as String,
+        endpoint: NotificationEndpoint.fromJson(
+            (j['endpoint'] as Map).cast<String, Object?>()),
+        newChaptersEnabled: (j['newChaptersEnabled'] as bool?) ?? false,
+        appUpdatesEnabled: (j['appUpdatesEnabled'] as bool?) ?? false,
+        extensionUpdatesEnabled: (j['extensionUpdatesEnabled'] as bool?) ?? false,
+        appVersion: (j['appVersion'] as String?) ?? '',
+        includedCategoryIds: {
+          for (final id in (j['includedCategoryIds'] as List? ?? const []))
+            (id as num).toInt(),
+        },
+        excludedCategoryIds: {
+          for (final id in (j['excludedCategoryIds'] as List? ?? const []))
+            (id as num).toInt(),
+        },
+        hideContent: (j['hideContent'] as bool?) ?? false,
+      );
+
+  /// Category scope as an allow-set for [detectNewChapters], or null (= all)
+  /// when there's no include list and nothing excluded. Computed against the
+  /// live library membership the worker fetches.
+  Set<int>? allowedMangaIds(Map<int, Set<int>> mangaCategoryIds) {
+    if (includedCategoryIds.isEmpty && excludedCategoryIds.isEmpty) return null;
+    return {
+      for (final entry in mangaCategoryIds.entries)
+        if (_categoryAllowed(entry.value)) entry.key,
+    };
+  }
+
+  bool _categoryAllowed(Set<int> mangaCats) {
+    if (excludedCategoryIds.isNotEmpty &&
+        mangaCats.any(excludedCategoryIds.contains)) {
+      return false;
+    }
+    if (includedCategoryIds.isEmpty) return true;
+    return mangaCats.any(includedCategoryIds.contains);
+  }
+}
+
+/// One series pending in the durable outbox — enough to (re)publish the
+/// notification without another network call.
+class PendingSeriesNotification {
+  const PendingSeriesNotification({
+    required this.mangaId,
+    required this.mangaTitle,
+    required this.thumbnailUrl,
+    required this.chapterIds,
+    required this.chapterNumbers,
+    required this.firstChapterId,
+    required this.totalCount,
+  });
+
+  final int mangaId;
+  final String mangaTitle;
+  final String? thumbnailUrl;
+  final List<int> chapterIds;
+  final List<double> chapterNumbers;
+
+  /// The earliest-by-number new chapter — the "open first new chapter" target.
+  final int firstChapterId;
+  final int totalCount;
+
+  Map<String, Object?> toJson() => {
+        'mangaId': mangaId,
+        'mangaTitle': mangaTitle,
+        'thumbnailUrl': thumbnailUrl,
+        'chapterIds': chapterIds,
+        'chapterNumbers': chapterNumbers,
+        'firstChapterId': firstChapterId,
+        'totalCount': totalCount,
+      };
+
+  factory PendingSeriesNotification.fromJson(Map<String, Object?> j) =>
+      PendingSeriesNotification(
+        mangaId: (j['mangaId'] as num).toInt(),
+        mangaTitle: j['mangaTitle'] as String,
+        thumbnailUrl: j['thumbnailUrl'] as String?,
+        chapterIds: [
+          for (final id in (j['chapterIds'] as List)) (id as num).toInt()
+        ],
+        chapterNumbers: [
+          for (final n in (j['chapterNumbers'] as List)) (n as num).toDouble()
+        ],
+        firstChapterId: (j['firstChapterId'] as num).toInt(),
+        totalCount: (j['totalCount'] as num).toInt(),
+      );
+}
+
+/// The durable outbox: the batch to publish plus the advanced cursor, written
+/// as ONE atomic value BEFORE publishing. A crash after this point re-publishes
+/// (stable ids + onlyAlertOnce → a replace, not a re-buzz), never loses the
+/// cursor advance, and never drops a detected chapter.
+class NotificationOutbox {
+  const NotificationOutbox({required this.pending, required this.nextWatermark});
+  final List<PendingSeriesNotification> pending;
+  final NewChapterWatermark nextWatermark;
+
+  Map<String, Object?> toJson() => {
+        'pending': [for (final p in pending) p.toJson()],
+        'nextWatermark': nextWatermark.toJson(),
+      };
+
+  factory NotificationOutbox.fromJson(Map<String, Object?> j) =>
+      NotificationOutbox(
+        pending: [
+          for (final p in (j['pending'] as List))
+            PendingSeriesNotification.fromJson((p as Map).cast<String, Object?>())
+        ],
+        nextWatermark: NewChapterWatermark.fromJson(
+            (j['nextWatermark'] as Map).cast<String, Object?>()),
+      );
+}
+
+/// SharedPreferences-backed store, readable from any isolate. Each value is a
+/// single JSON string, so every write is atomic — enough for the outbox
+/// protocol without a database.
+class NotificationStateStore {
+  NotificationStateStore(this._prefs);
+  final SharedPreferences _prefs;
+
+  static const _configKey = 'notif_worker_config';
+  static const _tokenKey = 'notif_token_record';
+  static const _cursorKey = 'notif_cursor';
+  static const _outboxKey = 'notif_outbox';
+
+  static Future<NotificationStateStore> open() async =>
+      NotificationStateStore(await SharedPreferences.getInstance());
+
+  Future<void> writeConfig(NotificationWorkerConfig config) =>
+      _prefs.setString(_configKey, jsonEncode(config.toJson()));
+
+  NotificationWorkerConfig? readConfig() {
+    final raw = _prefs.getString(_configKey);
+    if (raw == null) return null;
+    return NotificationWorkerConfig.fromJson(
+        (jsonDecode(raw) as Map).cast<String, Object?>());
+  }
+
+  /// The auth record rotates independently of config (a ui_login refresh bumps
+  /// its gen), so it lives under its own key — the broker reads/writes it here.
+  BackgroundTokenRecord? readTokenRecord() {
+    final raw = _prefs.getString(_tokenKey);
+    if (raw == null) return null;
+    return BackgroundTokenRecord.fromJson(
+        (jsonDecode(raw) as Map).cast<String, Object?>());
+  }
+
+  Future<void> writeTokenRecord(BackgroundTokenRecord record) =>
+      _prefs.setString(_tokenKey, jsonEncode(record.toJson()));
+
+  /// The cursor for [serverId]; resets to empty when the stored cursor belongs
+  /// to a different server (switch → no replay/skip).
+  NewChapterWatermark readWatermark(String serverId) {
+    final raw = _prefs.getString(_cursorKey);
+    if (raw == null) return const NewChapterWatermark();
+    final j = (jsonDecode(raw) as Map).cast<String, Object?>();
+    if (j['serverId'] != serverId) return const NewChapterWatermark();
+    return NewChapterWatermark.fromJson(
+        (j['watermark'] as Map).cast<String, Object?>());
+  }
+
+  Future<void> writeWatermark(String serverId, NewChapterWatermark wm) =>
+      _prefs.setString(_cursorKey,
+          jsonEncode({'serverId': serverId, 'watermark': wm.toJson()}));
+
+  NotificationOutbox? readOutbox() {
+    final raw = _prefs.getString(_outboxKey);
+    if (raw == null) return null;
+    return NotificationOutbox.fromJson(
+        (jsonDecode(raw) as Map).cast<String, Object?>());
+  }
+
+  Future<void> writeOutbox(NotificationOutbox outbox) =>
+      _prefs.setString(_outboxKey, jsonEncode(outbox.toJson()));
+
+  Future<void> clearOutbox() => _prefs.remove(_outboxKey);
+
+  // Dedup for the app/extension update checks — only notify when the state
+  // actually changes, not every wake.
+  String? get lastNotifiedAppVersion => _prefs.getString('notif_app_version');
+  Future<void> setLastNotifiedAppVersion(String v) =>
+      _prefs.setString('notif_app_version', v);
+
+  int get lastExtensionUpdateCount => _prefs.getInt('notif_ext_count') ?? 0;
+  Future<void> setLastExtensionUpdateCount(int c) =>
+      _prefs.setInt('notif_ext_count', c);
+
+  /// Reset detection state (server switch / disable) without touching config.
+  Future<void> clearState() async {
+    await _prefs.remove(_cursorKey);
+    await _prefs.remove(_outboxKey);
+  }
+}

--- a/lib/src/features/notifications/domain/new_chapter_detection.dart
+++ b/lib/src/features/notifications/domain/new_chapter_detection.dart
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Pure new-chapter detection for background notifications — no GraphQL, no
+/// isolate, fully unit-testable. The background worker feeds it the server's
+/// unread in-library chapters (already filtered `fetchedAt >= watermark`), and
+/// it returns which series to notify plus the advanced watermark.
+library;
+
+/// The minimal shape the detector reasons about. `fetchedAt` is the server's
+/// fetch timestamp as epoch millis — the authoritative "new" signal (never the
+/// device clock, so client/server skew can't drop or duplicate a chapter).
+typedef NotifiableChapter = ({
+  int id,
+  int mangaId,
+  double chapterNumber,
+  int fetchedAt,
+});
+
+/// Persisted detection cursor. `fetchedAt` is the high-water fetch time seen;
+/// `recent` maps recently-notified chapter id → its `fetchedAt`, kept only for
+/// the overlap window. The window (not a bare `>` cutoff) is what recovers a
+/// chapter that commits out of order *below* the high-water mark: the worker
+/// re-queries `fetchedAt >= high − overlap`, and `recent` dedupes what it
+/// already sent, so a late-but-below chapter still surfaces exactly once.
+class NewChapterWatermark {
+  const NewChapterWatermark({this.fetchedAt = 0, this.recent = const {}});
+  final int fetchedAt;
+  final Map<int, int> recent;
+
+  Map<String, dynamic> toJson() => {
+        'fetchedAt': fetchedAt,
+        'recent': {for (final e in recent.entries) '${e.key}': e.value},
+      };
+
+  factory NewChapterWatermark.fromJson(Map<String, dynamic> json) =>
+      NewChapterWatermark(
+        fetchedAt: (json['fetchedAt'] as num?)?.toInt() ?? 0,
+        recent: {
+          for (final e in (json['recent'] as Map? ?? const {}).entries)
+            int.parse('${e.key}'): (e.value as num).toInt(),
+        },
+      );
+}
+
+/// One series' worth of new chapters, chapter-number ordered so "open first new
+/// chapter" lands on the earliest, not the last-fetched.
+class MangaNewChapters {
+  const MangaNewChapters({required this.mangaId, required this.chapters});
+  final int mangaId;
+  final List<NotifiableChapter> chapters;
+}
+
+class NewChapterDetectionResult {
+  const NewChapterDetectionResult({required this.groups, required this.watermark});
+  final List<MangaNewChapters> groups;
+  final NewChapterWatermark watermark;
+}
+
+/// Default overlap window (ms) the worker re-scans below the high-water mark to
+/// catch out-of-order `fetchedAt` commits. Generous vs. realistic commit skew.
+const kDefaultOverlapMs = 5 * 60 * 1000;
+
+/// Given the server's candidate chapters (unread, in-library, `fetchedAt >=`
+/// high-water − overlap, paginated to exhaustion by the caller), returns the
+/// per-series groups to notify and the next watermark. [allowedMangaIds] null =
+/// all series; otherwise the category scope.
+///
+/// Fresh = any candidate not already in [watermark].recent (so an out-of-order
+/// commit within the overlap window still fires exactly once). The high-water
+/// advances over ALL candidates seen — read/excluded ones the server still
+/// returns included — so they don't re-surface; category scope is forward-only
+/// past the window (re-including a category doesn't retroactively notify old
+/// chapters).
+NewChapterDetectionResult detectNewChapters({
+  required List<NotifiableChapter> candidates,
+  required NewChapterWatermark watermark,
+  Set<int>? allowedMangaIds,
+  int overlapMs = kDefaultOverlapMs,
+}) {
+  final fresh = [
+    for (final c in candidates)
+      if (!watermark.recent.containsKey(c.id)) c,
+  ];
+  final notifiable = [
+    for (final c in fresh)
+      if (allowedMangaIds == null || allowedMangaIds.contains(c.mangaId)) c,
+  ];
+
+  final byManga = <int, List<NotifiableChapter>>{};
+  for (final c in notifiable) {
+    (byManga[c.mangaId] ??= []).add(c);
+  }
+  final groups = [
+    for (final entry in byManga.entries)
+      MangaNewChapters(
+        mangaId: entry.key,
+        chapters: entry.value
+          ..sort((a, b) => a.chapterNumber.compareTo(b.chapterNumber)),
+      ),
+  ];
+
+  var maxFetched = watermark.fetchedAt;
+  for (final c in candidates) {
+    if (c.fetchedAt > maxFetched) maxFetched = c.fetchedAt;
+  }
+  // Carry the old recent set + the ids we just notified, pruned to the window
+  // the next query will re-scan (`>= maxFetched − overlap`).
+  final cutoff = maxFetched - overlapMs;
+  final recent = <int, int>{
+    for (final e in watermark.recent.entries)
+      if (e.value >= cutoff) e.key: e.value,
+    for (final c in notifiable)
+      if (c.fetchedAt >= cutoff) c.id: c.fetchedAt,
+  };
+
+  return NewChapterDetectionResult(
+    groups: groups,
+    watermark: NewChapterWatermark(fetchedAt: maxFetched, recent: recent),
+  );
+}
+
+/// The per-series chapter-count phrase, ported 1:1 from Komikku/Mihon
+/// `getNewChaptersDescription` (`LibraryUpdateNotifier.kt:302-361`). Kept as a
+/// structured label so the presenter localizes it — the logic stays testable.
+sealed class NewChaptersLabel {
+  const NewChaptersLabel();
+}
+
+/// No parseable chapter numbers → "N new chapters".
+class GenericNewChapters extends NewChaptersLabel {
+  const GenericNewChapters(this.count);
+  final int count;
+}
+
+/// One parseable number → "Chapter X" (+ "and N more" when other chapters
+/// lacked a number).
+class SingleNewChapter extends NewChaptersLabel {
+  const SingleNewChapter(this.number, this.more);
+  final String number;
+  final int more;
+}
+
+/// Several parseable numbers → "Chapters 1, 2.5, 3" (+ "and N more" past the cap).
+class MultipleNewChapters extends NewChaptersLabel {
+  const MultipleNewChapters(this.numbers, this.more);
+  final List<String> numbers;
+  final int more;
+}
+
+/// Komikku's `NOTIF_MAX_CHAPTERS`.
+const _maxShownChapters = 5;
+
+NewChaptersLabel newChaptersLabel(
+    List<double> chapterNumbers, int totalCount) {
+  // Recognized numbers only (>= 0), sorted, formatted, de-duplicated — mirrors
+  // Komikku's `filter { isRecognizedNumber }.sortedBy { chapterNumber }.toSet()`.
+  final formatted = <String>{};
+  for (final n in chapterNumbers.where((n) => n >= 0).toList()..sort()) {
+    formatted.add(_formatChapterNumber(n));
+  }
+  final numbers = formatted.toList();
+
+  switch (numbers.length) {
+    case 0:
+      return GenericNewChapters(totalCount);
+    case 1:
+      return SingleNewChapter(numbers.first, totalCount - numbers.length);
+    default:
+      if (numbers.length > _maxShownChapters) {
+        return MultipleNewChapters(
+          numbers.take(_maxShownChapters).toList(),
+          numbers.length - _maxShownChapters,
+        );
+      }
+      return MultipleNewChapters(numbers, 0);
+  }
+}
+
+String _formatChapterNumber(double n) =>
+    n == n.roundToDouble() ? n.toInt().toString() : n.toString();

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -16,9 +16,12 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../constants/db_keys.dart';
 import '../../../../constants/enum.dart';
 import '../../../../global_providers/global_providers.dart';
+import '../../../../l10n/generated/app_localizations.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/logger/logger.dart';
 import '../../../auth/data/auth_credentials_store.dart';
+import '../../../notifications/controller/notification_settings_providers.dart';
+import '../../../notifications/data/local_notification_service.dart';
 import '../../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
 import '../../../settings/presentation/server/widget/credential_popup/credentials_popup.dart';
@@ -357,7 +360,49 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       await Future<void>.delayed(const Duration(milliseconds: 150));
     }
     final pending = await _pendingChapters();
-    if (pending.isNotEmpty) await ensureServiceRunning();
+    if (pending.isNotEmpty) {
+      await ensureServiceRunning();
+      return;
+    }
+    await _notifyDownloadsComplete();
+  }
+
+  /// Chapters that finished / failed this download session — drive the
+  /// completion + error notifications once the queue truly drains.
+  int _sessionDownloaded = 0;
+  int _sessionFailed = 0;
+
+  /// Fire the completion + error notifications on drain (opt-in). Only covers a
+  /// download session THIS device ran — a server/WebUI download with the app
+  /// closed has no observer here.
+  Future<void> _notifyDownloadsComplete() async {
+    final done = _sessionDownloaded;
+    final failed = _sessionFailed;
+    _sessionDownloaded = 0;
+    _sessionFailed = 0;
+    if (done == 0 && failed == 0) return;
+    if (!_ref.read(notificationsDownloadsEnabledProvider).ifNull(true)) return;
+    try {
+      final locales = WidgetsBinding.instance.platformDispatcher.locales;
+      final l10n = lookupAppLocalizations(
+          locales.isNotEmpty ? locales.first : const Locale('en'));
+      final service = LocalNotificationService();
+      await service.init();
+      if (done > 0) {
+        await service.showDownloadsComplete(
+          title: l10n.notificationDownloadsCompleteTitle,
+          body: l10n.notificationDownloadsCompleteBody(done),
+        );
+      }
+      if (failed > 0) {
+        await service.showDownloadError(
+          l10n.notificationDownloadErrorTitle,
+          l10n.notificationDownloadErrorBody(failed),
+        );
+      }
+    } catch (_) {
+      // Best-effort — a missed toast is not data loss.
+    }
   }
 
   Future<void> _onChapterDone(Map data) async {
@@ -378,6 +423,8 @@ class BackgroundDownloadController with WidgetsBindingObserver {
           status: status,
           bytes: bytes,
           eventGeneration: data['gen'] as int? ?? 0);
+      if (status == 'downloaded') _sessionDownloaded++;
+      if (status == 'error') _sessionFailed++;
     }
 
     // Drain handshake: if the worker just self-stopped, do post-stop

--- a/lib/src/features/settings/presentation/notifications/notifications_settings_screen.dart
+++ b/lib/src/features/settings/presentation/notifications/notifications_settings_screen.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../notifications/controller/notification_settings_providers.dart';
+import '../../../notifications/controller/notifications_controller.dart';
+
+class NotificationsSettingsScreen extends HookConsumerWidget {
+  const NotificationsSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final controller = ref.watch(notificationsControllerProvider);
+
+    final newChapters =
+        ref.watch(notificationsNewChaptersEnabledProvider).ifNull();
+    final downloads =
+        ref.watch(notificationsDownloadsEnabledProvider).ifNull(true);
+    final interval = ref.watch(notificationsCheckIntervalHoursProvider) ?? 6;
+    final wifiOnly = ref.watch(notificationsWifiOnlyProvider).ifNull(true);
+    final chargingOnly = ref.watch(notificationsChargingOnlyProvider).ifNull();
+    final hideContent = ref.watch(notificationsHideContentProvider).ifNull();
+
+    Future<void> reconcile() => controller.sync();
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.notifications)),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: Text(l10n.notificationsNewChapters),
+            subtitle: Text(l10n.notificationsNewChaptersSubtitle),
+            value: newChapters,
+            onChanged: (v) async {
+              ref
+                  .read(notificationsNewChaptersEnabledProvider.notifier)
+                  .update(v);
+              if (v) await controller.requestPermissionAndSync();
+              await reconcile();
+            },
+          ),
+          if (newChapters) ...[
+            ListTile(
+              enabled: newChapters,
+              title: Text(l10n.notificationsCheckInterval),
+              trailing: DropdownButton<int>(
+                value: interval,
+                onChanged: (v) async {
+                  if (v == null) return;
+                  ref
+                      .read(notificationsCheckIntervalHoursProvider.notifier)
+                      .update(v);
+                  await reconcile();
+                },
+                items: const [1, 2, 3, 6, 12, 24]
+                    .map((h) => DropdownMenuItem(value: h, child: Text('${h}h')))
+                    .toList(),
+              ),
+            ),
+            SwitchListTile(
+              title: Text(l10n.notificationsWifiOnly),
+              value: wifiOnly,
+              onChanged: (v) async {
+                ref.read(notificationsWifiOnlyProvider.notifier).update(v);
+                await reconcile();
+              },
+            ),
+            SwitchListTile(
+              title: Text(l10n.notificationsChargingOnly),
+              value: chargingOnly,
+              onChanged: (v) async {
+                ref.read(notificationsChargingOnlyProvider.notifier).update(v);
+                await reconcile();
+              },
+            ),
+            SwitchListTile(
+              title: Text(l10n.notificationsHideContent),
+              subtitle: Text(l10n.notificationsHideContentSubtitle),
+              value: hideContent,
+              onChanged: (v) async {
+                ref.read(notificationsHideContentProvider.notifier).update(v);
+                await reconcile();
+              },
+            ),
+            ListTile(
+              title: Text(l10n.notificationsCheckNow),
+              leading: const Icon(Icons.refresh),
+              onTap: () => controller.checkNow(),
+            ),
+          ],
+          const Divider(),
+          SwitchListTile(
+            title: Text(l10n.notificationsDownloadsComplete),
+            value: downloads,
+            onChanged: (v) async {
+              ref.read(notificationsDownloadsEnabledProvider.notifier).update(v);
+              await reconcile();
+            },
+          ),
+          SwitchListTile(
+            title: Text(l10n.notificationsAppUpdates),
+            value: ref.watch(notificationsAppUpdatesEnabledProvider).ifNull(),
+            onChanged: (v) async {
+              ref
+                  .read(notificationsAppUpdatesEnabledProvider.notifier)
+                  .update(v);
+              if (v) await controller.requestPermissionAndSync();
+              await reconcile();
+            },
+          ),
+          SwitchListTile(
+            title: Text(l10n.notificationsExtensionUpdates),
+            value:
+                ref.watch(notificationsExtensionUpdatesEnabledProvider).ifNull(),
+            onChanged: (v) async {
+              ref
+                  .read(notificationsExtensionUpdatesEnabledProvider.notifier)
+                  .update(v);
+              if (v) await controller.requestPermissionAndSync();
+              await reconcile();
+            },
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              l10n.notificationsReliabilityNote,
+              style: context.theme.textTheme.bodySmall
+                  ?.copyWith(color: context.theme.hintColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/settings/settings_screen.dart
+++ b/lib/src/features/settings/presentation/settings/settings_screen.dart
@@ -49,6 +49,11 @@ class SettingsScreen extends StatelessWidget {
             onTap: () => const DownloadsSettingsRoute().go(context),
           ),
           ListTile(
+            title: Text(context.l10n.notifications),
+            leading: const Icon(Icons.notifications_rounded),
+            onTap: () => const NotificationsSettingsRoute().go(context),
+          ),
+          ListTile(
             title: Text(context.l10n.reader),
             leading: const Icon(Icons.chrome_reader_mode_rounded),
             onTap: () => const ReaderSettingsRoute().go(context),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2145,6 +2145,81 @@
     "@migrationDoneCopied": {
         "placeholders": { "count": { "type": "int" } }
     },
+    "notificationNewChaptersTitle": "New chapters",
+    "notificationNewChaptersSummary": "Updates for {count} series",
+    "@notificationNewChaptersSummary": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "notificationChaptersGeneric": "{count} new chapters",
+    "@notificationChaptersGeneric": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "notificationChapterSingle": "Chapter {number}",
+    "@notificationChapterSingle": {
+        "placeholders": { "number": { "type": "String" } }
+    },
+    "notificationChapterSingleAndMore": "Chapter {number} and {count} more",
+    "@notificationChapterSingleAndMore": {
+        "placeholders": { "number": { "type": "String" }, "count": { "type": "int" } }
+    },
+    "notificationChaptersMultiple": "Chapters {numbers}",
+    "@notificationChaptersMultiple": {
+        "placeholders": { "numbers": { "type": "String" } }
+    },
+    "notificationChaptersMultipleAndMore": "Chapters {numbers} and {count} more",
+    "@notificationChaptersMultipleAndMore": {
+        "placeholders": { "numbers": { "type": "String" }, "count": { "type": "int" } }
+    },
+    "notificationLibraryErrorTitle": "Library update failed",
+    "notificationLibraryErrorBody": "{count} series failed to update",
+    "@notificationLibraryErrorBody": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "notificationDownloadErrorTitle": "Download failed",
+    "notificationDownloadErrorBody": "{count} chapters failed to download",
+    "@notificationDownloadErrorBody": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "notificationBackupCompleteTitle": "Backup complete",
+    "notificationRestoreCompleteTitle": "Restore complete",
+    "notificationBackupFailedTitle": "Backup failed",
+    "notificationRestoreFailedTitle": "Restore failed",
+    "notificationAppUpdateTitle": "Update available",
+    "notificationAppUpdateBody": "Tsumiru {version} is available",
+    "@notificationAppUpdateBody": {
+        "placeholders": { "version": { "type": "String" } }
+    },
+    "notificationExtensionUpdateTitle": "Extension updates",
+    "notificationExtensionUpdateBody": "{count} extensions have updates",
+    "@notificationExtensionUpdateBody": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "notificationIncognitoTitle": "Incognito mode",
+    "notificationIncognitoBody": "History and progress updates are paused",
+    "notificationsErrors": "Error notifications",
+    "notificationsErrorsSubtitle": "Failed downloads and library updates",
+    "notificationsBackup": "Backup notifications",
+    "notificationsAppUpdates": "App update notifications",
+    "notificationsExtensionUpdates": "Extension update notifications",
+    "notificationActionMarkRead": "Mark as read",
+    "notificationActionView": "View chapters",
+    "notificationActionDownload": "Download",
+    "notificationDownloadsCompleteTitle": "Downloads complete",
+    "notificationDownloadsCompleteBody": "{count} chapters downloaded",
+    "@notificationDownloadsCompleteBody": {
+        "placeholders": { "count": { "type": "int" } }
+    },
+    "notifications": "Notifications",
+    "notificationsNewChapters": "New chapter notifications",
+    "notificationsNewChaptersSubtitle": "Notify when followed series get new chapters",
+    "notificationsDownloadsComplete": "Download notifications",
+    "notificationsCheckInterval": "Check interval",
+    "notificationsWifiOnly": "Only on Wi-Fi",
+    "notificationsChargingOnly": "Only while charging",
+    "notificationsHideContent": "Hide notification content",
+    "notificationsHideContentSubtitle": "Show only a count, not titles or covers",
+    "notificationsCheckNow": "Check now",
+    "notificationsReliabilityNote": "Checks run periodically, not instantly. Some devices restrict background updates.",
     "selectTargetSource": "Select Target Source",
     "noSourcesAvailable": "No sources available for migration",
     "checkSourceConfiguration": "Please check your source configuration",

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -32,6 +32,7 @@ import '../features/migration/presentation/screens/migration_bulk_run_screen.dar
 import '../features/migration/presentation/screens/migration_global_search_screen.dart';
 import '../features/migration/presentation/screens/migration_source_picker_screen.dart';
 import '../features/offline/presentation/offline_settings_screen.dart';
+import '../features/settings/presentation/notifications/notifications_settings_screen.dart';
 import '../features/onboarding/data/onboarding_complete.dart';
 import '../features/onboarding/presentation/onboarding_screen.dart';
 import '../features/quick_open/presentation/search_stack/search_stack_screen.dart';
@@ -102,6 +103,7 @@ abstract class Routes {
   static const serverSettings = 'server';
   static const downloadsSettings = 'downloads';
   static const offlineSettings = 'offline';
+  static const notificationsSettings = 'notifications';
   static const connection = 'connection';
   static const trackingSettings = 'tracking';
   static const hotkeysSettings = 'hotkeys';
@@ -233,6 +235,8 @@ GoRouter routerConfig(Ref ref) {
                         path: Routes.downloadsSettings),
                     TypedGoRoute<OfflineSettingsRoute>(
                         path: Routes.offlineSettings),
+                    TypedGoRoute<NotificationsSettingsRoute>(
+                        path: Routes.notificationsSettings),
                     TypedGoRoute<TrackingSettingsRoute>(
                         path: Routes.trackingSettings),
                     TypedGoRoute<HotkeysSettingsRoute>(

--- a/lib/src/routes/sub_routes/more_routes.dart
+++ b/lib/src/routes/sub_routes/more_routes.dart
@@ -101,6 +101,14 @@ class OfflineSettingsRoute extends GoRouteData with $OfflineSettingsRoute {
   Widget build(context, state) => const OfflineSettingsScreen();
 }
 
+class NotificationsSettingsRoute extends GoRouteData
+    with $NotificationsSettingsRoute {
+  const NotificationsSettingsRoute();
+
+  @override
+  Widget build(context, state) => const NotificationsSettingsScreen();
+}
+
 class ConnectionRoute extends GoRouteData with $ConnectionRoute {
   const ConnectionRoute();
 

--- a/lib/src/sorayomi.dart
+++ b/lib/src/sorayomi.dart
@@ -4,39 +4,92 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'constants/app_theme.dart';
 import 'features/auth/presentation/reauth_banner.dart';
+import 'features/notifications/data/background/notification_worker.dart';
+import 'features/notifications/data/local_notification_service.dart';
 import 'features/settings/presentation/appearance/widgets/app_theme_selector/app_theme_providers.dart';
 import 'features/settings/presentation/appearance/widgets/is_true_black/is_true_black_tile.dart';
 import 'features/settings/presentation/general/widgets/force_portrait_tile.dart';
+import 'features/settings/presentation/incognito/incognito_mode.dart';
 import 'features/settings/widgets/app_theme_mode_tile/app_theme_mode_tile.dart';
 import 'global_providers/global_providers.dart';
 import 'l10n/generated/app_localizations.dart';
 import 'routes/router_config.dart';
 import 'utils/extensions/custom_extensions.dart';
+import 'utils/launch_url_in_web.dart';
+import 'utils/misc/toast/toast.dart';
 import 'utils/theme/app_theme_builder.dart';
 import 'widgets/desktop/desktop_window_scaffold.dart';
 
-class Sorayomi extends ConsumerWidget {
+class Sorayomi extends HookConsumerWidget {
   const Sorayomi({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final routes = ref.watch(routerConfigProvider);
+
+    // Also drains a cold-start tap that launched the app. Android-only — the
+    // plugin is initialized with Android settings.
+    useEffect(() {
+      if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) {
+        return null;
+      }
+      void go(NotificationPayload p) {
+        if (p.mangaId != null && p.chapterId != null) {
+          routes.go(ReaderRoute(mangaId: p.mangaId!, chapterId: p.chapterId!)
+              .location);
+        } else {
+          routes.go(const UpdatesRoute().location);
+        }
+      }
+
+      void onResponse(NotificationResponse r) {
+        final action = r.actionId;
+        // Also handled headlessly when the app is dead — no navigation needed.
+        if (action == kNotifActionMarkRead || action == kNotifActionDownload) {
+          handleNotificationAction(action, r.payload);
+          return;
+        }
+        final raw = r.payload;
+        if (raw != null && raw.startsWith('url:')) {
+          launchUrlInWeb(context, raw.substring(4), ref.read(toastProvider));
+          return;
+        }
+        final p = NotificationPayload.decode(r.payload);
+        if (action == kNotifActionView && p.mangaId != null) {
+          routes.go(MangaRoute(mangaId: p.mangaId!).location);
+        } else {
+          go(p);
+        }
+      }
+
+      final service = LocalNotificationService();
+      service
+          .init(onTap: onResponse, onBackgroundTap: notificationActionCallback)
+          .then((_) async {
+        final launch = await service.launchPayload();
+        if (launch != null) go(launch);
+      });
+      return null;
+    }, const []);
+
     final themeMode = ref.watch(appThemeModeProvider);
     final appLocale = ref.watch(l10nProvider);
     final appTheme = ref.watch(appThemeKeyProvider) ?? AppTheme.indigoNight;
     final customSeed = ref.watch(customThemeColorProvider);
     final isTrueBlack = ref.watch(isTrueBlackProvider).ifNull();
     final client = ref.watch(graphQlClientHolderProvider);
-    // Honour the portrait-lock preference on launch and whenever it changes
-    // (phones only; idempotent so re-applying on rebuild is harmless).
+    // Idempotent, so re-applying on every rebuild is harmless.
     applyForcePortrait(ref.watch(forcePortraitProvider).ifNull());
     return GraphQLProvider(
       client: client,
@@ -44,7 +97,9 @@ class Sorayomi extends ConsumerWidget {
         builder: (context, child) {
           final toastWrapped = FToastBuilder()(context, child);
           return DesktopWindowScaffold(
-            child: ReauthBannerHost(child: toastWrapped),
+            child: ReauthBannerHost(
+              child: _IncognitoNotificationBridge(child: toastWrapped),
+            ),
           );
         },
         onGenerateTitle: (context) => context.l10n.appTitle,
@@ -72,9 +127,34 @@ class Sorayomi extends ConsumerWidget {
   }
 }
 
-/// App-wide scroll behavior that lets the **mouse and trackpad** drag-scroll
-/// (Flutter's desktop default only scrolls via wheel/touch). Fixes click-drag
-/// on every scrollable — the theme picker, the webtoon reader, lists, etc.
+/// Must live below [MaterialApp] — `context.l10n` is null above it, which
+/// crashed the root at launch.
+class _IncognitoNotificationBridge extends ConsumerWidget {
+  const _IncognitoNotificationBridge({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      final incognitoTitle = context.l10n.notificationIncognitoTitle;
+      final incognitoBody = context.l10n.notificationIncognitoBody;
+      ref.listen<bool>(incognitoModeProvider, (_, on) async {
+        final service = LocalNotificationService();
+        await service.init();
+        if (on) {
+          await service.showIncognito(incognitoTitle, incognitoBody);
+        } else {
+          await service.cancelIncognito();
+        }
+      });
+    }
+    return child;
+  }
+}
+
+/// Lets mouse/trackpad drag-scroll — Flutter's desktop default only responds
+/// to wheel/touch.
 class AppScrollBehavior extends MaterialScrollBehavior {
   const AppScrollBehavior();
 

--- a/lib/src/widgets/shell/update_progress_banner.dart
+++ b/lib/src/widgets/shell/update_progress_banner.dart
@@ -6,13 +6,16 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../features/manga_book/data/updates/updates_repository.dart';
 import '../../features/manga_book/domain/update_status/update_status_model.dart';
+import '../../features/notifications/data/local_notification_service.dart';
 import '../../features/settings/presentation/library/widgets/show_update_progress_banner/show_update_progress_banner.dart';
+import '../../l10n/generated/app_localizations.dart';
 import '../../routes/router_config.dart';
 import '../../utils/extensions/custom_extensions.dart';
 import 'update_banner_state.dart';
@@ -51,6 +54,7 @@ class UpdateProgressBanner extends HookConsumerWidget {
     // stream errors, prefer a fresh one-shot read until it recovers.
     final effectiveRun = runSocket.hasError ? runFallback : runSocket;
 
+    final l10n = context.l10n;
     ref.listen(updateRunningSocketProvider, (previous, next) {
       if (next.hasError && !(previous?.hasError ?? false)) {
         ref.invalidate(updateRunningSummaryProvider);
@@ -59,6 +63,10 @@ class UpdateProgressBanner extends HookConsumerWidget {
       final running = next.value;
       if (running != null) {
         ref.read(updateOptimisticProvider.notifier).onRealRunning(running);
+      }
+      // Update just finished — notify if any series failed (Komikku parity).
+      if ((previous?.value ?? false) && running == false) {
+        _notifyUpdateErrors(ref, l10n);
       }
     });
     // Re-query the one-shot fallback on resume, so a running-state fetched
@@ -174,5 +182,24 @@ class UpdateProgressBanner extends HookConsumerWidget {
     final checked = status?.updateChecked ?? 0;
     final percent = (checked / total * 100).floor().clamp(0, 100);
     return context.l10n.updatingLibraryProgress(percent, checked, total);
+  }
+}
+
+/// Notifies when a just-finished library update left failures (Komikku parity).
+/// Best-effort + foreground-observed (our update runs server-side). Android only.
+Future<void> _notifyUpdateErrors(WidgetRef ref, AppLocalizations l10n) async {
+  if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+  try {
+    final summary = await ref.read(updatesRepositoryProvider).summaryUpdates();
+    final failed = summary?.failedJobs.mangaList.length ?? 0;
+    if (failed == 0) return;
+    final service = LocalNotificationService();
+    await service.init();
+    await service.showLibraryUpdateError(
+      l10n.notificationLibraryErrorTitle,
+      l10n.notificationLibraryErrorBody(failed),
+    );
+  } catch (_) {
+    // Best-effort — a missed error toast is not data loss.
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import app_links
 import connectivity_plus
 import file_picker
+import flutter_local_notifications
 import flutter_secure_storage_darwin
 import gal
 import network_info_plus
@@ -26,6 +27,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -455,6 +455,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "40c6a69189a622bda89ddcf50a139f4ba0f0eb9c0fef6718845b1f8b95452ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "22.1.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "4dfbae10debab9ac975d8b01943fed94c0c19dad43f825964b29f3c3f9a8a852"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1660,6 +1700,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.17"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:
@@ -1836,6 +1884,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+3"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+2"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+2"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,8 @@ dependencies:
   gal: ^2.3.2
   image: ^4.8.0
   window_manager: ^0.5.2
+  flutter_local_notifications: ^22.1.0
+  workmanager: ^0.9.0+3
 
 dev_dependencies:
   build_runner: ^2.4.14

--- a/test/app_boot_smoke_test.dart
+++ b/test/app_boot_smoke_test.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/routes/router_config.dart';
+import 'package:tsumiru/src/sorayomi.dart';
+
+/// Pumps the real root widget and asserts it builds without throwing — a
+/// root-build crash (e.g. `context.l10n` read above the `MaterialApp` that
+/// installs localizations) passes every unit test but only surfaces here.
+void main() {
+  const notifChannel = MethodChannel('dexterous.com/flutter/local_notifications');
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    // main.dart normally gets this instance from the native plugin registrant.
+    FlutterLocalNotificationsPlatform.instance =
+        AndroidFlutterLocalNotificationsPlugin();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(notifChannel, (call) async {
+      if (call.method == 'getNotificationAppLaunchDetails') {
+        return <String, Object?>{'notificationLaunchedApp': false};
+      }
+      return true;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(notifChannel, null);
+  });
+
+  testWidgets('app root builds and launches without throwing', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    // Keeps the test on the root scaffold's own build, not a real screen that
+    // would need a live server.
+    final router = GoRouter(
+      routes: [GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink())],
+    );
+
+    // The real client is Hive-backed and set up in main.dart before runApp.
+    final client = GraphQLClient(
+      link: HttpLink('http://localhost'),
+      cache: GraphQLCache(),
+    );
+
+    // Android so the notification-gated startup code (skipped on web) runs
+    // too; reset before flutter_test's end-of-test invariant check either way.
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            routerConfigProvider.overrideWith((ref) => router),
+            graphQlClientHolderProvider.overrideWithValue(ValueNotifier(client)),
+          ],
+          child: const Sorayomi(),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(tester.takeException(), isNull);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/test/src/features/notifications/new_chapter_detection_test.dart
+++ b/test/src/features/notifications/new_chapter_detection_test.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/notifications/domain/new_chapter_detection.dart';
+
+NotifiableChapter ch(int id, int mangaId, double number, int fetchedAt) =>
+    (id: id, mangaId: mangaId, chapterNumber: number, fetchedAt: fetchedAt);
+
+void main() {
+  group('detectNewChapters', () {
+    test('groups fresh chapters by manga and advances the watermark', () {
+      final r = detectNewChapters(
+        candidates: [
+          ch(1, 10, 1, 100),
+          ch(2, 10, 2, 110),
+          ch(3, 20, 5, 120),
+        ],
+        watermark: const NewChapterWatermark(fetchedAt: 0),
+      );
+      expect(r.groups.length, 2);
+      expect(r.watermark.fetchedAt, 120);
+      final manga10 = r.groups.firstWhere((g) => g.mangaId == 10);
+      expect(manga10.chapters.map((c) => c.id), [1, 2]);
+    });
+
+    test('an already-notified chapter in the overlap window is not re-sent', () {
+      // Prior run notified id 2 (fetchedAt 110). Re-query returns it again plus
+      // a late-committed id 3 below the mark — 3 fires, 2 is deduped.
+      final r = detectNewChapters(
+        candidates: [ch(2, 10, 2, 110), ch(3, 10, 3, 105)],
+        watermark: const NewChapterWatermark(fetchedAt: 110, recent: {2: 110}),
+      );
+      final ids = r.groups.expand((g) => g.chapters).map((c) => c.id).toList();
+      expect(ids, [3]); // 2 deduped, 3 (late, below the mark) caught
+      expect(r.watermark.recent.keys.toSet(), {2, 3});
+    });
+
+    test('recent ids outside the overlap window are pruned', () {
+      final r = detectNewChapters(
+        candidates: [ch(5, 10, 5, 1000000)],
+        watermark: NewChapterWatermark(fetchedAt: 100, recent: {2: 100}),
+        overlapMs: 1000,
+      );
+      // id 2 (fetchedAt 100) is far below 1000000 − 1000, so it's dropped.
+      expect(r.watermark.recent.containsKey(2), isFalse);
+      expect(r.watermark.recent.containsKey(5), isTrue);
+    });
+
+    test('per-series chapters are ordered by chapter number, not fetch order', () {
+      final r = detectNewChapters(
+        candidates: [ch(1, 10, 3, 100), ch(2, 10, 1, 130), ch(3, 10, 2, 120)],
+        watermark: const NewChapterWatermark(),
+      );
+      expect(r.groups.single.chapters.map((c) => c.chapterNumber), [1, 2, 3]);
+    });
+
+    test('category scope filters which series notify', () {
+      final r = detectNewChapters(
+        candidates: [ch(1, 10, 1, 100), ch(2, 20, 1, 110)],
+        watermark: const NewChapterWatermark(),
+        allowedMangaIds: {10},
+      );
+      expect(r.groups.map((g) => g.mangaId), [10]);
+      // Watermark still advances past the excluded chapter so it can't re-notify.
+      expect(r.watermark.fetchedAt, 110);
+    });
+
+    test('no candidates keeps the watermark and notifies nothing', () {
+      final r = detectNewChapters(
+        candidates: const [],
+        watermark: const NewChapterWatermark(fetchedAt: 500, recent: {9: 500}),
+      );
+      expect(r.groups, isEmpty);
+      expect(r.watermark.fetchedAt, 500);
+    });
+
+    test('watermark round-trips through json', () {
+      const wm = NewChapterWatermark(fetchedAt: 42, recent: {1: 40, 2: 41, 3: 42});
+      final back = NewChapterWatermark.fromJson(wm.toJson());
+      expect(back.fetchedAt, 42);
+      expect(back.recent, {1: 40, 2: 41, 3: 42});
+    });
+  });
+
+  group('newChaptersLabel (Komikku parity)', () {
+    test('no parseable numbers -> generic count', () {
+      expect(newChaptersLabel([-1, -1], 2), isA<GenericNewChapters>());
+      expect((newChaptersLabel([-1, -1], 2) as GenericNewChapters).count, 2);
+    });
+
+    test('single number, no unparsed remainder -> Chapter X', () {
+      final l = newChaptersLabel([12], 1) as SingleNewChapter;
+      expect(l.number, '12');
+      expect(l.more, 0);
+    });
+
+    test('single number with unparsed extras -> Chapter X and N more', () {
+      final l = newChaptersLabel([2.5, -1, -1], 3) as SingleNewChapter;
+      expect(l.number, '2.5');
+      expect(l.more, 2);
+    });
+
+    test('a few numbers -> Chapters a, b, c', () {
+      final l = newChaptersLabel([3, 1, 2], 3) as MultipleNewChapters;
+      expect(l.numbers, ['1', '2', '3']);
+      expect(l.more, 0);
+    });
+
+    test('more than the cap -> first 5 and N more', () {
+      final l = newChaptersLabel([1, 2, 3, 4, 5, 6, 7], 7) as MultipleNewChapters;
+      expect(l.numbers, ['1', '2', '3', '4', '5']);
+      expect(l.more, 2);
+    });
+
+    test('duplicate numbers collapse', () {
+      final l = newChaptersLabel([1, 1, 1], 3) as SingleNewChapter;
+      expect(l.number, '1');
+      expect(l.more, 2); // total 3 - 1 distinct
+    });
+  });
+}

--- a/test/src/features/notifications/notification_state_test.dart
+++ b/test/src/features/notifications/notification_state_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/notifications/data/background/notification_background_client.dart';
+import 'package:tsumiru/src/features/notifications/data/notification_state_store.dart';
+import 'package:tsumiru/src/features/notifications/domain/new_chapter_detection.dart';
+
+NotificationWorkerConfig config({
+  Set<int> include = const {},
+  Set<int> exclude = const {},
+}) =>
+    NotificationWorkerConfig(
+      serverId: 's',
+      endpoint: const NotificationEndpoint(baseUrl: 'http://x'),
+      newChaptersEnabled: true,
+      includedCategoryIds: include,
+      excludedCategoryIds: exclude,
+      hideContent: false,
+    );
+
+void main() {
+  group('category scope', () {
+    final mangaCats = {10: {1}, 20: {2}, 30: {1, 2}};
+
+    test('no include/exclude -> null (all series)', () {
+      expect(config().allowedMangaIds(mangaCats), isNull);
+    });
+
+    test('include list keeps only series in those categories', () {
+      expect(config(include: {1}).allowedMangaIds(mangaCats), {10, 30});
+    });
+
+    test('exclude drops series in excluded categories', () {
+      expect(config(exclude: {2}).allowedMangaIds(mangaCats), {10});
+    });
+
+    test('exclude wins over include', () {
+      expect(config(include: {1}, exclude: {2}).allowedMangaIds(mangaCats), {10});
+    });
+  });
+
+  test('outbox round-trips through json (crash recovery)', () {
+    final outbox = NotificationOutbox(
+      pending: [
+        const PendingSeriesNotification(
+          mangaId: 7,
+          mangaTitle: 'M7',
+          thumbnailUrl: '/t.jpg',
+          chapterIds: [1, 2],
+          chapterNumbers: [1, 2],
+          firstChapterId: 1,
+          totalCount: 2,
+        ),
+      ],
+      nextWatermark: const NewChapterWatermark(fetchedAt: 99, recent: {2: 99}),
+    );
+    final back = NotificationOutbox.fromJson(outbox.toJson());
+    expect(back.pending.single.mangaTitle, 'M7');
+    expect(back.pending.single.chapterIds, [1, 2]);
+    expect(back.nextWatermark.fetchedAt, 99);
+    expect(back.nextWatermark.recent, {2: 99});
+  });
+}

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -15,6 +15,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
   jni
 )
 


### PR DESCRIPTION
Adds system notifications, modeled on Mihon/Komikku. Closes #137.

**New chapters** — a periodic background job (WorkManager, user-set interval, wifi/charging constraints) polls the server's fetched-chapter delta and posts a grouped summary plus per-series notifications with the cover and Mark read / View / Download actions. Actions work with the app closed. Detection uses an overlap-window watermark with a durable outbox, so an interrupted check re-publishes instead of double-buzzing, and a read-elsewhere chapter never notifies.

**Also covered** — download complete, download errors, library-update errors, app updates, extension updates, and a persistent incognito reminder. Each has its own Android channel so they can be controlled individually. A Settings > Notifications screen holds the toggles, interval, and a privacy option that hides series titles.

**Boot guard** — a new smoke test pumps the real app root on the Android path and fails on any startup crash; it was added after a launch crash in an earlier cut of this branch (localizations read above the widget that installs them) and is proven to catch that class of bug.

Server needs no changes; everything runs against existing GraphQL queries. Backup notifications are intentionally absent — automatic backups run server-side where the client can't observe them, and manual backups happen with the user present.

Verified: 1167 tests green, launch verified on-device (clean boot to first frame, no fatals). Real-world new-chapter delivery still pending an actual release while the app is closed.