### PR TITLE
Manga recommendations on the details page

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -46,6 +46,10 @@ jobs:
       - run: flutter pub get
       - run: flutter gen-l10n
       - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Inject MyAnimeList client id
+        run: |
+          sed -i "s|defaultValue: '',|defaultValue: '${{ secrets.MAL_CLIENT_ID }}',|" \
+            lib/src/features/manga_book/data/recommendations/providers/myanimelist_provider.dart
       - run: flutter build linux --release
       - name: Stage bundle next to the manifest
         run: |

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -128,6 +128,14 @@ jobs:
             echo "keyPassword=${{ secrets.KEY_PASSWORD }}"
           } > key.properties
 
+      # Patch the empty MAL client-id default with the repo secret before any
+      # build so every platform (incl. fastforge/flatpak, which call flutter
+      # build internally) compiles it in — no per-tool --dart-define needed.
+      - name: Inject MyAnimeList client id
+        run: |
+          sed -i "s|defaultValue: '',|defaultValue: '${{ secrets.MAL_CLIENT_ID }}',|" \
+            lib/src/features/manga_book/data/recommendations/providers/myanimelist_provider.dart
+
       # ---- builds ----
       - name: Build Android
         if: matrix.target == 'android'

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -38,6 +38,8 @@ enum DBKeys {
   infinityScrollingMode(true),
   scrollAnimation(true),
   showNSFW(true),
+  showRecommendations(true),
+  recommendsInOverflow(false),
   downloadedBadge(false),
   // On by default: the badge shipped always-on, so off would change behavior.
   onDeviceBadge(true),

--- a/lib/src/features/manga_book/data/recommendations/providers/anilist_provider.dart
+++ b/lib/src/features/manga_book/data/recommendations/providers/anilist_provider.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import '../recommendation_provider.dart';
+
+// 1:1 with exh/recs/sources/AniListPagingSource.kt.
+const _endpoint = 'https://graphql.anilist.co/';
+
+const _recFields = r'''
+recommendations {
+  edges {
+    node {
+      mediaRecommendation {
+        countryOfOrigin
+        title { romaji english native }
+        synonyms
+        coverImage { large }
+        siteUrl
+      }
+    }
+  }
+}
+''';
+
+class AnilistProvider extends TrackerRecommendationProvider {
+  const AnilistProvider();
+
+  @override
+  String get name => 'AniList';
+  @override
+  String get category => 'Community recommendations';
+  @override
+  String get trackerKey => 'anilist';
+
+  @override
+  Future<List<Recommendation>> fetchById(
+      RecommendationContext ctx, String remoteId) {
+    const query = '''
+query Recommendations(\$id: Int!) {
+  Page { media(id: \$id, type: MANGA) { $_recFields } }
+}
+''';
+    return _run(ctx, query, {'id': int.tryParse(remoteId)});
+  }
+
+  @override
+  Future<List<Recommendation>> fetchBySearch(RecommendationContext ctx) {
+    const query = '''
+query Recommendations(\$search: String!) {
+  Page { media(search: \$search, type: MANGA) {
+    title { romaji english native }
+    synonyms
+    $_recFields
+  } }
+}
+''';
+    return _run(ctx, query, {'search': ctx.title}, searchFilter: ctx.title);
+  }
+
+  Future<List<Recommendation>> _run(
+    RecommendationContext ctx,
+    String query,
+    Map<String, dynamic> variables, {
+    String? searchFilter,
+  }) async {
+    final response = await ctx.client.post(
+      Uri.parse(_endpoint),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode({'query': query, 'variables': variables}),
+    );
+    if (response.statusCode != 200) {
+      throw RecommendationHttpException(response.statusCode);
+    }
+    var media = (jsonDecode(response.body)['data']?['Page']?['media']
+        as List?) ??
+        const [];
+    if (searchFilter != null) {
+      // Komikku keeps only search hits whose own title/synonyms contain the
+      // query, dropping loose full-text matches.
+      media = media.where((m) => _matches(m as Map, searchFilter)).toList();
+    }
+    final out = <Recommendation>[];
+    for (final m in media) {
+      final edges = ((m as Map)['recommendations']?['edges'] as List?) ??
+          const [];
+      for (final edge in edges) {
+        final rec = ((edge as Map)['node']?['mediaRecommendation']) as Map?;
+        if (rec == null) continue;
+        final url = rec['siteUrl'] as String?;
+        if (url == null) continue; // Komikku drops recs without a siteUrl.
+        out.add(Recommendation(
+          title: _title(rec),
+          category: category,
+          coverUrl: (rec['coverImage'] as Map?)?['large'] as String?,
+          sourceUrl: url,
+        ));
+      }
+    }
+    return out;
+  }
+
+  bool _matches(Map media, String search) {
+    final s = search.toLowerCase();
+    final t = (media['title'] as Map?) ?? const {};
+    for (final key in const ['romaji', 'english', 'native']) {
+      if ((t[key] as String?)?.toLowerCase().contains(s) ?? false) return true;
+    }
+    for (final syn in (media['synonyms'] as List?) ?? const []) {
+      if ((syn as String?)?.toLowerCase().contains(s) ?? false) return true;
+    }
+    return false;
+  }
+
+  // AniListPagingSource.getTitle: english, then romaji if Japanese, then a
+  // synonym, then romaji if not Japanese, then native.
+  String _title(Map rec) {
+    final t = (rec['title'] as Map?) ?? const {};
+    final english = t['english'] as String?;
+    final romaji = t['romaji'] as String?;
+    final native = t['native'] as String?;
+    final synonym = ((rec['synonyms'] as List?) ?? const []).isNotEmpty
+        ? (rec['synonyms'] as List).first as String?
+        : null;
+    final isJp = rec['countryOfOrigin'] == 'JP';
+    if (english != null && english.isNotEmpty) return english;
+    if (isJp && romaji != null && romaji.isNotEmpty) return romaji;
+    if (synonym != null && synonym.isNotEmpty) return synonym;
+    if (!isJp && romaji != null && romaji.isNotEmpty) return romaji;
+    return native ?? 'NO NAME FOUND';
+  }
+}

--- a/lib/src/features/manga_book/data/recommendations/providers/comick_provider.dart
+++ b/lib/src/features/manga_book/data/recommendations/providers/comick_provider.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import '../recommendation_provider.dart';
+
+// 1:1 with exh/recs/sources/ComickPagingSource.kt. Only applies to a
+// Comick-sourced manga; reads recommendations off that manga's own Comick page.
+const _thumbnailBase = 'https://meo.comick.pictures/';
+
+class ComickProvider extends RecommendationProvider {
+  const ComickProvider();
+
+  @override
+  String get name => 'Comick';
+  @override
+  String get category => 'Community recommendations';
+
+  @override
+  bool appliesTo(RecommendationContext ctx) =>
+      ctx.mangaUrl != null && ctx.sourceName.toLowerCase().contains('comick');
+
+  @override
+  Future<List<Recommendation>> fetch(RecommendationContext ctx) async {
+    // The Comick extension stores the manga url as '/comic/{hid}#'.
+    final uri = Uri.parse('https://api.comick.fun/v1.0${ctx.mangaUrl}')
+        .replace(queryParameters: {'tachiyomi': 'true'});
+    final response = await ctx.client.get(uri, headers: const {
+      'Referer': 'api.comick.fun/',
+      'User-Agent': 'Tachiyomi',
+    });
+    if (response.statusCode != 200) {
+      throw RecommendationHttpException(response.statusCode);
+    }
+    final recs = (((jsonDecode(response.body)['comic'] as Map?)
+            ?['recommendations']) as List?) ??
+        const [];
+    return [
+      for (final rec in recs)
+        if ((rec as Map)['relates'] != null)
+          Recommendation(
+            title: (rec['relates'] as Map)['title'] as String,
+            category: category,
+            sourceUrl: '/comic/${(rec['relates'] as Map)['hid']}#',
+            coverUrl: _cover((rec['relates'] as Map)['md_covers'] as List?),
+          ),
+    ];
+  }
+
+  String? _cover(List? covers) {
+    if (covers == null || covers.isEmpty) return null;
+    final b2key = (covers.first as Map)['b2key'] as String?;
+    return b2key == null ? null : '$_thumbnailBase$b2key';
+  }
+}

--- a/lib/src/features/manga_book/data/recommendations/providers/mangadex_provider.dart
+++ b/lib/src/features/manga_book/data/recommendations/providers/mangadex_provider.dart
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import '../recommendation_provider.dart';
+
+// Ports exh/md/similar/MangaDexSimilarPagingSource + SimilarHandler: pull
+// similar ids from similarmanga.com, then resolve them through the MangaDex API.
+const _similarApi = 'https://api.similarmanga.com/similar/';
+const _mangadexApi = 'https://api.mangadex.org';
+const _coverCdn = 'https://uploads.mangadex.org';
+
+class MangaDexProvider extends RecommendationProvider {
+  const MangaDexProvider();
+
+  @override
+  String get name => 'MangaDex';
+  @override
+  String get category => 'Similar titles';
+
+  @override
+  bool appliesTo(RecommendationContext ctx) =>
+      ctx.mangaUrl != null && ctx.sourceName.toLowerCase().contains('mangadex');
+
+  @override
+  Future<List<Recommendation>> fetch(RecommendationContext ctx) async {
+    // MdUtil.getMangaId: the uuid is the last path segment of the manga url.
+    final uuid = ctx.mangaUrl!.replaceAll(RegExp(r'/+$'), '').split('/').last;
+    final similar =
+        await ctx.client.get(Uri.parse('$_similarApi$uuid.json'));
+    if (similar.statusCode != 200) {
+      throw RecommendationHttpException(similar.statusCode);
+    }
+    final ids = [
+      for (final m in (jsonDecode(similar.body)['matches'] as List?) ?? const [])
+        (m as Map)['id'] as String?,
+    ].whereType<String>().toList();
+    if (ids.isEmpty) return const [];
+
+    final uri = Uri.parse('$_mangadexApi/manga').replace(queryParameters: {
+      'ids[]': ids,
+      'includes[]': 'cover_art',
+      'limit': '${ids.length}',
+    });
+    final response = await ctx.client.get(uri);
+    if (response.statusCode != 200) {
+      throw RecommendationHttpException(response.statusCode);
+    }
+    final data = (jsonDecode(response.body)['data'] as List?) ?? const [];
+    return [
+      for (final m in data)
+        Recommendation(
+          title: _title((m as Map)['attributes'] as Map?),
+          category: category,
+          sourceUrl: '/manga/${m['id']}',
+          coverUrl: _cover(m['id'] as String?, m['relationships'] as List?),
+        ),
+    ];
+  }
+
+  String _title(Map? attributes) {
+    final titles = (attributes?['title'] as Map?) ?? const {};
+    return (titles['en'] ?? (titles.values.isNotEmpty ? titles.values.first : null))
+            as String? ??
+        'Unknown';
+  }
+
+  String? _cover(String? mangaId, List? relationships) {
+    if (mangaId == null || relationships == null) return null;
+    for (final rel in relationships) {
+      if ((rel as Map)['type'] == 'cover_art') {
+        final file = (rel['attributes'] as Map?)?['fileName'] as String?;
+        if (file != null) return '$_coverCdn/covers/$mangaId/$file.256.jpg';
+      }
+    }
+    return null;
+  }
+}

--- a/lib/src/features/manga_book/data/recommendations/providers/mangaupdates_provider.dart
+++ b/lib/src/features/manga_book/data/recommendations/providers/mangaupdates_provider.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import '../recommendation_provider.dart';
+
+// 1:1 with exh/recs/sources/MangaUpdatesPagingSource.kt.
+const _endpoint = 'https://api.mangaupdates.com/v1';
+
+abstract class _MangaUpdatesProvider extends TrackerRecommendationProvider {
+  const _MangaUpdatesProvider();
+
+  @override
+  String get name => 'MangaUpdates';
+  @override
+  String get trackerKey => 'mangaupdates';
+
+  /// "recommendations" (community) vs "category_recommendations" (similar).
+  String get recommendationsKey;
+
+  @override
+  Future<List<Recommendation>> fetchById(
+      RecommendationContext ctx, String remoteId) async {
+    final response =
+        await ctx.client.get(Uri.parse('$_endpoint/series/$remoteId'));
+    if (response.statusCode != 200) {
+      throw RecommendationHttpException(response.statusCode);
+    }
+    final list = (jsonDecode(response.body)[recommendationsKey] as List?) ??
+        const [];
+    return [
+      for (final rec in list)
+        Recommendation(
+          title: (rec as Map)['series_name'] as String,
+          category: category,
+          sourceUrl: rec['series_url'] as String?,
+          coverUrl: (((rec['series_image'] as Map?)?['url']) as Map?)?['original']
+              as String?,
+        ),
+    ];
+  }
+
+  @override
+  Future<List<Recommendation>> fetchBySearch(RecommendationContext ctx) async {
+    final response = await ctx.client.post(
+      Uri.parse('$_endpoint/series/search'),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode({'search': ctx.title, 'stype': 'title'}),
+    );
+    if (response.statusCode != 200) {
+      throw RecommendationHttpException(response.statusCode);
+    }
+    final results = (jsonDecode(response.body)['results'] as List?) ?? const [];
+    if (results.isEmpty) return const [];
+    final seriesId =
+        ((results.first as Map)['record'] as Map?)?['series_id'];
+    if (seriesId == null) return const [];
+    return fetchById(ctx, seriesId.toString());
+  }
+}
+
+class MangaUpdatesCommunityProvider extends _MangaUpdatesProvider {
+  const MangaUpdatesCommunityProvider();
+  @override
+  String get category => 'Community recommendations';
+  @override
+  String get recommendationsKey => 'recommendations';
+}
+
+class MangaUpdatesSimilarProvider extends _MangaUpdatesProvider {
+  const MangaUpdatesSimilarProvider();
+  @override
+  String get category => 'Similar titles';
+  @override
+  String get recommendationsKey => 'category_recommendations';
+}

--- a/lib/src/features/manga_book/data/recommendations/providers/myanimelist_provider.dart
+++ b/lib/src/features/manga_book/data/recommendations/providers/myanimelist_provider.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import '../recommendation_provider.dart';
+
+// Official MyAnimeList API v2 — goes direct to MAL, avoiding Jikan's chronic
+// upstream 504s (Komikku still uses Jikan and fails whenever MAL's proxy does).
+// Read-only, app-level client id only — no per-user OAuth.
+const _endpoint = 'https://api.myanimelist.net/v2';
+
+// Public client id for the `X-MAL-CLIENT-ID` header — kept out of source. CI
+// patches this empty default with the repo secret at build time (a single step,
+// so every platform incl. fastforge/flatpak picks it up); local dev passes
+// --dart-define=MAL_CLIENT_ID=... to override it. With no key the provider hides
+// (see [appliesTo]) rather than erroring on every fetch.
+const _clientId = String.fromEnvironment(
+  'MAL_CLIENT_ID',
+  defaultValue: '',
+);
+const _headers = {'X-MAL-CLIENT-ID': _clientId};
+
+class MyAnimeListProvider extends TrackerRecommendationProvider {
+  const MyAnimeListProvider();
+
+  @override
+  String get name => 'MyAnimeList';
+  @override
+  String get category => 'Community recommendations';
+  @override
+  String get trackerKey => 'myanimelist';
+
+  // No client id (unconfigured build) → hide the section instead of 403-ing.
+  @override
+  bool appliesTo(RecommendationContext ctx) => _clientId.isNotEmpty;
+
+  @override
+  Future<List<Recommendation>> fetchById(
+      RecommendationContext ctx, String remoteId) async {
+    final response = await ctx.client.get(
+      Uri.parse('$_endpoint/manga/$remoteId?fields=recommendations'),
+      headers: _headers,
+    );
+    if (response.statusCode != 200) {
+      throw RecommendationHttpException(response.statusCode);
+    }
+    final list =
+        (jsonDecode(response.body)['recommendations'] as List?) ?? const [];
+    return [
+      for (final rec in list)
+        if ((rec as Map)['node'] != null)
+          Recommendation(
+            title: (rec['node'] as Map)['title'] as String,
+            category: category,
+            sourceUrl:
+                'https://myanimelist.net/manga/${(rec['node'] as Map)['id']}',
+            coverUrl: _image((rec['node'] as Map)['main_picture'] as Map?),
+          ),
+    ];
+  }
+
+  @override
+  Future<List<Recommendation>> fetchBySearch(RecommendationContext ctx) async {
+    final response = await ctx.client.get(
+      Uri.parse('$_endpoint/manga')
+          .replace(queryParameters: {'q': ctx.title, 'limit': '1'}),
+      headers: _headers,
+    );
+    if (response.statusCode != 200) {
+      throw RecommendationHttpException(response.statusCode);
+    }
+    final data = (jsonDecode(response.body)['data'] as List?) ?? const [];
+    if (data.isEmpty) return const [];
+    final id = ((data.first as Map)['node'] as Map?)?['id'];
+    if (id == null) return const [];
+    return fetchById(ctx, id.toString());
+  }
+
+  String? _image(Map? pic) {
+    if (pic == null) return null;
+    return (pic['medium'] as String?) ?? (pic['large'] as String?);
+  }
+}

--- a/lib/src/features/manga_book/data/recommendations/recommendation_provider.dart
+++ b/lib/src/features/manga_book/data/recommendations/recommendation_provider.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:http/http.dart' as http;
+
+/// One recommended title. Mirrors the fields Komikku's SManga recommendations
+/// carry (title + cover + the provider's own url).
+class Recommendation {
+  const Recommendation({
+    required this.title,
+    required this.category,
+    this.coverUrl,
+    this.sourceUrl,
+  });
+
+  final String title;
+
+  /// Provider grouping shown as a section header, e.g. "Community
+  /// recommendations" or "Similar titles" (Komikku's per-source category).
+  final String category;
+  final String? coverUrl;
+  final String? sourceUrl;
+
+  Map<String, dynamic> toJson() => {
+        'title': title,
+        'category': category,
+        'coverUrl': coverUrl,
+        'sourceUrl': sourceUrl,
+      };
+
+  factory Recommendation.fromJson(Map<String, dynamic> json) => Recommendation(
+        title: json['title'] as String,
+        category: json['category'] as String,
+        coverUrl: json['coverUrl'] as String?,
+        sourceUrl: json['sourceUrl'] as String?,
+      );
+}
+
+/// Everything a provider needs to decide between an exact tracker-id lookup and
+/// a title search, mirroring Komikku's TrackerRecommendationPagingSource.
+class RecommendationContext {
+  const RecommendationContext({
+    required this.title,
+    required this.remoteIdByTracker,
+    required this.sourceName,
+    required this.mangaUrl,
+    required this.client,
+  });
+
+  /// The manga's title (Komikku uses `ogTitle`), the search fallback key.
+  final String title;
+
+  /// Lowercased tracker name -> the manga's remote id on that tracker, from its
+  /// track records. Empty when the series isn't tracked there.
+  final Map<String, String> remoteIdByTracker;
+
+  final String sourceName;
+  final String? mangaUrl;
+  final http.Client client;
+}
+
+/// A provider's HTTP call returned a non-200. Surfaced per-section as an error
+/// (Komikku parity) instead of an empty list — a flaky upstream isn't "no recs".
+class RecommendationHttpException implements Exception {
+  const RecommendationHttpException(this.statusCode);
+  final int statusCode;
+}
+
+abstract class RecommendationProvider {
+  const RecommendationProvider();
+
+  String get name;
+  String get category;
+
+  /// Unique lookup id. [name] alone collides — MangaUpdates ships two providers
+  /// (community + similar) under the same name — so the per-provider Riverpod
+  /// family must key on name+category, or one silently shadows the other.
+  String get key => '$name|$category';
+
+  /// Source-specific providers (Comick, MangaDex) override this; tracker
+  /// providers apply everywhere.
+  bool appliesTo(RecommendationContext ctx) => true;
+
+  Future<List<Recommendation>> fetch(RecommendationContext ctx);
+}
+
+/// Base for providers backed by a tracker: query by the manga's remote id when
+/// it's tracked there, otherwise search by title (Komikku's id-or-search rule).
+abstract class TrackerRecommendationProvider extends RecommendationProvider {
+  const TrackerRecommendationProvider();
+
+  /// Lowercased tracker name this provider matches against (`anilist`,
+  /// `myanimelist`, `mangaupdates`).
+  String get trackerKey;
+
+  Future<List<Recommendation>> fetchById(
+      RecommendationContext ctx, String remoteId);
+  Future<List<Recommendation>> fetchBySearch(RecommendationContext ctx);
+
+  @override
+  Future<List<Recommendation>> fetch(RecommendationContext ctx) {
+    final id = ctx.remoteIdByTracker[trackerKey];
+    return id != null ? fetchById(ctx, id) : fetchBySearch(ctx);
+  }
+}

--- a/lib/src/features/manga_book/data/recommendations/recommendation_repository.dart
+++ b/lib/src/features/manga_book/data/recommendations/recommendation_repository.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../global_providers/global_providers.dart';
+import '../../../tracking/data/tracker_repository.dart';
+import '../../presentation/manga_details/controller/manga_details_controller.dart';
+import 'providers/anilist_provider.dart';
+import 'providers/comick_provider.dart';
+import 'providers/mangadex_provider.dart';
+import 'providers/mangaupdates_provider.dart';
+import 'providers/myanimelist_provider.dart';
+import 'recommendation_provider.dart';
+
+part 'recommendation_repository.g.dart';
+
+// Komikku's RecommendationPagingSource.createSources order.
+const _allProviders = <RecommendationProvider>[
+  AnilistProvider(),
+  MangaUpdatesCommunityProvider(),
+  MangaUpdatesSimilarProvider(),
+  MyAnimeListProvider(),
+  MangaDexProvider(),
+  ComickProvider(),
+];
+
+/// The recommendation context (title, tracker remote ids, source) for [mangaId]
+/// plus the providers that apply to it. Built once and shared by every section.
+@riverpod
+Future<({RecommendationContext ctx, List<RecommendationProvider> providers})?>
+    recommendationSetup(Ref ref, int mangaId) async {
+  final manga = await ref.watch(mangaWithIdProvider(mangaId: mangaId).future);
+  final title = manga?.title;
+  if (manga == null || title == null || title.isEmpty) return null;
+
+  final trackers = await ref.watch(trackersProvider.future);
+  final nameById = {for (final t in trackers) t.id: t.name.toLowerCase()};
+  final remoteIdByTracker = <String, String>{};
+  for (final rec in manga.trackRecords.nodes) {
+    final name = nameById[rec.trackerId];
+    if (name != null) remoteIdByTracker[name] = rec.remoteId;
+  }
+
+  final client = http.Client();
+  ref.onDispose(client.close);
+  final ctx = RecommendationContext(
+    title: title,
+    remoteIdByTracker: remoteIdByTracker,
+    sourceName: manga.source?.name ?? '',
+    mangaUrl: manga.url,
+    client: client,
+  );
+  return (
+    ctx: ctx,
+    providers: _allProviders.where((p) => p.appliesTo(ctx)).toList(),
+  );
+}
+
+/// Every applicable provider's recommendations for [mangaId], flattened and
+/// deduped, for the inline Suggestions row on the manga details page. Suwayomi
+/// has no related/similar source query (what Komikku uses there), so this
+/// reuses the tracker engine instead; a failing provider just drops out.
+@riverpod
+Future<List<Recommendation>> mangaRecommendations(Ref ref, int mangaId) async {
+  final setup = await ref.watch(recommendationSetupProvider(mangaId).future);
+  if (setup == null) return const [];
+  final lists = await Future.wait([
+    for (final p in setup.providers)
+      ref
+          .watch(providerRecommendationsProvider(mangaId, p.key).future)
+          .catchError((_) => const <Recommendation>[]),
+  ]);
+  final seen = <String>{};
+  return [
+    for (final list in lists)
+      for (final r in list)
+        if (seen.add(r.sourceUrl ?? r.title)) r,
+  ];
+}
+
+/// One provider's recommendations for [mangaId]; each screen section watches
+/// its own so they load, error, and empty independently (Komikku's per-source
+/// RecommendationItemResult).
+///
+/// A successful pull is cached, so a later failure serves the last-good list
+/// instead of an error.
+@riverpod
+Future<List<Recommendation>> providerRecommendations(
+  Ref ref,
+  int mangaId,
+  String providerKey,
+) async {
+  final setup = await ref.watch(recommendationSetupProvider(mangaId).future);
+  if (setup == null) return const [];
+  final provider = setup.providers.firstWhere((p) => p.key == providerKey);
+  final prefs = ref.read(sharedPreferencesProvider);
+  final cacheKey = 'recsCache:$mangaId:$providerKey';
+  try {
+    final recs = await provider.fetch(setup.ctx);
+    // Komikku de-dupes each source's list by url.
+    final seen = <String>{};
+    final deduped = [
+      for (final r in recs)
+        if (seen.add(r.sourceUrl ?? r.title)) r,
+    ];
+    if (deduped.isNotEmpty) {
+      await prefs.setString(
+        cacheKey,
+        jsonEncode([for (final r in deduped) r.toJson()]),
+      );
+    }
+    return deduped;
+  } catch (_) {
+    final cached = prefs.getString(cacheKey);
+    if (cached != null) {
+      return [
+        for (final j in jsonDecode(cached) as List)
+          Recommendation.fromJson(j as Map<String, dynamic>),
+      ];
+    }
+    rethrow;
+  }
+}

--- a/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
+++ b/lib/src/features/manga_book/domain/manga/graphql/fragment.graphql
@@ -49,7 +49,7 @@ fragment MangaDto on MangaType {
   }
   trackRecords {
     totalCount
-    nodes { id trackerId status score }
+    nodes { id trackerId remoteId status score }
   }
   unreadCount
   updateStrategy

--- a/lib/src/features/manga_book/domain/recommendation/suggestion_model.dart
+++ b/lib/src/features/manga_book/domain/recommendation/suggestion_model.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class Suggestion {
+  const Suggestion({
+    required this.anilistId,
+    required this.title,
+    required this.coverUrl,
+  });
+
+  final int anilistId;
+  final String title;
+  final String? coverUrl;
+}

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -20,6 +20,7 @@ import '../../../../utils/theme/brand.dart';
 import '../../../../widgets/emoticons.dart';
 import '../../../library/presentation/category/controller/edit_category_controller.dart';
 import '../../../library/presentation/library/controller/library_controller.dart';
+import '../../../settings/presentation/appearance/widgets/show_recommendations/show_recommendations_tile.dart';
 import '../../../library/presentation/library/controller/library_manga_list.dart';
 import '../../../migration/domain/migration_models.dart';
 import '../../domain/chapter/chapter_model.dart';
@@ -303,6 +304,20 @@ class MangaDetailsScreen extends HookConsumerWidget {
                               ),
                               icon: const Icon(Icons.more_vert_rounded),
                               itemBuilder: (context) => [
+                                if (ref
+                                        .watch(showRecommendationsProvider)
+                                        .ifNull(true) &&
+                                    ref
+                                        .watch(recommendsInOverflowProvider)
+                                        .ifNull(false))
+                                  PopupMenuItem(
+                                    onTap: () => RecommendsRoute(
+                                      mangaId: mangaId,
+                                      mangaTitle: data?.title,
+                                    ).push(context),
+                                    child:
+                                        Text(context.l10n.seeRecommendations),
+                                  ),
                                 PopupMenuItem(
                                   onTap: () => Future.microtask(
                                     () {

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/big_screen_manga_details.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/big_screen_manga_details.dart
@@ -20,6 +20,7 @@ import 'chapter_grid_tile.dart';
 import 'chapter_list_mode_toggle.dart';
 import 'chapter_list_tile.dart';
 import 'manga_description.dart';
+import 'recommends_row.dart';
 
 class BigScreenMangaDetails extends ConsumerWidget {
   const BigScreenMangaDetails({
@@ -49,13 +50,20 @@ class BigScreenMangaDetails extends ConsumerWidget {
         children: [
           Expanded(
             child: SingleChildScrollView(
-              child: MangaDescription(
-                manga: manga,
-                removeMangaFromLibrary: (() =>
-                    removeMangaFromLibraryAndPurge(ref, mangaId)),
-                addMangaToLibrary: (() =>
-                    addMangaToLibraryWithCategory(ref, context, mangaId)),
-                refresh: () => onDescriptionRefresh(false),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  MangaDescription(
+                    manga: manga,
+                    removeMangaFromLibrary: (() =>
+                        removeMangaFromLibraryAndPurge(ref, mangaId)),
+                    addMangaToLibrary: (() =>
+                        addMangaToLibraryWithCategory(ref, context, mangaId)),
+                    refresh: () => onDescriptionRefresh(false),
+                  ),
+                  if (manga.title.isNotBlank)
+                    RecommendsRow(mangaId: mangaId, mangaTitle: manga.title),
+                ],
               ),
             ),
           ),

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -189,10 +189,11 @@ class MangaDescription extends HookConsumerWidget {
               ),
             ),
             Padding(
-              // Clear the transparent app bar (status bar + toolbar) so the
-              // cover/title sit below the icons while the backdrop fills behind.
+              // Clear only the status bar; the transparent app-bar icons float
+              // over the top of the hero so the cover rides up into the backdrop
+              // instead of leaving a dead toolbar-height band above it.
               padding: EdgeInsets.only(
-                top: MediaQuery.paddingOf(context).top + kToolbarHeight,
+                top: MediaQuery.paddingOf(context).top + 8,
               ),
               child: MangaCoverDescriptiveListTile(
                 manga: manga,
@@ -273,11 +274,13 @@ class MangaDescription extends HookConsumerWidget {
           ),
         if (isExpanded.value)
           Padding(
-            padding: KEdgeInsets.h16.size,
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
             child: Wrap(
               spacing: 8,
               runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
               children: [
+                AddUserTagChip(mangaId: manga.id),
                 ...manga.genre.where((e) => e.isNotBlank).map<Widget>(
                       (e) => Builder(
                         builder: (chipContext) => BrandChip(
@@ -292,11 +295,16 @@ class MangaDescription extends HookConsumerWidget {
           )
         else
           Padding(
-            padding: KEdgeInsets.h16.size,
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
             child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
+                  Padding(
+                    padding: KEdgeInsets.h4.size,
+                    child: AddUserTagChip(mangaId: manga.id),
+                  ),
                   ...manga.genre.where((e) => e.isNotBlank).map<Widget>(
                         (e) => Padding(
                           padding: KEdgeInsets.h4.size,

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_user_tags_row.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_user_tags_row.dart
@@ -11,46 +11,74 @@ import '../../../../../utils/extensions/custom_extensions.dart';
 import '../controller/manga_details_controller.dart';
 import 'tag_actions_menu.dart';
 
-/// The user's own tags for a manga: deletable chips (styled distinctly from the
-/// source genre chips) plus an "add tag" affordance.
+Future<void> _showAddTagDialog(
+    BuildContext context, WidgetRef ref, int mangaId) async {
+  final controller = TextEditingController();
+  final tag = await showDialog<String>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(context.l10n.addTag),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        textCapitalization: TextCapitalization.words,
+        decoration: InputDecoration(hintText: context.l10n.addTag),
+        onSubmitted: (value) => Navigator.pop(context, value),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(context.l10n.cancel),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, controller.text),
+          child: Text(context.l10n.ok),
+        ),
+      ],
+    ),
+  );
+  if (tag != null && tag.trim().isNotEmpty) {
+    await ref.read(mangaUserTagsProvider(mangaId: mangaId).notifier).add(tag);
+  }
+}
+
+/// A compact "+" chip that opens the add-tag dialog. Sits at the front of the
+/// genre chips so adding a tag reads as part of the tag list, not a stray button.
+class AddUserTagChip extends ConsumerWidget {
+  const AddUserTagChip({super.key, required this.mangaId});
+
+  final int mangaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cs = context.theme.colorScheme;
+    return GestureDetector(
+      onTap: () => _showAddTagDialog(context, ref, mangaId),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: cs.primary.withValues(alpha: 0.14),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: cs.primary.withValues(alpha: 0.45)),
+        ),
+        child: Icon(Icons.add_rounded, size: 16, color: cs.primary),
+      ),
+    );
+  }
+}
+
+/// The user's own tags for a manga: deletable chips styled distinctly from the
+/// source genre chips. Hidden entirely when there are none — the add affordance
+/// lives inline with the genre chips as [AddUserTagChip].
 class MangaUserTagsRow extends ConsumerWidget {
   const MangaUserTagsRow({super.key, required this.mangaId});
 
   final int mangaId;
 
-  Future<void> _addTag(BuildContext context, WidgetRef ref) async {
-    final controller = TextEditingController();
-    final tag = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(context.l10n.addTag),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          textCapitalization: TextCapitalization.words,
-          decoration: InputDecoration(hintText: context.l10n.addTag),
-          onSubmitted: (value) => Navigator.pop(context, value),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(context.l10n.cancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, controller.text),
-            child: Text(context.l10n.ok),
-          ),
-        ],
-      ),
-    );
-    if (tag != null && tag.trim().isNotEmpty) {
-      await ref.read(mangaUserTagsProvider(mangaId: mangaId).notifier).add(tag);
-    }
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tags = ref.watch(mangaUserTagsProvider(mangaId: mangaId));
+    if (tags.isEmpty) return const SizedBox.shrink();
     final notifier = ref.read(mangaUserTagsProvider(mangaId: mangaId).notifier);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
@@ -75,13 +103,6 @@ class MangaUserTagsRow extends ConsumerWidget {
                 materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
             ),
-          ActionChip(
-            avatar: const Icon(Icons.add_rounded, size: 16),
-            label: Text(context.l10n.addTag),
-            onPressed: () => _addTag(context, ref),
-            visualDensity: VisualDensity.compact,
-            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          ),
         ],
       ),
     );

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/recommends_row.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/recommends_row.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../constants/app_sizes.dart';
+import '../../../../../routes/router_config.dart';
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../settings/presentation/appearance/widgets/show_recommendations/show_recommendations_tile.dart';
+import '../../../data/recommendations/recommendation_repository.dart';
+import '../../recommends/recommendation_card.dart';
+
+/// Komikku's inline "Suggestions" row on the manga details page: a header with a
+/// forward arrow that opens the grouped recommendations screen, above a
+/// horizontal row of cover cards. Komikku sources this from the source's related
+/// mangas; Suwayomi has no such query, so it reuses the tracker engine.
+class RecommendsRow extends ConsumerWidget {
+  const RecommendsRow({super.key, required this.mangaId, this.mangaTitle});
+
+  final int mangaId;
+  final String? mangaTitle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(showRecommendationsProvider).ifNull(true) ||
+        ref.watch(recommendsInOverflowProvider).ifNull(false)) {
+      return const SizedBox.shrink();
+    }
+    final recs = ref.watch(mangaRecommendationsProvider(mangaId));
+    // Drop the whole section when it resolves to nothing, matching Komikku only
+    // showing the row when the related list is non-empty.
+    if (recs.hasValue && recs.value!.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Divider(height: 0),
+        InkWell(
+          onTap: () =>
+              RecommendsRoute(mangaId: mangaId, mangaTitle: mangaTitle)
+                  .push(context),
+          child: Padding(
+            padding: KEdgeInsets.h16v8.size,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(context.l10n.suggestions,
+                    style: context.textTheme.titleMedium),
+                const Icon(Icons.arrow_forward_rounded),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(
+          height: 200,
+          child: recs.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (_, __) => const SizedBox.shrink(),
+            data: (list) => ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              itemCount: list.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 4),
+              itemBuilder: (context, i) => RecommendationCard(rec: list[i]),
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        const Divider(height: 0),
+      ],
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/small_screen_manga_details.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/small_screen_manga_details.dart
@@ -20,6 +20,7 @@ import 'chapter_grid_tile.dart';
 import 'chapter_list_mode_toggle.dart';
 import 'chapter_list_tile.dart';
 import 'manga_description.dart';
+import 'recommends_row.dart';
 
 class SmallScreenMangaDetails extends ConsumerWidget {
   const SmallScreenMangaDetails({
@@ -61,6 +62,9 @@ class SmallScreenMangaDetails extends ConsumerWidget {
               ),
             ),
           ),
+          if (manga.title.isNotBlank)
+            SliverToBoxAdapter(
+                child: RecommendsRow(mangaId: mangaId, mangaTitle: manga.title)),
           SliverToBoxAdapter(
             child: ListTile(
               title: Text(

--- a/lib/src/features/manga_book/presentation/recommends/recommendation_card.dart
+++ b/lib/src/features/manga_book/presentation/recommends/recommendation_card.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../../../constants/app_sizes.dart';
+import '../../../../routes/router_config.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../data/recommendations/recommendation_provider.dart';
+
+/// A single recommendation cover card. Recommendations are external titles, not
+/// local library entries, so tapping searches globally by title.
+class RecommendationCard extends StatelessWidget {
+  const RecommendationCard({super.key, required this.rec});
+
+  final Recommendation rec;
+
+  @override
+  Widget build(BuildContext context) {
+    // Komikku's MangaItem: 96dp-wide comfortable-grid card (2:3 cover -> 144
+    // tall) with the title below.
+    return SizedBox(
+      width: 96,
+      child: InkWell(
+        borderRadius: KBorderRadius.r8.radius,
+        onTap: () => GlobalSearchRoute(query: rec.title).push(context),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ClipRRect(
+              borderRadius: KBorderRadius.r8.radius,
+              child: SizedBox(
+                width: 96,
+                height: 144,
+                child: rec.coverUrl != null
+                    ? Image.network(
+                        rec.coverUrl!,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) =>
+                            const ColoredBox(color: Colors.black26),
+                      )
+                    : const ColoredBox(color: Colors.black26),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              rec.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: context.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/recommends/recommends_browse_screen.dart
+++ b/lib/src/features/manga_book/presentation/recommends/recommends_browse_screen.dart
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../constants/app_sizes.dart';
+import '../../../../routes/router_config.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../widgets/emoticons.dart';
+import '../../data/recommendations/recommendation_repository.dart';
+
+/// Komikku's BrowseRecommendsScreen: one provider's full recommendation list as
+/// a cover grid, opened from a section header on the recommendations screen.
+class RecommendsBrowseScreen extends ConsumerWidget {
+  const RecommendsBrowseScreen({
+    super.key,
+    required this.mangaId,
+    required this.providerName,
+  });
+
+  final int mangaId;
+
+  /// The provider [key] (name+category), not the display name — MangaUpdates
+  /// ships two providers under one name, so the lookup must be by key.
+  final String providerName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recs =
+        ref.watch(providerRecommendationsProvider(mangaId, providerName));
+    final providers =
+        ref.watch(recommendationSetupProvider(mangaId)).value?.providers ??
+            const [];
+    var title = providerName.split('|').first;
+    for (final p in providers) {
+      if (p.key == providerName) {
+        title = p.name;
+        break;
+      }
+    }
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: recs.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => Emoticons(title: context.l10n.errorSomethingWentWrong),
+        data: (list) => list.isEmpty
+            ? Emoticons(title: context.l10n.noResultFound)
+            : GridView.builder(
+                padding: KEdgeInsets.a8.size,
+                gridDelegate:
+                    const SliverGridDelegateWithMaxCrossAxisExtent(
+                  maxCrossAxisExtent: 120,
+                  childAspectRatio: 0.6,
+                  mainAxisSpacing: 8,
+                  crossAxisSpacing: 8,
+                ),
+                itemCount: list.length,
+                itemBuilder: (context, i) {
+                  final r = list[i];
+                  return InkWell(
+                    borderRadius: KBorderRadius.r8.radius,
+                    onTap: () =>
+                        GlobalSearchRoute(query: r.title).push(context),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: ClipRRect(
+                            borderRadius: KBorderRadius.r8.radius,
+                            child: r.coverUrl != null
+                                ? Image.network(
+                                    r.coverUrl!,
+                                    width: double.infinity,
+                                    fit: BoxFit.cover,
+                                    errorBuilder: (_, __, ___) =>
+                                        const ColoredBox(color: Colors.black26),
+                                  )
+                                : const ColoredBox(color: Colors.black26),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          r.title,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: context.textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/manga_book/presentation/recommends/recommends_screen.dart
+++ b/lib/src/features/manga_book/presentation/recommends/recommends_screen.dart
@@ -1,0 +1,176 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../constants/app_sizes.dart';
+import '../../../../routes/router_config.dart';
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../widgets/emoticons.dart';
+import '../../data/recommendations/recommendation_provider.dart';
+import '../../data/recommendations/recommendation_repository.dart';
+import 'recommendation_card.dart';
+
+/// Komikku's RecommendsScreen: "Similar to {title}", one section per provider,
+/// each loading, erroring, and emptying on its own.
+class RecommendsScreen extends ConsumerWidget {
+  const RecommendsScreen({super.key, required this.mangaId, this.mangaTitle});
+
+  final int mangaId;
+  final String? mangaTitle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final setup = ref.watch(recommendationSetupProvider(mangaId));
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(mangaTitle != null
+            ? context.l10n.similarTo(mangaTitle!)
+            : context.l10n.recommendations),
+      ),
+      body: setup.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => Emoticons(title: context.l10n.errorSomethingWentWrong),
+        data: (value) {
+          final providers = value?.providers ?? const [];
+          if (providers.isEmpty) {
+            return Emoticons(title: context.l10n.noRecommendationsForTitle);
+          }
+          // Komikku shows every applicable provider — each renders its own
+          // results, "No results found", or error; sections never drop out.
+          // Sink sources that resolved empty or errored below ones with results
+          // (still-loading stay in the middle); keep original order within a
+          // rank, and key each section so a reorder doesn't reload it.
+          int rankOf(RecommendationProvider p) {
+            final recs =
+                ref.watch(providerRecommendationsProvider(mangaId, p.key));
+            if (recs.hasError) return 2;
+            if (recs.hasValue) return recs.value!.isEmpty ? 2 : 0;
+            return 1;
+          }
+
+          final ordered = [
+            for (var i = 0; i < providers.length; i++) (i, providers[i])
+          ]..sort((a, b) {
+              final r = rankOf(a.$2).compareTo(rankOf(b.$2));
+              return r != 0 ? r : a.$1.compareTo(b.$1);
+            });
+          return ListView(
+            children: [
+              for (final e in ordered)
+                _ProviderSection(
+                  key: ValueKey(e.$2.key),
+                  mangaId: mangaId,
+                  provider: e.$2,
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ProviderSection extends ConsumerWidget {
+  const _ProviderSection(
+      {super.key, required this.mangaId, required this.provider});
+
+  final int mangaId;
+  final RecommendationProvider provider;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recs =
+        ref.watch(providerRecommendationsProvider(mangaId, provider.key));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        InkWell(
+          onTap: () => RecommendsBrowseRoute(
+            mangaId: mangaId,
+            providerName: provider.key,
+          ).push(context),
+          child: Padding(
+            padding: KEdgeInsets.h16v8.size,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(provider.name,
+                          style: context.textTheme.titleMedium),
+                      Text(
+                        provider.category,
+                        style: context.textTheme.bodySmall
+                            ?.copyWith(color: context.theme.hintColor),
+                      ),
+                    ],
+                  ),
+                ),
+                const Icon(Icons.arrow_forward_rounded),
+              ],
+            ),
+          ),
+        ),
+        recs.when(
+          loading: () => const SizedBox(
+              height: 200, child: Center(child: CircularProgressIndicator())),
+          error: (e, _) => _SectionMessage(
+            e is RecommendationHttpException
+                ? context.l10n.httpErrorCheckWebView(e.statusCode)
+                : context.l10n.errorSomethingWentWrong,
+          ),
+          data: (list) => list.isEmpty
+              ? _SectionMessage(context.l10n.noResultFound)
+              : SizedBox(
+                  height: 200,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    itemCount: list.length,
+                    separatorBuilder: (_, _) => const SizedBox(width: 8),
+                    itemBuilder: (context, i) =>
+                        RecommendationCard(rec: list[i]),
+                  ),
+                ),
+        ),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+}
+
+/// Komikku's per-section empty/error state: a centered info icon over a short
+/// message, in place of the cover row.
+class _SectionMessage extends StatelessWidget {
+  const _SectionMessage(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 16),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.info_outline_rounded, color: context.theme.hintColor),
+            const SizedBox(height: 8),
+            Text(
+              text,
+              textAlign: TextAlign.center,
+              style: context.textTheme.bodyMedium
+                  ?.copyWith(color: context.theme.hintColor),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/presentation/appearance/appearance_screen.dart
+++ b/lib/src/features/settings/presentation/appearance/appearance_screen.dart
@@ -15,6 +15,7 @@ import 'widgets/app_theme_selector/app_theme_providers.dart';
 import 'widgets/app_theme_selector/app_theme_selector.dart';
 import 'widgets/grid_cover_width_slider/grid_cover_width_slider.dart';
 import 'widgets/is_true_black/is_true_black_tile.dart';
+import 'widgets/show_recommendations/show_recommendations_tile.dart';
 
 class AppearanceScreen extends ConsumerWidget {
   const AppearanceScreen({super.key});
@@ -39,6 +40,8 @@ class AppearanceScreen extends ConsumerWidget {
             },
           ),
           const GridCoverWidthSlider(),
+          const ShowRecommendationsTile(),
+          const RecommendsInOverflowTile(),
         ],
       ),
     );

--- a/lib/src/features/settings/presentation/appearance/widgets/show_recommendations/show_recommendations_tile.dart
+++ b/lib/src/features/settings/presentation/appearance/widgets/show_recommendations/show_recommendations_tile.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'show_recommendations_tile.g.dart';
+
+@riverpod
+class ShowRecommendations extends _$ShowRecommendations
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.showRecommendations);
+}
+
+@riverpod
+class RecommendsInOverflow extends _$RecommendsInOverflow
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.recommendsInOverflow);
+}
+
+class ShowRecommendationsTile extends ConsumerWidget {
+  const ShowRecommendationsTile({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.recommend_rounded),
+      title: Text(context.l10n.showRecommendations),
+      subtitle: Text(context.l10n.showRecommendationsSubtitle),
+      onChanged: ref.read(showRecommendationsProvider.notifier).update,
+      value: ref.watch(showRecommendationsProvider).ifNull(true),
+    );
+  }
+}
+
+class RecommendsInOverflowTile extends ConsumerWidget {
+  const RecommendsInOverflowTile({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(showRecommendationsProvider).ifNull(true)) {
+      return const SizedBox.shrink();
+    }
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.more_vert_rounded),
+      title: Text(context.l10n.recommendsInOverflow),
+      subtitle: Text(context.l10n.recommendsInOverflowSubtitle),
+      onChanged: ref.read(recommendsInOverflowProvider.notifier).update,
+      value: ref.watch(recommendsInOverflowProvider).ifNull(false),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1933,6 +1933,40 @@
     "noDownloads": "No Downloads",
     "noMangaFound": "No Mangas Found",
     "noOfChapters": "{count} Chapters",
+    "seeRecommendations": "See Recommendations",
+    "@seeRecommendations": {
+        "description": "Button on the manga details page opening the recommendations screen"
+    },
+    "recommendations": "Recommendations",
+    "@recommendations": {
+        "description": "Title of the recommendations screen"
+    },
+    "noRecommendationsForTitle": "No recommendations for this title right now",
+    "@noRecommendationsForTitle": {
+        "description": "Empty state on the recommendations screen when no provider returned results"
+    },
+    "similarTo": "Similar to {title}",
+    "@similarTo": {
+        "description": "Recommendations screen title for a single manga",
+        "placeholders": { "title": { "type": "String" } }
+    },
+    "httpErrorCheckWebView": "HTTP {statusCode}, check website in WebView",
+    "@httpErrorCheckWebView": {
+        "description": "Per-provider error on the recommendations screen when its API returns a non-200",
+        "placeholders": { "statusCode": { "type": "int" } }
+    },
+    "suggestions": "Suggestions",
+    "@suggestions": {
+        "description": "Header for the inline suggestions row on the manga details page"
+    },
+    "showRecommendations": "Show recommendations",
+    "@showRecommendations": {
+        "description": "Appearance setting toggling the suggestions row on manga details"
+    },
+    "showRecommendationsSubtitle": "Show a row of similar titles on the manga details page",
+    "@showRecommendationsSubtitle": {
+        "description": "Subtitle for the show recommendations setting"
+    },
     "noPropFound": "No {prop} Found",
     "noResultFound": "No results found",
     "noServerFound": "No Server found in your local network",
@@ -2927,6 +2961,14 @@
     "extensionStoresDescription": "Add extension stores your server installs from",
     "@extensionStoresDescription": {
         "description": "Subtitle for the Extension stores settings row when no stores are added yet"
+    },
+    "recommendsInOverflow": "Recommendations in overflow",
+    "@recommendsInOverflow": {
+        "description": "Setting to move the recommendations button into the overflow menu"
+    },
+    "recommendsInOverflowSubtitle": "Move recommendations to the overflow menu instead of showing the row on the manga page",
+    "@recommendsInOverflowSubtitle": {
+        "description": "Subtitle for the recommendations-in-overflow setting"
     },
     "updateServerForExtensions": "Update your Suwayomi server to manage extensions",
     "@updateServerForExtensions": {

--- a/lib/src/routes/router_config.dart
+++ b/lib/src/routes/router_config.dart
@@ -23,6 +23,8 @@ import '../features/library/presentation/category/edit_category_screen.dart';
 import '../features/library/presentation/library/library_screen.dart';
 import '../features/manga_book/presentation/downloads/downloads_screen.dart';
 import '../features/manga_book/presentation/manga_details/manga_details_screen.dart';
+import '../features/manga_book/presentation/recommends/recommends_browse_screen.dart';
+import '../features/manga_book/presentation/recommends/recommends_screen.dart';
 import '../features/manga_book/presentation/reader/reader_screen.dart';
 import '../features/manga_book/presentation/upcoming/upcoming_screen.dart';
 import '../features/manga_book/presentation/updates/updates_screen.dart';
@@ -115,6 +117,8 @@ abstract class Routes {
   static const updateStatus = "/update-status";
   static const about = 'about';
   static const globalSearch = '/global-search';
+  static const recommends = '/recommends/:mangaId';
+  static const recommendsBrowse = '/recommends/:mangaId/:providerName';
   static const onboarding = '/onboarding';
 
   // Migration
@@ -263,6 +267,8 @@ GoRouter routerConfig(Ref ref) {
     ),
     TypedGoRoute<UpdateStatusRoute>(path: Routes.updateStatus),
     TypedGoRoute<GlobalSearchRoute>(path: Routes.globalSearch),
+    TypedGoRoute<RecommendsRoute>(path: Routes.recommends),
+    TypedGoRoute<RecommendsBrowseRoute>(path: Routes.recommendsBrowse),
     TypedGoRoute<SourceFilterRoute>(path: Routes.sourceFilter),
     TypedGoRoute<MigrationGlobalSearchRoute>(
         path: Routes.migrationGlobalSearch),

--- a/lib/src/routes/sub_routes/common_routes.dart
+++ b/lib/src/routes/sub_routes/common_routes.dart
@@ -11,6 +11,26 @@ class MangaRoute extends GoRouteData with $MangaRoute {
       MangaDetailsScreen(mangaId: mangaId, categoryId: categoryId);
 }
 
+class RecommendsRoute extends GoRouteData with $RecommendsRoute {
+  const RecommendsRoute({required this.mangaId, this.mangaTitle});
+  final int mangaId;
+  final String? mangaTitle;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      RecommendsScreen(mangaId: mangaId, mangaTitle: mangaTitle);
+}
+
+class RecommendsBrowseRoute extends GoRouteData with $RecommendsBrowseRoute {
+  const RecommendsBrowseRoute({required this.mangaId, required this.providerName});
+  final int mangaId;
+  final String providerName;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      RecommendsBrowseScreen(mangaId: mangaId, providerName: providerName);
+}
+
 class UpdateStatusRoute extends GoRouteData with $UpdateStatusRoute {
   const UpdateStatusRoute();
   @override

--- a/test/library/tracking_library_test.dart
+++ b/test/library/tracking_library_test.dart
@@ -27,6 +27,7 @@ Fragment$MangaDto$trackRecords$nodes _trackNode({
       trackerId: trackerId,
       status: status,
       score: score,
+      remoteId: '',
     );
 
 Fragment$MangaDto$trackRecords _trks(


### PR DESCRIPTION
Adds a recommendations feature to the manga details page — similar titles pulled from the trackers, following Komikku's layout.

## What's here

- An inline **Suggestions** row on the manga details page, with a grouped **"Similar to {title}"** screen behind its header arrow and a per-source drill-down grid.
- Six sources: AniList, MangaUpdates (community + similar), MyAnimeList, MangaDex, and Comick. Each queries by the manga's tracker id when it's tracked there, otherwise by title search.
- An appearance toggle to show the row (on by default) or move recommendations into the overflow menu.

## Notable choices

- **MyAnimeList uses the official MAL API**, not Jikan. Jikan (the usual MAL proxy) intermittently returns HTTP 504 when its link to MAL goes stale, which blanks the section; the official API goes direct and is far more reliable. It needs a client id in the `X-MAL-CLIENT-ID` header, injected from a `MAL_CLIENT_ID` CI secret at build time so it isn't committed. Without a key the MAL source simply hides.
- **Suwayomi has no source-related query**, so the inline row is fed by the tracker engine rather than the source's own related list (Komikku's source for it).
- **Last-good cache**: each source's last successful pull is cached per manga; a later failure (rate limit, upstream 504, offline) serves the previous results instead of an error.
- Every applicable source renders its own state — results, "No results found", or the HTTP error — and sources with results sort above empty ones.

## Also

A small manga-details header cleanup rode along: the cover reclaims the dead space it left below the app bar, and the standalone "add tag" control is now a "+" chip at the front of the genre tags.

## Note for CI

Releases need a `MAL_CLIENT_ID` repo secret; the release and flatpak workflows patch it into the build. Local builds work without it (the MAL source just hides) or with `--dart-define=MAL_CLIENT_ID=...`.

Closes #257
