### PR TITLE
Refresh the library list after a bulk add

### DIFF
--- a/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_display_view.dart
+++ b/lib/src/features/browse_center/presentation/source_manga_list/widgets/source_manga_display_view.dart
@@ -13,6 +13,7 @@ import '../../../../../constants/db_keys.dart';
 import '../../../../../constants/enum.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../widgets/selection_action_bar.dart';
+import '../../../../library/presentation/library/controller/library_manga_list.dart';
 import '../../../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../../../manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
@@ -69,11 +70,11 @@ class SourceMangaDisplayView extends HookConsumerWidget {
         }
       }
       controller.itemList = items;
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text('Added ${ids.length} to library'),
-        ));
-      }
+      if (!context.mounted) return;
+      ref.invalidate(libraryMangaListProvider);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text('Added ${ids.length} to library'),
+      ));
     }
 
     final display = switch (displayMode) {


### PR DESCRIPTION
Bulk-adding series from a source's browse grid updated the loaded covers but never invalidated the cached library list, so the new entries didn't show up in the library until something else refreshed it (navigating in a way that rebuilt the list, a manual refresh, etc.).

Invalidate `libraryMangaListProvider` after a successful bulk add, matching what the single-add path already does. Also guards the post-add UI work behind `context.mounted` since the widget can go away during the mutation.