### PR TITLE
Drop the destructive per-item history removal

### DIFF
--- a/lib/src/features/history/data/history_repository.dart
+++ b/lib/src/features/history/data/history_repository.dart
@@ -11,17 +11,14 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../global_providers/global_providers.dart';
 import '../../../graphql/__generated__/schema.graphql.dart';
 import '../../../utils/extensions/custom_extensions.dart';
-import '../../manga_book/data/manga_book/manga_book_repository.dart';
-import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../domain/history_item.dart';
 import 'graphql/__generated__/query.graphql.dart';
 
 part 'history_repository.g.dart';
 
 class HistoryRepository {
-  const HistoryRepository(this.client, this.mangaBookRepository);
+  const HistoryRepository(this.client);
   final GraphQLClient client;
-  final MangaBookRepository mangaBookRepository;
 
   /// Most-recently-read chapter per manga, newest first.
   ///
@@ -104,7 +101,7 @@ class HistoryRepository {
     final seen = <int>{};
     final items = <HistoryItemDto>[];
     for (final chapter in chapters?.nodes ?? const <HistoryItemDto>[]) {
-      // Skip no-progress rows left behind by "remove from history".
+      // A timestamp with no read progress isn't history worth showing.
       if (!chapter.isRead && chapter.lastPageRead <= 0) continue;
       // First-seen per manga wins (server order is already newest-first).
       if (seen.add(chapter.mangaId)) items.add(chapter);
@@ -142,21 +139,6 @@ class HistoryRepository {
         .getData((data) => data.chapters.nodes);
   }
 
-  /// Clear reading history for a specific chapter
-  Future<void> removeChapterFromHistory(int chapterId) async {
-    // This removes it from history queries since our filter requires:
-    // either isRead: true OR lastPageRead > 0
-    await mangaBookRepository.putChapter(
-      chapterId: chapterId,
-      patch: ChapterChange(
-        isRead: false,
-        lastPageRead: 0,
-        // Note: lastReadAt cannot be cleared via this API
-        // Some chapters may still appear until server is restarted
-      ),
-    );
-  }
-
   /// Clear all reading history (mark all chapters as unread)
   /// This is a destructive operation and should be used with caution
   Future<void> clearAllHistory() async {
@@ -168,5 +150,5 @@ class HistoryRepository {
 }
 
 @riverpod
-HistoryRepository historyRepository(Ref ref) => HistoryRepository(
-    ref.watch(graphQlClientProvider), ref.watch(mangaBookRepositoryProvider));
+HistoryRepository historyRepository(Ref ref) =>
+    HistoryRepository(ref.watch(graphQlClientProvider));

--- a/lib/src/features/history/domain/history_menu_action.dart
+++ b/lib/src/features/history/domain/history_menu_action.dart
@@ -9,16 +9,13 @@ import 'package:flutter/material.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 
 enum HistoryMenuAction {
-  viewManga,
-  removeFromHistory;
+  viewManga;
 
   String toLocale(BuildContext context) => switch (this) {
         HistoryMenuAction.viewManga => context.l10n.viewManga,
-        HistoryMenuAction.removeFromHistory => context.l10n.removeFromHistory,
       };
 
   IconData get icon => switch (this) {
         HistoryMenuAction.viewManga => Icons.book,
-        HistoryMenuAction.removeFromHistory => Icons.delete_outline,
       };
 }

--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -9,9 +9,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../constants/db_keys.dart';
 import '../../../utils/extensions/custom_extensions.dart';
-import '../../../utils/misc/toast/toast.dart';
 import '../../../utils/mixin/shared_preferences_client_mixin.dart';
-import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import '../data/history_repository.dart';
 import '../domain/history_group.dart';
 import '../domain/history_item.dart';
@@ -43,33 +41,6 @@ class ReadingHistory extends _$ReadingHistory {
     // On error keep the current list (the pull spinner has dismissed).
   }
 
-  /// Remove a chapter from reading history.
-  Future<void> removeFromHistory(int chapterId) async {
-    final current = state.value ?? const <HistoryItemDto>[];
-    HistoryItemDto? removed;
-    for (final item in current) {
-      if (item.id == chapterId) {
-        removed = item;
-        break;
-      }
-    }
-    final result = await AsyncValue.guard(
-      () =>
-          ref.read(historyRepositoryProvider).removeChapterFromHistory(chapterId),
-    );
-    if (!ref.mounted) return;
-    if (result.hasError) {
-      // Don't invalidate as though it succeeded — item would just reappear.
-      ref.read(toastProvider)?.showError(result.error.toString());
-      return;
-    }
-    if (removed != null) {
-      ref.invalidate(mangaChapterListProvider(mangaId: removed.mangaId));
-      ref.invalidate(mangaWithIdProvider(mangaId: removed.mangaId));
-    }
-    // Rebuild from the top so the removed chapter drops out.
-    ref.invalidateSelf();
-  }
 }
 
 @riverpod

--- a/lib/src/features/history/presentation/history_screen.dart
+++ b/lib/src/features/history/presentation/history_screen.dart
@@ -82,8 +82,6 @@ class HistoryScreen extends ConsumerWidget {
                       final group = historyGroups[index];
                       return HistoryGroupWidget(
                         group: group,
-                        onRemoveItem: (chapterId) =>
-                            notifier.removeFromHistory(chapterId),
                       );
                     },
                   ),

--- a/lib/src/features/history/presentation/widgets/history_group_widget.dart
+++ b/lib/src/features/history/presentation/widgets/history_group_widget.dart
@@ -15,11 +15,9 @@ class HistoryGroupWidget extends StatelessWidget {
   const HistoryGroupWidget({
     super.key,
     required this.group,
-    required this.onRemoveItem,
   });
 
   final HistoryGroup group;
-  final Function(int chapterId) onRemoveItem;
 
   @override
   Widget build(BuildContext context) {
@@ -67,7 +65,6 @@ class HistoryGroupWidget extends StatelessWidget {
         // Group items
         ...group.items.map((HistoryItemDto item) => HistoryItemTile(
               item: item,
-              onRemove: () => onRemoveItem(item.id),
             )),
         const SizedBox(height: 16),
       ],

--- a/lib/src/features/history/presentation/widgets/history_item_tile.dart
+++ b/lib/src/features/history/presentation/widgets/history_item_tile.dart
@@ -22,12 +22,10 @@ class HistoryItemTile extends ConsumerWidget {
     super.key,
     required this.item,
     this.onTap,
-    required this.onRemove,
   });
 
   final HistoryItemDto item;
   final VoidCallback? onTap;
-  final VoidCallback onRemove;
 
   bool _isChapterCompleted() {
     final isFullyRead = item.isRead == true;
@@ -159,9 +157,6 @@ class HistoryItemTile extends ConsumerWidget {
                 ),
                 onSelected: (action) {
                   switch (action) {
-                    case HistoryMenuAction.removeFromHistory:
-                      _showRemoveDialog(context);
-                      break;
                     case HistoryMenuAction.viewManga:
                       _navigateToManga(context);
                       break;
@@ -189,28 +184,6 @@ class HistoryItemTile extends ConsumerWidget {
     );
   }
 
-  void _showRemoveDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(context.l10n.removeFromHistory),
-        content: Text(context.l10n.removeFromHistoryConfirmation),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: Text(context.l10n.cancel),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-              onRemove();
-            },
-            child: Text(context.l10n.remove),
-          ),
-        ],
-      ),
-    );
-  }
 
   /// Ensures all preference providers required for chapter filtering/sorting are initialized
   void _ensurePreferenceProvidersInitialized(WidgetRef ref) {

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2416,8 +2416,6 @@
     "tryDifferentSearchTerm": "Try a different search term",
     "errorOccurred": "An error occurred",
     "viewManga": "View Manga",
-    "removeFromHistory": "Remove from History",
-    "removeFromHistoryConfirmation": "Are you sure you want to remove this chapter from your reading history?",
     "timeoutSettings": "Timeout Settings",
     "serverRequestTimeout": "Server Request Timeout",
     "@serverRequestTimeout": {


### PR DESCRIPTION
## What

Removes the per-item "Remove from History" action (the ⋮ menu keeps "View manga").

## Why

The action had no honest implementation on a Suwayomi client. The server exposes no way to clear a chapter's `lastReadAt`, so "Remove from History" faked removal by marking the chapter **unread** and **zeroing its page progress** — silently destroying real reading state to drop a row from a timestamp-derived list. Because the timestamp itself was never cleared, the row could also resurface later.

Suwayomi-WebUI, the reference client on the same server, deliberately offers **no** per-item history removal — precisely because the server has no primitive for it. This matches that: history relies on retention (already configurable) to age entries out, and read state is never touched.

Note this removes a feature that shipped in 0.9.2. That's intentional — the feature could not be made non-destructive, and a misleading version that wipes read state is worse than not offering it.

## Changes

- Remove the `removeFromHistory` menu action and its confirmation dialog.
- Delete the destructive `removeChapterFromHistory` repository method and its now-unused `MangaBookRepository` dependency.
- Drop the now-unused `onRemove`/`onRemoveItem` wiring and l10n strings.

## Testing

- Full suite green (1209).
- Live-verified on device: History renders and ages out via retention; the ⋮ menu no longer offers a destructive remove.