### PR TITLE
Preferred scanlation groups

### DIFF
--- a/docs/architecture/manga-details-downloads.md
+++ b/docs/architecture/manga-details-downloads.md
@@ -18,8 +18,11 @@
 | `.../manga_details/widgets/chapter_list_tile.dart` | Chapter row + trailing `DownloadStatusIcon` |
 | `.../manga_details/widgets/chapter_grid_tile.dart` | Compact number tile for the grid view (read/downloaded/bookmark/in-progress states) |
 | `.../manga_details/widgets/chapter_list_mode_toggle.dart` | List/grid segmented toggle in the chapter-count header |
-| `.../manga_details/widgets/chapter_download_presets_button.dart` | Bulk-download presets (operates on the **unfiltered** list) |
-| `.../manga_details/widgets/manga_chapter_{organizer,filter,sort,display}.dart` | Filter/Sort/Display sheet (tri-state + scanlator radio; sort radios; title-vs-number display) |
+| `.../manga_details/widgets/chapter_download_presets_button.dart` | Bulk-download presets (deduped-but-unfiltered list via `mangaChapterListForBulkActionsProvider`) |
+| `.../manga_details/widgets/manga_chapter_{organizer,filter,sort,display}.dart` | Filter/Sort/Display sheet (tri-state filters + preferred-groups row + show-all-versions switch; sort radios; title-vs-number display) |
+| `.../manga_details/controller/scanlator_dedup.dart` | Pure dedup engine: winner group per chapter number, aggregate row state, duplicate-id expansion |
+| `.../manga_details/controller/scanlator_propagation.dart` | Write-side duplicate expansion (`expandIdsAcrossScanlators`) + one-time read reconciliation |
+| `.../manga_details/widgets/scanlator_preference_dialog.dart` | Ranked-groups dialog (check to prefer, drag to reorder) |
 | `manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart` | Multi-select action bar |
 | `manga_book/widgets/download_status_icon.dart` | Inline per-chapter download progress/state |
 | `.../downloads/downloads_screen.dart` (+ `controller/`, `widgets/`) | Standalone queue screen |
@@ -30,11 +33,12 @@
 
 ## Chapters & actions
 
-- Filtering/sorting is client-side in `mangaChapterListWithFilterProvider`. Filter/sort/display state is **global** (SharedPreferences); the **scanlator** filter is **per-manga** (server meta `flutter_scanlator`). `ChapterSort`: `source`, `fetchedDate`, `uploadDate`, `chapterNumber`, `alphabetical` (enum indices are persisted — append new values last). `ChapterDisplay` (`sourceTitle` | `chapterNumber`) swaps the tile title between `chapter.name` and a formatted "Chapter N" (Komikku-style `#.###` number formatting); offline-fallback rows fake `chapterNumber` from `chapterIndex`, so number display/sort degrade to source order there.
+- Filtering/sorting is client-side in `mangaChapterListWithFilterProvider`. Filter/sort/display state is **global** (SharedPreferences); the **scanlator preference** is **per-manga** (server meta `flutter_preferredScanlators`, a ranked JSON list; legacy single-value `flutter_scanlator` is read as a one-item fallback and mirrored on write, never cleared).
+- **Preferred scanlation groups (#141):** with a non-empty preference, `applyPreferredScanlators` runs **before** the unread/downloaded/bookmarked filters — one row per chapter number (winner: reader's in-flight copy > in-progress copy > downloaded copy > highest rank > lowest `sourceOrder`; all same-group entries at a number survive), rows carry aggregate read/downloaded/bookmarked state across copies, `chapterNumber <= 0` passes through. Consumers inherit it from the one provider (list, reader chain via `keepChapterId`, resume, delete-on-read). Write actions expand to every same-number copy (`scanlator_propagation.dart`); setting a preference reconciles historical reads once. No offline gate: catalog rows have unique fabricated numbers, so dedup no-ops on offline data structurally. `ChapterSort`: `source`, `fetchedDate`, `uploadDate`, `chapterNumber`, `alphabetical` (enum indices are persisted — append new values last). `ChapterDisplay` (`sourceTitle` | `chapterNumber`) swaps the tile title between `chapter.name` and a formatted "Chapter N" (Komikku-style `#.###` number formatting); offline-fallback rows fake `chapterNumber` from `chapterIndex`, so number display/sort degrade to source order there.
 - **List vs grid** (`ChapterListMode`) is **per-manga** (server meta `flutter_chapterListMode`, default list) via `mangaChapterListModeProvider`. Grid tiles show the chapter number only (`ChapterGridTile.label`: whole numbers drop `.0`, unparsed fall back to `#sourceOrder`); states = dim read, gradient dot downloaded, bookmark icon, gradient ring + page marker on the in-progress chapter. Same tap/long-press/right-click semantics as list rows.
 - Tile: tap → reader; long-press / right-click → multi-select.
 - Multi-select bar: bookmark add/remove, mark-previous-read, mark read (`lastPageRead: 0`), mark unread, download, delete — then clears selection + refreshes.
-- **Bulk-download presets** operate on the **full unfiltered** list: sort by `chapterNumber` asc, find highest read, walk forward collecting un-downloaded IDs ("Next N" skips downloaded).
+- **Bulk-download presets** operate on the **deduped-but-unfiltered** list (`mangaChapterListForBulkActionsProvider`; raw when no preference/show-all/offline): sort by `chapterNumber` asc, find highest read, walk forward collecting un-downloaded IDs ("Next N" skips downloaded).
 - Single vs bulk: `SingleChapterActionIcon` → `putChapter`; `MultiChaptersActionIcon` → `modifyBulkChapters` (`UpdateChapters`).
 
 ## Downloads
@@ -46,7 +50,9 @@ Two-source state: `downloadStatusProvider` polls `GetDownloadStatus` for the ini
 - **Bottom inset for the multi-select bar** must be read from `View.of(context).viewPadding.bottom / devicePixelRatio` — inside the shell nav, `MediaQuery` padding/viewPadding report 0 for the bottom-sheet's descendants. (Upstream PR #381.)
 - **`fetchChapters` is a mutation** — it triggers a source fetch, not a DB read. Use `query$Chapters` for a local-only lookup.
 - **Download presets use the unfiltered list** and compute from the highest **read** chapter by `chapterNumber`, independent of UI sort.
-- **Scanlator "no filter" sentinel is the string `"flutter_scanlator"`**, not `null`.
+- **Scanlator "no filter" sentinel is the string `"flutter_scanlator"`**, not `null` (legacy key; still mirrored for older installs).
+- **`setPreference` reports success once the server writes land** — local refresh (state publish, invalidates, reconciliation) is best-effort and must never block or fail the save acknowledgment.
+- **Dedup selection treats `!(chapterNumber > 0)` as unnumbered** — the negated form is NaN-safe; "simplifying" to `<= 0` reintroduces a vanishing-chapter bug.
 - **`DownloadStatusIcon` `FINISHED` refresh uses `Future.microtask`** — removing it causes "setState during build".
 - **`downloadsMapProvider` throws `UnimplementedError` on an unknown `DownloadUpdateType`** — a new server state crashes the subscription listener until handled.
 - **Two distinct GraphQL clients** (query + subscription) — auth/interceptor changes must touch both in `global_providers.dart`.

--- a/lib/src/features/history/presentation/widgets/history_item_tile.dart
+++ b/lib/src/features/history/presentation/widgets/history_item_tile.dart
@@ -192,7 +192,7 @@ class HistoryItemTile extends ConsumerWidget {
     ref.read(mangaChapterFilterUnreadProvider);
     ref.read(mangaChapterFilterDownloadedProvider);
     ref.read(mangaChapterFilterBookmarkedProvider);
-    ref.read(mangaChapterFilterScanlatorProvider(mangaId: item.mangaId));
+    ref.read(mangaPreferredScanlatorsProvider(mangaId: item.mangaId));
   }
 
   void _navigateToReader(BuildContext context, WidgetRef ref) {

--- a/lib/src/features/manga_book/domain/manga/manga_model.dart
+++ b/lib/src/features/manga_book/domain/manga/manga_model.dart
@@ -85,6 +85,11 @@ abstract class MangaMeta with _$MangaMeta {
     int? rating,
     @JsonKey(name: "flutter_tags", fromJson: MangaMeta.fromJsonToStringList)
     List<String>? userTags,
+    @JsonKey(
+      name: "flutter_preferredScanlators",
+      fromJson: MangaMeta.fromJsonToStringList,
+    )
+    List<String>? preferredScanlators,
   }) = _MangaMeta;
 
   static bool? fromJsonToBool(dynamic val) => val != null && val is String
@@ -126,6 +131,7 @@ enum MangaMetaKeys {
   chapterListMode("flutter_chapterListMode"),
   rating("flutter_rating"),
   tags("flutter_tags"),
+  preferredScanlators("flutter_preferredScanlators"),
   ;
 
   const MangaMetaKeys(this.key);

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -23,6 +23,8 @@ import '../../../../library/presentation/library/controller/library_manga_list.d
 import '../../../data/manga_book/manga_book_repository.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/manga/manga_model.dart';
+import 'scanlator_dedup.dart';
+import 'scanlator_propagation.dart';
 
 part 'manga_details_controller.g.dart';
 
@@ -188,34 +190,75 @@ Set<String> mangaScanlatorList(Ref ref, {required int mangaId}) {
   chapterList.whenData((data) {
     if (data == null) return;
     for (final chapter in data) {
-      if (chapter.scanlator.isNotBlank) {
-        scanlatorList.add(chapter.scanlator!);
-      }
+      scanlatorList.add(scanlatorGroupOf(chapter));
     }
   });
   return scanlatorList;
 }
 
+/// Effective per-series preferred scanlation groups (issue #141).
+/// Read path: new JSON-list key, else the legacy single-scanlator key as a
+/// one-item list (never written back from here — no writes on read paths).
 @riverpod
-class MangaChapterFilterScanlator extends _$MangaChapterFilterScanlator {
+class MangaPreferredScanlators extends _$MangaPreferredScanlators {
   @override
-  String build({required int mangaId}) {
-    final manga = ref.watch(mangaWithIdProvider(mangaId: mangaId));
-    return manga.value?.metaData.scanlator ?? MangaMetaKeys.scanlator.key;
+  List<String> build({required int mangaId}) {
+    final meta =
+        ref.watch(mangaWithIdProvider(mangaId: mangaId)).value?.metaData;
+    final stored = meta?.preferredScanlators;
+    if (stored != null) return stored;
+    final legacy = meta?.scanlator;
+    // The legacy key's own name doubles as its "no filter" sentinel value.
+    if (legacy == null || legacy == MangaMetaKeys.scanlator.key) {
+      return const [];
+    }
+    return [legacy];
   }
 
-  void update(String? scanlator) async {
-    await AsyncValue.guard(
-      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
-            mangaId: mangaId,
-            key: MangaMetaKeys.scanlator.key,
-            value: scanlator ?? MangaMetaKeys.scanlator.key,
-          ),
-    );
-    if (!ref.mounted) return;
-    ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
-    state = scanlator ?? MangaMetaKeys.scanlator.key;
+  /// Returns whether the server writes succeeded, so the dialog can surface
+  /// a failure instead of closing over silently-unsaved state.
+  Future<bool> setPreference(List<String> groups) async {
+    final repo = ref.read(mangaBookRepositoryProvider);
+    final result = await AsyncValue.guard(() async {
+      await repo.patchMangaMeta(
+        mangaId: mangaId,
+        key: MangaMetaKeys.preferredScanlators.key,
+        value: jsonEncode(groups),
+      );
+      // Mirror rank-1 into the legacy key so older installs keep a sane filter.
+      await repo.patchMangaMeta(
+        mangaId: mangaId,
+        key: MangaMetaKeys.scanlator.key,
+        value: groups.isNotEmpty ? groups.first : MangaMetaKeys.scanlator.key,
+      );
+    });
+    if (result.hasError) return false;
+    // Write succeeded; treat the refresh below as best-effort.
+    try {
+      if (ref.mounted) {
+        state = groups;
+        ref.invalidate(mangaWithIdProvider(mangaId: mangaId));
+        if (groups.isEmpty) {
+          // Stale ON would silently resume show-all on the next preference.
+          ref.invalidate(
+              mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+        } else {
+          unawaited(AsyncValue.guard(
+              () => reconcileReadAcrossScanlators(ref, mangaId: mangaId)));
+        }
+      }
+    } catch (_) {}
+    return true;
   }
+}
+
+/// Session-scoped "Show all versions" escape hatch. autoDispose: resets once
+/// the series screen and any reader on it stop watching.
+@riverpod
+class MangaShowAllScanlatorVersions extends _$MangaShowAllScanlatorVersions {
+  @override
+  bool build({required int mangaId}) => false;
+  void update(bool value) => state = value;
 }
 
 /// List vs grid presentation for the chapter list, per-series in the manga
@@ -312,6 +355,7 @@ class MangaUserTags extends _$MangaUserTags {
 AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
   Ref ref, {
   required int mangaId,
+  int? keepChapterId,
 }) {
   final chapterList = ref.watch(mangaChapterListProvider(mangaId: mangaId));
   final chapterFilterUnread = ref.watch(mangaChapterFilterUnreadProvider);
@@ -323,8 +367,13 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
   final sortedDirection =
       ref.watch(mangaChapterSortDirectionProvider).ifNull(true);
 
-  final chapterFilterScanlator =
-      ref.watch(mangaChapterFilterScanlatorProvider(mangaId: mangaId));
+  final preferredScanlators =
+      ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+  final showAllVersions =
+      ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+  // No offline gate: catalog rows have unique fabricated numbers, so dedup
+  // can't collapse them anyway.
+  final dedupActive = preferredScanlators.isNotEmpty && !showAllVersions;
 
   bool applyChapterFilter(ChapterDto chapter) {
     if (chapterFilterUnread != null &&
@@ -342,10 +391,6 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
       return false;
     }
 
-    if (chapterFilterScanlator != MangaMetaKeys.scanlator.key &&
-        chapter.scanlator != chapterFilterScanlator) {
-      return false;
-    }
     return true;
   }
 
@@ -368,9 +413,35 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
     return result != 0 ? result : m1.index.compareTo(m2.index);
   }
 
+  return chapterList.copyWithData((data) {
+    var list = data ?? const <ChapterDto>[];
+    if (dedupActive) {
+      // Dedup BEFORE filters: filters must see aggregate row state, or an
+      // unread filter would strip a read copy and silently swap the winner.
+      list = applyPreferredScanlators(list, preferredScanlators,
+          keepChapterId: keepChapterId);
+    }
+    return [...list.where(applyChapterFilter)]..sort(applyChapterSort);
+  });
+}
+
+/// Deduped-but-unfiltered list for bulk actions (download presets): presets
+/// must count chapters, not duplicate copies.
+@riverpod
+AsyncValue<List<ChapterDto>?> mangaChapterListForBulkActions(
+  Ref ref, {
+  required int mangaId,
+}) {
+  final chapterList = ref.watch(mangaChapterListProvider(mangaId: mangaId));
+  final preferred =
+      ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+  final showAll =
+      ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+  // No offline gate — see mangaChapterListWithFilter: catalog rows can't
+  // collapse (unique fabricated numbers).
+  if (preferred.isEmpty || showAll) return chapterList;
   return chapterList.copyWithData(
-    (data) => [...?data?.where(applyChapterFilter)]..sort(applyChapterSort),
-  );
+      (data) => data == null ? null : applyPreferredScanlators(data, preferred));
 }
 
 @riverpod
@@ -406,7 +477,8 @@ ChapterDto? firstUnreadInFilteredChapterList(
   final isAscSorted = ref.watch(mangaChapterSortDirectionProvider) ??
       DBKeys.chapterSortDirection.initial;
   final filteredList = ref
-      .watch(mangaChapterListWithFilterProvider(mangaId: mangaId))
+      .watch(mangaChapterListWithFilterProvider(
+          mangaId: mangaId, keepChapterId: chapterId))
       .value;
   if (filteredList == null) {
     return null;

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:collection/collection.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../domain/chapter/chapter_model.dart';
+// The generated copyWith is an extension; it must be imported directly.
+import '../../../domain/chapter/graphql/__generated__/fragment.graphql.dart';
+
+/// Group key for chapters with no scanlator; displayed via l10n as "Unknown".
+const String kUnknownScanlatorGroup = '';
+
+String scanlatorGroupOf(ChapterDto c) =>
+    c.scanlator.isNotBlank ? c.scanlator! : kUnknownScanlatorGroup;
+
+/// One row per chapter number when [preferred] is non-empty.
+///
+/// Winner group per number: the in-flight copy ([keepChapterId], so an open
+/// reader never loses its chapter), else an in-progress copy, else a
+/// downloaded copy, else the highest-ranked group in [preferred] covering the
+/// number, else the copy the source lists first. All of the winning group's
+/// entries at that number survive (split chapters / v2 re-uploads share a
+/// number). Rows carry aggregate read/downloaded/bookmarked state across ALL
+/// copies of the number. Entries with chapterNumber <= 0 pass through.
+List<ChapterDto> applyPreferredScanlators(
+  List<ChapterDto> chapters,
+  List<String> preferred, {
+  int? keepChapterId,
+}) {
+  if (preferred.isEmpty) return chapters;
+
+  final byNumber = <double, List<ChapterDto>>{};
+  for (final c in chapters) {
+    if (c.chapterNumber > 0) {
+      byNumber.putIfAbsent(c.chapterNumber, () => []).add(c);
+    }
+  }
+
+  final winnersByNumber = <double, String>{};
+  for (final entry in byNumber.entries) {
+    final copies = entry.value;
+    final kept = keepChapterId == null
+        ? null
+        : copies.firstWhereOrNull((c) => c.id == keepChapterId);
+    final inProgress =
+        copies.firstWhereOrNull((c) => !c.isRead && c.lastPageRead > 0);
+    final downloaded = copies.firstWhereOrNull((c) => c.isDownloaded);
+    String? winner;
+    if (kept != null) {
+      winner = scanlatorGroupOf(kept);
+    } else if (inProgress != null) {
+      winner = scanlatorGroupOf(inProgress);
+    } else if (downloaded != null) {
+      winner = scanlatorGroupOf(downloaded);
+    } else {
+      winner = preferred.firstWhereOrNull(
+          (g) => copies.any((c) => scanlatorGroupOf(c) == g));
+      winner ??= scanlatorGroupOf(
+          copies.reduce((a, b) => a.sourceOrder <= b.sourceOrder ? a : b));
+    }
+    winnersByNumber[entry.key] = winner;
+  }
+
+  return [
+    for (final c in chapters)
+      // Negated: `!(x > 0)` also catches NaN, unlike `x <= 0`.
+      if (!(c.chapterNumber > 0))
+        c
+      else if (scanlatorGroupOf(c) == winnersByNumber[c.chapterNumber])
+        c.copyWith(
+          isRead: byNumber[c.chapterNumber]!.any((x) => x.isRead),
+          isDownloaded:
+              byNumber[c.chapterNumber]!.any((x) => x.isDownloaded),
+          isBookmarked:
+              byNumber[c.chapterNumber]!.any((x) => x.isBookmarked),
+        ),
+  ];
+}
+
+/// Ids of every copy sharing [chapterId]'s chapter number (self included).
+/// Number <= 0 or unknown id: just the id itself.
+List<int> duplicateChapterIds(List<ChapterDto> allChapters, int chapterId) {
+  final chapter = allChapters.firstWhereOrNull((c) => c.id == chapterId);
+  // Same NaN-safe negation as applyPreferredScanlators.
+  if (chapter == null || !(chapter.chapterNumber > 0)) return [chapterId];
+  return [
+    for (final c in allChapters)
+      if (c.chapterNumber == chapter.chapterNumber) c.id,
+  ];
+}
+
+/// Write-side union of every same-number copy for each id (self included).
+/// Identity when the raw list is unavailable.
+List<int> expandIdsForDuplicates(
+  List<ChapterDto>? allChapters,
+  List<int> chapterIds,
+) {
+  if (allChapters == null) return chapterIds;
+  final out = <int>{};
+  for (final id in chapterIds) {
+    out.addAll(duplicateChapterIds(allChapters, id));
+  }
+  return out.toList();
+}
+
+/// Unread copies whose chapter number has at least one read copy — the
+/// one-time catch-up set when a preference is set on a series with history.
+List<int> reconcileIdsForReadNumbers(List<ChapterDto> allChapters) {
+  final readNumbers = <double>{
+    for (final c in allChapters)
+      if (c.isRead && c.chapterNumber > 0) c.chapterNumber,
+  };
+  return [
+    for (final c in allChapters)
+      if (!c.isRead && readNumbers.contains(c.chapterNumber)) c.id,
+  ];
+}

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../data/manga_book/manga_book_repository.dart';
+import '../../../domain/chapter_batch/chapter_batch_model.dart';
+import 'manga_details_controller.dart';
+import 'scanlator_dedup.dart';
+
+/// Write-side counterpart of the deduped view, for widget call sites.
+/// Identity when the series has no preference.
+List<int> expandIdsAcrossScanlators(
+  WidgetRef ref, {
+  required int mangaId,
+  required List<int> chapterIds,
+}) {
+  if (ref.read(mangaPreferredScanlatorsProvider(mangaId: mangaId)).isEmpty) {
+    return chapterIds;
+  }
+  return expandIdsForDuplicates(
+    ref.read(mangaChapterListProvider(mangaId: mangaId)).value,
+    chapterIds,
+  );
+}
+
+/// One-time catch-up when a preference is set: copies of already-read numbers
+/// get marked read so badges/other clients converge.
+Future<void> reconcileReadAcrossScanlators(
+  Ref ref, {
+  required int mangaId,
+}) async {
+  final all = ref.read(mangaChapterListProvider(mangaId: mangaId)).value;
+  if (all == null) return;
+  final ids = reconcileIdsForReadNumbers(all);
+  if (ids.isEmpty) return;
+  await ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
+        // lastPageRead reset matches the bulk mark-read action's shape.
+        ChapterBatch(
+            ids: ids, patch: ChapterChange(isRead: true, lastPageRead: 0)),
+      );
+  ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
+}

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -44,8 +44,10 @@ class MangaDetailsScreen extends HookConsumerWidget {
         mangaChapterListWithFilterProvider(mangaId: mangaId);
 
     final manga = ref.watch(mangaProvider);
-    final chapterList = ref.watch(chapterListProvider);
     final filteredChapterList = ref.watch(chapterListFilteredProvider);
+    final bulkActionsChapterList = ref.watch(
+      mangaChapterListForBulkActionsProvider(mangaId: mangaId),
+    );
     final firstUnreadChapter = ref.watch(
       firstUnreadInFilteredChapterListProvider(mangaId: mangaId),
     );
@@ -273,7 +275,7 @@ class MangaDetailsScreen extends HookConsumerWidget {
                             )
                           ],
                           ChapterDownloadPresetsButton(
-                            chapterList: chapterList,
+                            chapterList: bulkActionsChapterList,
                             refresh: refresh,
                           ),
                           Builder(

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
@@ -20,7 +20,8 @@ class ChapterDownloadPresetsButton extends ConsumerWidget {
     required this.refresh,
   });
 
-  /// The full (unfiltered) chapter list as the screen has it.
+  /// Chapter list for preset computation: deduped one-row-per-chapter when a
+  /// scanlator preference is active, otherwise the full raw list.
   final AsyncValue<List<ChapterDto>?> chapterList;
 
   /// Callback to re-fetch chapters after a successful enqueue.

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_filter.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_chapter_filter.dart
@@ -9,8 +9,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../widgets/custom_checkbox_list_tile.dart';
-import '../../../domain/manga/manga_model.dart';
 import '../controller/manga_details_controller.dart';
+import '../controller/scanlator_dedup.dart';
+import 'scanlator_preference_dialog.dart';
 
 class MangaChapterFilter extends ConsumerWidget {
   const MangaChapterFilter({super.key, required this.mangaId});
@@ -19,8 +20,10 @@ class MangaChapterFilter extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final scanlatorList =
         ref.watch(mangaScanlatorListProvider(mangaId: mangaId));
-    final selectedScanlator =
-        ref.watch(mangaChapterFilterScanlatorProvider(mangaId: mangaId));
+    final preferred =
+        ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+    final showAll =
+        ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
     return ListView(
       children: [
         CustomCheckboxListTile(
@@ -40,7 +43,9 @@ class MangaChapterFilter extends ConsumerWidget {
           onChanged:
               ref.read(mangaChapterFilterDownloadedProvider.notifier).update,
         ),
-        if (scanlatorList.isNotBlank && scanlatorList.length > 1) ...[
+        // Unknown-inclusive: a series with one named group plus blanks still
+        // needs the section, since Unknown must be rankable too.
+        if (scanlatorList.length > 1) ...[
           ListTile(
             title: Text(
               context.l10n.scanlators,
@@ -48,25 +53,35 @@ class MangaChapterFilter extends ConsumerWidget {
             ),
             dense: true,
           ),
-          RadioListTile(
-            title: Text(context.l10n.allScanlators),
-            value: MangaMetaKeys.scanlator.key,
-            groupValue: selectedScanlator,
-            onChanged: (val) => ref
-                .read(mangaChapterFilterScanlatorProvider(mangaId: mangaId)
-                    .notifier)
-                .update(val),
-          ),
-          for (final scanlator in scanlatorList)
-            RadioListTile(
-              title: Text(scanlator),
-              value: scanlator,
-              groupValue: selectedScanlator,
-              onChanged: (val) => ref
-                  .read(mangaChapterFilterScanlatorProvider(mangaId: mangaId)
-                      .notifier)
-                  .update(val),
+          ListTile(
+            title: Text(context.l10n.preferredScanlationGroups),
+            subtitle: Text(
+              preferred.isEmpty
+                  ? context.l10n.noGroupPreference
+                  : preferred
+                      .map((g) => g == kUnknownScanlatorGroup
+                          ? context.l10n.unknownScanlator
+                          : g)
+                      .join(', '),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
             ),
+            onTap: () => showDialog(
+              context: context,
+              builder: (_) => ScanlatorPreferenceDialog(mangaId: mangaId),
+            ),
+          ),
+          SwitchListTile(
+            title: Text(context.l10n.showAllChapterVersions),
+            value: showAll,
+            onChanged: preferred.isEmpty
+                ? null
+                : ref
+                    .read(mangaShowAllScanlatorVersionsProvider(
+                            mangaId: mangaId)
+                        .notifier)
+                    .update,
+          ),
         ],
       ],
     );

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/scanlator_preference_dialog.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/scanlator_preference_dialog.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/misc/toast/toast.dart';
+import '../controller/manga_details_controller.dart';
+import '../controller/scanlator_dedup.dart';
+
+/// Set-once ranking dialog for issue #141's preferred-scanlator-groups
+/// feature: checked groups (in drag order) become the preference; unchecked
+/// groups fall back to source order at dedup time.
+class ScanlatorPreferenceDialog extends HookConsumerWidget {
+  const ScanlatorPreferenceDialog({super.key, required this.mangaId});
+  final int mangaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final derived = ref.watch(mangaScanlatorListProvider(mangaId: mangaId));
+    final saved =
+        ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+    // Union: a ranked group whose chapters vanished from the source must stay
+    // visible so it can be unranked.
+    final allGroups = {...derived, ...saved};
+    final ranked = useState<List<String>>([...saved]);
+
+    String label(String g) =>
+        g == kUnknownScanlatorGroup ? context.l10n.unknownScanlator : g;
+
+    final unranked = [
+      for (final g in allGroups)
+        if (!ranked.value.contains(g)) g,
+    ]..sort(
+        (a, b) => label(a).toLowerCase().compareTo(label(b).toLowerCase()));
+
+    return AlertDialog(
+      title: Text(context.l10n.preferredScanlationGroups),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            Text(
+              context.l10n.preferredGroupsHint,
+              style: context.textTheme.bodySmall,
+            ),
+            if (ranked.value.isNotEmpty)
+              ReorderableListView(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                buildDefaultDragHandles: true,
+                onReorder: (oldIndex, newIndex) {
+                  final list = [...ranked.value];
+                  if (newIndex > oldIndex) newIndex--;
+                  list.insert(newIndex, list.removeAt(oldIndex));
+                  ranked.value = list;
+                },
+                children: [
+                  for (final g in ranked.value)
+                    CheckboxListTile(
+                      key: ValueKey('ranked-$g'),
+                      value: true,
+                      title: Text(label(g)),
+                      controlAffinity: ListTileControlAffinity.leading,
+                      onChanged: (_) =>
+                          ranked.value = [...ranked.value]..remove(g),
+                    ),
+                ],
+              ),
+            for (final g in unranked)
+              CheckboxListTile(
+                key: ValueKey('unranked-$g'),
+                value: false,
+                title: Text(label(g)),
+                controlAffinity: ListTileControlAffinity.leading,
+                onChanged: (_) => ranked.value = [...ranked.value, g],
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(context.l10n.cancel),
+        ),
+        TextButton(
+          onPressed: () async {
+            var ok = false;
+            try {
+              ok = await ref
+                  .read(mangaPreferredScanlatorsProvider(mangaId: mangaId)
+                      .notifier)
+                  .setPreference(ranked.value);
+            } catch (_) {}
+            if (!context.mounted) return;
+            if (!ok) {
+              ref.read(toastProvider)?.showError(
+                    context.l10n.errorSomethingWentWrong,
+                  );
+              return;
+            }
+            Navigator.of(context).pop();
+          },
+          child: Text(context.l10n.save),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -20,7 +20,6 @@ import '../../../history/presentation/history_controller.dart';
 import '../../../library/presentation/library/controller/library_controller.dart';
 import '../../../library/presentation/library/controller/library_manga_list.dart';
 import '../../../offline/data/offline_download_providers.dart';
-import '../../../offline/data/offline_repository.dart';
 import '../../../settings/presentation/general/widgets/force_portrait_tile.dart';
 import '../../../settings/presentation/incognito/incognito_mode.dart';
 import '../../../settings/presentation/reader/widgets/reader_auto_webtoon_mode/reader_auto_webtoon_mode.dart';
@@ -30,7 +29,6 @@ import '../../../settings/presentation/reader/widgets/reader_keep_screen_on_tile
 import '../../../settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart';
 import '../../../settings/presentation/reader/widgets/reader_orientation/reader_orientation.dart';
 import '../../../tracking/domain/track_progress_gate.dart';
-import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/manga/manga_model.dart';
 import '../manga_details/controller/manga_details_controller.dart';
 import 'controller/auto_webtoon.dart';
@@ -64,10 +62,6 @@ class ReaderScreen extends HookConsumerWidget {
     final ignoreSafeArea = ref.watch(readerIgnoreSafeAreaProvider).ifNull();
     final providerContainer = ProviderScope.containerOf(context, listen: false);
     final incognitoMode = ref.watch(incognitoModeProvider);
-    final offlineEnabled = ref.watch(offlineEnabledProvider);
-    final offlineDatabase =
-        offlineEnabled ? ref.watch(offlineDatabaseProvider) : null;
-    final mangaBookRepository = ref.watch(mangaBookRepositoryProvider);
 
     // Auto reading mode: a Default-mode long-strip series (manhwa/manhua/
     // webtoon) opens in webtoon scroll THIS session; never written to meta.
@@ -133,10 +127,9 @@ class ReaderScreen extends HookConsumerWidget {
 
       // Persist locally first (survives offline + app restart), then push to
       // the server; if offline it stays pending and up-syncs on reconnect.
-      final progressResult = await recordReadingProgressWithDependencies(
-        offlineEnabled: offlineEnabled,
-        offlineDatabase: offlineDatabase,
-        repository: mangaBookRepository,
+      final progressResult = await recordReadingProgress(
+        ref,
+        mangaId: mangaId,
         chapterId: chapterValue.id,
         lastPageRead: isReadingCompleted ? 0 : currentPage,
         isRead: isReadingCompleted,
@@ -175,9 +168,6 @@ class ReaderScreen extends HookConsumerWidget {
       chapter.value,
       chapterPages.value,
       incognitoMode,
-      offlineEnabled,
-      offlineDatabase,
-      mangaBookRepository,
       providerContainer,
     ]);
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
@@ -266,8 +266,13 @@ Future<void> _showChapterPicker({
             ),
             child: Consumer(
               builder: (context, ref, _) {
+                // keepChapterId: keeps the open chapter visible even if dedup
+                // would otherwise hide it.
                 final chapters = ref.watch(
-                  mangaChapterListWithFilterProvider(mangaId: mangaId),
+                  mangaChapterListWithFilterProvider(
+                    mangaId: mangaId,
+                    keepChapterId: currentChapterId,
+                  ),
                 );
                 return chapters.showUiWhenData(
                   context,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -242,6 +242,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       }
       final progressResult = await recordReadingProgress(
         ref,
+        mangaId: manga.id,
         chapterId: chapterId,
         lastPageRead: completed ? 0 : rel,
         isRead: completed,
@@ -1171,6 +1172,7 @@ void _markChapterRead(
   // silently lost.
   unawaited(recordReadingProgress(
     ref,
+    mangaId: mangaId,
     chapterId: chapter.id,
     lastPageRead: 0,
     isRead: true,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -229,6 +229,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       }
       final progressResult = await recordReadingProgress(
         ref,
+        mangaId: manga.id,
         chapterId: chapterId,
         lastPageRead: completed ? 0 : rel,
         isRead: completed,
@@ -303,12 +304,9 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         final lc = loadedById(p.chapterId);
         final pageCount = lc?.pages.pages.length ?? 0;
         final isCompletion = pageCount > 0 && p.rel >= pageCount - 1;
-        // Flush through the offline-safe path — the on-device catalog when
-        // downloaded, otherwise the server repository — so leaving mid-chapter
-        // saves the spot even with offline disabled (the single-chapter reader
-        // did this via its PopScope flush; the offline-DB-only flush dropped it).
-        // Fire-and-forget teardown flush; ignore() swallows any local-write
-        // throw (the server push is already guarded internally).
+        // Fire-and-forget so leaving mid-chapter still saves the spot; no
+        // scanlator-duplicate expansion here since this only persists a
+        // position, not a completion.
         recordReadingProgressWithDependencies(
           offlineEnabled: offlineEnabledForFlush,
           offlineDatabase: offlineDbForFlush,
@@ -741,6 +739,7 @@ void _markChapterRead(
   completedChapterIds.value = {...completedChapterIds.value, chapter.id};
   unawaited(recordReadingProgress(
     ref,
+    mangaId: mangaId,
     chapterId: chapter.id,
     lastPageRead: 0,
     isRead: true,

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -74,7 +74,9 @@ class MultiChaptersActionIcon extends ConsumerWidget {
             ref,
             chapterIds: idsForWrite,
             isRead: change.isRead!,
-            resetPosition: change.lastPageRead == 0 && change.isRead == true,
+            // Also true on mark-unread — stale progress there still reads
+            // as in-progress.
+            resetPosition: change.lastPageRead == 0,
           );
           if (!ok && context.mounted && !ref.read(offlineActiveProvider)) {
             ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -18,6 +18,7 @@ import '../../../tracking/domain/track_progress_gate.dart';
 import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/chapter/chapter_model.dart';
 import '../../domain/chapter_batch/chapter_batch_model.dart';
+import '../../presentation/manga_details/controller/scanlator_propagation.dart';
 
 class MultiChaptersActionIcon extends ConsumerWidget {
   const MultiChaptersActionIcon({
@@ -45,6 +46,23 @@ class MultiChaptersActionIcon extends ConsumerWidget {
       icon: icon ?? Icon(iconData),
       onPressed: () async {
         final ids = [for (final c in chapters) c.id];
+        // Read/unread expands to every scanlator duplicate; other patches
+        // stay per-copy.
+        final expandedByManga = <int, List<int>>{
+          if (change.isRead != null)
+            for (final mangaId in {for (final c in chapters) c.mangaId})
+              mangaId: expandIdsAcrossScanlators(
+                ref,
+                mangaId: mangaId,
+                chapterIds: [
+                  for (final c in chapters)
+                    if (c.mangaId == mangaId) c.id,
+                ],
+              ),
+        };
+        final idsForWrite = change.isRead == null
+            ? ids
+            : [for (final l in expandedByManga.values) ...l];
         final bool ok;
         if (change.isRead != null) {
           // Read/unread goes through the offline-aware write-through path: the
@@ -54,7 +72,7 @@ class MultiChaptersActionIcon extends ConsumerWidget {
           // no local fallback.
           ok = await recordReadState(
             ref,
-            chapterIds: ids,
+            chapterIds: idsForWrite,
             isRead: change.isRead!,
             resetPosition: change.lastPageRead == 0 && change.isRead == true,
           );
@@ -64,7 +82,7 @@ class MultiChaptersActionIcon extends ConsumerWidget {
         } else {
           final result = await AsyncValue.guard(
             () => ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
-                  ChapterBatch(ids: ids, patch: change),
+                  ChapterBatch(ids: idsForWrite, patch: change),
                 ),
           );
           if (context.mounted) {
@@ -85,10 +103,13 @@ class MultiChaptersActionIcon extends ConsumerWidget {
               manual: true,
             ));
           }
-          for (final c in chapters) {
-            unawaited(maybeDeleteOnManualLocal(ref, chapterId: c.id));
-            unawaited(maybeDeleteOnManualServer(ref,
-                mangaId: c.mangaId, chapterId: c.id));
+          // Expanded set: hidden duplicates get delete-on-manual-read too.
+          for (final entry in expandedByManga.entries) {
+            for (final id in entry.value) {
+              unawaited(maybeDeleteOnManualLocal(ref, chapterId: id));
+              unawaited(maybeDeleteOnManualServer(ref,
+                  mangaId: entry.key, chapterId: id));
+            }
           }
         }
         await refresh(true);

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -18,6 +18,7 @@ import '../../data/downloads/downloads_repository.dart';
 import '../../data/manga_book/manga_book_repository.dart';
 import '../../domain/chapter/chapter_model.dart';
 import '../../domain/chapter_batch/chapter_batch_model.dart';
+import '../../presentation/manga_details/controller/scanlator_propagation.dart';
 import 'multi_chapters_action_icon.dart';
 
 class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
@@ -149,16 +150,31 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
                   false;
               if (!ok) return;
             }
+            // Delete expands to every scanlator duplicate, grouped per manga.
+            final deleteIds = <int>[
+              for (final entry
+                  in {for (final c in selectedChapterDtos) c.mangaId: true}
+                      .keys)
+                ...expandIdsAcrossScanlators(
+                  ref,
+                  mangaId: entry,
+                  chapterIds: [
+                    for (final c in selectedChapterDtos)
+                      if (c.mangaId == entry) c.id,
+                  ],
+                ),
+            ];
             final result = await AsyncValue.guard(
               () => ref
                   .read(mangaBookRepositoryProvider)
-                  .deleteChapters(selectedChapterList),
+                  .deleteChapters(deleteIds),
             );
             if (context.mounted) {
               result.showToastOnError(ref.read(toastProvider));
             }
             if (!result.hasError) {
-              await cascadeServerDeleteToDevice(ref, selectedChapterList);
+              // Same expanded set (device ⊆ server).
+              await cascadeServerDeleteToDevice(ref, deleteIds);
             }
             await refresh(true);
           },

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -77,7 +77,8 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
         MultiChaptersActionIcon(
           iconData: Icons.remove_done_rounded,
           chapters: selectedChapterDtos,
-          change: ChapterChange(isRead: false),
+          // Stale progress on "unread" would still count as in-progress.
+          change: ChapterChange(isRead: false, lastPageRead: 0),
           refresh: refresh,
         ),
         IconButton(

--- a/lib/src/features/manga_book/widgets/download_status_icon.dart
+++ b/lib/src/features/manga_book/widgets/download_status_icon.dart
@@ -20,6 +20,7 @@ import '../data/manga_book/manga_book_repository.dart';
 import '../domain/chapter/chapter_model.dart';
 import '../domain/downloads/downloads_model.dart';
 import '../presentation/downloads/controller/downloads_controller.dart';
+import '../presentation/manga_details/controller/scanlator_propagation.dart';
 
 class DownloadStatusIcon extends HookConsumerWidget {
   const DownloadStatusIcon({
@@ -110,14 +111,17 @@ class DownloadStatusIcon extends HookConsumerWidget {
             // Cloud = the SERVER copy; solid indigo = "you have it".
             icon: brandGradientIcon(context, Icons.cloud_done_rounded),
             onPressed: () async {
+              final deleteIds = expandIdsAcrossScanlators(ref,
+                  mangaId: chapter.mangaId, chapterIds: [chapter.id]);
               final result = await AsyncValue.guard(
                 () => ref
                     .read(mangaBookRepositoryProvider)
-                    .deleteChapters([chapter.id]),
+                    .deleteChapters(deleteIds),
               );
               result.showToastOnError(toast);
               if (!result.hasError) {
-                await cascadeServerDeleteToDevice(ref, [chapter.id]);
+                // Same expanded set (device ⊆ server).
+                await cascadeServerDeleteToDevice(ref, deleteIds);
               }
               await newUpdatePair(ref, (value) => isLoading.value = value);
             },

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -21,6 +21,7 @@ import '../../manga_book/data/downloads/downloads_repository.dart';
 import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import '../../manga_book/presentation/manga_details/controller/scanlator_propagation.dart';
 import '../../settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
 import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
 import '../../settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
@@ -230,12 +231,13 @@ Future<void> saveChapterToDevice(WidgetRef ref, int chapterId) async {
 /// dirty flag is cleared, otherwise it stays pending for the next online sync.
 Future<AsyncValue<void>> recordReadingProgress(
   WidgetRef ref, {
+  required int mangaId,
   required int chapterId,
   required int lastPageRead,
   required bool isRead,
 }) async {
   final offline = ref.read(offlineActiveProvider);
-  return recordReadingProgressWithDependencies(
+  final result = await recordReadingProgressWithDependencies(
     offlineEnabled: offline,
     offlineDatabase: offline ? ref.read(offlineDatabaseProvider) : null,
     repository: ref.read(mangaBookRepositoryProvider),
@@ -243,6 +245,33 @@ Future<AsyncValue<void>> recordReadingProgress(
     lastPageRead: lastPageRead,
     isRead: isRead,
   );
+  // Completing a chapter also marks its hidden scanlator duplicates read, or
+  // they'd corrupt counts and resume on other clients.
+  if (isRead && !result.hasError) {
+    final siblings = expandIdsAcrossScanlators(ref,
+        mangaId: mangaId, chapterIds: [chapterId])
+      ..remove(chapterId);
+    if (siblings.isNotEmpty) {
+      final siblingsOk = await recordReadStateWithDependencies(
+        offlineEnabled: offline,
+        offlineDatabase: offline ? ref.read(offlineDatabaseProvider) : null,
+        repository: ref.read(mangaBookRepositoryProvider),
+        chapterIds: siblings,
+        isRead: true,
+        // Match the bulk mark-read action: siblings drop stale progress too.
+        resetPosition: true,
+      );
+      // No retry state for a failed sibling write — surface it rather than
+      // reporting the read as fully recorded.
+      if (!siblingsOk) {
+        return AsyncValue.error(
+          Exception('marking duplicate copies read failed'),
+          StackTrace.current,
+        );
+      }
+    }
+  }
+  return result;
 }
 
 /// Returns the server-push outcome so callers aren't blind to a failed write.

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2980,5 +2980,25 @@
     "add": "Add",
     "@add": {
         "description": "Generic button text for Add"
+    },
+    "preferredScanlationGroups": "Preferred groups",
+    "@preferredScanlationGroups": {
+        "description": "Title for the preferred scanlation groups filter-sheet row and ranking dialog"
+    },
+    "preferredGroupsHint": "Checked groups are preferred in order; chapters they don't cover fall back to other groups.",
+    "@preferredGroupsHint": {
+        "description": "Hint text explaining the preferred scanlation groups ranking dialog"
+    },
+    "noGroupPreference": "No preference",
+    "@noGroupPreference": {
+        "description": "Subtitle shown when no preferred scanlation groups are set"
+    },
+    "showAllChapterVersions": "Show all versions",
+    "@showAllChapterVersions": {
+        "description": "Switch title to show every scanlator's copy of each chapter instead of the deduped preferred version"
+    },
+    "unknownScanlator": "Unknown",
+    "@unknownScanlator": {
+        "description": "Label for chapters with no scanlator group, shown in the preferred scanlation groups dialog"
     }
 }

--- a/test/src/features/manga_book/manga_details/chapter_list_dedup_wiring_test.dart
+++ b/test/src/features/manga_book/manga_details/chapter_list_dedup_wiring_test.dart
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+import 'chapter_test_helpers.dart';
+
+class _FixedChapterList extends MangaChapterList {
+  _FixedChapterList(this.chapters);
+  final List<ChapterDto> chapters;
+  @override
+  Future<List<ChapterDto>?> build({required int mangaId}) async => chapters;
+}
+
+class _FixedPreferredScanlators extends MangaPreferredScanlators {
+  _FixedPreferredScanlators(this.groups);
+  final List<String> groups;
+  @override
+  List<String> build({required int mangaId}) => groups;
+}
+
+class _FixedShowAll extends MangaShowAllScanlatorVersions {
+  _FixedShowAll(this.value);
+  final bool value;
+  @override
+  bool build({required int mangaId}) => value;
+}
+
+class _FixedUnreadFilter extends MangaChapterFilterUnread {
+  _FixedUnreadFilter(this.value);
+  final bool? value;
+  @override
+  bool? build() => value;
+}
+
+/// Fixed manga id 1 fixture:
+/// number 1: A copy (id 1), B copy (id 2)
+/// number 2: B copy only (id 3)
+/// number 3: A copy read (id 4), B copy unread (id 5)
+/// sourceOrder ascends with id (0..4) so the default descending-by-source
+/// sort (DBKeys.chapterSortDirection.initial == false, i.e. dsc) resolves to
+/// highest sourceOrder first, unambiguously.
+final _chapters = [
+  ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+  ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+  ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
+  ch(id: 4, number: 3, scanlator: 'A', isRead: true, sourceOrder: 3),
+  ch(id: 5, number: 3, scanlator: 'B', sourceOrder: 4),
+];
+
+Future<ProviderContainer> _container({
+  List<ChapterDto>? chapters,
+  List<String> preference = const [],
+  bool showAll = false,
+  bool offline = false,
+  bool? unreadFilter,
+  int? keepChapterId,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final c = ProviderContainer(overrides: [
+    sharedPreferencesProvider.overrideWithValue(prefs),
+    mangaChapterListProvider(mangaId: 1)
+        .overrideWith(() => _FixedChapterList(chapters ?? _chapters)),
+    mangaPreferredScanlatorsProvider(mangaId: 1)
+        .overrideWith(() => _FixedPreferredScanlators(preference)),
+    mangaShowAllScanlatorVersionsProvider(mangaId: 1)
+        .overrideWith(() => _FixedShowAll(showAll)),
+    offlineActiveProvider.overrideWithValue(offline),
+    if (unreadFilter != null)
+      mangaChapterFilterUnreadProvider
+          .overrideWith(() => _FixedUnreadFilter(unreadFilter)),
+  ]);
+  addTearDown(c.dispose);
+  await c.read(mangaChapterListProvider(mangaId: 1).future);
+  return c;
+}
+
+List<int> _ids(ProviderContainer c, {int? keepChapterId}) =>
+    c
+        .read(mangaChapterListWithFilterProvider(
+            mangaId: 1, keepChapterId: keepChapterId))
+        .value!
+        .map((e) => e.id)
+        .toList();
+
+void main() {
+  test('dedup runs before filters: unread filter sees aggregate state',
+      () async {
+    // preference ['B'], unread filter ON: ch3's B row aggregates isRead=true
+    // from A's read copy (id 4) -> filtered OUT. Survivors: ch1-B(2), ch2-B(3).
+    final c = await _container(preference: const ['B'], unreadFilter: true);
+    expect(_ids(c), [3, 2]);
+  });
+
+  test('no preference -> identical to today (all copies)', () async {
+    final c = await _container();
+    expect(_ids(c), [5, 4, 3, 2, 1]);
+  });
+
+  test('show-all ON -> raw list passes through', () async {
+    final c = await _container(preference: const ['B'], showAll: true);
+    expect(_ids(c), [5, 4, 3, 2, 1]);
+  });
+
+  test('catalog-shaped rows (unique fabricated numbers) never collapse',
+      () async {
+    // The offline catalog fabricates chapterNumber from the list index, so
+    // every row has a distinct number and dedup structurally no-ops — this is
+    // the offline safety property (there is no offlineActive gate).
+    final catalogShaped = [
+      ch(id: 1, number: 0, scanlator: 'A', sourceOrder: 0),
+      ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+      ch(id: 3, number: 2, scanlator: 'A', sourceOrder: 2),
+      ch(id: 4, number: 3, scanlator: 'B', sourceOrder: 3),
+    ];
+    final c = await _container(
+        chapters: catalogShaped, preference: const ['B'], offline: true);
+    expect(_ids(c), [4, 3, 2, 1]);
+  });
+
+  test('keepChapterId surfaces a hidden copy', () async {
+    // preference ['B'], keepChapterId = ch1-A's id (1) -> ch1's row is A's
+    // copy instead of B's; ch2/ch3 dedup normally (B wins both).
+    final c = await _container(preference: const ['B']);
+    expect(_ids(c, keepChapterId: 1), [5, 3, 1]);
+  });
+
+  test('getNextAndPreviousChapters resolves neighbours from a hidden copy',
+      () async {
+    // n1: A(id 1) + B(id 2); n2: B(id 3) only. Preference ['B'] would
+    // normally hide id 1 (A loses n1 to B), but the reader chain passes
+    // its own chapterId as keepChapterId, forcing id 1 to win n1 instead
+    // -> deduped chain is [id 1, id 3].
+    final hiddenCopyChapters = [
+      ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+      ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+      ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
+    ];
+    final c = await _container(
+      chapters: hiddenCopyChapters,
+      preference: const ['B'],
+    );
+    final pair = c.read(
+      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1),
+    );
+    expect(pair, isNotNull);
+    // Default sort is source-order descending (id 3 first, id 1 last), so
+    // id 1's only neighbour (id 3) resolves as "first", not (null, null).
+    expect(pair!.first?.id, 3);
+    expect(pair.second, isNull);
+  });
+
+  test('bulk-actions list dedups but stays unfiltered', () async {
+    final c = await _container(preference: const ['B']);
+    final rows = c
+        .read(mangaChapterListForBulkActionsProvider(mangaId: 1))
+        .value!
+        .map((e) => e.id)
+        .toList();
+    expect(rows, unorderedEquals([2, 3, 5]));
+  });
+
+  test('bulk-actions list is raw when show-all is on', () async {
+    final c = await _container(preference: const ['B'], showAll: true);
+    final rows = c
+        .read(mangaChapterListForBulkActionsProvider(mangaId: 1))
+        .value!
+        .map((e) => e.id)
+        .toList();
+    expect(rows, unorderedEquals([1, 2, 3, 4, 5]));
+  });
+}

--- a/test/src/features/manga_book/manga_details/chapter_test_helpers.dart
+++ b/test/src/features/manga_book/manga_details/chapter_test_helpers.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+
+Fragment$ChapterDto ch({
+  required int id,
+  required double number,
+  String? scanlator,
+  bool isRead = false,
+  bool isDownloaded = false,
+  bool isBookmarked = false,
+  int lastPageRead = 0,
+  int sourceOrder = 0,
+}) =>
+    Fragment$ChapterDto(
+      id: id,
+      mangaId: 1,
+      name: 'Chapter $number',
+      chapterNumber: number,
+      sourceOrder: sourceOrder,
+      isRead: isRead,
+      isBookmarked: isBookmarked,
+      isDownloaded: isDownloaded,
+      lastPageRead: lastPageRead,
+      pageCount: 10,
+      fetchedAt: '0',
+      uploadDate: '0',
+      lastReadAt: '0',
+      url: '',
+      scanlator: scanlator,
+      meta: const [],
+    );

--- a/test/src/features/manga_book/manga_details/preferred_scanlators_meta_test.dart
+++ b/test/src/features/manga_book/manga_details/preferred_scanlators_meta_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+
+void main() {
+  group('MangaMeta.preferredScanlators parse', () {
+    test('decodes a JSON string array', () {
+      expect(
+        MangaMeta.fromJson({'flutter_preferredScanlators': '["A","B"]'})
+            .preferredScanlators,
+        ['A', 'B'],
+      );
+    });
+    test('null on empty / non-JSON / non-list', () {
+      expect(MangaMeta.fromJson(const {}).preferredScanlators, isNull);
+      expect(
+          MangaMeta.fromJson({'flutter_preferredScanlators': ''})
+              .preferredScanlators,
+          isNull);
+      expect(
+          MangaMeta.fromJson({'flutter_preferredScanlators': 'nope'})
+              .preferredScanlators,
+          isNull);
+      expect(
+          MangaMeta.fromJson({'flutter_preferredScanlators': '{}'})
+              .preferredScanlators,
+          isNull);
+    });
+    test('enum key matches', () {
+      expect(MangaMetaKeys.preferredScanlators.key,
+          'flutter_preferredScanlators');
+    });
+  });
+}

--- a/test/src/features/manga_book/manga_details/preferred_scanlators_provider_test.dart
+++ b/test/src/features/manga_book/manga_details/preferred_scanlators_provider_test.dart
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _RecordingRepo extends MangaBookRepository {
+  _RecordingRepo({this.failWrites = false}) : super(_dummyClient());
+  final bool failWrites;
+  final List<(int, String, dynamic)> patched = [];
+  @override
+  Future<void> patchMangaMeta({
+    required int mangaId,
+    required String key,
+    required dynamic value,
+  }) async {
+    if (failWrites) throw Exception('server unreachable');
+    patched.add((mangaId, key, value));
+  }
+}
+
+/// A manga carrying the given raw meta entries.
+class _MetaSeededManga extends MangaWithId {
+  _MetaSeededManga(this.metaEntries);
+  final List<Fragment$MangaDto$meta> metaEntries;
+  @override
+  Future<MangaDto?> build({required int mangaId}) async => Fragment$MangaDto(
+        id: mangaId,
+        title: 'M',
+        bookmarkCount: 0,
+        chapters: Fragment$MangaDto$chapters(totalCount: 0),
+        downloadCount: 0,
+        genre: const [],
+        inLibrary: true,
+        inLibraryAt: '0',
+        initialized: true,
+        meta: metaEntries,
+        sourceId: '1',
+        status: Enum$MangaStatus.ONGOING,
+        categories: Fragment$MangaDto$categories(nodes: const []),
+        trackRecords:
+            Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+        unreadCount: 0,
+        updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+        url: '/manga/$mangaId',
+      );
+}
+
+void main() {
+  Future<ProviderContainer> seeded(
+      _RecordingRepo repo, List<Fragment$MangaDto$meta> meta) async {
+    final c = ProviderContainer(overrides: [
+      mangaBookRepositoryProvider.overrideWithValue(repo),
+      mangaWithIdProvider(mangaId: 1)
+          .overrideWith(() => _MetaSeededManga(meta)),
+    ]);
+    addTearDown(c.dispose);
+    // Resolve the async manga first so the (synchronous) preference provider
+    // reads the seeded meta on its first build.
+    await c.read(mangaWithIdProvider(mangaId: 1).future);
+    return c;
+  }
+
+  group('mangaPreferredScanlatorsProvider effective value', () {
+    test('new key wins when present', () async {
+      final c = await seeded(_RecordingRepo(), [
+        Fragment$MangaDto$meta(
+            key: 'flutter_preferredScanlators', value: '["A","B"]'),
+        Fragment$MangaDto$meta(key: 'flutter_scanlator', value: 'C'),
+      ]);
+      expect(c.read(mangaPreferredScanlatorsProvider(mangaId: 1)), ['A', 'B']);
+    });
+
+    test('legacy key falls back as one-item list', () async {
+      final c = await seeded(_RecordingRepo(), [
+        Fragment$MangaDto$meta(key: 'flutter_scanlator', value: 'C'),
+      ]);
+      expect(c.read(mangaPreferredScanlatorsProvider(mangaId: 1)), ['C']);
+    });
+
+    test('legacy sentinel means no preference', () async {
+      final c = await seeded(_RecordingRepo(), [
+        Fragment$MangaDto$meta(
+            key: 'flutter_scanlator', value: 'flutter_scanlator'),
+      ]);
+      expect(c.read(mangaPreferredScanlatorsProvider(mangaId: 1)), isEmpty);
+    });
+
+    test('no keys → []', () async {
+      final c = await seeded(_RecordingRepo(), const []);
+      expect(c.read(mangaPreferredScanlatorsProvider(mangaId: 1)), isEmpty);
+    });
+  });
+
+  group('setPreference', () {
+    test('writes new key as JSON, then mirrors rank-1 into legacy key',
+        () async {
+      final repo = _RecordingRepo();
+      final c = await seeded(repo, const []);
+      final ok = await c
+          .read(mangaPreferredScanlatorsProvider(mangaId: 1).notifier)
+          .setPreference(['B', 'A']);
+      expect(ok, isTrue);
+      // Ordered: the authoritative new key writes before the legacy mirror.
+      expect(repo.patched, [
+        (1, 'flutter_preferredScanlators', jsonEncode(['B', 'A'])),
+        (1, 'flutter_scanlator', 'B'),
+      ]);
+    });
+
+    test('a failed write reports failure and publishes no local success',
+        () async {
+      final repo = _RecordingRepo(failWrites: true);
+      final c = await seeded(repo, [
+        Fragment$MangaDto$meta(key: 'flutter_scanlator', value: 'C'),
+      ]);
+      final notifier =
+          c.read(mangaPreferredScanlatorsProvider(mangaId: 1).notifier);
+      final ok = await notifier.setPreference(['B']);
+      expect(ok, isFalse);
+      // State still reflects the seeded legacy value, not the failed edit.
+      expect(c.read(mangaPreferredScanlatorsProvider(mangaId: 1)), ['C']);
+    });
+
+    test('empty preference mirrors the legacy sentinel', () async {
+      final repo = _RecordingRepo();
+      final c = await seeded(repo, const []);
+      await c
+          .read(mangaPreferredScanlatorsProvider(mangaId: 1).notifier)
+          .setPreference([]);
+      expect(repo.patched, contains((1, 'flutter_preferredScanlators', '[]')));
+      expect(
+        repo.patched,
+        contains((1, 'flutter_scanlator', 'flutter_scanlator')),
+      );
+    });
+  });
+}

--- a/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart';
+
+import 'chapter_test_helpers.dart';
+
+void main() {
+  group('applyPreferredScanlators', () {
+    test('empty preference returns list unchanged', () {
+      final list = [ch(id: 1, number: 1, scanlator: 'A'),
+                    ch(id: 2, number: 1, scanlator: 'B')];
+      expect(applyPreferredScanlators(list, const []), same(list));
+    });
+
+    test('highest-ranked group wins its chapters', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+        ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
+      ], const ['B', 'A']);
+      expect(rows.map((c) => c.id), [2, 3]);
+    });
+
+    test('falls back to next rank, then source order, when unranked', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 1),
+        ch(id: 2, number: 1, scanlator: 'C', sourceOrder: 0),
+      ], const ['B']); // B has nothing; C is listed first by the source
+      expect(rows.single.id, 2);
+    });
+
+    test('in-progress copy beats rank; downloaded beats rank', () {
+      final inProgress = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']);
+      expect(inProgress.single.id, 1);
+
+      final downloaded = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']);
+      expect(downloaded.single.id, 1);
+    });
+
+    test('a read copy does NOT beat rank (aggregate covers it)', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', isRead: true),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']);
+      expect(rows.single.id, 2);
+      expect(rows.single.isRead, isTrue); // aggregate
+    });
+
+    test('aggregate state unions read/downloaded/bookmarked across copies', () {
+      final row = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A',
+            isRead: true, isBookmarked: true),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']).single;
+      expect((row.isRead, row.isBookmarked, row.isDownloaded),
+          (true, true, false));
+    });
+
+    test('same-group siblings (split chapters/v2) all survive', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 10, scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 10, scanlator: 'A', sourceOrder: 1),
+        ch(id: 3, number: 10, scanlator: 'B', sourceOrder: 2),
+      ], const ['A']);
+      expect(rows.map((c) => c.id), [1, 2]);
+    });
+
+    test('chapterNumber <= 0 passes through undeduped', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 0, scanlator: 'A'),
+        ch(id: 2, number: 0, scanlator: 'B'),
+        ch(id: 3, number: -1, scanlator: 'A'),
+      ], const ['A']);
+      expect(rows.length, 3);
+    });
+
+    test('blank scanlator is rankable as the Unknown group', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: null),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const [kUnknownScanlatorGroup, 'B']);
+      expect(rows.single.id, 1);
+    });
+
+    test('keepChapterId forces the in-flight copy\'s group to win', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B'], keepChapterId: 1);
+      expect(rows.single.id, 1);
+    });
+
+    test('preserves input order of surviving rows', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 2, scanlator: 'A', sourceOrder: 5),
+        ch(id: 2, number: 1, scanlator: 'A', sourceOrder: 0),
+      ], const ['A']);
+      expect(rows.map((c) => c.id), [1, 2]);
+    });
+
+    test('tied in-progress copies resolve to the first in input order', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 3),
+        ch(id: 2, number: 1, scanlator: 'B', lastPageRead: 7),
+      ], const ['B']);
+      expect(rows.single.id, 1);
+    });
+
+    test('keepChapterId outranks in-progress and downloaded copies', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
+        ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
+        ch(id: 3, number: 1, scanlator: 'C'),
+      ], const ['A'], keepChapterId: 3);
+      expect(rows.single.id, 3);
+    });
+
+    test('unknown keepChapterId falls back to normal rules', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B'], keepChapterId: 99);
+      expect(rows.single.id, 2);
+    });
+
+    test('keepChapterId on a passthrough (<= 0) row changes nothing', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 0, scanlator: 'A'),
+        ch(id: 2, number: 0, scanlator: 'B'),
+        ch(id: 3, number: 1, scanlator: 'B'),
+      ], const ['B'], keepChapterId: 1);
+      expect(rows.map((c) => c.id), [1, 2, 3]);
+    });
+
+    test('aggregation preserves the winner copy\'s other fields', () {
+      final row = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', isRead: true, sourceOrder: 4),
+        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 9),
+      ], const ['B']).single;
+      expect((row.id, row.scanlator, row.sourceOrder, row.name),
+          (2, 'B', 9, 'Chapter 1.0'));
+    });
+
+    test('NaN chapter number passes through instead of vanishing', () {
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: double.nan, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']);
+      expect(rows.map((c) => c.id), [1, 2]);
+    });
+  });
+
+  group('duplicateChapterIds', () {
+    final list = [
+      ch(id: 1, number: 1, scanlator: 'A'),
+      ch(id: 2, number: 1, scanlator: 'B'),
+      ch(id: 3, number: 2, scanlator: 'A'),
+      ch(id: 4, number: 0, scanlator: 'A'),
+      ch(id: 5, number: 0, scanlator: 'B'),
+    ];
+    test('returns every copy of the chapter number, self included', () {
+      expect(duplicateChapterIds(list, 1), unorderedEquals([1, 2]));
+    });
+    test('number <= 0 returns only self', () {
+      expect(duplicateChapterIds(list, 4), [4]);
+    });
+    test('unknown id returns only itself', () {
+      expect(duplicateChapterIds(list, 99), [99]);
+    });
+    test('NaN number returns only self, never an empty list', () {
+      final withNan = [...list, ch(id: 6, number: double.nan, scanlator: 'A')];
+      expect(duplicateChapterIds(withNan, 6), [6]);
+    });
+  });
+}

--- a/test/src/features/manga_book/manga_details/scanlator_preference_dialog_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_preference_dialog_test.dart
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/widgets/scanlator_preference_dialog.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+import 'chapter_test_helpers.dart';
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _RecordingRepo extends MangaBookRepository {
+  _RecordingRepo() : super(_dummyClient());
+  final List<(int, String, dynamic)> patched = [];
+  @override
+  Future<void> patchMangaMeta({
+    required int mangaId,
+    required String key,
+    required dynamic value,
+  }) async {
+    patched.add((mangaId, key, value));
+  }
+}
+
+class _FailingRepo extends MangaBookRepository {
+  _FailingRepo() : super(_dummyClient());
+  @override
+  Future<void> patchMangaMeta({
+    required int mangaId,
+    required String key,
+    required dynamic value,
+  }) async {
+    throw Exception('server write failed');
+  }
+}
+
+/// A manga seeded with the given meta entries. keepAlive matches the real
+/// provider — without it the fake disposes between pre-warm and dialog open.
+class _FakeMangaWithId extends MangaWithId {
+  _FakeMangaWithId(this.meta);
+  final Map<String, String> meta;
+  @override
+  Future<MangaDto?> build({required int mangaId}) async {
+    ref.keepAlive();
+    return _manga(mangaId);
+  }
+
+  Fragment$MangaDto _manga(int mangaId) => Fragment$MangaDto(
+        id: mangaId,
+        title: 'M',
+        bookmarkCount: 0,
+        chapters: Fragment$MangaDto$chapters(totalCount: 0),
+        downloadCount: 0,
+        genre: const [],
+        inLibrary: true,
+        inLibraryAt: '0',
+        initialized: true,
+        meta: [
+          for (final e in meta.entries)
+            Fragment$MangaDto$meta(key: e.key, value: e.value),
+        ],
+        sourceId: '1',
+        status: Enum$MangaStatus.ONGOING,
+        categories: Fragment$MangaDto$categories(nodes: const []),
+        trackRecords:
+            Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+        unreadCount: 0,
+        updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+        url: '/manga/$mangaId',
+      );
+}
+
+class _FixedChapterList extends MangaChapterList {
+  _FixedChapterList(this.chapters);
+  final List<ChapterDto> chapters;
+  @override
+  Future<List<ChapterDto>?> build({required int mangaId}) async {
+    ref.keepAlive();
+    return chapters;
+  }
+}
+
+class _DialogHost extends ConsumerWidget {
+  const _DialogHost();
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => showDialog<void>(
+            context: context,
+            builder: (_) => const ScanlatorPreferenceDialog(mangaId: 1),
+          ),
+          child: const Text('open'),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  // number 1: A copy, B copy; number 2: no scanlator (Unknown group).
+  final chapters = [
+    ch(id: 1, number: 1, scanlator: 'A'),
+    ch(id: 2, number: 1, scanlator: 'B'),
+    ch(id: 3, number: 2, scanlator: null),
+  ];
+
+  Future<T> pumpDialog<T extends MangaBookRepository>(
+    WidgetTester tester, {
+    required T repo,
+    List<String> preference = const ['B'],
+  }) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          mangaBookRepositoryProvider.overrideWithValue(repo),
+          offlineActiveProvider.overrideWithValue(false),
+          mangaChapterListProvider(mangaId: 1)
+              .overrideWith(() => _FixedChapterList(chapters)),
+          mangaWithIdProvider(mangaId: 1).overrideWith(
+            () => _FakeMangaWithId({
+              'flutter_preferredScanlators': jsonEncode(preference),
+            }),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const _DialogHost(),
+        ),
+      ),
+    );
+
+    // Resolve the manga before opening: in the app the details screen has
+    // long since loaded it (keepAlive), so the dialog never sees a loading
+    // preference. Without this the draft rank list seeds from [].
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(_DialogHost)));
+    await container.read(mangaWithIdProvider(mangaId: 1).future);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ScanlatorPreferenceDialog), findsOneWidget);
+    return repo;
+  }
+
+  testWidgets('renders all three groups; B ranked, blank shown as Unknown',
+      (tester) async {
+    await pumpDialog(tester, repo: _RecordingRepo());
+
+    expect(find.byType(CheckboxListTile), findsNWidgets(3));
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('B'), findsOneWidget);
+    expect(find.text('Unknown'), findsOneWidget);
+
+    final rankedTile = tester
+        .widget<CheckboxListTile>(find.byKey(const ValueKey('ranked-B')));
+    expect(rankedTile.value, isTrue);
+  });
+
+  testWidgets('checking A then saving persists the new rank order',
+      (tester) async {
+    final repo = await pumpDialog(tester, repo: _RecordingRepo());
+
+    await tester.tap(find.byKey(const ValueKey('unranked-A')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(
+      repo.patched,
+      contains((1, 'flutter_preferredScanlators', '["B","A"]')),
+    );
+    expect(find.byType(ScanlatorPreferenceDialog), findsNothing);
+  });
+
+  testWidgets('a failed server write keeps the dialog open',
+      (tester) async {
+    await pumpDialog(tester, repo: _FailingRepo());
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ScanlatorPreferenceDialog), findsOneWidget);
+  });
+}

--- a/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart';
+
+import 'chapter_test_helpers.dart';
+
+void main() {
+  final chapters = [
+    ch(id: 1, number: 1, scanlator: 'A', isRead: true),
+    ch(id: 2, number: 1, scanlator: 'B'),
+    ch(id: 3, number: 2, scanlator: 'A'),
+    ch(id: 4, number: 2, scanlator: 'B'),
+  ];
+
+  group('expandIdsForDuplicates', () {
+    test('unions sibling ids per chapter number', () {
+      expect(expandIdsForDuplicates(chapters, [1]), unorderedEquals([1, 2]));
+      expect(expandIdsForDuplicates(chapters, [1, 3]),
+          unorderedEquals([1, 2, 3, 4]));
+    });
+    test('identity when the raw list is unavailable', () {
+      expect(expandIdsForDuplicates(null, [1, 3]), [1, 3]);
+    });
+  });
+
+  group('reconcileIdsForReadNumbers', () {
+    test('returns unread copies of read numbers only', () {
+      // number 1 has a read copy (id 1) → its unread sibling id 2 qualifies;
+      // number 2 has no read copy → ids 3,4 untouched.
+      expect(reconcileIdsForReadNumbers(chapters), [2]);
+    });
+    test('empty when nothing to mark', () {
+      expect(
+        reconcileIdsForReadNumbers(
+            [ch(id: 1, number: 1, scanlator: 'A')]),
+        isEmpty,
+      );
+    });
+  });
+
+  group('expandIdsForDuplicates (delete propagation)', () {
+    test('covers a hidden downloaded copy', () {
+      final downloaded = [
+        ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
+        ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
+      ];
+      expect(
+          expandIdsForDuplicates(downloaded, [1]), unorderedEquals([1, 2]));
+    });
+  });
+}


### PR DESCRIPTION
Closes #141

Aggregator sources list the same chapter from several scanlation groups, so a 10-chapter series can show 50+ rows, and the old pick-one scanlator filter dropped any chapter the chosen group never translated.

This replaces that filter with a ranked preference per series:

- Rank one or more groups in a dialog from the chapter filter sheet; the list collapses to one row per chapter, preferring your ranking and falling back to other groups so no chapter can disappear.
- Rows carry combined read/downloaded/bookmarked state across all copies, and a copy you're mid-reading or have downloaded is never swapped out from under you.
- Marking read/unread and deleting downloads apply to every duplicate copy, so hidden copies can't drift out of sync (mark-unread also resets reading position — separate commit).
- Setting a preference reconciles existing read history across copies once, so other clients and badges converge.
- "Show all versions" in the filter sheet temporarily reveals every copy; download presets count chapters, not copies.
- The old single-scanlator setting is honored as a one-item ranking and mirrored back so older installs keep working.

Existing behavior is unchanged for series without a preference. 1,254 tests pass including ~60 new ones; verified live against a duplicate-heavy series (8 groups, 51 entries → 10 rows).