### PR TITLE
Fix the extension stores help link

### DIFF
--- a/lib/src/features/browse_center/presentation/extension_store/extension_store_screen.dart
+++ b/lib/src/features/browse_center/presentation/extension_store/extension_store_screen.dart
@@ -20,7 +20,7 @@ import '../../domain/extension_store/extension_store_model.dart';
 import 'widgets/add_store_dialog.dart';
 
 /// Guide page ships in a later task; linked from the empty-state Help button.
-const kStoreHelpUrl = 'https://tsumiru.app/docs/guides/adding-sources/';
+const kStoreHelpUrl = 'https://tsumiru.app/docs/guides/adding-sources';
 
 class ExtensionStoreScreen extends ConsumerWidget {
   const ExtensionStoreScreen({super.key});


### PR DESCRIPTION
The empty-state Help button on the Extension stores screen pointed at `.../docs/guides/adding-sources/` with a trailing slash, which 404s — the docs site (VitePress cleanUrls) serves guides without one. Drops the trailing slash so the link resolves.

Follow-up to #252.