### PR TITLE
Fix startup Out of Memory crash from the unbounded GraphQL cache

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,7 +11,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -45,6 +44,7 @@ import 'src/sorayomi.dart';
 import 'src/utils/crash/crash_log.dart';
 import 'src/utils/crash/redact_tokens.dart';
 import 'src/utils/desktop/desktop_window.dart';
+import 'src/utils/hive/graphql_cache_guard.dart';
 import 'src/utils/misc/toast/toast.dart';
 import 'src/utils/platform/is_android_native.dart';
 import 'src/widgets/app_error_app.dart';
@@ -78,11 +78,18 @@ Future<void> _startApp() async {
     Workmanager().initialize(notificationCallbackDispatcher);
   }
   final packageInfo = await PackageInfo.fromPlatform();
+  _logBoot('start v${packageInfo.version}+${packageInfo.buildNumber} '
+      '(${defaultTargetPlatform.name})');
   final sharedPreferences = await SharedPreferences.getInstance();
   // Desktop: hide the OS title bar + restore saved window size before first
   // frame. No-op on web/mobile.
   await initDesktopWindow(sharedPreferences);
-  await initHiveForFlutter();
+  // The GraphQL cache is in-memory now; reclaim the legacy on-disk box, whose
+  // unbounded growth OOM-crashed startup when Hive loaded it whole.
+  final legacyBoxBytes = await deleteLegacyGraphqlCacheBox();
+  if (legacyBoxBytes != null) {
+    _logBoot('deleted legacy graphql cache box: $legacyBoxBytes bytes');
+  }
 
   SystemChrome.setPreferredOrientations(DeviceOrientation.values);
   GoRouter.optionURLReflectsImperativeAPIs = true;
@@ -94,9 +101,11 @@ Future<void> _startApp() async {
       return await initOfflineStorage();
     } catch (e, st) {
       debugPrint('offline storage init failed: $e\n$st');
+      _logBoot('offline storage init FAILED: ${redactTokens('$e')}');
       return null;
     }
   }();
+  _logBoot(offlineStorage != null ? 'offline storage ready' : 'offline off');
 
   // Build a ProviderContainer so we can run migration and preload auth
   // providers before the first frame. Using UncontrolledProviderScope below
@@ -105,7 +114,6 @@ Future<void> _startApp() async {
     overrides: [
       packageInfoProvider.overrideWithValue(packageInfo),
       sharedPreferencesProvider.overrideWithValue(sharedPreferences),
-      hiveStoreProvider.overrideWithValue(HiveStore()),
       if (offlineStorage != null) ...[
         offlineDatabaseProvider.overrideWithValue(offlineStorage.db),
         offlinePathsProvider.overrideWithValue(offlineStorage.paths),
@@ -281,6 +289,7 @@ Future<void> _startApp() async {
     }));
   }
 
+  _logBoot('runApp');
   runApp(
     UncontrolledProviderScope(
       container: container,
@@ -290,7 +299,20 @@ Future<void> _startApp() async {
   // Mark the app as up once it has painted a frame. After this, a stray
   // uncaught async error is recoverable and must NOT replace the whole UI with
   // the fatal screen (see [_onFatalError]).
-  WidgetsBinding.instance.addPostFrameCallback((_) => _appRendered = true);
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    _appRendered = true;
+    _logBoot('first frame');
+  });
+}
+
+/// Startup breadcrumbs in the crash log: a boot that dies pre-frame leaves the
+/// last completed stage next to the error, instead of a bare stack with no
+/// context (the startup-OOM class was undiagnosable without this).
+void _logBoot(String stage) {
+  writeCrashLog(
+    _crashLogPath,
+    '[${DateTime.now().toIso8601String()}] boot: $stage\n',
+  );
 }
 
 /// Install the framework + async error handlers and resolve the crash-log file.

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -132,7 +132,7 @@ class OfflineRepository {
   Future<int> totalDownloadedBytes() => db.totalDownloadedBytes();
 }
 
-// These are overridden at app startup (like hiveStoreProvider) with the
+// These are overridden at app startup with the
 // runtime database + base dir resolved via path_provider on native platforms.
 // They are NOT read on web (offline is disabled there), so the throwing default
 // is never hit in that configuration.

--- a/lib/src/features/settings/presentation/general/general_screen.dart
+++ b/lib/src/features/settings/presentation/general/general_screen.dart
@@ -50,7 +50,8 @@ class GeneralScreen extends ConsumerWidget {
             leading: const Icon(Icons.cleaning_services_rounded),
             title: Text(context.l10n.clearCache),
             onTap: () async {
-              await ref.read(hiveStoreProvider).reset();
+              // The GraphQL cache is in-memory (and bypassed by noCache), so
+              // "clear cache" now means the image cache.
               await DefaultCacheManager().emptyCache();
               if (context.mounted) {
                 ref.read(toastProvider)?.show(context.l10n.cacheCleared);

--- a/lib/src/global_providers/global_providers.dart
+++ b/lib/src/global_providers/global_providers.dart
@@ -14,9 +14,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../constants/db_keys.dart';
-import '../constants/timeout_constants.dart';
 import '../constants/endpoints.dart';
 import '../constants/enum.dart';
+import '../constants/timeout_constants.dart';
 import '../features/auth/data/auth_coordinator.dart';
 import '../features/auth/data/auth_credentials_store.dart';
 import '../features/auth/data/auth_state.dart';
@@ -143,7 +143,10 @@ GraphQLClient graphQlClient(Ref ref) {
     queryRequestTimeout: Duration(
         milliseconds:
             timeoutMs * (retryCount + 1) + retryDelayMs * retryCount + 2000),
-    cache: GraphQLCache(store: ref.watch(hiveStoreProvider)),
+    // In-memory only: the default fetch policy is noCache, so a persisted
+    // store is write-only bloat (its Hive box grew ~100 MB/week and its
+    // whole-file load OOM-crashed startup).
+    cache: GraphQLCache(store: InMemoryStore()),
   );
 }
 
@@ -225,7 +228,8 @@ GraphQLClient graphQlSubscriptionClient(Ref ref) {
     ),
     // Same package-level timeout as the query client (default is a hard 5s).
     queryRequestTimeout: Duration(milliseconds: timeoutMs + 2000),
-    cache: GraphQLCache(store: ref.watch(hiveStoreProvider)),
+    // In-memory only, matching the query client.
+    cache: GraphQLCache(store: InMemoryStore()),
   );
 }
 
@@ -278,9 +282,6 @@ class L10n extends _$L10n with SharedPreferenceClientMixin<Locale> {
 
 @riverpod
 SharedPreferences sharedPreferences(Ref ref) => throw UnimplementedError();
-
-@riverpod
-HiveStore hiveStore(Ref ref) => throw UnimplementedError();
 
 @riverpod
 Queue rateLimitQueue(Ref ref, [String? query]) {

--- a/lib/src/utils/hive/graphql_cache_guard.dart
+++ b/lib/src/utils/hive/graphql_cache_guard.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'graphql_cache_guard_stub.dart'
+    if (dart.library.io) 'graphql_cache_guard_io.dart' as platform;
+
+/// Delete the legacy on-disk GraphQL cache box, returning its size in bytes
+/// (null when absent). The cache is in-memory now (the default fetch policy is
+/// noCache, so persisting it was write-only bloat); older installs carry a box
+/// file of unbounded size — up to GBs — whose whole-file load OOM-crashed
+/// startup.
+Future<int?> deleteLegacyGraphqlCacheBox() =>
+    platform.deleteLegacyGraphqlCacheBox();

--- a/lib/src/utils/hive/graphql_cache_guard_io.dart
+++ b/lib/src/utils/hive/graphql_cache_guard_io.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+// Hive lowercased the box name ("graphqlClientStore") for its file names.
+const _legacyFiles = ['graphqlclientstore.hive', 'graphqlclientstore.lock'];
+
+/// Returns the deleted box's size in bytes (null when there was none), so the
+/// caller can log how big the file had grown — the number that diagnoses the
+/// startup-OOM class from a single crash-log line.
+Future<int?> deleteLegacyGraphqlCacheBox() async {
+  try {
+    final docs = await getApplicationDocumentsDirectory();
+    int? boxBytes;
+    for (final name in _legacyFiles) {
+      final f = File('${docs.path}/$name');
+      if (!f.existsSync()) continue;
+      if (name.endsWith('.hive')) boxBytes = f.lengthSync();
+      f.deleteSync();
+    }
+    return boxBytes;
+  } catch (_) {
+    // Best-effort: a failed cleanup must never block startup.
+    return null;
+  }
+}

--- a/lib/src/utils/hive/graphql_cache_guard_stub.dart
+++ b/lib/src/utils/hive/graphql_cache_guard_stub.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Web: no box file ever existed.
+Future<int?> deleteLegacyGraphqlCacheBox() async => null;


### PR DESCRIPTION
The GraphQL response cache persisted to a Hive box that grew without bound — about 100 MB per week of normal use — and Hive loads the entire box file into memory when opening it at startup. After enough growth the load dies to an OutOfMemoryError before the first frame: splash, then a white screen, every launch.

The store was effectively write-only: the client's default fetch policy is noCache, so screens never read it back. The cache is now in-memory only, so the file (and the crash class) is gone structurally. On the first launch after updating, the legacy box file is deleted and its size recorded in the crash log — reclaiming up to gigabytes of storage and confirming the diagnosis per device.

Startup now also writes stage breadcrumbs to the crash log (version, cache cleanup, offline storage, runApp, first frame), so any future pre-frame crash pinpoints the stage it died in instead of leaving a bare framework stack.

Verified on-device: an organically grown box was deleted and logged at boot, the file no longer regrows, and the full suite passes.