### PR TITLE
Store real chapter numbers in the offline catalog

### DIFF
--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -20,8 +20,9 @@ class OfflineMangas extends Table {
   TextColumn get thumbnailUrl => text().nullable()();
   TextColumn get thumbnailRelPath => text().nullable()();
   DateTimeColumn get updatedAt => dateTime()();
-  TextColumn get keepRule => textEnum<OfflineKeepRule>()
-      .withDefault(Constant(OfflineKeepRule.off.name))();
+  TextColumn get keepRule => textEnum<OfflineKeepRule>().withDefault(
+    Constant(OfflineKeepRule.off.name),
+  )();
   IntColumn get keepUnreadCount => integer().withDefault(const Constant(3))();
 
   // Server-sourced metadata for offline filters / sort / badges / grouping.
@@ -64,8 +65,9 @@ class OfflineChapters extends Table {
   BoolColumn get isBookmarked => boolean().withDefault(const Constant(false))();
   BoolColumn get serverIsDownloaded =>
       boolean().withDefault(const Constant(false))();
-  TextColumn get deviceState => textEnum<OfflineDeviceState>()
-      .withDefault(Constant(OfflineDeviceState.none.name))();
+  TextColumn get deviceState => textEnum<OfflineDeviceState>().withDefault(
+    Constant(OfflineDeviceState.none.name),
+  )();
   IntColumn get pageCount => integer().withDefault(const Constant(0))();
   IntColumn get bytes => integer().withDefault(const Constant(0))();
   DateTimeColumn get updatedAt => dateTime()();
@@ -151,89 +153,129 @@ class OfflineDatabase extends _$OfflineDatabase {
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
-        onCreate: (m) => m.createAll(),
-        onUpgrade: (m, from, to) async {
-          // Idempotent adds: a device migrated by an intermediate/dev build can
-          // already have a column while still recording an older schema version,
-          // which would make a plain addColumn crash with "duplicate column".
-          if (from < 2) {
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.keepRule);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.keepUnreadCount);
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.pinned);
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.downloadedAt);
-          }
-          if (from < 3) {
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.progressDirty);
-          }
-          if (from < 4) {
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.lastReadAt);
-          }
-          if (from < 5) {
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.bookmarkDirty);
-          }
-          if (from < 6) {
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceId);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.sourceName);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.sourceLang);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.sourceIsNsfw);
-            await _addColumnIfMissing(m, offlineMangas, offlineMangas.status);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.unreadCount);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.downloadCount);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.bookmarkCount);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.inLibraryAt);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.latestFetchedAt);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.latestUploadedAt);
-            await _addColumnIfMissing(
-                m, offlineMangas, offlineMangas.totalChapters);
-          }
-          if (from < 7) {
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.readStateDirty);
-            // Carry pending reads across the split: a progress-dirty row with
-            // isRead=true is usually a completed offline read awaiting push
-            // (it may also be a server-sourced true on a partial re-read —
-            // pushing true is the safe direction). is_read=0 dirty rows are
-            // exactly the stale class; they stay position-only.
-            await customStatement(
-                'UPDATE offline_chapters SET read_state_dirty = 1 '
-                'WHERE progress_dirty = 1 AND is_read = 1');
-          }
-          if (from < 8) {
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.downloadGeneration);
-          }
-          if (from < 9) {
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.chapterNumber);
-            await _addColumnIfMissing(
-                m, offlineChapters, offlineChapters.scanlator);
-          }
-        },
-      );
+    onCreate: (m) => m.createAll(),
+    onUpgrade: (m, from, to) async {
+      // Idempotent adds: a device migrated by an intermediate/dev build can
+      // already have a column while still recording an older schema version,
+      // which would make a plain addColumn crash with "duplicate column".
+      if (from < 2) {
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.keepRule);
+        await _addColumnIfMissing(
+          m,
+          offlineMangas,
+          offlineMangas.keepUnreadCount,
+        );
+        await _addColumnIfMissing(m, offlineChapters, offlineChapters.pinned);
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.downloadedAt,
+        );
+      }
+      if (from < 3) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.progressDirty,
+        );
+      }
+      if (from < 4) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.lastReadAt,
+        );
+      }
+      if (from < 5) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.bookmarkDirty,
+        );
+      }
+      if (from < 6) {
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceId);
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceName);
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceLang);
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.sourceIsNsfw);
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.status);
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.unreadCount);
+        await _addColumnIfMissing(
+          m,
+          offlineMangas,
+          offlineMangas.downloadCount,
+        );
+        await _addColumnIfMissing(
+          m,
+          offlineMangas,
+          offlineMangas.bookmarkCount,
+        );
+        await _addColumnIfMissing(m, offlineMangas, offlineMangas.inLibraryAt);
+        await _addColumnIfMissing(
+          m,
+          offlineMangas,
+          offlineMangas.latestFetchedAt,
+        );
+        await _addColumnIfMissing(
+          m,
+          offlineMangas,
+          offlineMangas.latestUploadedAt,
+        );
+        await _addColumnIfMissing(
+          m,
+          offlineMangas,
+          offlineMangas.totalChapters,
+        );
+      }
+      if (from < 7) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.readStateDirty,
+        );
+        // Carry pending reads across the split: a progress-dirty row with
+        // isRead=true is usually a completed offline read awaiting push
+        // (it may also be a server-sourced true on a partial re-read —
+        // pushing true is the safe direction). is_read=0 dirty rows are
+        // exactly the stale class; they stay position-only.
+        await customStatement(
+          'UPDATE offline_chapters SET read_state_dirty = 1 '
+          'WHERE progress_dirty = 1 AND is_read = 1',
+        );
+      }
+      if (from < 8) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.downloadGeneration,
+        );
+      }
+      if (from < 9) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.chapterNumber,
+        );
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.scanlator,
+        );
+      }
+    },
+  );
 
   /// drift's [Migrator.addColumn] throws if the column already exists — a
   /// device migrated by an intermediate/dev build can have it present at an
   /// older recorded schema version, so guard each add to stay idempotent.
   Future<void> _addColumnIfMissing(
-      Migrator m, TableInfo table, GeneratedColumn column) async {
-    final info =
-        await customSelect("PRAGMA table_info('${table.actualTableName}')")
-            .get();
+    Migrator m,
+    TableInfo table,
+    GeneratedColumn column,
+  ) async {
+    final info = await customSelect(
+      "PRAGMA table_info('${table.actualTableName}')",
+    ).get();
     final exists = info.any((row) => row.read<String>('name') == column.name);
     if (!exists) await m.addColumn(table, column);
   }
@@ -259,29 +301,29 @@ class OfflineDatabase extends _$OfflineDatabase {
     String? latestFetchedAt,
     String? latestUploadedAt,
     int totalChapters = 0,
-  }) =>
-      into(offlineMangas).insertOnConflictUpdate(
-        OfflineMangasCompanion(
-          id: Value(id),
-          title: Value(title),
-          updatedAt: Value(updatedAt),
-          thumbnailUrl:
-              thumbnailUrl == null ? const Value.absent() : Value(thumbnailUrl),
-          // device-managed: thumbnailRelPath, keepRule, keepUnreadCount stay absent
-          sourceId: Value(sourceId),
-          sourceName: Value(sourceName),
-          sourceLang: Value(sourceLang),
-          sourceIsNsfw: Value(sourceIsNsfw),
-          status: Value(status),
-          unreadCount: Value(unreadCount),
-          downloadCount: Value(downloadCount),
-          bookmarkCount: Value(bookmarkCount),
-          inLibraryAt: Value(inLibraryAt),
-          latestFetchedAt: Value(latestFetchedAt),
-          latestUploadedAt: Value(latestUploadedAt),
-          totalChapters: Value(totalChapters),
-        ),
-      );
+  }) => into(offlineMangas).insertOnConflictUpdate(
+    OfflineMangasCompanion(
+      id: Value(id),
+      title: Value(title),
+      updatedAt: Value(updatedAt),
+      thumbnailUrl: thumbnailUrl == null
+          ? const Value.absent()
+          : Value(thumbnailUrl),
+      // device-managed: thumbnailRelPath, keepRule, keepUnreadCount stay absent
+      sourceId: Value(sourceId),
+      sourceName: Value(sourceName),
+      sourceLang: Value(sourceLang),
+      sourceIsNsfw: Value(sourceIsNsfw),
+      status: Value(status),
+      unreadCount: Value(unreadCount),
+      downloadCount: Value(downloadCount),
+      bookmarkCount: Value(bookmarkCount),
+      inLibraryAt: Value(inLibraryAt),
+      latestFetchedAt: Value(latestFetchedAt),
+      latestUploadedAt: Value(latestUploadedAt),
+      totalChapters: Value(totalChapters),
+    ),
+  );
 
   Future<void> upsertChapterMetadata({
     required int id,
@@ -297,28 +339,30 @@ class OfflineDatabase extends _$OfflineDatabase {
     String? lastReadAt,
     double? chapterNumber,
     String? scanlator,
-  }) =>
-      into(offlineChapters).insertOnConflictUpdate(
-        OfflineChaptersCompanion(
-          id: Value(id),
-          mangaId: Value(mangaId),
-          name: Value(name),
-          chapterIndex: Value(chapterIndex),
-          chapterNumber: Value(chapterNumber),
-          scanlator: Value(scanlator),
-          isRead: Value(isRead),
-          lastPageRead: Value(lastPageRead),
-          isBookmarked: Value(isBookmarked),
-          serverIsDownloaded: Value(serverIsDownloaded),
-          pageCount: Value(pageCount),
-          updatedAt: Value(updatedAt),
-          // lastReadAt is server-managed: always take the server's value on
-          // re-sync (absent only when an older caller doesn't supply it).
-          lastReadAt:
-              lastReadAt == null ? const Value.absent() : Value(lastReadAt),
-          // deviceState + bytes intentionally absent — device-managed.
-        ),
-      );
+  }) => into(offlineChapters).insertOnConflictUpdate(
+    OfflineChaptersCompanion(
+      id: Value(id),
+      mangaId: Value(mangaId),
+      name: Value(name),
+      chapterIndex: Value(chapterIndex),
+      // Absent when omitted (like lastReadAt): a caller that doesn't carry
+      // these must not null-clobber values a full sync already wrote.
+      chapterNumber: chapterNumber == null
+          ? const Value.absent()
+          : Value(chapterNumber),
+      scanlator: scanlator == null ? const Value.absent() : Value(scanlator),
+      isRead: Value(isRead),
+      lastPageRead: Value(lastPageRead),
+      isBookmarked: Value(isBookmarked),
+      serverIsDownloaded: Value(serverIsDownloaded),
+      pageCount: Value(pageCount),
+      updatedAt: Value(updatedAt),
+      // lastReadAt is server-managed: always take the server's value on
+      // re-sync (absent only when an older caller doesn't supply it).
+      lastReadAt: lastReadAt == null ? const Value.absent() : Value(lastReadAt),
+      // deviceState + bytes intentionally absent — device-managed.
+    ),
+  );
 
   Future<void> upsertCategory(int id, String name, int sortOrder) =>
       into(offlineCategories).insertOnConflictUpdate(
@@ -333,9 +377,9 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// Safe to call with an empty list — just removes all memberships.
   Future<void> replaceMangaCategories(int mangaId, List<int> categoryIds) =>
       transaction(() async {
-        await (delete(offlineMangaCategories)
-              ..where((t) => t.mangaId.equals(mangaId)))
-            .go();
+        await (delete(
+          offlineMangaCategories,
+        )..where((t) => t.mangaId.equals(mangaId))).go();
         for (final catId in categoryIds) {
           await into(offlineMangaCategories).insertOnConflictUpdate(
             OfflineMangaCategoriesCompanion(
@@ -354,24 +398,23 @@ class OfflineDatabase extends _$OfflineDatabase {
         offlineMangaCategories.categoryId.equalsExp(offlineCategories.id) &
             offlineMangaCategories.mangaId.equals(mangaId),
       ),
-    ])
-      ..orderBy([OrderingTerm(expression: offlineCategories.sortOrder)]);
+    ])..orderBy([OrderingTerm(expression: offlineCategories.sortOrder)]);
     return (await query.get())
         .map((row) => row.readTable(offlineCategories))
         .toList();
   }
 
   /// All persisted categories — for the offline category-list fallback.
-  Future<List<OfflineCategory>> allOfflineCategories() =>
-      (select(offlineCategories)
-            ..orderBy([(t) => OrderingTerm(expression: t.sortOrder)]))
-          .get();
+  Future<List<OfflineCategory>> allOfflineCategories() => (select(
+    offlineCategories,
+  )..orderBy([(t) => OrderingTerm(expression: t.sortOrder)])).get();
 
   // --- device-managed mutations ---------------------------------------------
 
   Future<void> setMangaCoverPath(int mangaId, String relPath) =>
-      (update(offlineMangas)..where((t) => t.id.equals(mangaId)))
-          .write(OfflineMangasCompanion(thumbnailRelPath: Value(relPath)));
+      (update(offlineMangas)..where((t) => t.id.equals(mangaId))).write(
+        OfflineMangasCompanion(thumbnailRelPath: Value(relPath)),
+      );
 
   Future<void> setKeepRule(int mangaId, OfflineKeepRule rule, int count) =>
       (update(offlineMangas)..where((t) => t.id.equals(mangaId))).write(
@@ -382,30 +425,32 @@ class OfflineDatabase extends _$OfflineDatabase {
       );
 
   Future<void> setChapterPinned(int chapterId, bool pinned) =>
-      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
-          .write(OfflineChaptersCompanion(pinned: Value(pinned)));
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        OfflineChaptersCompanion(pinned: Value(pinned)),
+      );
 
   /// Set a chapter's resolved page count — drives the determinate download
   /// progress arc for chapters (e.g. webtoon) whose total wasn't known until
   /// the downloader resolved their pages.
   Future<void> setChapterPageCount(int chapterId, int pageCount) =>
-      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
-          .write(OfflineChaptersCompanion(pageCount: Value(pageCount)));
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        OfflineChaptersCompanion(pageCount: Value(pageCount)),
+      );
 
   Future<void> setChapterDeviceState(
     int chapterId,
     OfflineDeviceState state, {
     int? bytes,
     DateTime? downloadedAt,
-  }) =>
-      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
-        OfflineChaptersCompanion(
-          deviceState: Value(state),
-          bytes: bytes == null ? const Value.absent() : Value(bytes),
-          downloadedAt:
-              downloadedAt == null ? const Value.absent() : Value(downloadedAt),
-        ),
-      );
+  }) => (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+    OfflineChaptersCompanion(
+      deviceState: Value(state),
+      bytes: bytes == null ? const Value.absent() : Value(bytes),
+      downloadedAt: downloadedAt == null
+          ? const Value.absent()
+          : Value(downloadedAt),
+    ),
+  );
 
   /// Atomically record a chapter whose page files were transferred from a
   /// migration source: rewrite the target's page rows and mark it downloaded in
@@ -418,57 +463,63 @@ class OfflineDatabase extends _$OfflineDatabase {
     required DateTime downloadedAt,
     required bool pinned,
     int? clearSourceChapterId,
-  }) =>
-      transaction(() async {
-        await (delete(offlinePages)
-              ..where((t) => t.chapterId.equals(toChapterId)))
-            .go();
-        for (final pg in pages) {
-          await into(offlinePages).insertOnConflictUpdate(
-            OfflinePagesCompanion(
-              chapterId: Value(toChapterId),
-              pageIndex: Value(pg.pageIndex),
-              relativePath: Value(pg.relPath),
-            ),
-          );
-        }
-        await (update(offlineChapters)..where((t) => t.id.equals(toChapterId)))
-            .write(OfflineChaptersCompanion(
-          deviceState: const Value(OfflineDeviceState.downloaded),
-          bytes: Value(pages.fold<int>(0, (s, p) => s + p.bytes)),
-          pageCount: Value(pages.length),
-          downloadedAt: Value(downloadedAt),
-          pinned: Value(pinned),
-        ));
-        if (clearSourceChapterId != null) {
-          await (delete(offlinePages)
-                ..where((t) => t.chapterId.equals(clearSourceChapterId)))
-              .go();
-          await (update(offlineChapters)
-                ..where((t) => t.id.equals(clearSourceChapterId)))
-              .write(const OfflineChaptersCompanion(
-            deviceState: Value(OfflineDeviceState.none),
-            bytes: Value(0),
-          ));
-        }
-      });
+  }) => transaction(() async {
+    await (delete(
+      offlinePages,
+    )..where((t) => t.chapterId.equals(toChapterId))).go();
+    for (final pg in pages) {
+      await into(offlinePages).insertOnConflictUpdate(
+        OfflinePagesCompanion(
+          chapterId: Value(toChapterId),
+          pageIndex: Value(pg.pageIndex),
+          relativePath: Value(pg.relPath),
+        ),
+      );
+    }
+    await (update(
+      offlineChapters,
+    )..where((t) => t.id.equals(toChapterId))).write(
+      OfflineChaptersCompanion(
+        deviceState: const Value(OfflineDeviceState.downloaded),
+        bytes: Value(pages.fold<int>(0, (s, p) => s + p.bytes)),
+        pageCount: Value(pages.length),
+        downloadedAt: Value(downloadedAt),
+        pinned: Value(pinned),
+      ),
+    );
+    if (clearSourceChapterId != null) {
+      await (delete(
+        offlinePages,
+      )..where((t) => t.chapterId.equals(clearSourceChapterId))).go();
+      await (update(
+        offlineChapters,
+      )..where((t) => t.id.equals(clearSourceChapterId))).write(
+        const OfflineChaptersCompanion(
+          deviceState: Value(OfflineDeviceState.none),
+          bytes: Value(0),
+        ),
+      );
+    }
+  });
 
   /// Unpin every chapter of a manga — used on Migrate so the source's kept
   /// chapters aren't held back from the post-removal purge reconcile.
   Future<void> unpinChaptersForManga(int mangaId) =>
-      (update(offlineChapters)..where((t) => t.mangaId.equals(mangaId)))
-          .write(const OfflineChaptersCompanion(pinned: Value(false)));
+      (update(offlineChapters)..where((t) => t.mangaId.equals(mangaId))).write(
+        const OfflineChaptersCompanion(pinned: Value(false)),
+      );
 
   /// Bump a chapter's persistent download generation and return the new
   /// value — called on every delete so a re-queued download outranks any
   /// still-in-flight event, and persisted so it survives a restart.
   Future<int> bumpChapterGeneration(int chapterId) => transaction(() async {
-        final current = await chapterById(chapterId);
-        final next = (current?.downloadGeneration ?? 0) + 1;
-        await (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
-            .write(OfflineChaptersCompanion(downloadGeneration: Value(next)));
-        return next;
-      });
+    final current = await chapterById(chapterId);
+    final next = (current?.downloadGeneration ?? 0) + 1;
+    await (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+      OfflineChaptersCompanion(downloadGeneration: Value(next)),
+    );
+    return next;
+  });
 
   /// Record local reading progress (read offline / always). Marks it
   /// `progressDirty` so it's pushed to the server on the next online sync.
@@ -476,19 +527,17 @@ class OfflineDatabase extends _$OfflineDatabase {
     int chapterId, {
     required int lastPageRead,
     bool? isRead,
-  }) =>
-      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
-        OfflineChaptersCompanion(
-          lastPageRead: Value(lastPageRead),
-          progressDirty: const Value(true),
-          // null → leave read-state untouched (a partial write must not
-          // un-read); a read-state change rides its OWN flag so position-only
-          // writes can't push a stale isRead (the ch-99 loop).
-          isRead: isRead == null ? const Value.absent() : Value(isRead),
-          readStateDirty:
-              isRead == null ? const Value.absent() : const Value(true),
-        ),
-      );
+  }) => (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+    OfflineChaptersCompanion(
+      lastPageRead: Value(lastPageRead),
+      progressDirty: const Value(true),
+      // null → leave read-state untouched (a partial write must not
+      // un-read); a read-state change rides its OWN flag so position-only
+      // writes can't push a stale isRead (the ch-99 loop).
+      isRead: isRead == null ? const Value.absent() : Value(isRead),
+      readStateDirty: isRead == null ? const Value.absent() : const Value(true),
+    ),
+  );
 
   /// Record a local read/unread change (list actions, mark-read). Position
   /// untouched; pushed under its own flag on the next online sync.
@@ -502,40 +551,48 @@ class OfflineDatabase extends _$OfflineDatabase {
 
   /// Clear the progress dirty flag after the progress was pushed to the server.
   Future<void> clearProgressDirty(int chapterId) =>
-      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
-          .write(const OfflineChaptersCompanion(progressDirty: Value(false)));
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        const OfflineChaptersCompanion(progressDirty: Value(false)),
+      );
 
   /// Clear the bookmark dirty flag after the bookmark was pushed to the server.
   Future<void> clearBookmarkDirty(int chapterId) =>
-      (update(offlineChapters)..where((t) => t.id.equals(chapterId)))
-          .write(const OfflineChaptersCompanion(bookmarkDirty: Value(false)));
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        const OfflineChaptersCompanion(bookmarkDirty: Value(false)),
+      );
 
   /// Clear progressDirty only if the row still holds the exact pushed values —
   /// so a newer local write landing mid-push isn't marked clean and lost (the
   /// snapshot-then-clear race); a non-matching row keeps its flag and re-syncs.
-  Future<void> clearProgressDirtyIfUnchanged(int chapterId,
-          {required int lastPageRead}) =>
-      (update(offlineChapters)
-            ..where((t) =>
-                t.id.equals(chapterId) & t.lastPageRead.equals(lastPageRead)))
+  Future<void> clearProgressDirtyIfUnchanged(
+    int chapterId, {
+    required int lastPageRead,
+  }) =>
+      (update(offlineChapters)..where(
+            (t) => t.id.equals(chapterId) & t.lastPageRead.equals(lastPageRead),
+          ))
           .write(const OfflineChaptersCompanion(progressDirty: Value(false)));
 
   /// Clear readStateDirty only if the row's isRead still matches what was
   /// pushed — the same race guard as [clearProgressDirtyIfUnchanged], mirroring
   /// [clearBookmarkDirtyIfUnchanged].
-  Future<void> clearReadStateDirtyIfUnchanged(int chapterId,
-          {required bool isRead}) =>
+  Future<void> clearReadStateDirtyIfUnchanged(
+    int chapterId, {
+    required bool isRead,
+  }) =>
       (update(offlineChapters)
             ..where((t) => t.id.equals(chapterId) & t.isRead.equals(isRead)))
           .write(const OfflineChaptersCompanion(readStateDirty: Value(false)));
 
   /// Clear bookmarkDirty only if the bookmark still matches what was pushed —
   /// same race guard as [clearProgressDirtyIfUnchanged].
-  Future<void> clearBookmarkDirtyIfUnchanged(int chapterId,
-          {required bool isBookmarked}) =>
-      (update(offlineChapters)
-            ..where((t) =>
-                t.id.equals(chapterId) & t.isBookmarked.equals(isBookmarked)))
+  Future<void> clearBookmarkDirtyIfUnchanged(
+    int chapterId, {
+    required bool isBookmarked,
+  }) =>
+      (update(offlineChapters)..where(
+            (t) => t.id.equals(chapterId) & t.isBookmarked.equals(isBookmarked),
+          ))
           .write(const OfflineChaptersCompanion(bookmarkDirty: Value(false)));
 
   /// Record a local bookmark change, marking `bookmarkDirty` (separate from
@@ -550,43 +607,45 @@ class OfflineDatabase extends _$OfflineDatabase {
       );
 
   /// Chapters whose local read progress hasn't been pushed to the server.
-  Future<List<OfflineChapter>> dirtyProgressChapters() =>
-      (select(offlineChapters)..where((t) => t.progressDirty.equals(true)))
-          .get();
+  Future<List<OfflineChapter>> dirtyProgressChapters() => (select(
+    offlineChapters,
+  )..where((t) => t.progressDirty.equals(true))).get();
 
   /// Chapters with any unpushed local change — read progress OR bookmark — for
   /// the up-sync to flush and the down-sync to preserve.
-  Future<List<OfflineChapter>> dirtyChapters() => (select(offlineChapters)
-        ..where((t) =>
-            t.progressDirty.equals(true) |
-            t.bookmarkDirty.equals(true) |
-            t.readStateDirty.equals(true)))
-      .get();
+  Future<List<OfflineChapter>> dirtyChapters() =>
+      (select(offlineChapters)..where(
+            (t) =>
+                t.progressDirty.equals(true) |
+                t.bookmarkDirty.equals(true) |
+                t.readStateDirty.equals(true),
+          ))
+          .get();
 
   // --- offline queries -------------------------------------------------------
 
-  Future<OfflineManga?> mangaById(int mangaId) =>
-      (select(offlineMangas)..where((t) => t.id.equals(mangaId)))
-          .getSingleOrNull();
+  Future<OfflineManga?> mangaById(int mangaId) => (select(
+    offlineMangas,
+  )..where((t) => t.id.equals(mangaId))).getSingleOrNull();
 
-  Future<OfflineChapter?> chapterById(int chapterId) =>
-      (select(offlineChapters)..where((t) => t.id.equals(chapterId)))
-          .getSingleOrNull();
+  Future<OfflineChapter?> chapterById(int chapterId) => (select(
+    offlineChapters,
+  )..where((t) => t.id.equals(chapterId))).getSingleOrNull();
 
-  Future<List<OfflineManga>> libraryManga() => (select(offlineMangas)
-        ..orderBy([(t) => OrderingTerm(expression: t.title)]))
-      .get();
+  Future<List<OfflineManga>> libraryManga() => (select(
+    offlineMangas,
+  )..orderBy([(t) => OrderingTerm(expression: t.title)])).get();
 
   Future<bool> hasCatalogData() async =>
       (await (select(offlineMangas)..limit(1)).get()).isNotEmpty;
 
   Future<void> clearAll() => transaction(() async {
-        await delete(offlinePages).go();
-        await delete(offlineMangaCategories).go();
-        await delete(offlineCategories).go();
-        await delete(offlineChapters).go();
-        await delete(offlineMangas).go();
-      });
+    await delete(offlinePages).go();
+    await delete(offlineMangaCategories).go();
+    await delete(offlineCategories).go();
+    await delete(offlineChapters).go();
+    await delete(offlineMangas).go();
+  });
 
   /// Sweep browsed-not-added manga a past bug wrote here: no library timestamp
   /// and nothing downloaded. Never touches downloads — a swept stray row just
@@ -594,13 +653,14 @@ class OfflineDatabase extends _$OfflineDatabase {
   Future<int> purgeNonLibraryManga() {
     final withDeviceContent = selectOnly(offlineChapters)
       ..addColumns([offlineChapters.mangaId])
-      ..where(offlineChapters.deviceState
-          .equalsValue(OfflineDeviceState.none)
-          .not());
-    return (delete(offlineMangas)
-          ..where((t) =>
+      ..where(
+        offlineChapters.deviceState.equalsValue(OfflineDeviceState.none).not(),
+      );
+    return (delete(offlineMangas)..where(
+          (t) =>
               (t.inLibraryAt.isNull() | t.inLibraryAt.equals('0')) &
-              t.id.isNotInQuery(withDeviceContent)))
+              t.id.isNotInQuery(withDeviceContent),
+        ))
         .go();
   }
 
@@ -629,15 +689,18 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// "continue reading" button; a manga with none downloaded is absent from
   /// the map.
   Future<Map<int, OfflineChapter>> firstUnreadDownloadedChapterByManga() async {
-    final rows = await (select(offlineChapters)
-          ..where((t) =>
-              t.isRead.equals(false) &
-              t.deviceState.equalsValue(OfflineDeviceState.downloaded))
-          ..orderBy([
-            (t) => OrderingTerm(expression: t.mangaId),
-            (t) => OrderingTerm(expression: t.chapterIndex),
-          ]))
-        .get();
+    final rows =
+        await (select(offlineChapters)
+              ..where(
+                (t) =>
+                    t.isRead.equals(false) &
+                    t.deviceState.equalsValue(OfflineDeviceState.downloaded),
+              )
+              ..orderBy([
+                (t) => OrderingTerm(expression: t.mangaId),
+                (t) => OrderingTerm(expression: t.chapterIndex),
+              ]))
+            .get();
     final result = <int, OfflineChapter>{};
     for (final c in rows) {
       // Rows are ordered by chapterIndex, so the first seen per manga is the
@@ -664,20 +727,21 @@ class OfflineDatabase extends _$OfflineDatabase {
 
   /// Live stream of a manga's chapter rows — drives the series download
   /// progress UI (emits as device states change during a background download).
-  Stream<List<OfflineChapter>> watchChaptersForManga(int mangaId) =>
-      (select(offlineChapters)..where((t) => t.mangaId.equals(mangaId)))
-          .watch();
+  Stream<List<OfflineChapter>> watchChaptersForManga(int mangaId) => (select(
+    offlineChapters,
+  )..where((t) => t.mangaId.equals(mangaId))).watch();
 
   /// Live stream of every chapter downloaded OR actively downloading/queued —
   /// drives the Downloads → Offline files tab, so in-progress downloads show
   /// too, not just finished ones.
   Stream<List<OfflineChapter>> watchOfflineChapters() =>
-      (select(offlineChapters)
-            ..where((t) => t.deviceState.isIn([
-                  OfflineDeviceState.downloaded.name,
-                  OfflineDeviceState.downloading.name,
-                  OfflineDeviceState.queued.name,
-                ])))
+      (select(offlineChapters)..where(
+            (t) => t.deviceState.isIn([
+              OfflineDeviceState.downloaded.name,
+              OfflineDeviceState.downloading.name,
+              OfflineDeviceState.queued.name,
+            ]),
+          ))
           .watch();
 
   /// Live list of every series with an offline footprint — chapters present
@@ -686,48 +750,62 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// nothing downloaded yet still appears, and hand-saved chapters with no
   /// rule still appear.
   Stream<List<({OfflineManga manga, int downloaded, int inFlight, int bytes})>>
-      watchOfflineSeries() {
+  watchOfflineSeries() {
     final downloaded = offlineChapters.id.count(
-        filter: offlineChapters.deviceState
-            .equalsValue(OfflineDeviceState.downloaded));
+      filter: offlineChapters.deviceState.equalsValue(
+        OfflineDeviceState.downloaded,
+      ),
+    );
     final inFlight = offlineChapters.id.count(
-        filter: offlineChapters.deviceState
-                .equalsValue(OfflineDeviceState.downloading) |
-            offlineChapters.deviceState.equalsValue(OfflineDeviceState.queued));
+      filter:
+          offlineChapters.deviceState.equalsValue(
+            OfflineDeviceState.downloading,
+          ) |
+          offlineChapters.deviceState.equalsValue(OfflineDeviceState.queued),
+    );
     final byteSum = offlineChapters.bytes.sum(
-        filter: offlineChapters.deviceState
-            .equalsValue(OfflineDeviceState.downloaded));
-    final query = select(offlineMangas).join([
-      leftOuterJoin(
-          offlineChapters, offlineChapters.mangaId.equalsExp(offlineMangas.id)),
-    ])
-      ..addColumns([downloaded, inFlight, byteSum])
-      ..groupBy(
-        [offlineMangas.id],
-        // Keep series that have files OR a rule; drop the rest of the library.
-        having: downloaded.isBiggerThanValue(0) |
-            inFlight.isBiggerThanValue(0) |
-            offlineMangas.keepRule.equalsValue(OfflineKeepRule.off).not(),
-      );
-    return query.watch().map((rows) => [
-          for (final row in rows)
-            (
-              manga: row.readTable(offlineMangas),
-              downloaded: row.read(downloaded) ?? 0,
-              inFlight: row.read(inFlight) ?? 0,
-              bytes: row.read(byteSum) ?? 0,
+      filter: offlineChapters.deviceState.equalsValue(
+        OfflineDeviceState.downloaded,
+      ),
+    );
+    final query =
+        select(offlineMangas).join([
+            leftOuterJoin(
+              offlineChapters,
+              offlineChapters.mangaId.equalsExp(offlineMangas.id),
             ),
-        ]);
+          ])
+          ..addColumns([downloaded, inFlight, byteSum])
+          ..groupBy(
+            [offlineMangas.id],
+            // Keep series that have files OR a rule; drop the rest of the library.
+            having:
+                downloaded.isBiggerThanValue(0) |
+                inFlight.isBiggerThanValue(0) |
+                offlineMangas.keepRule.equalsValue(OfflineKeepRule.off).not(),
+          );
+    return query.watch().map(
+      (rows) => [
+        for (final row in rows)
+          (
+            manga: row.readTable(offlineMangas),
+            downloaded: row.read(downloaded) ?? 0,
+            inFlight: row.read(inFlight) ?? 0,
+            bytes: row.read(byteSum) ?? 0,
+          ),
+      ],
+    );
   }
 
   /// How many pages of a chapter are already on disk. Cheap COUNT (no row
   /// materialisation) — called on the main isolate on every page completion.
   Future<int> downloadedPageCount(int chapterId) async {
     final cnt = offlinePages.pageIndex.count();
-    final row = await (selectOnly(offlinePages)
-          ..addColumns([cnt])
-          ..where(offlinePages.chapterId.equals(chapterId)))
-        .getSingle();
+    final row =
+        await (selectOnly(offlinePages)
+              ..addColumns([cnt])
+              ..where(offlinePages.chapterId.equals(chapterId)))
+            .getSingle();
     return row.read(cnt) ?? 0;
   }
 
@@ -744,30 +822,36 @@ class OfflineDatabase extends _$OfflineDatabase {
 
   /// The next chapter waiting in the queue (oldest by manga/chapter order), or
   /// null if the queue is empty.
-  Future<OfflineChapter?> nextQueuedChapter() => (select(offlineChapters)
-        ..where((t) => t.deviceState.equalsValue(OfflineDeviceState.queued))
-        ..orderBy([
-          (t) => OrderingTerm(expression: t.mangaId),
-          (t) => OrderingTerm(expression: t.chapterIndex),
-        ])
-        ..limit(1))
-      .getSingleOrNull();
+  Future<OfflineChapter?> nextQueuedChapter() =>
+      (select(offlineChapters)
+            ..where((t) => t.deviceState.equalsValue(OfflineDeviceState.queued))
+            ..orderBy([
+              (t) => OrderingTerm(expression: t.mangaId),
+              (t) => OrderingTerm(expression: t.chapterIndex),
+            ])
+            ..limit(1))
+          .getSingleOrNull();
 
   Future<List<OfflineChapter>> downloadedChaptersForManga(int mangaId) =>
-      (select(offlineChapters)
-            ..where((t) =>
+      (select(offlineChapters)..where(
+            (t) =>
                 t.mangaId.equals(mangaId) &
-                t.deviceState.equalsValue(OfflineDeviceState.downloaded)))
+                t.deviceState.equalsValue(OfflineDeviceState.downloaded),
+          ))
           .get();
 
   /// Manga ids that have at least one chapter with [OfflineDeviceState.downloaded]
   /// on this device — used by the "On device" library filter.
   Future<Set<int>> mangaIdsWithDeviceDownloads() async {
-    final rows = await (selectOnly(offlineChapters, distinct: true)
-          ..addColumns([offlineChapters.mangaId])
-          ..where(offlineChapters.deviceState
-              .equalsValue(OfflineDeviceState.downloaded)))
-        .get();
+    final rows =
+        await (selectOnly(offlineChapters, distinct: true)
+              ..addColumns([offlineChapters.mangaId])
+              ..where(
+                offlineChapters.deviceState.equalsValue(
+                  OfflineDeviceState.downloaded,
+                ),
+              ))
+            .get();
     return {for (final r in rows) r.read(offlineChapters.mangaId)!};
   }
 
@@ -775,11 +859,15 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// filesystem walk.
   Future<int> totalDownloadedBytes() async {
     final sum = offlineChapters.bytes.sum();
-    final row = await (selectOnly(offlineChapters)
-          ..addColumns([sum])
-          ..where(offlineChapters.deviceState
-              .equalsValue(OfflineDeviceState.downloaded)))
-        .getSingle();
+    final row =
+        await (selectOnly(offlineChapters)
+              ..addColumns([sum])
+              ..where(
+                offlineChapters.deviceState.equalsValue(
+                  OfflineDeviceState.downloaded,
+                ),
+              ))
+            .getSingle();
     return row.read(sum) ?? 0;
   }
 }

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -55,6 +55,10 @@ class OfflineChapters extends Table {
   // The server's per-manga ordinal (sourceOrder). Stored for display/order only;
   // never used as a stable key.
   IntColumn get chapterIndex => integer()();
+  // Real chapter number + scanlator, synced so the offline list can group
+  // scanlator duplicates (#141). Null until the row's next down-sync.
+  RealColumn get chapterNumber => real().nullable()();
+  TextColumn get scanlator => text().nullable()();
   BoolColumn get isRead => boolean().withDefault(const Constant(false))();
   IntColumn get lastPageRead => integer().withDefault(const Constant(0))();
   BoolColumn get isBookmarked => boolean().withDefault(const Constant(false))();
@@ -143,7 +147,7 @@ class OfflineDatabase extends _$OfflineDatabase {
   OfflineDatabase(super.e);
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -212,6 +216,12 @@ class OfflineDatabase extends _$OfflineDatabase {
           if (from < 8) {
             await _addColumnIfMissing(
                 m, offlineChapters, offlineChapters.downloadGeneration);
+          }
+          if (from < 9) {
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.chapterNumber);
+            await _addColumnIfMissing(
+                m, offlineChapters, offlineChapters.scanlator);
           }
         },
       );
@@ -285,6 +295,8 @@ class OfflineDatabase extends _$OfflineDatabase {
     required int pageCount,
     required DateTime updatedAt,
     String? lastReadAt,
+    double? chapterNumber,
+    String? scanlator,
   }) =>
       into(offlineChapters).insertOnConflictUpdate(
         OfflineChaptersCompanion(
@@ -292,6 +304,8 @@ class OfflineDatabase extends _$OfflineDatabase {
           mangaId: Value(mangaId),
           name: Value(name),
           chapterIndex: Value(chapterIndex),
+          chapterNumber: Value(chapterNumber),
+          scanlator: Value(scanlator),
           isRead: Value(isRead),
           lastPageRead: Value(lastPageRead),
           isBookmarked: Value(isBookmarked),

--- a/lib/src/features/offline/data/offline_dto_mappers.dart
+++ b/lib/src/features/offline/data/offline_dto_mappers.dart
@@ -153,7 +153,9 @@ ChapterDto offlineChapterToDto(OfflineChapter c) => Fragment$ChapterDto(
       id: c.id,
       mangaId: c.mangaId,
       name: c.name,
-      chapterNumber: c.chapterIndex.toDouble(),
+      // Real number when synced (lets dedup group duplicates offline, #141);
+      // index fallback for pre-v9 rows keeps numbers unique = no collapse.
+      chapterNumber: c.chapterNumber ?? c.chapterIndex.toDouble(),
       sourceOrder: c.chapterIndex,
       isRead: c.isRead,
       isBookmarked: c.isBookmarked,
@@ -164,6 +166,7 @@ ChapterDto offlineChapterToDto(OfflineChapter c) => Fragment$ChapterDto(
       uploadDate: '0',
       lastReadAt: '0',
       url: '',
+      scanlator: c.scanlator,
       meta: const <Fragment$ChapterDto$meta>[],
     );
 

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -73,6 +73,8 @@ class OfflineSync {
         mangaId: c.mangaId,
         name: c.name,
         chapterIndex: c.sourceOrder,
+        chapterNumber: c.chapterNumber,
+        scanlator: c.scanlator,
         isRead: keepReadState ? local!.isRead : c.isRead,
         lastPageRead: keepPosition ? local!.lastPageRead : c.lastPageRead,
         isBookmarked: keepBookmark ? local!.isBookmarked : c.isBookmarked,

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -54,38 +54,41 @@ class OfflineSync {
     // Preserve read progress that was updated locally but not yet pushed to the
     // server — otherwise a down-sync would overwrite it with the stale server
     // value (the up-sync pushes it; this just stops it being lost in the gap).
-    final dirty = {
-      for (final c in await _db.dirtyChapters()) c.id: c,
-    };
-    for (final c in chapters) {
-      final local = dirty[c.id];
-      // Keep a locally-changed value only while its OWN flag is still dirty;
-      // otherwise take the server's. Position, read-state, and bookmark each
-      // have their own flag, so a server change to one still lands locally
-      // while another is pending up-sync — instead of the old code pinning
-      // isRead to the stale local value whenever position was dirty (the ch-99
-      // un-read loop), and vice versa (#13).
-      final keepPosition = local?.progressDirty ?? false;
-      final keepReadState = local?.readStateDirty ?? false;
-      final keepBookmark = local?.bookmarkDirty ?? false;
-      await _db.upsertChapterMetadata(
-        id: c.id,
-        mangaId: c.mangaId,
-        name: c.name,
-        chapterIndex: c.sourceOrder,
-        chapterNumber: c.chapterNumber,
-        scanlator: c.scanlator,
-        isRead: keepReadState ? local!.isRead : c.isRead,
-        lastPageRead: keepPosition ? local!.lastPageRead : c.lastPageRead,
-        isBookmarked: keepBookmark ? local!.isBookmarked : c.isBookmarked,
-        serverIsDownloaded: c.isDownloaded,
-        pageCount: c.pageCount,
-        updatedAt: now,
-        // Server-managed: always the server's value (drives the offline
-        // "Last Read" sort). Never preserve the local one, unlike read progress.
-        lastReadAt: c.lastReadAt,
-      );
-    }
+    final dirty = {for (final c in await _db.dirtyChapters()) c.id: c};
+    // One transaction per list: an interrupted sync must not leave a manga
+    // with a mix of real and index-fallback chapter numbers — a legacy row at
+    // index N would falsely dedup-merge with a real chapter N.
+    await _db.transaction(() async {
+      for (final c in chapters) {
+        final local = dirty[c.id];
+        // Keep a locally-changed value only while its OWN flag is still dirty;
+        // otherwise take the server's. Position, read-state, and bookmark each
+        // have their own flag, so a server change to one still lands locally
+        // while another is pending up-sync — instead of the old code pinning
+        // isRead to the stale local value whenever position was dirty (the ch-99
+        // un-read loop), and vice versa (#13).
+        final keepPosition = local?.progressDirty ?? false;
+        final keepReadState = local?.readStateDirty ?? false;
+        final keepBookmark = local?.bookmarkDirty ?? false;
+        await _db.upsertChapterMetadata(
+          id: c.id,
+          mangaId: c.mangaId,
+          name: c.name,
+          chapterIndex: c.sourceOrder,
+          chapterNumber: c.chapterNumber,
+          scanlator: c.scanlator,
+          isRead: keepReadState ? local!.isRead : c.isRead,
+          lastPageRead: keepPosition ? local!.lastPageRead : c.lastPageRead,
+          isBookmarked: keepBookmark ? local!.isBookmarked : c.isBookmarked,
+          serverIsDownloaded: c.isDownloaded,
+          pageCount: c.pageCount,
+          updatedAt: now,
+          // Server-managed: always the server's value (drives the offline
+          // "Last Read" sort). Never preserve the local one, unlike read progress.
+          lastReadAt: c.lastReadAt,
+        );
+      }
+    });
 
     // Device ⊆ server: a chapter the server no longer lists (deleted there) must
     // lose its on-device copy too. Mark any FULLY-DOWNLOADED local chapter

--- a/test/src/features/offline/data/offline_chapter_number_schema_test.dart
+++ b/test/src/features/offline/data/offline_chapter_number_schema_test.dart
@@ -4,7 +4,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as raw;
 import 'package:tsumiru/src/features/offline/data/offline_database.dart';
 import 'package:tsumiru/src/features/offline/data/offline_dto_mappers.dart';
 
@@ -54,5 +58,70 @@ void main() {
     final c = await upsert(id: 12);
     final dto = offlineChapterToDto(c);
     expect((dto.chapterNumber, dto.scanlator), (12.0, null));
+  });
+
+  test('omitting the fields on a later upsert preserves synced values',
+      () async {
+    await upsert(id: 13, number: 4, scanlator: 'B');
+    final c = await upsert(id: 13); // e.g. a caller without the new fields
+    expect((c.chapterNumber, c.scanlator), (4.0, 'B'));
+  });
+
+  group('v8 -> v9 upgrade (real fixture, columns genuinely absent)', () {
+    late Directory tmp;
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('offline_v9_migration_');
+    });
+    tearDown(() => tmp.delete(recursive: true));
+
+    test('adds the columns, preserves rows, lands on version 9', () async {
+      final dbPath = p.join(tmp.path, 'test.db');
+
+      // Build a genuine v8 file: the chapters table WITHOUT the new columns,
+      // one row, user_version stamped 8. Raw sqlite so drift can't migrate it.
+      final v8 = raw.sqlite3.open(dbPath);
+      v8.execute('''
+        CREATE TABLE offline_chapters (
+          id INTEGER NOT NULL PRIMARY KEY,
+          manga_id INTEGER NOT NULL,
+          name TEXT NOT NULL,
+          chapter_index INTEGER NOT NULL,
+          is_read INTEGER NOT NULL DEFAULT 0,
+          last_page_read INTEGER NOT NULL DEFAULT 0,
+          is_bookmarked INTEGER NOT NULL DEFAULT 0,
+          server_is_downloaded INTEGER NOT NULL DEFAULT 0,
+          device_state TEXT NOT NULL DEFAULT 'none',
+          page_count INTEGER NOT NULL DEFAULT 0,
+          bytes INTEGER NOT NULL DEFAULT 0,
+          updated_at INTEGER NOT NULL,
+          pinned INTEGER NOT NULL DEFAULT 0,
+          downloaded_at INTEGER,
+          progress_dirty INTEGER NOT NULL DEFAULT 0,
+          bookmark_dirty INTEGER NOT NULL DEFAULT 0,
+          read_state_dirty INTEGER NOT NULL DEFAULT 0,
+          last_read_at TEXT,
+          download_generation INTEGER NOT NULL DEFAULT 0
+        );
+      ''');
+      v8.execute(
+          "INSERT INTO offline_chapters (id, manga_id, name, chapter_index, "
+          "is_read, updated_at) VALUES (10, 1, 'c10', 9, 1, 0)");
+      v8.execute('PRAGMA user_version = 8');
+      v8.dispose();
+
+      final db = testOfflineDatabaseFile(dbPath);
+      final c = await (db.select(db.offlineChapters)
+            ..where((t) => t.id.equals(10)))
+          .getSingle();
+      // Old data survived; the new columns exist and read as null.
+      expect((c.name, c.chapterIndex, c.isRead), ('c10', 9, true));
+      expect((c.chapterNumber, c.scanlator), (null, null));
+      final version = await db
+          .customSelect('PRAGMA user_version')
+          .getSingle()
+          .then((r) => r.read<int>('user_version'));
+      expect(version, 9);
+      await db.close();
+    });
   });
 }

--- a/test/src/features/offline/data/offline_chapter_number_schema_test.dart
+++ b/test/src/features/offline/data/offline_chapter_number_schema_test.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_dto_mappers.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<OfflineChapter> upsert({
+    required int id,
+    double? number,
+    String? scanlator,
+  }) async {
+    await db.upsertChapterMetadata(
+      id: id,
+      mangaId: 1,
+      name: 'c$id',
+      chapterIndex: id,
+      isRead: false,
+      lastPageRead: 0,
+      isBookmarked: false,
+      serverIsDownloaded: false,
+      pageCount: 3,
+      updatedAt: DateTime(2026),
+      chapterNumber: number,
+      scanlator: scanlator,
+    );
+    return (db.select(db.offlineChapters)..where((t) => t.id.equals(id)))
+        .getSingle();
+  }
+
+  test('chapterNumber and scanlator persist through the upsert', () async {
+    final c = await upsert(id: 10, number: 9.5, scanlator: 'Nyx Scans');
+    expect((c.chapterNumber, c.scanlator), (9.5, 'Nyx Scans'));
+  });
+
+  test('mapper prefers the real number and carries the scanlator', () async {
+    final c = await upsert(id: 11, number: 2, scanlator: 'A');
+    final dto = offlineChapterToDto(c);
+    expect((dto.chapterNumber, dto.scanlator, dto.sourceOrder), (2.0, 'A', 11));
+  });
+
+  test('mapper falls back to the index for pre-v9 rows (null number)',
+      () async {
+    final c = await upsert(id: 12);
+    final dto = offlineChapterToDto(c);
+    expect((dto.chapterNumber, dto.scanlator), (12.0, null));
+  });
+}

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -16,8 +16,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 8', () {
-    expect(db.schemaVersion, 8);
+  test('opens at schema version 9', () {
+    expect(db.schemaVersion, 9);
   });
 
   test('inserts and reads a manga', () async {

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 8', () {
-    expect(db.schemaVersion, 8);
+  test('opens at schema version 9', () {
+    expect(db.schemaVersion, 9);
   });
 
   test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',


### PR DESCRIPTION
Follows #258. The offline catalog faked chapter numbers from list position, so the scanlator dedup from #141 couldn't group duplicates when reading offline — the list fell back to showing every copy.

- Catalog schema v9 adds nullable chapter number and scanlator columns; the normal down-sync fills them, so one online visit to a series makes its offline list preference-aware.
- Rows that haven't re-synced fall back to the old index-based number, which keeps numbers unique — the list can never wrongly merge chapters mid-transition, and the per-series sync is now atomic so an interrupted sync can't leave a mix.
- Migration follows the catalog's established idempotent column-add pattern and is tested against a real v8 database fixture, not a version rewind.