### PR TITLE
Let auto-scroll yield to the reader, and stop a moving page without opening the controls

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -65,6 +65,18 @@ double autoScrollDelta({
   return pxPerMs * dtMs;
 }
 
+/// When auto-scroll picks up again after the user grabs the strip: the next
+/// interval boundary on the ticker's clock. Komikku sleeps a whole interval
+/// between glides, so a drag costs the remainder of the current one and no
+/// more — that is the brief hesitation before it carries on.
+Duration autoScrollResumeAt(Duration elapsed, int intervalSeconds) {
+  if (intervalSeconds <= 0) return elapsed;
+  final periodMs = intervalSeconds * 1000;
+  return Duration(
+    milliseconds: ((elapsed.inMilliseconds ~/ periodMs) + 1) * periodMs,
+  );
+}
+
 typedef _LoadedChapter = ({
   ChapterPagesDto pages,
   ChapterDto chapter,
@@ -418,9 +430,13 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         DBKeys.autoScrollIntervalSeconds.initial as int;
     // Set around every auto-scroll-driven jump so the manual-scroll listener
     // (below) doesn't mistake the engine's own motion for the user grabbing
-    // the strip and stop itself.
+    // the strip and yield to it.
     final programmaticScroll = useRef<bool>(false);
     final lastAutoScrollTick = useRef<Duration>(Duration.zero);
+    final autoScrollPausedUntil = useRef<Duration>(Duration.zero);
+    // Auto-scroll holds while the chrome is up and carries on when it goes,
+    // rather than switching itself off; only the toggle ends it.
+    final bool chromeVisible = ref.watch(readerChromeVisibleProvider) ?? false;
 
     // Decode a page's image off-screen AND record its true rendered height from
     // the decoded aspect ratio. Caching the height
@@ -881,9 +897,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     //
     // Smooth mode drives per-frame pixel deltas straight on the
     // ScrollPosition; jump mode reuses handlePageNavigation on a periodic
-    // timer (Komikku's scrollDown() analog). Both stop themselves at the end
-    // of the last loaded chapter, and are stopped externally by the manual-
-    // scroll listener and the app-lifecycle listener below.
+    // timer (Komikku's scrollDown() analog). Both hold while the chrome is up
+    // and yield to a user drag until the next interval boundary, so only the
+    // toggle switches auto-scroll off — plus reaching the end of the last
+    // loaded chapter, and the app-lifecycle listener below.
 
     bool atLastLoadedPage() =>
         hasReachedEnd.value &&
@@ -895,6 +912,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       final dtMs = (elapsed - lastAutoScrollTick.value).inMilliseconds;
       lastAutoScrollTick.value = elapsed;
       if (dtMs <= 0) return;
+      if (elapsed < autoScrollPausedUntil.value) return;
       try {
         final pos = scrollOffsetController.position;
         final interval =
@@ -929,20 +947,21 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     );
 
     useEffect(() {
-      if (autoScrollActive && smoothAutoScroll) {
+      if (autoScrollActive && smoothAutoScroll && !chromeVisible) {
         lastAutoScrollTick.value = Duration.zero;
+        autoScrollPausedUntil.value = Duration.zero;
         if (!autoScrollTicker.isActive) autoScrollTicker.start();
       } else if (autoScrollTicker.isActive) {
         autoScrollTicker.stop();
       }
       return null;
-    }, [autoScrollActive, smoothAutoScroll]);
+    }, [autoScrollActive, smoothAutoScroll, chromeVisible]);
 
     // Jump mode (smoothAutoScroll off): periodic page-advance instead of a
     // per-frame glide.
     useEffect(() {
       Timer? timer;
-      if (autoScrollActive && !smoothAutoScroll) {
+      if (autoScrollActive && !smoothAutoScroll && !chromeVisible) {
         timer = Timer.periodic(Duration(seconds: autoScrollIntervalSeconds), (
           _,
         ) {
@@ -956,7 +975,12 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         });
       }
       return () => timer?.cancel();
-    }, [autoScrollActive, smoothAutoScroll, autoScrollIntervalSeconds]);
+    }, [
+      autoScrollActive,
+      smoothAutoScroll,
+      autoScrollIntervalSeconds,
+      chromeVisible,
+    ]);
 
     // The ticker outlives both effects above (it's created once); stop and
     // dispose it only on the widget's own teardown.
@@ -1111,14 +1135,19 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       separatorBuilder: buildSeparator,
     );
 
-    // A real user drag/fling stops auto-scroll immediately; the engine's own
-    // jumps are excluded via the programmaticScroll guard set around them.
+    // A real user drag/fling yields the strip until the next interval boundary
+    // instead of ending auto-scroll, so the reader can nudge the page without
+    // re-arming the toggle. The engine's own jumps are excluded via the
+    // programmaticScroll guard set around them.
     final autoScrollAwareList = NotificationListener<UserScrollNotification>(
       onNotification: (notification) {
         if (!programmaticScroll.value &&
             notification.direction != ScrollDirection.idle &&
             ref.read(autoScrollActiveProvider)) {
-          ref.read(autoScrollActiveProvider.notifier).stop();
+          autoScrollPausedUntil.value = autoScrollResumeAt(
+            lastAutoScrollTick.value,
+            autoScrollIntervalSeconds,
+          );
         }
         return false;
       },

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -65,10 +65,8 @@ double autoScrollDelta({
   return pxPerMs * dtMs;
 }
 
-/// When auto-scroll picks up again after the user grabs the strip: the next
-/// interval boundary on the ticker's clock. Komikku sleeps a whole interval
-/// between glides, so a drag costs the remainder of the current one and no
-/// more — that is the brief hesitation before it carries on.
+/// Next interval boundary after [elapsed]. Komikku sleeps a full interval
+/// between glides, so a drag costs at most the remainder of one.
 Duration autoScrollResumeAt(Duration elapsed, int intervalSeconds) {
   if (intervalSeconds <= 0) return elapsed;
   final periodMs = intervalSeconds * 1000;
@@ -429,17 +427,13 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         ref.watch(autoScrollIntervalSecondsProvider) ??
         DBKeys.autoScrollIntervalSeconds.initial as int;
     // Set around every auto-scroll-driven jump so the manual-scroll listener
-    // (below) doesn't mistake the engine's own motion for the user grabbing
-    // the strip and yield to it.
+    // below doesn't mistake the engine's own motion for a user drag.
     final programmaticScroll = useRef<bool>(false);
     final lastAutoScrollTick = useRef<Duration>(Duration.zero);
     final autoScrollPausedUntil = useRef<Duration>(Duration.zero);
-    // True from the moment the strip starts moving under the reader until it
-    // comes to rest, so a touch landing mid-coast can be told from one landing
-    // on a still page. Start/end fire once per gesture, never per frame.
+    // Tracked between ScrollStart/ScrollEnd so a touch landing mid-coast can be
+    // told from one landing on a still page.
     final stripInMotion = useRef<bool>(false);
-    // Auto-scroll holds while the chrome is up and carries on when it goes,
-    // rather than switching itself off; only the toggle ends it.
     final bool chromeVisible = ref.watch(readerChromeVisibleProvider) ?? false;
 
     // Decode a page's image off-screen AND record its true rendered height from
@@ -934,9 +928,12 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         }
         programmaticScroll.value = true;
         pos.jumpTo(target.clamp(pos.minScrollExtent, pos.maxScrollExtent));
-        programmaticScroll.value = false;
       } catch (_) {
         // Attached but not laid out yet (no ScrollPosition) — skip this tick.
+      } finally {
+        // A throw mid-jump would otherwise latch the guard on and every later
+        // drag would read as the engine's own motion.
+        programmaticScroll.value = false;
       }
     }
 
@@ -969,13 +966,17 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         timer = Timer.periodic(Duration(seconds: autoScrollIntervalSeconds), (
           _,
         ) {
+          if (stripInMotion.value) return;
           if (atLastLoadedPage()) {
             ref.read(autoScrollActiveProvider.notifier).stop();
             return;
           }
           programmaticScroll.value = true;
-          handlePageNavigation(isNext: true);
-          programmaticScroll.value = false;
+          try {
+            handlePageNavigation(isNext: true);
+          } finally {
+            programmaticScroll.value = false;
+          }
         });
       }
       return () => timer?.cancel();
@@ -1236,11 +1237,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           )
         : edgeAwareList;
 
-    // A touch that lands while the strip is still coasting from the reader's
-    // own fling arrests it and nothing more; the chrome waits for the next tap.
-    // Pointer-down is the only moment the ballistic activity is still live —
-    // the drag that follows cancels it — so the answer is snapshotted here and
-    // read at tap time rather than watched throughout the scroll.
+    // Pointer-down is the last moment the fling is still live before the drag
+    // cancels it, so the arrest decision is snapshotted here.
     final flingAwareChild = Listener(
       onPointerDown: (_) {
         final arrests = stripInMotion.value && !programmaticScroll.value;

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -434,6 +434,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     final programmaticScroll = useRef<bool>(false);
     final lastAutoScrollTick = useRef<Duration>(Duration.zero);
     final autoScrollPausedUntil = useRef<Duration>(Duration.zero);
+    // True from the moment the strip starts moving under the reader until it
+    // comes to rest, so a touch landing mid-coast can be told from one landing
+    // on a still page. Start/end fire once per gesture, never per frame.
+    final stripInMotion = useRef<bool>(false);
     // Auto-scroll holds while the chrome is up and carries on when it goes,
     // rather than switching itself off; only the toggle ends it.
     final bool chromeVisible = ref.watch(readerChromeVisibleProvider) ?? false;
@@ -1151,7 +1155,19 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         }
         return false;
       },
-      child: positionedList,
+      child: NotificationListener<ScrollEndNotification>(
+        onNotification: (_) {
+          stripInMotion.value = false;
+          return false;
+        },
+        child: NotificationListener<ScrollStartNotification>(
+          onNotification: (_) {
+            if (!programmaticScroll.value) stripInMotion.value = true;
+            return false;
+          },
+          child: positionedList,
+        ),
+      ),
     );
 
     // Pinned at the scroll clamp a drag moves nothing, so the position
@@ -1220,6 +1236,20 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           )
         : edgeAwareList;
 
+    // A touch that lands while the strip is still coasting from the reader's
+    // own fling arrests it and nothing more; the chrome waits for the next tap.
+    // Pointer-down is the only moment the ballistic activity is still live —
+    // the drag that follows cancels it — so the answer is snapshotted here and
+    // read at tap time rather than watched throughout the scroll.
+    final flingAwareChild = Listener(
+      onPointerDown: (_) {
+        final arrests = stripInMotion.value && !programmaticScroll.value;
+        final gate = ref.read(readerTapArrestsFlingProvider.notifier);
+        if (gate.state != arrests) gate.state = arrests;
+      },
+      child: wheelAware,
+    );
+
     final child = AppUtils.wrapOn(
       !kIsWeb &&
               (Platform.isAndroid || Platform.isIOS) &&
@@ -1235,7 +1265,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
               child: child,
             )
           : null,
-      wheelAware,
+      flingAwareChild,
     );
 
     return ReaderWrapper(

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -106,6 +106,13 @@ class ReaderInputScope extends InheritedWidget {
 
 bool _noBoundaryNavigation() => false;
 
+/// Whether the touch that is currently down landed while the strip was still
+/// coasting from the reader's own fling. Such a tap arrests the scroll and
+/// nothing else — the next one opens the chrome. The long strip snapshots this
+/// on pointer-down, mirroring Komikku's `tapDuringManualScroll`
+/// (`WebtoonRecyclerView.kt:72-75`, consumed at `:244-248`).
+final readerTapArrestsFlingProvider = StateProvider<bool>((ref) => false);
+
 /// Whether the reader chrome is on screen. Public so the long strip can hold
 /// auto-scroll while it is up.
 final readerChromeVisibleProvider =
@@ -626,8 +633,10 @@ class ReaderWrapper extends HookConsumerWidget {
                     child: Listener(
                       child: RepaintBoundary(
                         child: ReaderView(
-                          toggleVisibility: () =>
-                              visibility.value = !visibility.value,
+                          toggleVisibility: () {
+                            if (ref.read(readerTapArrestsFlingProvider)) return;
+                            visibility.value = !visibility.value;
+                          },
                           scrollDirection: scrollDirection,
                           mangaId: manga.id,
                           mangaReaderPadding: mangaReaderPadding.value,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -106,7 +106,9 @@ class ReaderInputScope extends InheritedWidget {
 
 bool _noBoundaryNavigation() => false;
 
-final _readerChromeSessionVisibilityProvider =
+/// Whether the reader chrome is on screen. Public so the long strip can hold
+/// auto-scroll while it is up.
+final readerChromeVisibleProvider =
     StateProvider.autoDispose<bool?>((Ref ref) {
   final link = ref.keepAlive();
   Timer? timer;
@@ -245,7 +247,7 @@ class ReaderWrapper extends HookConsumerWidget {
         ref.watch(readerMagnifierSizeKeyProvider) ??
             DBKeys.readerMagnifierSize.initial;
 
-    final sessionVisibility = ref.watch(_readerChromeSessionVisibilityProvider);
+    final sessionVisibility = ref.watch(readerChromeVisibleProvider);
     final visibility = useState(
       sessionVisibility ?? ref.read(readerInitialOverlayProvider).ifNull(),
     );
@@ -309,7 +311,7 @@ class ReaderWrapper extends HookConsumerWidget {
       void syncVisibility() {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (disposed) return;
-          ref.read(_readerChromeSessionVisibilityProvider.notifier).state =
+          ref.read(readerChromeVisibleProvider.notifier).state =
               visibility.value;
         });
       }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -634,7 +634,14 @@ class ReaderWrapper extends HookConsumerWidget {
                       child: RepaintBoundary(
                         child: ReaderView(
                           toggleVisibility: () {
-                            if (ref.read(readerTapArrestsFlingProvider)) return;
+                            final gate =
+                                ref.read(readerTapArrestsFlingProvider.notifier);
+                            // Cleared on use: only the long strip arms it, so a
+                            // stale true would swallow taps in the paged reader.
+                            if (gate.state) {
+                              gate.state = false;
+                              return;
+                            }
                             visibility.value = !visibility.value;
                           },
                           scrollDirection: scrollDirection,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,7 +13,6 @@ import flutter_secure_storage_darwin
 import gal
 import network_info_plus
 import package_info_plus
-import path_provider_foundation
 import screen_brightness_macos
 import screen_retriever_macos
 import share_plus
@@ -32,7 +31,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/test/src/features/manga_book/reader/auto_scroll_delta_test.dart
+++ b/test/src/features/manga_book/reader/auto_scroll_delta_test.dart
@@ -48,4 +48,50 @@ void main() {
       );
     });
   });
+
+  group('autoScrollResumeAt', () {
+    test('resumes at the next interval boundary', () {
+      expect(
+        autoScrollResumeAt(const Duration(milliseconds: 1500), 5),
+        const Duration(seconds: 5),
+      );
+      expect(
+        autoScrollResumeAt(const Duration(milliseconds: 12000), 5),
+        const Duration(seconds: 15),
+      );
+    });
+
+    test('a drag landing on a boundary waits the next full interval', () {
+      expect(
+        autoScrollResumeAt(const Duration(seconds: 10), 5),
+        const Duration(seconds: 15),
+      );
+    });
+
+    test('a later drag never resumes earlier than an earlier one', () {
+      final early = autoScrollResumeAt(const Duration(milliseconds: 200), 5);
+      final late = autoScrollResumeAt(const Duration(milliseconds: 4800), 5);
+      expect(late, greaterThanOrEqualTo(early));
+    });
+
+    test('the pause never outlasts one interval', () {
+      for (var ms = 0; ms < 5000; ms += 250) {
+        final elapsed = Duration(milliseconds: ms);
+        final wait = autoScrollResumeAt(elapsed, 5) - elapsed;
+        expect(wait, lessThanOrEqualTo(const Duration(seconds: 5)));
+        expect(wait, greaterThan(Duration.zero));
+      }
+    });
+
+    test('zero or negative interval resumes immediately', () {
+      expect(
+        autoScrollResumeAt(const Duration(seconds: 3), 0),
+        const Duration(seconds: 3),
+      );
+      expect(
+        autoScrollResumeAt(const Duration(seconds: 3), -1),
+        const Duration(seconds: 3),
+      );
+    });
+  });
 }

--- a/test/src/features/manga_book/reader/auto_scroll_drag_test.dart
+++ b/test/src/features/manga_book/reader/auto_scroll_drag_test.dart
@@ -4,10 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Auto-scroll yields to the reader instead of switching itself off: a drag
-// hands the strip over until the next interval boundary, the chrome holds it
-// while it is up, and only the toggle ends it.
-
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/src/features/manga_book/reader/auto_scroll_drag_test.dart
+++ b/test/src/features/manga_book/reader/auto_scroll_drag_test.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Auto-scroll yields to the reader instead of switching itself off: a drag
+// hands the strip over until the next interval boundary, the chrome holds it
+// while it is up, and only the toggle ends it.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_page/chapter_page_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/auto_scroll_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/reader_screen.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+const _png1x1 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+class _FakeMangaWithId extends MangaWithId {
+  _FakeMangaWithId(this.manga);
+  final MangaDto? manga;
+  @override
+  Future<MangaDto?> build({required int mangaId}) async => manga;
+}
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _FakeTrackerRepository extends TrackerRepository {
+  _FakeTrackerRepository() : super(_dummyClient());
+  @override
+  Future<void> trackProgress(int mangaId) async {}
+}
+
+class _QuietRepo extends Fake implements MangaBookRepository {
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {}
+}
+
+List<String> _localPages(int count) {
+  final dir = Directory.systemTemp.createTempSync('tsumiru-autoscroll-');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final bytes = base64Decode(_png1x1);
+  return [
+    for (var i = 0; i < count; i++)
+      (File('${dir.path}/$i.png')..writeAsBytesSync(bytes)).uri.toString(),
+  ];
+}
+
+MangaDto _webtoonManga() => Fragment$MangaDto(
+      id: 1,
+      title: 'Test Webtoon',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 1),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: ReaderMode.webtoon.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 1,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
+
+ChapterDto _chapter() => Fragment$ChapterDto(
+      chapterNumber: 1,
+      fetchedAt: '0',
+      id: 1,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: 'Chapter 1',
+      pageCount: 12,
+      sourceOrder: 1,
+      uploadDate: '0',
+      url: '/chapter/1',
+      meta: const [],
+    );
+
+Future<ProviderContainer> _pumpReader(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(800, 1600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  SharedPreferences.setMockInitialValues(const {});
+  final prefs = await SharedPreferences.getInstance();
+  final chapter = _chapter();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        mangaBookRepositoryProvider.overrideWithValue(_QuietRepo()),
+        mangaWithIdProvider(mangaId: 1)
+            .overrideWith(() => _FakeMangaWithId(_webtoonManga())),
+        chapterProvider(chapterId: 1).overrideWith((ref) => chapter),
+        chapterPagesProvider(chapterId: 1).overrideWith(
+          (ref) => ChapterPagesDto(
+            chapter: ChapterPagesChapterDto(id: 1, pageCount: 12),
+            pages: _localPages(12),
+          ),
+        ),
+        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+            .overrideWithValue((first: null, second: null)),
+        trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const ReaderScreen(mangaId: 1, chapterId: 1),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return ProviderScope.containerOf(tester.element(find.byType(MaterialApp)));
+}
+
+void main() {
+  testWidgets('a drag leaves auto-scroll armed', (tester) async {
+    final container = await _pumpReader(tester);
+
+    container.read(autoScrollActiveProvider.notifier).start();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(container.read(autoScrollActiveProvider), isTrue);
+
+    await tester.timedDrag(
+      find.byType(Scrollable).first,
+      const Offset(0, -200),
+      const Duration(milliseconds: 120),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(autoScrollActiveProvider),
+      isTrue,
+      reason: 'a drag hands over the strip; only the toggle ends auto-scroll',
+    );
+  });
+
+  testWidgets('the reader can still move the strip while auto-scroll runs',
+      (tester) async {
+    final container = await _pumpReader(tester);
+
+    container.read(autoScrollActiveProvider.notifier).start();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final position = tester.state<ScrollableState>(
+      find.byType(Scrollable).first,
+    );
+    final before = position.position.pixels;
+
+    await tester.timedDrag(
+      find.byType(Scrollable).first,
+      const Offset(0, -240),
+      const Duration(milliseconds: 120),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      position.position.pixels - before,
+      greaterThan(200),
+      reason: 'the finger wins: the engine must not fight the drag',
+    );
+  });
+}


### PR DESCRIPTION
Two long-strip reader fixes, both matching Komikku.

**Auto-scroll used to switch itself off.** Any drag ended it, so nudging the page meant re-arming the toggle, and opening the controls left the strip gliding underneath them. It now hands the strip over to a drag until the next interval boundary and holds while the controls are up. Only the toggle ends it.

Komikku's loop skips its tick while the menu is visible and sleeps a full interval between glides, so a drag there costs the remainder of the current one — the brief hesitation before it carries on. The per-frame glide is unchanged.

**Tapping a moving page opened the controls.** Stopping at a panel meant dismissing them again. If the strip was moving when the finger landed, the tap now just stops it, and the next tap opens the controls. The motion flag is set and cleared on scroll start and end, twice per gesture, so nothing is added to the scrolling path.

Verified on device. 1595 tests pass.

Closes #274