### PR TITLE
Hide Quick Search on touch devices

### DIFF
--- a/lib/src/features/settings/presentation/general/general_screen.dart
+++ b/lib/src/features/settings/presentation/general/general_screen.dart
@@ -13,6 +13,7 @@ import '../../../../global_providers/global_providers.dart';
 import '../../../../l10n/generated/app_localizations.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
+import '../../../../utils/platform/platform_runtime.dart';
 import '../../../../widgets/popup_widgets/radio_list_popup.dart';
 import 'quick_search_toggle/quick_search_toggle_tile.dart';
 import 'timeout_settings/timeout_settings_section.dart';
@@ -58,7 +59,10 @@ class GeneralScreen extends ConsumerWidget {
               }
             },
           ),
-          const QuickSearchToggleTile(),
+          // A keyboard shortcut is the only way to open quick search, so on a
+          // touch device this switch turned on something unreachable. Same
+          // gate the Keyboard shortcuts entry already uses.
+          if (isKeyboardRuntime) const QuickSearchToggleTile(),
           const ForcePortraitTile(),
           const TimeoutSettingsSection(),
         ],


### PR DESCRIPTION
Quick search opens from a keyboard shortcut and nothing else — there is no button, gesture or menu item anywhere. But its switch in General settings rendered on every platform, so on a phone you got a setting called "Quick Search" with no explanation that turned on something you could never reach.

Settings already hides the Keyboard shortcuts entry on runtimes without a physical keyboard. This switch uses the same gate now.

Desktop and web are unchanged. Bringing quick search to touch devices is a separate question, not addressed here.
