### PR TITLE
Make release build steps portable across runners

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -72,6 +72,8 @@ jobs:
         # Stops a release built from a commit whose pubspec version doesn't match
         # the tag (e.g. tagging v0.9.2 while pubspec still says 0.9.1); the
         # artifacts would report the wrong in-app version.
+        # Windows defaults to PowerShell, which can't parse this script.
+        shell: bash
         run: |
           tag_ver="${GITHUB_REF_NAME#v}"
           pubspec_ver="$(grep -m1 '^version:' pubspec.yaml | sed -E 's/version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
@@ -132,9 +134,13 @@ jobs:
       # build so every platform (incl. fastforge/flatpak, which call flutter
       # build internally) compiles it in — no per-tool --dart-define needed.
       - name: Inject MyAnimeList client id
+        # -i.bak (no space) is the one in-place form GNU and BSD sed agree on;
+        # bare -i breaks macOS/iOS runners.
+        shell: bash
         run: |
-          sed -i "s|defaultValue: '',|defaultValue: '${{ secrets.MAL_CLIENT_ID }}',|" \
+          sed -i.bak "s|defaultValue: '',|defaultValue: '${{ secrets.MAL_CLIENT_ID }}',|" \
             lib/src/features/manga_book/data/recommendations/providers/myanimelist_provider.dart
+          rm lib/src/features/manga_book/data/recommendations/providers/myanimelist_provider.dart.bak
 
       # ---- builds ----
       - name: Build Android


### PR DESCRIPTION
The v1.0.0 tag build failed on Windows, macOS, and iOS: the new tag-version guard runs as PowerShell on Windows and can't parse bash, and the MyAnimeList client-id injection used GNU sed's bare `-i`, which BSD sed on the mac runners rejects. Forces `shell: bash` on both steps and switches to the portable `-i.bak` form. Android, Linux, and web built fine, so those steps are untouched.