### PR TITLE
Keep a way back out of global search

### DIFF
--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -902,7 +902,7 @@ class _LibrarySearchBar extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.travel_explore_rounded),
             tooltip: context.l10n.globalSearch,
-            onPressed: () => GlobalSearchRoute(query: query).go(context),
+            onPressed: () => GlobalSearchRoute(query: query).push(context),
           ),
       ],
       highlightDsl: true,


### PR DESCRIPTION
Searching globally from the library search bar left you stranded: no bottom bar and no back button, with nothing to do but restart the app.

That button was the only one of eight global-search entry points using `go()` instead of `push()`. Global search renders above the navigation shell, so `go()` replaced the location outright — the shell page was gone, and with an empty stack behind it the app bar had no back arrow to draw.

Swept the other above-shell routes (reader, manga, upcoming, migration, recommendations, duplicates) for the same mistake; this was the only one.
