### PR TITLE
Make reader tap zones work

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -30,7 +30,10 @@ enum DBKeys {
   readerMode(ReaderMode.singleHorizontalRTL),
   readerPadding(0.0),
   readerMagnifierSize(1.0),
-  readerNavigationLayout(ReaderNavigationLayout.disabled),
+  // Migration source for the per-viewer keys below only; nothing reads this
+  // directly. Default changed from disabled to defaultNavigation to match
+  // Komikku's tap zones on by default.
+  readerNavigationLayout(ReaderNavigationLayout.defaultNavigation),
   invertTap(false),
   quickSearchToggle(true),
   swipeToggle(true),
@@ -235,6 +238,16 @@ enum DBKeys {
   cropBorders(false),
   // Shared by the paged and long-strip sections.
   smallerTapZones(false),
+  // Per-viewer tap zones, seeded from the single keys above on upgrade.
+  pagedNavigationLayout(ReaderNavigationLayout.defaultNavigation),
+  longStripNavigationLayout(ReaderNavigationLayout.defaultNavigation),
+  pagedTapInvert(TapInvert.none),
+  longStripTapInvert(TapInvert.none),
+  // Off by default, matching Komikku.
+  showTapZonesOverlay(false),
+  // One free look for someone who has never seen the zones (Komikku's
+  // showNavigationOverlayNewUser), then it turns itself off.
+  tapZonesOverlayUnseen(true),
   animatePageTransitions(true),
   // Wide-page handling. Split needs
   // page-list remapping, so it persists here and the engine wires it later;

--- a/lib/src/constants/enum.dart
+++ b/lib/src/constants/enum.dart
@@ -52,12 +52,25 @@ enum ReaderMode {
 }
 
 enum ReaderNavigationLayout {
+  // Declaration order is the stored value — these persist by index, so this
+  // list is append-only. Use [displayOrder] for anything user-facing.
   defaultNavigation,
   lShaped,
   rightAndLeft,
   edge,
   kindlish,
   disabled;
+
+  /// Komikku's order (`ReaderPreferences.TapZones`), which differs from the
+  /// declaration order above.
+  static const List<ReaderNavigationLayout> displayOrder = [
+    ReaderNavigationLayout.defaultNavigation,
+    ReaderNavigationLayout.lShaped,
+    ReaderNavigationLayout.kindlish,
+    ReaderNavigationLayout.edge,
+    ReaderNavigationLayout.rightAndLeft,
+    ReaderNavigationLayout.disabled,
+  ];
 
   String toLocale(BuildContext context) => switch (this) {
         ReaderNavigationLayout.defaultNavigation =>
@@ -115,6 +128,15 @@ enum TapInvert {
       this == TapInvert.horizontal || this == TapInvert.both;
   bool get invertsVertical =>
       this == TapInvert.vertical || this == TapInvert.both;
+
+  /// Swaps the left/right zones. Right-and-Left is a spatial layout, so a
+  /// right-to-left series has to mirror it: tapping the right edge goes back.
+  TapInvert get horizontallyFlipped => switch (this) {
+        TapInvert.none => TapInvert.horizontal,
+        TapInvert.horizontal => TapInvert.none,
+        TapInvert.vertical => TapInvert.both,
+        TapInvert.both => TapInvert.vertical,
+      };
 
   String toLocale(BuildContext context) => switch (this) {
         TapInvert.none => context.l10n.readerTapInvertNone,

--- a/lib/src/features/manga_book/presentation/reader/controller/reader_settings_model.dart
+++ b/lib/src/features/manga_book/presentation/reader/controller/reader_settings_model.dart
@@ -838,6 +838,10 @@ class ReaderSettingsModel extends _$ReaderSettingsModel {
     );
   }
 
+  /// The sheet only ever writes per-series. The global branch still targets the
+  /// pre-split key, which no reader consults — wire any future "apply to all"
+  /// control to the paged/long-strip keys instead, or it will silently do
+  /// nothing.
   Future<void> setNavigationLayout(
     ReaderNavigationLayout layout, {
     bool perSeries = true,

--- a/lib/src/features/manga_book/presentation/reader/utils/reader_mode_kind.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/reader_mode_kind.dart
@@ -4,7 +4,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
 import '../../../../../constants/enum.dart';
+import '../../../../settings/presentation/reader/widgets/reader_navigation_layout_tile/reader_navigation_layout_tile.dart';
+import '../../../../settings/presentation/reader/widgets/reader_tap_invert/reader_tap_invert.dart';
 
 /// Whether a reading mode is paged (page-flip) rather than continuous/webtoon
 /// scroll. Single source of truth for the gesture routing and the bottom
@@ -21,3 +25,73 @@ bool isPagedReaderMode(ReaderMode mode) => switch (mode) {
       ReaderMode.webtoon =>
         false,
     };
+
+/// Whether a mode reads right-to-left. Lives here so the page-transition
+/// direction and the spatial tap zones can't drift apart.
+bool isRTLReaderMode(ReaderMode mode) => switch (mode) {
+      ReaderMode.singleHorizontalRTL ||
+      ReaderMode.continuousHorizontalRTL =>
+        true,
+      ReaderMode.singleHorizontalLTR ||
+      ReaderMode.continuousHorizontalLTR ||
+      ReaderMode.singleVertical ||
+      ReaderMode.continuousVertical ||
+      ReaderMode.webtoon ||
+      ReaderMode.defaultReader =>
+        false,
+    };
+
+/// What the "Default" tap-zone setting resolves to for a given mode.
+/// Komikku (`PagerConfig.defaultNavigation`): right-and-left for horizontal
+/// paged, L-shaped for everything else.
+ReaderNavigationLayout defaultNavigationFor(ReaderMode mode) => switch (mode) {
+      ReaderMode.singleHorizontalLTR ||
+      ReaderMode.singleHorizontalRTL ||
+      ReaderMode.continuousHorizontalLTR ||
+      ReaderMode.continuousHorizontalRTL =>
+        ReaderNavigationLayout.rightAndLeft,
+      ReaderMode.singleVertical ||
+      ReaderMode.continuousVertical ||
+      ReaderMode.webtoon ||
+      ReaderMode.defaultReader =>
+        ReaderNavigationLayout.lShaped,
+    };
+
+/// The tap-zone layout actually in force: the series' own choice if it made
+/// one, else that viewer's setting, with Default resolved to a real layout.
+/// Reader, settings sheet, and chapter separator all go through this so
+/// they can't disagree about whether zones are on.
+ReaderNavigationLayout effectiveNavigationLayout(
+  WidgetRef ref, {
+  required ReaderMode mode,
+  ReaderNavigationLayout? seriesOverride,
+}) {
+  var layout = seriesOverride ?? ReaderNavigationLayout.defaultNavigation;
+  if (layout == ReaderNavigationLayout.defaultNavigation) {
+    layout = (isPagedReaderMode(mode)
+            ? ref.watch(pagedNavigationLayoutKeyProvider)
+            : ref.watch(longStripNavigationLayoutKeyProvider)) ??
+        ReaderNavigationLayout.defaultNavigation;
+  }
+  return layout == ReaderNavigationLayout.defaultNavigation
+      ? defaultNavigationFor(mode)
+      : layout;
+}
+
+/// Tap inversion in force for [mode], including the right-to-left mirror that
+/// only the spatial Right-and-Left layout needs.
+TapInvert effectiveTapInvert(
+  WidgetRef ref, {
+  required ReaderMode mode,
+  required ReaderNavigationLayout layout,
+  TapInvert? seriesOverride,
+}) {
+  final invert = seriesOverride ??
+      (isPagedReaderMode(mode)
+          ? ref.watch(pagedTapInvertKeyProvider)
+          : ref.watch(longStripTapInvertKeyProvider)) ??
+      TapInvert.none;
+  return layout == ReaderNavigationLayout.rightAndLeft && isRTLReaderMode(mode)
+      ? invert.horizontallyFlipped
+      : invert;
+}

--- a/lib/src/features/manga_book/presentation/reader/widgets/chapter_separator.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chapter_separator.dart
@@ -13,9 +13,11 @@ import '../../../../../constants/enum.dart';
 import '../../../../../routes/router_config.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../settings/presentation/reader/widgets/reader_navigation_layout_tile/reader_navigation_layout_tile.dart';
+import '../../../../settings/presentation/reader/widgets/reader_mode_tile/reader_mode_tile.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/manga/manga_model.dart';
 import '../../manga_details/controller/manga_details_controller.dart';
+import '../utils/reader_mode_kind.dart';
 
 class ChapterSeparator extends ConsumerWidget {
   const ChapterSeparator({
@@ -23,11 +25,17 @@ class ChapterSeparator extends ConsumerWidget {
     required this.manga,
     required this.chapter,
     required this.isPreviousChapterSeparator,
+    required this.readerMode,
     this.alwaysShow = true,
   });
   final MangaDto manga;
   final ChapterDto chapter;
   final bool isPreviousChapterSeparator;
+
+  /// The mode actually in use, from the reader that built this. Deriving it
+  /// from metadata here would miss auto-selected modes and could check the
+  /// paged tap-zone setting while the reader is running long strip.
+  final ReaderMode readerMode;
 
   /// "Always show chapter transition": OFF collapses the prev/next
   /// transition to a slim label so chapters flow with less interruption.
@@ -52,13 +60,14 @@ class ChapterSeparator extends ConsumerWidget {
       getNextAndPreviousChaptersProvider(
           mangaId: manga.id, chapterId: chapter.id),
     );
-    final navigationLayout = ref.watch(readerNavigationLayoutKeyProvider);
-    final showPrevNextButtons = manga.metaData.readerNavigationLayout ==
-            ReaderNavigationLayout.disabled ||
-        ((manga.metaData.readerNavigationLayout == null ||
-                manga.metaData.readerNavigationLayout ==
-                    ReaderNavigationLayout.defaultNavigation) &&
-            navigationLayout == ReaderNavigationLayout.disabled);
+    // Same resolver the reader uses: these buttons exist for people with no
+    // tap zones, so "disabled" has to mean the same thing in both places.
+    final showPrevNextButtons = effectiveNavigationLayout(
+          ref,
+          mode: readerMode,
+          seriesOverride: manga.metaData.readerNavigationLayout,
+        ) ==
+        ReaderNavigationLayout.disabled;
     return Center(
       child: SingleChildScrollView(
         child: Column(

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/reading_mode_tab.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/tabs/reading_mode_tab.dart
@@ -14,6 +14,7 @@ import '../../../../../../settings/presentation/reader/widgets/reader_mode_tile/
 import '../../../../../../settings/presentation/reader/widgets/reader_navigation_layout_tile/reader_navigation_layout_tile.dart';
 import '../../../../../../settings/presentation/reader/widgets/reader_padding_slider/reader_padding_slider.dart';
 import '../../../controller/reader_mode_adapter.dart';
+import '../../../utils/reader_mode_kind.dart';
 import '../../../controller/reader_settings_model.dart';
 import 'int_slider_tile.dart';
 
@@ -54,11 +55,13 @@ class ReadingModeTab extends ConsumerWidget {
     // The stored mode's chip; null for the legacy continuous-horizontal
     // orphans, which get their own honest extra chip (§2.5).
     final storedChip = ReaderModeAdapter.toChip(settings.readerMode);
-    final resolvedNav =
-        settings.navigationLayout == ReaderNavigationLayout.defaultNavigation
-            ? (ref.watch(readerNavigationLayoutKeyProvider) ??
-                ReaderNavigationLayout.defaultNavigation)
-            : settings.navigationLayout;
+    // Through the shared resolver, so the sheet can't disagree with the reader
+    // about whether zones are on for this mode.
+    final resolvedNav = effectiveNavigationLayout(
+      ref,
+      mode: resolvedMode,
+      seriesOverride: settings.navigationLayout,
+    );
 
     // I7: own scroll view; never the sheet's controller.
     return ListView(
@@ -108,7 +111,7 @@ class ReadingModeTab extends ConsumerWidget {
         _SectionLabel(context.l10n.readerSectionTapZones),
         _ChipRow(
           children: [
-            for (final layout in ReaderNavigationLayout.values)
+            for (final layout in ReaderNavigationLayout.displayOrder)
               FilterChip(
                 selected: settings.navigationLayout == layout,
                 showCheckmark: false,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/continuous_reader_mode.dart
@@ -339,6 +339,7 @@ class ContinuousReaderMode extends HookConsumerWidget {
                   manga: manga,
                   chapter: chapter,
                   isPreviousChapterSeparator: (index == 0),
+                  readerMode: wrapperReaderMode,
                   alwaysShow: alwaysShowTransition,
                 ),
               );

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -21,7 +21,8 @@ enum _DragOwner { page, pager }
 
 enum _PanDirection { left, right, up, down }
 
-enum _TapAction { previous, next, menu }
+/// Public so the zone geometry can be tested against the overlay.
+enum TapAction { previous, next, menu }
 
 class PagedReaderController {
   _PagedReaderViewportState? _state;
@@ -710,75 +711,30 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     final callbacks = ReaderInputScope.maybeOf(context);
     if (callbacks == null) return;
     switch (_tapActionFor(position, _viewportSize, callbacks)) {
-      case _TapAction.previous:
+      case TapAction.previous:
         callbacks.onPrevious();
         break;
-      case _TapAction.next:
+      case TapAction.next:
         callbacks.onNext();
         break;
-      case _TapAction.menu:
+      case TapAction.menu:
         callbacks.onTap();
         break;
     }
   }
 
-  _TapAction _tapActionFor(
+  TapAction _tapActionFor(
     Offset position,
     Size size,
     ReaderInputCallbacks callbacks,
-  ) {
-    final layout = callbacks.navigationLayout;
-    if (layout == ReaderNavigationLayout.disabled ||
-        layout == ReaderNavigationLayout.defaultNavigation) {
-      return _TapAction.menu;
-    }
-
-    final leftAction = callbacks.tapInvert.invertsHorizontal
-        ? _TapAction.next
-        : _TapAction.previous;
-    final rightAction = callbacks.tapInvert.invertsHorizontal
-        ? _TapAction.previous
-        : _TapAction.next;
-    final topAction = callbacks.tapInvert.invertsVertical
-        ? _TapAction.next
-        : _TapAction.previous;
-    final bottomAction = callbacks.tapInvert.invertsVertical
-        ? _TapAction.previous
-        : _TapAction.next;
-    final edgeWidth = size.width * (callbacks.smallerTapZones ? 0.25 : 1 / 3);
-    final edgeHeight = size.height * (callbacks.smallerTapZones ? 0.25 : 1 / 3);
-
-    return switch (layout) {
-      ReaderNavigationLayout.rightAndLeft => position.dx < edgeWidth
-          ? leftAction
-          : position.dx > size.width - edgeWidth
-              ? rightAction
-              : _TapAction.menu,
-      ReaderNavigationLayout.edge =>
-        position.dx < edgeWidth || position.dx > size.width - edgeWidth
-            ? rightAction
-            : position.dy > size.height - edgeHeight
-                ? leftAction
-                : _TapAction.menu,
-      ReaderNavigationLayout.kindlish => position.dy < size.height - edgeHeight
-          ? _TapAction.menu
-          : position.dx < edgeWidth
-              ? leftAction
-              : rightAction,
-      ReaderNavigationLayout.lShaped => position.dy < edgeHeight
-          ? topAction
-          : position.dy > size.height - edgeHeight
-              ? bottomAction
-              : position.dx < edgeWidth
-                  ? leftAction
-                  : position.dx > size.width - edgeWidth
-                      ? rightAction
-                      : _TapAction.menu,
-      ReaderNavigationLayout.defaultNavigation ||
-      ReaderNavigationLayout.disabled =>
-        _TapAction.menu,
-    };
-  }
+  ) =>
+      tapActionForZone(
+        position: position,
+        size: size,
+        layout: callbacks.navigationLayout,
+        tapInvert: callbacks.tapInvert,
+        smallerTapZones: callbacks.smallerTapZones,
+      );
 
   Offset _releaseVelocity(PointerUpEvent event) {
     if (_velocityPointer != event.pointer) return Offset.zero;
@@ -1215,4 +1171,58 @@ class _PageZoomController extends ChangeNotifier {
       value.dy.clamp(-maxPan.dy, maxPan.dy).toDouble(),
     );
   }
+}
+
+/// Which action a tap at [position] lands on. Pure, so the zone geometry can
+/// be tested against the overlay that draws it.
+@visibleForTesting
+TapAction tapActionForZone({
+  required Offset position,
+  required Size size,
+  required ReaderNavigationLayout layout,
+  required TapInvert tapInvert,
+  required bool smallerTapZones,
+}) {
+  final leftAction =
+      tapInvert.invertsHorizontal ? TapAction.next : TapAction.previous;
+  final rightAction =
+      tapInvert.invertsHorizontal ? TapAction.previous : TapAction.next;
+  final topAction =
+      tapInvert.invertsVertical ? TapAction.next : TapAction.previous;
+  final bottomAction =
+      tapInvert.invertsVertical ? TapAction.previous : TapAction.next;
+  final edgeWidth = size.width * (smallerTapZones ? 0.25 : 1 / 3);
+  final edgeHeight = size.height * (smallerTapZones ? 0.25 : 1 / 3);
+
+  return switch (layout) {
+    ReaderNavigationLayout.rightAndLeft => position.dx < edgeWidth
+        ? leftAction
+        : position.dx >= size.width - edgeWidth
+            ? rightAction
+            : TapAction.menu,
+    ReaderNavigationLayout.edge =>
+      position.dx < edgeWidth || position.dx >= size.width - edgeWidth
+          ? rightAction
+          : position.dy >= size.height - edgeHeight
+              ? leftAction
+              : TapAction.menu,
+    // Komikku's kindlish layout: menu across the top, left/right below it.
+    ReaderNavigationLayout.kindlish => position.dy < edgeHeight
+        ? TapAction.menu
+        : position.dx < edgeWidth
+            ? leftAction
+            : rightAction,
+    ReaderNavigationLayout.lShaped => position.dy < edgeHeight
+        ? topAction
+        : position.dy >= size.height - edgeHeight
+            ? bottomAction
+            : position.dx < edgeWidth
+                ? leftAction
+                : position.dx >= size.width - edgeWidth
+                    ? rightAction
+                    : TapAction.menu,
+    ReaderNavigationLayout.defaultNavigation ||
+    ReaderNavigationLayout.disabled =>
+      TapAction.menu,
+  };
 }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_navigation_layout/reader_navigation_layout.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_navigation_layout/reader_navigation_layout.dart
@@ -45,15 +45,18 @@ class ReaderNavigationLayoutWidget extends HookConsumerWidget {
     final prevColorTween = ColorTween(
       begin: showReaderLayoutAnimation ? Colors.blue : Colors.transparent,
     ).animate(animationController).value;
-    useEffect(() {
-      animationController.forward();
-      return;
-    }, []);
+    // Callers resolve this (see effectiveNavigationLayout); an unresolved
+    // value just draws nothing rather than falling back here and risking
+    // disagreement with the reader.
+    final layout = navigationLayout;
 
-    final layout = navigationLayout == null ||
-            navigationLayout == ReaderNavigationLayout.defaultNavigation
-        ? ref.watch(readerNavigationLayoutKeyProvider)
-        : navigationLayout;
+    // Replays on every layout change, not just the first build, so picking a
+    // different one flashes the zones for it too (Komikku's
+    // navigationModeChanged).
+    useEffect(() {
+      animationController.forward(from: 0);
+      return;
+    }, [layout]);
     // Axis-wise inversion: horizontal swaps the
     // left/right zones, vertical swaps the L-shaped top/bottom rows.
     final TapInvert invert =

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -32,6 +32,7 @@ import '../../../../settings/presentation/reader/widgets/reader_padding_slider/r
 import '../../../../settings/presentation/reader/widgets/reader_paged_prefs/reader_paged_prefs.dart';
 import '../../../../settings/presentation/reader/widgets/reader_swipe_toggle_tile/reader_swipe_chapter_toggle_tile.dart';
 import '../../../../settings/presentation/reader/widgets/reader_tap_invert/reader_tap_invert.dart';
+import '../../../../settings/presentation/reader/widgets/tap_zones_overlay/tap_zones_overlay.dart';
 import '../../../../settings/presentation/reader/widgets/reader_volume_tap_invert_tile/reader_volume_tap_invert_tile.dart';
 import '../../../../settings/presentation/reader/widgets/reader_volume_tap_tile/reader_volume_tap_tile.dart';
 import '../../../data/manga_book/manga_book_repository.dart';
@@ -194,22 +195,6 @@ class ReaderWrapper extends HookConsumerWidget {
       case ReaderMode.continuousHorizontalRTL:
         return false;
 
-      case ReaderMode.defaultReader:
-        return false;
-    }
-  }
-
-  bool _isRTLReaderMode(ReaderMode readerMode) {
-    switch (readerMode) {
-      case ReaderMode.singleHorizontalRTL:
-      case ReaderMode.continuousHorizontalRTL:
-        return true;
-
-      case ReaderMode.singleHorizontalLTR:
-      case ReaderMode.continuousHorizontalLTR:
-      case ReaderMode.singleVertical:
-      case ReaderMode.continuousVertical:
-      case ReaderMode.webtoon:
       case ReaderMode.defaultReader:
         return false;
     }
@@ -423,7 +408,7 @@ class ReaderWrapper extends HookConsumerWidget {
     bool pushNextChapter() {
       if (nextPrevChapterPair?.first == null) return false;
       final transVertical = _shouldUseVerticalTransition(resolvedReaderMode);
-      final toPrev = _isRTLReaderMode(resolvedReaderMode);
+      final toPrev = isRTLReaderMode(resolvedReaderMode);
       ReaderRoute(
         mangaId: manga.id,
         chapterId: nextPrevChapterPair!.first!.id,
@@ -436,7 +421,7 @@ class ReaderWrapper extends HookConsumerWidget {
     bool pushPreviousChapter() {
       if (nextPrevChapterPair?.second == null) return false;
       final transVertical = _shouldUseVerticalTransition(resolvedReaderMode);
-      final toPrev = !_isRTLReaderMode(resolvedReaderMode);
+      final toPrev = !isRTLReaderMode(resolvedReaderMode);
       ReaderRoute(
         mangaId: manga.id,
         chapterId: nextPrevChapterPair!.second!.id,
@@ -550,7 +535,7 @@ class ReaderWrapper extends HookConsumerWidget {
             Positioned.fill(
               child: Shortcuts.manager(
                 manager: readerShortcutManager(scrollDirection,
-                    isRtl: _isRTLReaderMode(resolvedReaderMode),
+                    isRtl: isRTLReaderMode(resolvedReaderMode),
                     autoScrollSupported: onToggleAutoScroll != null),
                 child: Actions(
                   actions: {
@@ -705,7 +690,7 @@ class ReaderWrapper extends HookConsumerWidget {
                 nextPrevChapterPair: nextPrevChapterPair,
                 resolvedReaderMode: resolvedReaderMode,
                 autoScrollSupported: onToggleAutoScroll != null,
-                reverseSeekBar: _isRTLReaderMode(resolvedReaderMode),
+                reverseSeekBar: isRTLReaderMode(resolvedReaderMode),
                 onChanged: onChanged,
                 onOpenSettings: () async {
                   await showReaderSettingsSheet(
@@ -1060,15 +1045,47 @@ class ReaderView extends HookConsumerWidget {
       showMagnification.value = false;
     }
 
+    final resolvedNavigationLayout = effectiveNavigationLayout(
+      ref,
+      mode: resolvedReaderMode,
+      seriesOverride: mangaReaderNavigationLayout,
+    );
+
+    // Komikku's showNavigationOverlayOnStart plus its new-user one-shot.
+    // Read once and held, not watched: watching would clear the flag and
+    // take the flash away in the same frame it was granted.
+    final overlayAlways = ref.watch(showTapZonesOverlayProvider).ifNull();
+    final unseenAtOpen = useRef<bool?>(null);
+    unseenAtOpen.value ??= ref.read(tapZonesOverlayUnseenProvider).ifNull(true);
+    // No point spending the one-shot on a layout that draws nothing.
+    final zonesAreVisible =
+        resolvedNavigationLayout != ReaderNavigationLayout.disabled;
+    final showZonesOnOpen = showReaderLayoutAnimation &&
+        zonesAreVisible &&
+        (overlayAlways || unseenAtOpen.value!);
+    useEffect(() {
+      if (!showZonesOnOpen || !unseenAtOpen.value!) return null;
+      // Guard context.mounted: a reader popped in the same turn would write
+      // through a disposed ref.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+        // Latch too, or turning the hint off and on again replays the one look.
+        unseenAtOpen.value = false;
+        ref.read(tapZonesOverlayUnseenProvider.notifier).update(false);
+      });
+      return null;
+    }, [showZonesOnOpen]);
+
+    final resolvedTapInvert = effectiveTapInvert(
+      ref,
+      mode: resolvedReaderMode,
+      layout: resolvedNavigationLayout,
+      seriesOverride: mangaTapInvert,
+    );
+
     if (childHandlesGestures) {
-      final layout = mangaReaderNavigationLayout ==
-              ReaderNavigationLayout.defaultNavigation
-          ? ref.watch(readerNavigationLayoutKeyProvider) ??
-              ReaderNavigationLayout.defaultNavigation
-          : mangaReaderNavigationLayout;
-      final tapInvert = mangaTapInvert ??
-          ref.watch(readerTapInvertKeyProvider) ??
-          TapInvert.fromLegacyInvert(ref.watch(invertTapProvider));
+      final layout = resolvedNavigationLayout;
+      final tapInvert = resolvedTapInvert;
       final smallerTapZones = ref.watch(smallerTapZonesProvider) ?? false;
       content = ReaderInputScope(
         callbacks: ReaderInputCallbacks(
@@ -1115,14 +1132,18 @@ class ReaderView extends HookConsumerWidget {
     return Stack(
       children: [
         content,
-        if (!childHandlesGestures)
-          ReaderNavigationLayoutWidget(
+        // Paged routes taps through ReaderInputScope, so this overlay is
+        // display-only there.
+        IgnorePointer(
+          ignoring: childHandlesGestures,
+          child: ReaderNavigationLayoutWidget(
             onNext: onNext,
             onPrevious: onPrevious,
-            navigationLayout: mangaReaderNavigationLayout,
-            tapInvert: mangaTapInvert,
-            showReaderLayoutAnimation: showReaderLayoutAnimation,
+            navigationLayout: resolvedNavigationLayout,
+            tapInvert: resolvedTapInvert,
+            showReaderLayoutAnimation: showZonesOnOpen,
           ),
+        ),
         if (showMagnification.value)
           Positioned(
             left: positionOffset.dx,

--- a/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
+++ b/lib/src/features/settings/presentation/reader/reader_settings_screen.dart
@@ -21,7 +21,6 @@ import 'widgets/reader_general_prefs/reader_general_prefs.dart';
 import 'widgets/reader_ignore_safe_area_tile/reader_ignore_safe_area_tile.dart';
 import 'widgets/reader_infinity_scrolling_mode_tile/reader_infinity_scrolling_mode_tile.dart';
 import 'widgets/reader_initial_overlay_tile/reader_initial_overlay_tile.dart';
-import 'widgets/reader_invert_tap_tile/reader_invert_tap_tile.dart';
 import 'widgets/reader_keep_screen_on_tile/reader_keep_screen_on_tile.dart';
 import 'widgets/reader_last_page_swipe_tile/reader_last_page_swipe_tile.dart';
 import 'widgets/reader_left_handed_seekbar_tile/reader_left_handed_seekbar_tile.dart';
@@ -33,6 +32,7 @@ import 'widgets/reader_paged_prefs/reader_paged_prefs.dart';
 import 'widgets/reader_pinch_to_zoom/reader_pinch_to_zoom.dart';
 import 'widgets/reader_scroll_animation_tile/reader_scroll_animation_tile.dart';
 import 'widgets/reader_swipe_toggle_tile/reader_swipe_chapter_toggle_tile.dart';
+import 'widgets/tap_zones_overlay/tap_zones_overlay.dart';
 import 'widgets/reader_volume_tap_invert_tile/reader_volume_tap_invert_tile.dart';
 import 'widgets/reader_volume_tap_tile/reader_volume_tap_tile.dart';
 import 'widgets/reader_webtoon_prefs/reader_webtoon_prefs.dart';
@@ -67,8 +67,10 @@ class ReaderSettingsScreen extends ConsumerWidget {
           // first, then Display, E-Ink, Reading, Paged, Long strip,
           // Navigation, Actions.
           const ReaderModeTile(),
-          const ReaderNavigationLayoutTile(),
-          const ReaderInvertTapTile(),
+          // Tap zones and their inversion are per viewer, so they live in the
+          // Paged and Long strip groups below — same as Komikku. Only the
+          // overlay and the zone size are shared.
+          const ShowTapZonesOverlayTile(),
           _BoolTile(
             title: context.l10n.smallerTapZones,
             value: ref.watch(smallerTapZonesProvider).ifNull(false),
@@ -191,6 +193,8 @@ class ReaderSettingsScreen extends ConsumerWidget {
 
           // ── Paged ──
           _Header(context.l10n.readerGroupPagerViewer),
+          const ReaderNavigationLayoutTile(longStrip: false),
+          const ReaderTapInvertTile(longStrip: false),
           _EnumChips<ImageScaleType>(
             label: context.l10n.imageScaleType,
             values: ImageScaleType.values,
@@ -284,6 +288,8 @@ class ReaderSettingsScreen extends ConsumerWidget {
 
           // ── Long strip ──
           _Header(context.l10n.readerGroupWebtoonViewer),
+          const ReaderNavigationLayoutTile(longStrip: true),
+          const ReaderTapInvertTile(longStrip: true),
           _EnumChips<WebtoonScaleType>(
             label: context.l10n.webtoonScaleType,
             values: WebtoonScaleType.values,

--- a/lib/src/features/settings/presentation/reader/widgets/reader_navigation_layout_tile/reader_navigation_layout_tile.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_navigation_layout_tile/reader_navigation_layout_tile.dart
@@ -13,9 +13,12 @@ import '../../../../../../constants/enum.dart';
 import '../../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../../../widgets/popup_widgets/radio_list_popup.dart';
+import '../reader_tap_invert/reader_tap_invert.dart';
 
 part 'reader_navigation_layout_tile.g.dart';
 
+/// Migration source for the two per-viewer keys below. Nothing reads this to
+/// decide tap zones any more.
 @riverpod
 class ReaderNavigationLayoutKey extends _$ReaderNavigationLayoutKey
     with SharedPreferenceEnumClientMixin<ReaderNavigationLayout> {
@@ -26,29 +29,101 @@ class ReaderNavigationLayoutKey extends _$ReaderNavigationLayoutKey
       );
 }
 
+// Komikku keeps tap zones per viewer (navigationModePager /
+// navigationModeWebtoon), which is why they sit inside the Paged and Long
+// strip groups rather than above them.
+
+@riverpod
+class PagedNavigationLayoutKey extends _$PagedNavigationLayoutKey
+    with SharedPreferenceEnumClientMixin<ReaderNavigationLayout> {
+  @override
+  ReaderNavigationLayout? build() => initialize(
+        DBKeys.pagedNavigationLayout,
+        enumList: ReaderNavigationLayout.values,
+        initial: ref.read(readerNavigationLayoutKeyProvider),
+      );
+}
+
+@riverpod
+class LongStripNavigationLayoutKey extends _$LongStripNavigationLayoutKey
+    with SharedPreferenceEnumClientMixin<ReaderNavigationLayout> {
+  @override
+  ReaderNavigationLayout? build() => initialize(
+        DBKeys.longStripNavigationLayout,
+        enumList: ReaderNavigationLayout.values,
+        initial: ref.read(readerNavigationLayoutKeyProvider),
+      );
+}
+
+/// Tap zones for one viewer. Paged and long strip keep their own, so the tile
+/// appears once in each viewer group rather than above both.
 class ReaderNavigationLayoutTile extends ConsumerWidget {
-  const ReaderNavigationLayoutTile({super.key});
+  const ReaderNavigationLayoutTile({super.key, required this.longStrip});
+
+  final bool longStrip;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final readerNavigationLayout = ref.watch(readerNavigationLayoutKeyProvider);
+    final layout = (longStrip
+            ? ref.watch(longStripNavigationLayoutKeyProvider)
+            : ref.watch(pagedNavigationLayoutKeyProvider)) ??
+        ReaderNavigationLayout.defaultNavigation;
+    void set(ReaderNavigationLayout? value) => longStrip
+        ? ref.read(longStripNavigationLayoutKeyProvider.notifier).update(value)
+        : ref.read(pagedNavigationLayoutKeyProvider.notifier).update(value);
     return ListTile(
       leading: const Icon(Icons.touch_app_rounded),
-      subtitle: readerNavigationLayout != null
-          ? Text(readerNavigationLayout.toLocale(context))
-          : null,
+      subtitle: Text(layout.toLocale(context)),
       title: Text(context.l10n.readerNavigationLayout),
       onTap: () => showDialog(
         context: context,
         builder: (context) => RadioListPopup<ReaderNavigationLayout>(
           title: context.l10n.readerNavigationLayout,
-          optionList: ReaderNavigationLayout.values.sublist(1),
+          // Komikku's order, and it keeps Default now that Default resolves to
+          // a real layout rather than meaning "off".
+          optionList: ReaderNavigationLayout.displayOrder,
           getOptionTitle: (value) => value.toLocale(context),
-          value: readerNavigationLayout ?? ReaderNavigationLayout.disabled,
+          value: layout,
           onChange: (enumValue) async {
-            ref
-                .read(readerNavigationLayoutKeyProvider.notifier)
-                .update(enumValue);
+            set(enumValue);
+            if (context.mounted) Navigator.pop(context);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Four-value tap inversion for one viewer, matching Komikku's
+/// pagerNavInverted / webtoonNavInverted. Settings previously offered only a
+/// legacy on/off switch.
+class ReaderTapInvertTile extends ConsumerWidget {
+  const ReaderTapInvertTile({super.key, required this.longStrip});
+
+  final bool longStrip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final invert = (longStrip
+            ? ref.watch(longStripTapInvertKeyProvider)
+            : ref.watch(pagedTapInvertKeyProvider)) ??
+        TapInvert.none;
+    void set(TapInvert? value) => longStrip
+        ? ref.read(longStripTapInvertKeyProvider.notifier).update(value)
+        : ref.read(pagedTapInvertKeyProvider.notifier).update(value);
+    return ListTile(
+      leading: const Icon(Icons.switch_left_rounded),
+      subtitle: Text(invert.toLocale(context)),
+      title: Text(context.l10n.readerNavigationLayoutInvert),
+      onTap: () => showDialog(
+        context: context,
+        builder: (context) => RadioListPopup<TapInvert>(
+          title: context.l10n.readerNavigationLayoutInvert,
+          optionList: TapInvert.values,
+          getOptionTitle: (value) => value.toLocale(context),
+          value: invert,
+          onChange: (enumValue) async {
+            set(enumValue);
             if (context.mounted) Navigator.pop(context);
           },
         ),

--- a/lib/src/features/settings/presentation/reader/widgets/reader_tap_invert/reader_tap_invert.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/reader_tap_invert/reader_tap_invert.dart
@@ -30,3 +30,28 @@ class ReaderTapInvertKey extends _$ReaderTapInvertKey
 TapInvert readerTapInvertCompat(Ref ref) =>
     ref.watch(readerTapInvertKeyProvider) ??
     TapInvert.fromLegacyInvert(ref.watch(invertTapProvider));
+
+// Per-viewer, like Komikku's pagerNavInverted / webtoonNavInverted. Both seed
+// from whatever the single key resolved to, so upgrading changes nothing.
+
+@riverpod
+class PagedTapInvertKey extends _$PagedTapInvertKey
+    with SharedPreferenceEnumClientMixin<TapInvert> {
+  @override
+  TapInvert? build() => initialize(
+        DBKeys.pagedTapInvert,
+        enumList: TapInvert.values,
+        initial: ref.read(readerTapInvertCompatProvider),
+      );
+}
+
+@riverpod
+class LongStripTapInvertKey extends _$LongStripTapInvertKey
+    with SharedPreferenceEnumClientMixin<TapInvert> {
+  @override
+  TapInvert? build() => initialize(
+        DBKeys.longStripTapInvert,
+        enumList: TapInvert.values,
+        initial: ref.read(readerTapInvertCompatProvider),
+      );
+}

--- a/lib/src/features/settings/presentation/reader/widgets/tap_zones_overlay/tap_zones_overlay.dart
+++ b/lib/src/features/settings/presentation/reader/widgets/tap_zones_overlay/tap_zones_overlay.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../../constants/db_keys.dart';
+import '../../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+
+part 'tap_zones_overlay.g.dart';
+
+/// Flash the tap zones every time a chapter opens. Off by default, like
+/// Komikku.
+@riverpod
+class ShowTapZonesOverlay extends _$ShowTapZonesOverlay
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.showTapZonesOverlay);
+}
+
+/// True until the zones have been shown once. Gives someone who has never seen
+/// them a single look, then never again unless they ask for it.
+@riverpod
+class TapZonesOverlayUnseen extends _$TapZonesOverlayUnseen
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.tapZonesOverlayUnseen);
+}
+
+class ShowTapZonesOverlayTile extends ConsumerWidget {
+  const ShowTapZonesOverlayTile({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      secondary: const Icon(Icons.touch_app_rounded),
+      title: Text(context.l10n.showTapZonesOverlay),
+      subtitle: Text(context.l10n.showTapZonesOverlaySubtitle),
+      value: ref.watch(showTapZonesOverlayProvider).ifNull(),
+      onChanged: ref.read(showTapZonesOverlayProvider.notifier).update,
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -171,6 +171,12 @@
     "@readerForThisSeries": {
         "description": "Group heading for the per-manga override settings in the reader sheet"
     },
+    "@showTapZonesOverlay": {
+        "description": "Reader setting: flash the tap zones when a chapter opens"
+    },
+    "@showTapZonesOverlaySubtitle": {
+        "description": "Subtitle for the tap zones overlay setting"
+    },
     "@readerGroupActions": {
         "description": "Reader settings group heading for long-tap actions"
     },
@@ -1414,6 +1420,8 @@
     "pageLayoutSinglePage": "Single page",
     "readerForThisSeries": "For this series",
     "readerGroupActions": "Actions",
+    "showTapZonesOverlay": "Show tap zones overlay",
+    "showTapZonesOverlaySubtitle": "Briefly show when reader is opened",
     "readerGroupDisplay": "Display",
     "readerGroupEInk": "E-Ink",
     "readerGroupNavigation": "Navigation",
@@ -2051,11 +2059,11 @@
     "readerModeSingleHorizontalRTL": "Paged (right to left)",
     "readerModeSingleVertical": "Paged (vertical)",
     "readerModeWebtoon": "Long strip",
-    "readerNavigationLayout": "Navigation layout",
+    "readerNavigationLayout": "Tap zones",
     "readerNavigationLayoutDefault": "Default",
     "readerNavigationLayoutDisabled": "Disabled",
     "readerNavigationLayoutEdge": "Edge",
-    "readerNavigationLayoutInvert": "Invert tapping",
+    "readerNavigationLayoutInvert": "Invert tap zones",
     "readerNavigationLayoutKindlish": "Kindle-ish",
     "readerNavigationLayoutLShaped": "L Shaped",
     "readerNavigationLayoutRightAndLeft": "Right And Left",

--- a/lib/src/utils/mixin/shared_preferences_client_mixin.dart
+++ b/lib/src/utils/mixin/shared_preferences_client_mixin.dart
@@ -118,10 +118,13 @@ mixin SharedPreferenceEnumClientMixin<T extends Enum> {
     void Function(Object error, StackTrace stackTrace)? onError,
   });
 
-  T? initialize(DBKeys key, {required List<T> enumList}) {
+  /// [initial] overrides the key's own default — used when a new key inherits
+  /// whatever the pref it was split out of already held, so an upgrade keeps
+  /// the reader behaving the way it did.
+  T? initialize(DBKeys key, {required List<T> enumList, T? initial}) {
     _client = ref.watch(sharedPreferencesProvider);
     _key = key.name;
-    _initial = key.initial;
+    _initial = initial ?? key.initial;
     _enumList = enumList;
     _persistenceRefreshLogic();
     return _get;

--- a/test/src/features/manga_book/reader/chapter_separator_transition_test.dart
+++ b/test/src/features/manga_book/reader/chapter_separator_transition_test.dart
@@ -9,6 +9,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
@@ -22,43 +23,42 @@ import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
 import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
 
 MangaDto _manga() => Fragment$MangaDto(
-      id: 1,
-      title: 'Test Manga',
-      bookmarkCount: 0,
-      chapters: Fragment$MangaDto$chapters(totalCount: 0),
-      downloadCount: 0,
-      genre: const [],
-      inLibrary: true,
-      inLibraryAt: '0',
-      initialized: true,
-      meta: const [],
-      sourceId: '1',
-      status: Enum$MangaStatus.ONGOING,
-      categories: Fragment$MangaDto$categories(nodes: const []),
-      trackRecords:
-          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
-      unreadCount: 0,
-      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
-      url: '/manga/1',
-    );
+  id: 1,
+  title: 'Test Manga',
+  bookmarkCount: 0,
+  chapters: Fragment$MangaDto$chapters(totalCount: 0),
+  downloadCount: 0,
+  genre: const [],
+  inLibrary: true,
+  inLibraryAt: '0',
+  initialized: true,
+  meta: const [],
+  sourceId: '1',
+  status: Enum$MangaStatus.ONGOING,
+  categories: Fragment$MangaDto$categories(nodes: const []),
+  trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+  unreadCount: 0,
+  updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+  url: '/manga/1',
+);
 
 ChapterDto _chapter() => Fragment$ChapterDto(
-      chapterNumber: 1,
-      fetchedAt: '0',
-      id: 1,
-      isBookmarked: false,
-      isDownloaded: false,
-      isRead: false,
-      lastPageRead: 0,
-      lastReadAt: '0',
-      mangaId: 1,
-      name: 'Chapter 1',
-      pageCount: 3,
-      sourceOrder: 1,
-      uploadDate: '0',
-      url: '/chapter/1',
-      meta: const [],
-    );
+  chapterNumber: 1,
+  fetchedAt: '0',
+  id: 1,
+  isBookmarked: false,
+  isDownloaded: false,
+  isRead: false,
+  lastPageRead: 0,
+  lastReadAt: '0',
+  mangaId: 1,
+  name: 'Chapter 1',
+  pageCount: 3,
+  sourceOrder: 1,
+  uploadDate: '0',
+  url: '/chapter/1',
+  meta: const [],
+);
 
 Future<void> _pump(WidgetTester tester, {required bool alwaysShow}) async {
   SharedPreferences.setMockInitialValues(const {});
@@ -68,8 +68,10 @@ Future<void> _pump(WidgetTester tester, {required bool alwaysShow}) async {
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
         // Neighbour lookup null → no nav buttons; isolates the label/name test.
-        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
-            .overrideWithValue(null),
+        getNextAndPreviousChaptersProvider(
+          mangaId: 1,
+          chapterId: 1,
+        ).overrideWithValue(null),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -79,6 +81,7 @@ Future<void> _pump(WidgetTester tester, {required bool alwaysShow}) async {
             manga: _manga(),
             chapter: _chapter(),
             isPreviousChapterSeparator: true,
+            readerMode: ReaderMode.webtoon,
             alwaysShow: alwaysShow,
           ),
         ),
@@ -90,14 +93,16 @@ Future<void> _pump(WidgetTester tester, {required bool alwaysShow}) async {
 
 void main() {
   group('chapter transition separator', () {
-    testWidgets('ON (default) shows the full transition with chapter name',
-        (tester) async {
+    testWidgets('ON (default) shows the full transition with chapter name', (
+      tester,
+    ) async {
       await _pump(tester, alwaysShow: true);
       expect(find.text('Chapter 1'), findsOneWidget);
     });
 
-    testWidgets('OFF minimizes: slim label only, no chapter name',
-        (tester) async {
+    testWidgets('OFF minimizes: slim label only, no chapter name', (
+      tester,
+    ) async {
       await _pump(tester, alwaysShow: false);
       expect(find.text('Chapter 1'), findsNothing);
       // Collapsed form renders exactly one Text (the start/finished label).

--- a/test/src/features/manga_book/reader/tap_zone_geometry_test.dart
+++ b/test/src/features/manga_book/reader/tap_zone_geometry_test.dart
@@ -1,0 +1,95 @@
+// Pins tapActionForZone's geometry against the overlay it's meant to match.
+// Komikku's edge band: 1/3 of the axis, or 1/4 with smaller tap zones on.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart';
+
+const _size = Size(300, 600);
+
+TapAction _at(
+  double x,
+  double y, {
+  required ReaderNavigationLayout layout,
+  TapInvert tapInvert = TapInvert.none,
+  bool smaller = false,
+}) =>
+    tapActionForZone(
+      position: Offset(x, y),
+      size: _size,
+      layout: layout,
+      tapInvert: tapInvert,
+      smallerTapZones: smaller,
+    );
+
+void main() {
+  group('Kindle-ish', () {
+    // KindlishNavigation.kt: menu is the top third; below it, the left third
+    // goes back and the remaining two thirds go forward.
+    const layout = ReaderNavigationLayout.kindlish;
+
+    test('menu is the top band, not the bottom', () {
+      expect(_at(150, 50, layout: layout), TapAction.menu);
+      expect(_at(150, 550, layout: layout), isNot(TapAction.menu));
+    });
+
+    test('below the menu band, left goes back and the rest forward', () {
+      expect(_at(50, 400, layout: layout), TapAction.previous);
+      expect(_at(150, 400, layout: layout), TapAction.next);
+      expect(_at(280, 400, layout: layout), TapAction.next);
+    });
+
+    test('smaller tap zones shrink the menu band, growing the active area', () {
+      // y = 180 is inside the default 200px menu band but outside the 150px one.
+      expect(_at(150, 180, layout: layout), TapAction.menu);
+      expect(_at(150, 180, layout: layout, smaller: true),
+          isNot(TapAction.menu));
+    });
+  });
+
+  group('L-shaped', () {
+    const layout = ReaderNavigationLayout.lShaped;
+
+    test('top goes back, bottom goes forward', () {
+      expect(_at(150, 50, layout: layout), TapAction.previous);
+      expect(_at(150, 550, layout: layout), TapAction.next);
+    });
+
+    test('the middle band splits left, centre and right', () {
+      expect(_at(50, 300, layout: layout), TapAction.previous);
+      expect(_at(150, 300, layout: layout), TapAction.menu);
+      expect(_at(280, 300, layout: layout), TapAction.next);
+    });
+  });
+
+  group('Right and Left', () {
+    const layout = ReaderNavigationLayout.rightAndLeft;
+
+    test('edges page, the centre opens the menu', () {
+      expect(_at(20, 300, layout: layout), TapAction.previous);
+      expect(_at(280, 300, layout: layout), TapAction.next);
+      expect(_at(150, 300, layout: layout), TapAction.menu);
+    });
+
+    test('horizontal inversion swaps the two edges', () {
+      expect(_at(20, 300, layout: layout, tapInvert: TapInvert.horizontal),
+          TapAction.next);
+      expect(_at(280, 300, layout: layout, tapInvert: TapInvert.horizontal),
+          TapAction.previous);
+    });
+  });
+
+  group('off', () {
+    test('disabled and an unresolved default both just open the menu', () {
+      for (final x in [20.0, 150.0, 280.0]) {
+        for (final y in [20.0, 300.0, 580.0]) {
+          expect(_at(x, y, layout: ReaderNavigationLayout.disabled),
+              TapAction.menu);
+          expect(_at(x, y, layout: ReaderNavigationLayout.defaultNavigation),
+              TapAction.menu);
+        }
+      }
+    });
+  });
+}

--- a/test/src/features/manga_book/reader/tap_zones_test.dart
+++ b/test/src/features/manga_book/reader/tap_zones_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/utils/reader_mode_kind.dart';
+
+void main() {
+  group('Default resolves to a real layout', () {
+    test('never resolves to Default or Disabled', () {
+      for (final mode in ReaderMode.values) {
+        final resolved = defaultNavigationFor(mode);
+        expect(resolved, isNot(ReaderNavigationLayout.defaultNavigation),
+            reason: '$mode');
+        expect(resolved, isNot(ReaderNavigationLayout.disabled), reason: '$mode');
+      }
+    });
+
+    test('horizontal paged gets right-and-left, everything else L-shaped', () {
+      // Komikku: PagerConfig.defaultNavigation returns RightAndLeftNavigation
+      // for horizontal pagers and LNavigation otherwise; WebtoonConfig always
+      // returns LNavigation.
+      const horizontal = [
+        ReaderMode.singleHorizontalLTR,
+        ReaderMode.singleHorizontalRTL,
+        ReaderMode.continuousHorizontalLTR,
+        ReaderMode.continuousHorizontalRTL,
+      ];
+      for (final mode in ReaderMode.values) {
+        expect(
+          defaultNavigationFor(mode),
+          horizontal.contains(mode)
+              ? ReaderNavigationLayout.rightAndLeft
+              : ReaderNavigationLayout.lShaped,
+          reason: '$mode',
+        );
+      }
+    });
+  });
+
+  group('right-to-left mirrors the spatial layout', () {
+    test('flipping horizontally toggles only the horizontal axis', () {
+      expect(TapInvert.none.horizontallyFlipped, TapInvert.horizontal);
+      expect(TapInvert.horizontal.horizontallyFlipped, TapInvert.none);
+      expect(TapInvert.vertical.horizontallyFlipped, TapInvert.both);
+      expect(TapInvert.both.horizontallyFlipped, TapInvert.vertical);
+    });
+
+    test('vertical inversion survives the flip', () {
+      for (final invert in TapInvert.values) {
+        expect(
+          invert.horizontallyFlipped.invertsVertical,
+          invert.invertsVertical,
+          reason: '$invert',
+        );
+        expect(
+          invert.horizontallyFlipped.invertsHorizontal,
+          !invert.invertsHorizontal,
+          reason: '$invert',
+        );
+      }
+    });
+  });
+
+  group('display order', () {
+    test('matches Komikku, and the stored order is left alone', () {
+      expect(ReaderNavigationLayout.displayOrder, [
+        ReaderNavigationLayout.defaultNavigation,
+        ReaderNavigationLayout.lShaped,
+        ReaderNavigationLayout.kindlish,
+        ReaderNavigationLayout.edge,
+        ReaderNavigationLayout.rightAndLeft,
+        ReaderNavigationLayout.disabled,
+      ]);
+      // These persist by index — reordering the enum would silently move
+      // everyone's saved setting to a different layout.
+      expect(ReaderNavigationLayout.values, [
+        ReaderNavigationLayout.defaultNavigation,
+        ReaderNavigationLayout.lShaped,
+        ReaderNavigationLayout.rightAndLeft,
+        ReaderNavigationLayout.edge,
+        ReaderNavigationLayout.kindlish,
+        ReaderNavigationLayout.disabled,
+      ]);
+    });
+
+    test('every layout is offered exactly once', () {
+      expect(
+        ReaderNavigationLayout.displayOrder.toSet(),
+        ReaderNavigationLayout.values.toSet(),
+      );
+      expect(ReaderNavigationLayout.displayOrder.length,
+          ReaderNavigationLayout.values.length);
+    });
+  });
+}


### PR DESCRIPTION
Tapping the screen edge to turn the page did nothing unless you went looking for the setting and picked a layout by hand, and even then it behaved oddly. Reported on Discord.

## Default meant nothing

Both gesture paths treated `Default` as no-zones, identical to `Disabled`. Komikku resolves it per viewer instead — L-shaped, or right-and-left on horizontal paged. The shipped default was `Disabled` as well, so the feature was off out of the box; Komikku ships it on.

## The overlay never drew on paged reading

The zone overlay was gated to the long-strip path, so on paged reading nothing appeared for any layout and the setting looked inert. It draws on both now, display-only where the reader owns its own taps, and replays when you pick a different layout.

It is also no longer unconditional. **Show tap zones overlay** is off by default, matching Komikku, with one free look for anyone who has never seen them. Previously the zones flashed on every chapter open with no way to stop it.

## Kindle-ish was inverted

Its menu band was the bottom third and its paging band the top two thirds, the reverse of Komikku and of our own overlay. Invisible until the overlay started drawing over paged reading, at which point it would have advertised a zone that ignores you. The geometry now lives outside the viewport so it can be tested against the overlay it mirrors.

## Right-to-left

Right-and-Left is the one spatial layout — its zones mean physical left and right, not previous and next — so a right-to-left series mirrors it, as Komikku's `moveLeft`/`moveRight` do. The other three are direction-independent and were already correct.

## Per viewer

Tap zones and their inversion are per viewer in Komikku, which is why they now sit inside the Paged and Long strip groups rather than above both. Each seeds from the single old value, so upgrading changes nothing. Inversion in settings was a legacy on/off switch and is now the four-value control the reader already had.

## Wording

Settings said "Navigation layout" and "Invert tapping" while the reader said "Tap zones" and "Invert tap zones". The reader's wording is Komikku's, so settings follows it. The layout list runs in Komikku's order without touching the enum, which persists by index.

## Upgrade note

Anyone who never opened the setting gets tap zones on after updating — edge taps that opened the menu will turn the page. Intended, and it is what makes the feature discoverable, but it belongs in the release notes.
