### PR TITLE
Add a Migrate tab to Browse

### DIFF
--- a/lib/src/features/browse_center/presentation/browse/browse_screen.dart
+++ b/lib/src/features/browse_center/presentation/browse/browse_screen.dart
@@ -28,7 +28,7 @@ class BrowseScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tabController =
-        useTabController(initialLength: 2, initialIndex: currentIndex);
+        useTabController(initialLength: 3, initialIndex: currentIndex);
 
     useEffect(() {
       if (currentIndex != tabController.index) {
@@ -69,15 +69,17 @@ class BrowseScreen extends HookConsumerWidget {
             ),
             const InstallExtensionFile(),
           ],
-          IconButton(
-            onPressed: () => showDialog(
-              context: context,
-              builder: (context) => tabController.index == 0
-                  ? const SourceLanguageFilter()
-                  : const ExtensionLanguageFilterDialog(),
+          // Language filter applies to Sources/Extensions only, not Migrate.
+          if (tabController.index != 2)
+            IconButton(
+              onPressed: () => showDialog(
+                context: context,
+                builder: (context) => tabController.index == 0
+                    ? const SourceLanguageFilter()
+                    : const ExtensionLanguageFilterDialog(),
+              ),
+              icon: const Icon(Icons.translate_rounded),
             ),
-            icon: const Icon(Icons.translate_rounded),
-          ),
         ],
         bottom: TabBar(
           dividerColor: Colors.transparent,
@@ -86,6 +88,7 @@ class BrowseScreen extends HookConsumerWidget {
           tabs: [
             Tab(text: context.l10n.sources),
             Tab(text: context.l10n.extensions),
+            Tab(text: context.l10n.migrate),
           ],
         ),
       ),

--- a/lib/src/features/migration/presentation/screens/migration_source_picker_screen.dart
+++ b/lib/src/features/migration/presentation/screens/migration_source_picker_screen.dart
@@ -23,8 +23,22 @@ enum _SortMode { alphabetical, total }
 /// Screen 1 — Migrate off a source (Komikku `MigrateSourceScreen`). Lists the
 /// library's sources with entry counts; an obsolete filter and sort mode/
 /// direction; tapping a source drills into its manga.
-class MigrationSourcePickerScreen extends HookConsumerWidget {
+///
+/// [MigrationSourcePickerBody] is the chrome-less body so the same screen hosts
+/// both the standalone route (this Scaffold wrapper) and the Browse → Migrate
+/// tab, which supplies its own app bar.
+class MigrationSourcePickerScreen extends StatelessWidget {
   const MigrationSourcePickerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: Text(context.l10n.migrationPickSourceTitle)),
+        body: const MigrationSourcePickerBody(),
+      );
+}
+
+class MigrationSourcePickerBody extends HookConsumerWidget {
+  const MigrationSourcePickerBody({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -38,101 +52,105 @@ class MigrationSourcePickerScreen extends HookConsumerWidget {
     final sortMode = useState(_SortMode.alphabetical);
     final ascending = useState(true);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.migrationPickSourceTitle),
-        actions: [
-          IconButton(
-            tooltip: l10n.migrationFilterObsolete,
-            icon: const Icon(Icons.new_releases_outlined),
-            color: obsoleteOnly.value ? context.theme.colorScheme.error : null,
-            onPressed: () => obsoleteOnly.value = !obsoleteOnly.value,
-          ),
-          IconButton(
-            tooltip: l10n.migrationSortMode,
-            icon: Icon(sortMode.value == _SortMode.alphabetical
-                ? Icons.sort_by_alpha
-                : Icons.numbers),
-            onPressed: () => sortMode.value =
-                sortMode.value == _SortMode.alphabetical
-                    ? _SortMode.total
-                    : _SortMode.alphabetical,
-          ),
-          IconButton(
-            tooltip: l10n.migrationSortDirection,
-            icon: Icon(ascending.value
-                ? Icons.arrow_upward
-                : Icons.arrow_downward),
-            onPressed: () => ascending.value = !ascending.value,
-          ),
-        ],
-      ),
-      body: groupsAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('$e')),
-        data: (all) {
-          final q = query.value.trim().toLowerCase();
-          var groups = [
-            for (final g in all)
-              if ((!obsoleteOnly.value || g.isObsolete) &&
-                  (q.isEmpty || g.displayName.toLowerCase().contains(q)))
-                g,
-          ];
-          groups = [...groups]..sort((a, b) {
-              final c = sortMode.value == _SortMode.alphabetical
-                  ? a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase())
-                  : a.count.compareTo(b.count);
-              return ascending.value ? c : -c;
-            });
-          if (all.isEmpty) {
-            return Center(child: Text(l10n.migrationNoLibrarySources));
-          }
-          return Column(
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                child: SearchField(
-                  autofocus: false,
-                  initialText: query.value,
-                  hintText: l10n.migrationSearchForSource,
-                  onChanged: (v) => query.value = v ?? '',
-                  onClose: () => query.value = '',
+    return groupsAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('$e')),
+      data: (all) {
+        final q = query.value.trim().toLowerCase();
+        var groups = [
+          for (final g in all)
+            if ((!obsoleteOnly.value || g.isObsolete) &&
+                (q.isEmpty || g.displayName.toLowerCase().contains(q)))
+              g,
+        ];
+        groups = [...groups]..sort((a, b) {
+            final c = sortMode.value == _SortMode.alphabetical
+                ? a.displayName
+                    .toLowerCase()
+                    .compareTo(b.displayName.toLowerCase())
+                : a.count.compareTo(b.count);
+            return ascending.value ? c : -c;
+          });
+        if (all.isEmpty) {
+          return Center(child: Text(l10n.migrationNoLibrarySources));
+        }
+        return Column(
+          children: [
+            // Filter/sort controls sit inline: the Browse tab host owns the
+            // app bar, so they can't live in AppBar actions here.
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  tooltip: l10n.migrationFilterObsolete,
+                  icon: const Icon(Icons.new_releases_outlined),
+                  color: obsoleteOnly.value
+                      ? context.theme.colorScheme.error
+                      : null,
+                  onPressed: () => obsoleteOnly.value = !obsoleteOnly.value,
                 ),
+                IconButton(
+                  tooltip: l10n.migrationSortMode,
+                  icon: Icon(sortMode.value == _SortMode.alphabetical
+                      ? Icons.sort_by_alpha
+                      : Icons.numbers),
+                  onPressed: () => sortMode.value =
+                      sortMode.value == _SortMode.alphabetical
+                          ? _SortMode.total
+                          : _SortMode.alphabetical,
+                ),
+                IconButton(
+                  tooltip: l10n.migrationSortDirection,
+                  icon: Icon(ascending.value
+                      ? Icons.arrow_upward
+                      : Icons.arrow_downward),
+                  onPressed: () => ascending.value = !ascending.value,
+                ),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: SearchField(
+                autofocus: false,
+                initialText: query.value,
+                hintText: l10n.migrationSearchForSource,
+                onChanged: (v) => query.value = v ?? '',
+                onClose: () => query.value = '',
               ),
-              Expanded(
-                child: ListView.builder(
-                  itemCount: groups.length,
-                  itemBuilder: (context, i) {
-                    final g = groups[i];
-                    return ListTile(
-                      leading: ClipRRect(
-                        borderRadius: KBorderRadius.r8.radius,
-                        child: ServerImage(
-                          imageUrl: iconById[g.sourceId] ?? '',
-                          size: const Size.square(40),
-                        ),
+            ),
+            Expanded(
+              child: ListView.builder(
+                itemCount: groups.length,
+                itemBuilder: (context, i) {
+                  final g = groups[i];
+                  return ListTile(
+                    leading: ClipRRect(
+                      borderRadius: KBorderRadius.r8.radius,
+                      child: ServerImage(
+                        imageUrl: iconById[g.sourceId] ?? '',
+                        size: const Size.square(40),
                       ),
-                      title: Text(g.displayName),
-                      subtitle: g.isObsolete
-                          ? Text(l10n.migrationObsoleteSource,
-                              style: TextStyle(
-                                  color: context.theme.colorScheme.error))
-                          : null,
-                      trailing: _CountBadge(g.count),
-                      onTap: () => MigrationSourceMangaRoute(
-                        $extra: MigrationSourceMangaData(
-                          sourceId: g.sourceId,
-                          sourceName: g.displayName,
-                        ),
-                      ).push(context),
-                    );
-                  },
-                ),
+                    ),
+                    title: Text(g.displayName),
+                    subtitle: g.isObsolete
+                        ? Text(l10n.migrationObsoleteSource,
+                            style: TextStyle(
+                                color: context.theme.colorScheme.error))
+                        : null,
+                    trailing: _CountBadge(g.count),
+                    onTap: () => MigrationSourceMangaRoute(
+                      $extra: MigrationSourceMangaData(
+                        sourceId: g.sourceId,
+                        sourceName: g.displayName,
+                      ),
+                    ).push(context),
+                  );
+                },
               ),
-            ],
-          );
-        },
-      ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -83,6 +83,7 @@ abstract class Routes {
   static const history = 'history';
 
   static const extensionRoute = '/extension';
+  static const migrate = '/migrate';
   static const source = '/source';
   static const sourceFilter = '/source-filter';
   static const sourceManga = ':sourceId';
@@ -187,6 +188,13 @@ GoRouter routerConfig(Ref ref) {
                   routes: [
                     TypedGoRoute<BrowseExtensionRoute>(
                       path: Routes.extensionRoute,
+                    ),
+                  ],
+                ),
+                TypedStatefulShellBranch<BrowseMigrateBranch>(
+                  routes: [
+                    TypedGoRoute<BrowseMigrateRoute>(
+                      path: Routes.migrate,
                     ),
                   ],
                 ),

--- a/lib/src/routes/sub_routes/browser_routes.dart
+++ b/lib/src/routes/sub_routes/browser_routes.dart
@@ -53,6 +53,18 @@ class BrowseSourceRoute extends GoRouteData with $BrowseSourceRoute {
   Widget build(context, state) => const SourceScreen();
 }
 
+class BrowseMigrateBranch extends StatefulShellBranchData {
+  const BrowseMigrateBranch();
+  static final $initialLocation = const BrowseMigrateRoute().location;
+}
+
+class BrowseMigrateRoute extends GoRouteData with $BrowseMigrateRoute {
+  const BrowseMigrateRoute();
+
+  @override
+  Widget build(context, state) => const MigrationSourcePickerBody();
+}
+
 class SourceTypeRoute extends GoRouteData with $SourceTypeRoute {
   const SourceTypeRoute({
     required this.sourceId,

--- a/test/src/features/browse_center/extension_repo_affordance_test.dart
+++ b/test/src/features/browse_center/extension_repo_affordance_test.dart
@@ -20,6 +20,7 @@ Widget _harness(int currentIndex) => ProviderScope(
           children: const [
             Center(child: Text('sources')),
             Center(child: Text('extensions')),
+            Center(child: Text('migrate')),
           ],
         ),
       ),
@@ -36,5 +37,13 @@ void main() {
     await tester.pumpWidget(_harness(0));
     await tester.pump();
     expect(find.byTooltip('Extension Repository'), findsNothing);
+  });
+
+  testWidgets('Migrate tab shows neither repo nor language affordance',
+      (tester) async {
+    await tester.pumpWidget(_harness(2));
+    await tester.pump();
+    expect(find.byTooltip('Extension Repository'), findsNothing);
+    expect(find.byIcon(Icons.translate_rounded), findsNothing);
   });
 }

--- a/test/src/features/browse_center/source_filter_affordance_test.dart
+++ b/test/src/features/browse_center/source_filter_affordance_test.dart
@@ -20,6 +20,7 @@ Widget _harness(int currentIndex) => ProviderScope(
           children: const [
             Center(child: Text('sources')),
             Center(child: Text('extensions')),
+            Center(child: Text('migrate')),
           ],
         ),
       ),
@@ -36,6 +37,13 @@ void main() {
   testWidgets('Filter sources affordance is absent on the Extensions tab',
       (tester) async {
     await tester.pumpWidget(_harness(1));
+    await tester.pump();
+    expect(find.byTooltip('Filter sources'), findsNothing);
+  });
+
+  testWidgets('Filter sources affordance is absent on the Migrate tab',
+      (tester) async {
+    await tester.pumpWidget(_harness(2));
     await tester.pump();
     expect(find.byTooltip('Filter sources'), findsNothing);
   });


### PR DESCRIPTION
## What

Adds a third tab to Browse — **Sources · Extensions · Migrate** — that opens the source-migration picker.

## Why

Bulk source migration already shipped, but its only entry point was a swap-horizontal icon that renders solely in the library's non-default grouping modes (By Source / By Status), which most users never switch into. So a feature that exists was effectively unreachable. Komikku and Suwayomi-WebUI both surface migration as a Browse destination; this brings Tsumiru in line.

## How

- The source picker's body is split into a chrome-less `MigrationSourcePickerBody` so it hosts both the new tab and the existing standalone route. Its filter/sort controls move inline, since the tab draws no app bar of its own.
- A `BrowseMigrateBranch` / `BrowseMigrateRoute` is added as a third `StatefulShellBranch`, registered after Extensions so tab order and branch order stay in sync.
- The language-filter action is gated off the Migrate tab (it only applies to Sources/Extensions).
- Tapping a source opens the existing per-source multi-select screen full-screen, unchanged.

## Testing

- Full suite green (1171).
- Affordance widget tests updated for the third tab, with added coverage that the Migrate tab shows neither the repo nor the language-filter affordance.
- Live-verified on device: the tab appears, lists library sources with counts and obsolete flags, and drills into per-source multi-select migration.