### PR TITLE
Defer refresh-on-mount effects out of the build phase

### DIFF
--- a/lib/src/features/browse_center/presentation/extension/extension_screen.dart
+++ b/lib/src/features/browse_center/presentation/extension/extension_screen.dart
@@ -60,7 +60,12 @@ class ExtensionScreen extends HookConsumerWidget {
     refresh() => ref.refresh(extensionProvider.future);
 
     useEffect(() {
-      if (extensionMapData.isNotLoading) refresh();
+      // Effect bodies run during build; invalidating a provider there throws.
+      if (extensionMapData.isNotLoading) {
+        Future.microtask(() {
+          if (context.mounted) refresh();
+        });
+      }
       return;
     }, []);
 

--- a/lib/src/features/browse_center/presentation/source/source_screen.dart
+++ b/lib/src/features/browse_center/presentation/source/source_screen.dart
@@ -35,7 +35,12 @@ class SourceScreen extends HookConsumerWidget {
 
     refresh() => ref.refresh(sourceListProvider.future);
     useEffect(() {
-      if (sourceMapData.isNotLoading) refresh();
+      // Effect bodies run during build; invalidating a provider there throws.
+      if (sourceMapData.isNotLoading) {
+        Future.microtask(() {
+          if (context.mounted) refresh();
+        });
+      }
       return;
     }, []);
 

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -65,7 +65,12 @@ class CategoryMangaList extends HookConsumerWidget {
             : mangaCoverGridDelegate(gridWidth, titleBelow: titleBelow);
     refresh() => ref.invalidate(categoryMangaListProvider(categoryId));
     useEffect(() {
-      if (mangaList.isNotLoading) refresh();
+      // Effect bodies run during build; invalidating a provider there throws.
+      if (mangaList.isNotLoading) {
+        Future.microtask(() {
+          if (context.mounted) refresh();
+        });
+      }
       return;
     }, []);
 

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -111,7 +111,12 @@ class MangaDetailsScreen extends HookConsumerWidget {
     }, [context, mangaRefresh, chapterListRefresh]);
 
     useEffect(() {
-      if (filteredChapterList.isNotLoading && manga.isNotLoading) refresh();
+      // Effect bodies run during build; invalidating a provider there throws.
+      if (filteredChapterList.isNotLoading && manga.isNotLoading) {
+        Future.microtask(() {
+          if (context.mounted) refresh();
+        });
+      }
       return;
     }, []);
 

--- a/test/src/riverpod/build_phase_invalidation_test.dart
+++ b/test/src/riverpod/build_phase_invalidation_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Pins the Riverpod 3 behavior behind the refresh-on-mount deferrals in
+/// manga details, sources, extensions, and the library category list:
+/// flutter_hooks runs effect bodies during build, and invalidating a provider
+/// there throws "setState() or markNeedsBuild() called during build". If the
+/// sync case stops throwing after a riverpod upgrade, the microtask
+/// workarounds at those sites can be dropped.
+final _tickProvider = NotifierProvider<_TickNotifier, int>(_TickNotifier.new);
+
+class _TickNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+  void refresh() => ref.invalidateSelf();
+}
+
+class _RefreshOnMount extends HookConsumerWidget {
+  const _RefreshOnMount({required this.defer});
+  final bool defer;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final v = ref.watch(_tickProvider);
+    useEffect(() {
+      if (defer) {
+        Future.microtask(() => ref.read(_tickProvider.notifier).refresh());
+      } else {
+        ref.read(_tickProvider.notifier).refresh();
+      }
+      return null;
+    }, const []);
+    return Text('$v', textDirection: TextDirection.ltr);
+  }
+}
+
+void main() {
+  testWidgets('invalidating during build throws', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: _RefreshOnMount(defer: false)),
+    );
+    final e = tester.takeException();
+    expect('$e', contains('called during build'));
+  });
+
+  testWidgets('microtask-deferred invalidation is clean', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: _RefreshOnMount(defer: true)),
+    );
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Four screens (manga details, sources, extensions, library category list) fired their refresh-on-mount effect synchronously during build — flutter_hooks runs effect bodies inline, so re-entering an already-loaded screen invalidated providers mid-build and tripped Riverpod 3's setState-during-build assert. Manga details hit it repeatedly in field crash logs. The mount condition still reads synchronously; only the invalidation moves one microtask past build, behind a mounted guard.

A canary test pins the throwing behavior. Riverpod has the complementary internal bug (dirty-provider flush during build, rrousselGit/riverpod#4781) fixed upstream but unreleased — when that release lands, a failing canary flags that these workarounds can be dropped.

Verified: full suite green (1150).