### PR TITLE
Make the Started filter mean started

### DIFF
--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -15,6 +15,7 @@ import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
 import '../../../../../global_providers/global_providers.dart';
 import '../../../../../utils/mixin/state_provider_mixin.dart';
+import '../../../../manga_book/domain/chapter/chapter_model.dart';
 import '../../../../manga_book/domain/manga/manga_model.dart';
 import '../../../../tracking/data/tracker_repository.dart';
 import '../../../domain/category/category_model.dart';
@@ -90,8 +91,12 @@ List<MangaDto> applyLibraryFilterSort(
         (mangaFilterCompleted ^ (manga.status.name == "COMPLETED"))) {
       return false;
     }
+    // The server sends a lastReadChapter for everything, unread included — it
+    // just has no progress on it. Testing the object for null matched every
+    // manga and made this filter a no-op both ways round.
     if (mangaFilterStarted != null &&
-        (mangaFilterStarted ^ (manga.lastReadChapter != null))) {
+        (mangaFilterStarted ^
+            (manga.lastReadChapter?.hasReadingProgress ?? false))) {
       return false;
     }
     if (mangaFilterBookmarked != null &&

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,7 +13,6 @@ import flutter_secure_storage_darwin
 import gal
 import network_info_plus
 import package_info_plus
-import path_provider_foundation
 import screen_brightness_macos
 import screen_retriever_macos
 import share_plus
@@ -32,7 +31,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/test/src/features/library/library_started_filter_test.dart
+++ b/test/src/features/library/library_started_filter_test.dart
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/library/presentation/library/controller/library_controller.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+
+MangaDto _manga(int id, {required bool started}) => Fragment$MangaDto(
+      id: id,
+      title: 'M$id',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 5),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: const [],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 5,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/$id',
+      lastReadChapter: Fragment$ChapterDto(
+        id: id * 100,
+        chapterNumber: 1,
+        fetchedAt: '0',
+        isBookmarked: false,
+        isDownloaded: false,
+        isRead: started,
+        lastPageRead: 0,
+        lastReadAt: started ? '1700000000' : '0',
+        mangaId: id,
+        name: 'Chapter 1',
+        pageCount: 10,
+        realUrl: null,
+        scanlator: null,
+        sourceOrder: 1,
+        uploadDate: '0',
+        url: '/c/$id',
+        meta: const [],
+      ),
+    );
+
+List<MangaDto> _run(List<MangaDto> input, {required bool? started}) =>
+    applyLibraryFilterSort(
+      input,
+      query: null,
+      mangaFilterUnread: null,
+      mangaFilterDownloaded: null,
+      mangaFilterCompleted: null,
+      mangaFilterStarted: started,
+      mangaFilterBookmarked: null,
+      mangaFilterOffline: null,
+      offlineMangaIds: const {},
+      mangaFilterLewd: null,
+      mangaFilterMinRating: 0,
+      filterCategories: false,
+      filterCategoriesInclude: const {},
+      filterCategoriesExclude: const {},
+      filterTags: false,
+      filterTagsInclude: const {},
+      filterTagsExclude: const {},
+      sortedBy: MangaSort.alphabetical,
+      sortedDirection: true,
+    );
+
+void main() {
+  final items = [
+    _manga(1, started: true),
+    _manga(2, started: false),
+    _manga(3, started: true),
+  ];
+
+  test('Started keeps only the ones with reading progress', () {
+    expect(_run(items, started: true).map((m) => m.id), [1, 3]);
+  });
+
+  test('Not started keeps only the untouched ones', () {
+    expect(_run(items, started: false).map((m) => m.id), [2]);
+  });
+
+  test('unset keeps everything', () {
+    expect(_run(items, started: null).map((m) => m.id), [1, 2, 3]);
+  });
+}


### PR DESCRIPTION
The server sends a `lastReadChapter` for every manga, unread ones included — it just carries no progress on it. Testing that object for null matched everything, so Started showed the entire library and Not started showed none of it.

Filters on actual progress instead. Verified on device.

Closes #272