### PR TITLE
Load manga metadata when opening details from Browse

### DIFF
--- a/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
+++ b/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
@@ -259,11 +259,9 @@ class MangaBookRepository {
       )
       .getData((data) => data.fetchChapters?.chapters);
 
-  /// Scrapes the source for both the manga's metadata (description, author,
-  /// status, genres) AND its chapter list in one call. Needed on detail open:
-  /// the deprecated chapters-only fetch no longer populates metadata as a side
-  /// effect on Tachiyomix 1.6+ servers, so a browse-opened entry showed
-  /// chapters but a blank synopsis until it was added to the library.
+  /// Scrapes the source for metadata + chapters together; on Tachiyomix 1.6+
+  /// servers the chapters-only fetch stopped populating metadata as a side
+  /// effect.
   Future<List<ChapterDto>?> getMangaAndChapterList(int mangaId) async => client
       .mutate$GetMangaAndChaptersByMangaId(
         Options$Mutation$GetMangaAndChaptersByMangaId(

--- a/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
+++ b/lib/src/features/manga_book/data/manga_book/manga_book_repository.dart
@@ -259,6 +259,25 @@ class MangaBookRepository {
       )
       .getData((data) => data.fetchChapters?.chapters);
 
+  /// Scrapes the source for both the manga's metadata (description, author,
+  /// status, genres) AND its chapter list in one call. Needed on detail open:
+  /// the deprecated chapters-only fetch no longer populates metadata as a side
+  /// effect on Tachiyomix 1.6+ servers, so a browse-opened entry showed
+  /// chapters but a blank synopsis until it was added to the library.
+  Future<List<ChapterDto>?> getMangaAndChapterList(int mangaId) async => client
+      .mutate$GetMangaAndChaptersByMangaId(
+        Options$Mutation$GetMangaAndChaptersByMangaId(
+          variables: Variables$Mutation$GetMangaAndChaptersByMangaId(
+            input: Input$FetchMangaAndChaptersInput(
+              id: mangaId,
+              fetchManga: true,
+              fetchChapters: true,
+            ),
+          ),
+        ),
+      )
+      .getData((data) => data.fetchMangaAndChapters?.chapters);
+
   /// Reads the chapters the server already has STORED for this entry, without
   /// touching the source. Works whenever the server is reachable, even if the
   /// source is down — this is what the WebUI shows.

--- a/lib/src/features/manga_book/data/manga_book/query.graphql
+++ b/lib/src/features/manga_book/data/manga_book/query.graphql
@@ -120,6 +120,14 @@ mutation GetChaptersByMangaId($input: FetchChaptersInput!) {
   }
 }
 
+mutation GetMangaAndChaptersByMangaId($input: FetchMangaAndChaptersInput!) {
+  fetchMangaAndChapters(input: $input) {
+    chapters {
+      ...ChapterDto
+    }
+  }
+}
+
 query GetMangaCategories($id: Int!) {
   manga(id: $id) {
     categories {

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -62,8 +62,8 @@ class MangaChapterList extends _$MangaChapterList {
     final repo = ref.watch(mangaBookRepositoryProvider);
     final refreshFromSource =
         ref.watch(refreshChaptersFromSourceProvider).ifNull();
-    // Tracks whether we actually scraped the source on this open. A source
-    // scrape (getChapterList) also populates the manga's description/metadata
+    // Tracks whether we actually scraped the source on this open. The scrape
+    // (getMangaAndChapterList) also populates the manga's description/metadata
     // server-side, so afterwards we refresh MangaWithId to pick it up (#363).
     var didSourceFetch = false;
     // Read before the await: touching ref after the async gap throws if this
@@ -79,7 +79,7 @@ class MangaChapterList extends _$MangaChapterList {
           return stored;
         }
         try {
-          final fetched = await repo.getChapterList(mangaId);
+          final fetched = await repo.getMangaAndChapterList(mangaId);
           if (fetched != null && fetched.isNotEmpty) {
             didSourceFetch = true;
             return fetched;
@@ -125,6 +125,7 @@ class MangaChapterList extends _$MangaChapterList {
         onlineFetch || ref.read(refreshChaptersFromSourceProvider).ifNull();
     // offlineDatabaseProvider throws on web; only touch it when offline is on.
     final offlineDb = ref.read(offlineReadDatabaseProvider);
+    var didSourceFetch = false;
     // Wrap in chaptersWithOfflineFallback like build() does, so an explicit
     // refresh while the device is offline serves the on-device catalog instead
     // of erroring/clearing the list.
@@ -135,8 +136,11 @@ class MangaChapterList extends _$MangaChapterList {
               return stored;
             }
             try {
-              final fetched = await repo.getChapterList(mangaId);
-              if (fetched != null && fetched.isNotEmpty) return fetched;
+              final fetched = await repo.getMangaAndChapterList(mangaId);
+              if (fetched != null && fetched.isNotEmpty) {
+                didSourceFetch = true;
+                return fetched;
+              }
             } catch (_) {
               // Source down / gone — fall back to stored instead of clearing.
             }
@@ -147,6 +151,11 @@ class MangaChapterList extends _$MangaChapterList {
           mangaId: mangaId,
         ));
     if (ref.mounted) ref.keepAlive();
+    // The scrape refreshed metadata server-side too; pick it up so pull-to-
+    // refresh updates the synopsis, not just the chapter list.
+    if (didSourceFetch && ref.mounted) {
+      ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
+    }
     // On a refresh failure keep the current chapters visible instead of
     // overwriting the list with an errored state (drops the internal
     // copyWithPrevious API the analyzer flagged).

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -62,9 +62,8 @@ class MangaChapterList extends _$MangaChapterList {
     final repo = ref.watch(mangaBookRepositoryProvider);
     final refreshFromSource =
         ref.watch(refreshChaptersFromSourceProvider).ifNull();
-    // Tracks whether we actually scraped the source on this open. The scrape
-    // (getMangaAndChapterList) also populates the manga's description/metadata
-    // server-side, so afterwards we refresh MangaWithId to pick it up (#363).
+    // getMangaAndChapterList also refreshes metadata server-side; track it so
+    // we know to refresh MangaWithId too (#363).
     var didSourceFetch = false;
     // Read before the await: touching ref after the async gap throws if this
     // provider was disposed mid-build.
@@ -100,12 +99,9 @@ class MangaChapterList extends _$MangaChapterList {
           .then((_) => reconcileManga(ref, mangaId)));
     }
     if (didSourceFetch) {
-      // The source scrape above also populated this manga's description and
-      // metadata server-side, but MangaWithId loaded BEFORE that with an empty
-      // description (the client never calls fetchManga). Refresh it so the
-      // details screen shows the metadata on first open instead of only after a
-      // manual refresh (#363). Deferred past this build so we don't invalidate a
-      // provider mid-build.
+      // MangaWithId loaded before the scrape refreshed metadata; refresh it so
+      // the synopsis shows on first open (#363). Deferred to avoid invalidating
+      // mid-build.
       Future.microtask(() {
         if (ref.mounted) ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
       });
@@ -151,8 +147,8 @@ class MangaChapterList extends _$MangaChapterList {
           mangaId: mangaId,
         ));
     if (ref.mounted) ref.keepAlive();
-    // The scrape refreshed metadata server-side too; pick it up so pull-to-
-    // refresh updates the synopsis, not just the chapter list.
+    // The scrape refreshes metadata too; pick it up so pull-to-refresh
+    // updates the synopsis, not just the chapter list.
     if (didSourceFetch && ref.mounted) {
       ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
     }


### PR DESCRIPTION
Opening a series from Browse showed its chapters but left the synopsis, author, and status blank until you added it to your library.

The detail screen was using a chapters-only fetch that no longer populates the manga's own metadata on Tachiyomix 1.6 servers. Switched to fetchMangaAndChapters on detail open, which pulls metadata and chapters together. Pull-to-refresh now refreshes the metadata too.

Targets the current server schema, no version gating.

Verified on-device against Asura Scans, and confirmed at the API level that the fetch fills in author, status, and description where the chapters-only fetch left them empty.
