### PR TITLE
Delete finished chapters by reading order, not by what the list is showing

### DIFF
--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -425,13 +425,17 @@ Future<bool> recordReadState(
 /// isn't loaded.
 int? _whileReadingTarget(
     WidgetRef ref, int mangaId, int readChapterId, int slots) {
-  final chapters = ref
-      .read(mangaChapterListWithFilterProvider(mangaId: mangaId))
-      .value;
+  // Deliberately NOT the on-screen list: an unread filter drops the chapter the
+  // moment it is read, and any filter makes "N back" count gaps instead of
+  // chapters. Source order is the reading order regardless of how the list is
+  // displayed.
+  final chapters =
+      ref.read(mangaChapterListForBulkActionsProvider(mangaId: mangaId)).value;
   if (chapters == null) return null;
-  final isAsc = ref.read(mangaChapterSortDirectionProvider) ??
-      (DBKeys.chapterSortDirection.initial as bool);
-  return chapterIdToDeleteWhileReading(chapters, isAsc, readChapterId, slots);
+  final inReadingOrder = [...chapters]
+    ..sort((a, b) => a.sourceOrder.compareTo(b.sourceOrder));
+  return chapterIdToDeleteWhileReading(
+      inReadingOrder, true, readChapterId, slots);
 }
 
 /// The server delete settings, loaded from the server (null offline / on error,

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -424,7 +425,8 @@ Future<bool> recordReadState(
 /// Resolve the chapter to delete `slots` behind [readChapterId] in the manga's
 /// reading order (1 = the just-read chapter). Null if out of range or the list
 /// isn't loaded.
-Future<int?> _whileReadingTarget(
+@visibleForTesting
+Future<int?> whileReadingDeleteTarget(
     WidgetRef ref, int mangaId, int readChapterId, int slots) async {
   try {
     // Not the filtered/on-screen list: a filter can drop the just-read chapter
@@ -478,7 +480,7 @@ Future<void> maybeDeleteOnReadLocal(
   if (!ref.read(offlineActiveProvider)) return;
   final s = ref.read(localDeleteSettingsProvider);
   if (s.deleteWhileReading <= 0) return;
-  final targetId = await _whileReadingTarget(
+  final targetId = await whileReadingDeleteTarget(
       ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
   await _deleteDeviceCopyIfDeletable(ref, targetId, s.deleteWithBookmark);
@@ -528,7 +530,7 @@ Future<void> maybeDeleteOnReadServer(
 }) async {
   final s = await _serverDeleteSettings(ref);
   if (s == null || s.deleteWhileReading <= 0) return;
-  final targetId = await _whileReadingTarget(
+  final targetId = await whileReadingDeleteTarget(
       ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
   await _deleteServerCopyIfDeletable(

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -449,12 +449,19 @@ Future<int?> whileReadingDeleteTarget(
         : applyPreferredScanlators(chapters, preferred,
             keepChapterId: readChapterId);
 
+    // Tie-broken by id: List.sort is unstable, so duplicate source orders would
+    // otherwise let the Nth-back target move between reads.
     final inReadingOrder = [...deduped]
-      ..sort((a, b) => a.sourceOrder.compareTo(b.sourceOrder));
+      ..sort((a, b) {
+        final byOrder = a.sourceOrder.compareTo(b.sourceOrder);
+        return byOrder != 0 ? byOrder : a.id.compareTo(b.id);
+      });
     return chapterIdToDeleteWhileReading(
         inReadingOrder, true, readChapterId, slots);
-  } catch (_) {
-    // Leaving the reader mid-await disposes the ref; never surface that.
+  } catch (e) {
+    // Expected when leaving the reader mid-await; anything else is a real
+    // failure that would otherwise look exactly like the bug this fixes.
+    logger.e('Offline: resolving the delete-while-reading target failed: $e');
     return null;
   }
 }
@@ -483,7 +490,11 @@ Future<void> maybeDeleteOnReadLocal(
   final targetId = await whileReadingDeleteTarget(
       ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
-  await _deleteDeviceCopyIfDeletable(ref, targetId, s.deleteWithBookmark);
+  // Re-read: the wait above is unbounded, and the setting may have been turned
+  // off while it ran.
+  final now = ref.read(localDeleteSettingsProvider);
+  if (now.deleteWhileReading <= 0) return;
+  await _deleteDeviceCopyIfDeletable(ref, targetId, now.deleteWithBookmark);
 }
 
 /// Delete THIS phone's copy when a chapter is manually marked read.
@@ -533,8 +544,12 @@ Future<void> maybeDeleteOnReadServer(
   final targetId = await whileReadingDeleteTarget(
       ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
+  // Both waits above are unbounded; a stale snapshot must not delete a server
+  // copy the setting no longer covers.
+  final now = ref.read(deleteChaptersSettingsControllerProvider).value;
+  if (now == null || now.deleteWhileReading <= 0) return;
   await _deleteServerCopyIfDeletable(
-      ref, mangaId, targetId, s.deleteWithBookmark);
+      ref, mangaId, targetId, now.deleteWithBookmark);
 }
 
 /// Tell the SERVER to delete its copy when a chapter is manually marked read.

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -22,6 +22,7 @@ import '../../manga_book/data/downloads/downloads_repository.dart';
 import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import '../../manga_book/presentation/manga_details/controller/scanlator_dedup.dart';
 import '../../manga_book/presentation/manga_details/controller/scanlator_propagation.dart';
 import '../../settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
 import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
@@ -423,19 +424,37 @@ Future<bool> recordReadState(
 /// Resolve the chapter to delete `slots` behind [readChapterId] in the manga's
 /// reading order (1 = the just-read chapter). Null if out of range or the list
 /// isn't loaded.
-int? _whileReadingTarget(
-    WidgetRef ref, int mangaId, int readChapterId, int slots) {
-  // Deliberately NOT the on-screen list: an unread filter drops the chapter the
-  // moment it is read, and any filter makes "N back" count gaps instead of
-  // chapters. Source order is the reading order regardless of how the list is
-  // displayed.
-  final chapters =
-      ref.read(mangaChapterListForBulkActionsProvider(mangaId: mangaId)).value;
-  if (chapters == null) return null;
-  final inReadingOrder = [...chapters]
-    ..sort((a, b) => a.sourceOrder.compareTo(b.sourceOrder));
-  return chapterIdToDeleteWhileReading(
-      inReadingOrder, true, readChapterId, slots);
+Future<int?> _whileReadingTarget(
+    WidgetRef ref, int mangaId, int readChapterId, int slots) async {
+  try {
+    // Not the filtered/on-screen list: a filter can drop the just-read chapter
+    // or turn "N back" into counting gaps instead of chapters.
+    final listProvider = mangaChapterListProvider(mangaId: mangaId);
+    var chapters = ref.read(listProvider).value;
+    // A chapter finished before the list resolves would otherwise be skipped
+    // with no second chance.
+    chapters ??= await ref.read(listProvider.future);
+    if (chapters == null) return null;
+
+    final preferred =
+        ref.read(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+    final showAll =
+        ref.read(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+    // Pinned to the chapter actually being read: without it dedup can keep a
+    // different group's copy of that number and drop this id from the list.
+    final deduped = preferred.isEmpty || showAll
+        ? chapters
+        : applyPreferredScanlators(chapters, preferred,
+            keepChapterId: readChapterId);
+
+    final inReadingOrder = [...deduped]
+      ..sort((a, b) => a.sourceOrder.compareTo(b.sourceOrder));
+    return chapterIdToDeleteWhileReading(
+        inReadingOrder, true, readChapterId, slots);
+  } catch (_) {
+    // Leaving the reader mid-await disposes the ref; never surface that.
+    return null;
+  }
 }
 
 /// The server delete settings, loaded from the server (null offline / on error,
@@ -459,8 +478,8 @@ Future<void> maybeDeleteOnReadLocal(
   if (!ref.read(offlineActiveProvider)) return;
   final s = ref.read(localDeleteSettingsProvider);
   if (s.deleteWhileReading <= 0) return;
-  final targetId =
-      _whileReadingTarget(ref, mangaId, readChapterId, s.deleteWhileReading);
+  final targetId = await _whileReadingTarget(
+      ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
   await _deleteDeviceCopyIfDeletable(ref, targetId, s.deleteWithBookmark);
 }
@@ -509,8 +528,8 @@ Future<void> maybeDeleteOnReadServer(
 }) async {
   final s = await _serverDeleteSettings(ref);
   if (s == null || s.deleteWhileReading <= 0) return;
-  final targetId =
-      _whileReadingTarget(ref, mangaId, readChapterId, s.deleteWhileReading);
+  final targetId = await _whileReadingTarget(
+      ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
   await _deleteServerCopyIfDeletable(
       ref, mangaId, targetId, s.deleteWithBookmark);

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -459,9 +459,10 @@ Future<int?> whileReadingDeleteTarget(
     return chapterIdToDeleteWhileReading(
         inReadingOrder, true, readChapterId, slots);
   } catch (e) {
-    // Expected when leaving the reader mid-await; anything else is a real
-    // failure that would otherwise look exactly like the bug this fixes.
-    logger.e('Offline: resolving the delete-while-reading target failed: $e');
+    // Leaving the reader mid-await lands here too, so this is a warning rather
+    // than an error — but it must be recorded, or a real failure looks exactly
+    // like the bug this fixes.
+    logger.w('Offline: resolving the delete-while-reading target failed: $e');
     return null;
   }
 }
@@ -490,10 +491,10 @@ Future<void> maybeDeleteOnReadLocal(
   final targetId = await whileReadingDeleteTarget(
       ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
-  // Re-read: the wait above is unbounded, and the setting may have been turned
-  // off while it ran.
+  // The wait above is unbounded: a setting changed while it ran would leave
+  // targetId computed from a slot count that no longer applies.
   final now = ref.read(localDeleteSettingsProvider);
-  if (now.deleteWhileReading <= 0) return;
+  if (now.deleteWhileReading != s.deleteWhileReading) return;
   await _deleteDeviceCopyIfDeletable(ref, targetId, now.deleteWithBookmark);
 }
 
@@ -544,10 +545,11 @@ Future<void> maybeDeleteOnReadServer(
   final targetId = await whileReadingDeleteTarget(
       ref, mangaId, readChapterId, s.deleteWhileReading);
   if (targetId == null) return;
-  // Both waits above are unbounded; a stale snapshot must not delete a server
-  // copy the setting no longer covers.
-  final now = ref.read(deleteChaptersSettingsControllerProvider).value;
-  if (now == null || now.deleteWhileReading <= 0) return;
+  // Both waits above are unbounded, so re-resolve rather than reading .value —
+  // this controller autoDisposes and would come back as loading, reading null
+  // and cancelling a delete the setting still calls for.
+  final now = await _serverDeleteSettings(ref);
+  if (now == null || now.deleteWhileReading != s.deleteWhileReading) return;
   await _deleteServerCopyIfDeletable(
       ref, mangaId, targetId, now.deleteWithBookmark);
 }

--- a/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
+++ b/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
@@ -4,79 +4,113 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
 import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
-import 'package:tsumiru/src/features/settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
 
-ChapterDto _ch(int id, {bool isRead = false}) => Fragment$ChapterDto(
+ChapterDto _ch(
+  int id, {
+  required double number,
+  required int sourceOrder,
+  String? scanlator,
+  bool isRead = false,
+  bool isDownloaded = true,
+}) => Fragment$ChapterDto(
   id: id,
   mangaId: 1,
-  name: 'c$id',
-  chapterNumber: id.toDouble(),
-  sourceOrder: id,
+  name: 'c$number',
+  chapterNumber: number,
+  sourceOrder: sourceOrder,
+  scanlator: scanlator,
   isRead: isRead,
   isBookmarked: false,
-  isDownloaded: true,
+  isDownloaded: isDownloaded,
   lastPageRead: 0,
   pageCount: 10,
-  fetchedAt: '$id',
-  uploadDate: '$id',
+  fetchedAt: '0',
+  uploadDate: '0',
   lastReadAt: '0',
   url: '',
   meta: const <Fragment$ChapterDto$meta>[],
 );
 
-List<ChapterDto> _readingOrder(List<ChapterDto> chapters) =>
-    [...chapters]..sort((a, b) => a.sourceOrder.compareTo(b.sourceOrder));
+class _PreferAlpha extends MangaPreferredScanlators {
+  @override
+  List<String> build({required int mangaId}) => const ['Alpha'];
+}
+
+class _SlowChapterList extends MangaChapterList {
+  final gate = Completer<List<ChapterDto>?>();
+
+  @override
+  Future<List<ChapterDto>?> build({required int mangaId}) => gate.future;
+}
 
 void main() {
-  group('delete-while-reading targets reading order, not the visible list', () {
-    final library = [
-      _ch(1, isRead: true),
-      _ch(2, isRead: true),
-      _ch(3, isRead: true),
-      _ch(4),
-      _ch(5),
-    ];
+  testWidgets(
+    'the delete target is the chapter 2 back in reading order, whatever the '
+    'screen is showing and whichever scanlator was read',
+    (tester) async {
+      SharedPreferences.setMockInitialValues(const {});
+      final prefs = await SharedPreferences.getInstance();
+      final slow = _SlowChapterList();
 
-    test('slot N targets N-1 chapters behind the one just read', () {
-      final order = _readingOrder(library);
-      expect(chapterIdToDeleteWhileReading(order, true, 3, 1), 3);
-      expect(chapterIdToDeleteWhileReading(order, true, 3, 2), 2);
-      expect(chapterIdToDeleteWhileReading(order, true, 3, 3), 1);
-    });
+      // Chapter 3 exists twice. The reader is on Bravo's copy, but Alpha is the
+      // preferred group, so dedup would drop id 33 unless it is pinned.
+      // Newest first, as the details screen would show it.
+      final chapters = [
+        _ch(4, number: 4, sourceOrder: 5, scanlator: 'Alpha'),
+        _ch(3, number: 3, sourceOrder: 4, scanlator: 'Alpha'),
+        _ch(
+          33,
+          number: 3,
+          sourceOrder: 3,
+          scanlator: 'Bravo',
+          isRead: true,
+          isDownloaded: false,
+        ),
+        _ch(2, number: 2, sourceOrder: 2, scanlator: 'Alpha', isRead: true),
+        _ch(1, number: 1, sourceOrder: 1, scanlator: 'Alpha', isRead: true),
+      ];
 
-    test('a newest-first screen makes no difference', () {
-      final asDisplayed = library.reversed.toList(growable: false);
+      late WidgetRef captured;
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            mangaChapterListProvider(mangaId: 1).overrideWith(() => slow),
+            mangaPreferredScanlatorsProvider(
+              mangaId: 1,
+            ).overrideWith(() => _PreferAlpha()),
+          ],
+          child: Consumer(
+            builder: (context, ref, _) {
+              captured = ref;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      final pending = whileReadingDeleteTarget(captured, 1, 33, 2);
+      slow.gate.complete(chapters);
+      await tester.pump();
+
       expect(
-        chapterIdToDeleteWhileReading(_readingOrder(asDisplayed), true, 3, 2),
+        await pending,
         2,
-      );
-    });
-
-    test('read chapters stay in range, so every slot still resolves', () {
-      final order = _readingOrder(library);
-      for (var slots = 1; slots <= 3; slots++) {
-        expect(
-          chapterIdToDeleteWhileReading(order, true, 3, slots),
-          isNotNull,
-          reason: 'slot $slots must still find chapter 3 once it is read',
-        );
-      }
-    });
-
-    test('slots count chapters, never gaps left by a filtered-out chapter', () {
-      final everything = _readingOrder(library);
-      final asIfFiltered = [_ch(1, isRead: true), _ch(3, isRead: true), _ch(5)];
-      expect(chapterIdToDeleteWhileReading(everything, true, 3, 2), 2);
-      expect(
-        chapterIdToDeleteWhileReading(asIfFiltered, true, 3, 2),
-        1,
         reason:
-            'the old path counted positions in the visible list, which '
-            'skipped chapter 2 entirely',
+            'two slots back from chapter 3 is chapter 2, found even though '
+            'the list arrived late and dedup prefers the other group',
       );
-    });
-  });
+    },
+  );
 }

--- a/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
+++ b/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
@@ -27,8 +27,6 @@ ChapterDto _ch(int id, {bool isRead = false}) => Fragment$ChapterDto(
   meta: const <Fragment$ChapterDto$meta>[],
 );
 
-/// What `_whileReadingTarget` now hands the shared calculation: every chapter,
-/// in source order, whatever the details screen happens to be showing.
 List<ChapterDto> _readingOrder(List<ChapterDto> chapters) =>
     [...chapters]..sort((a, b) => a.sourceOrder.compareTo(b.sourceOrder));
 

--- a/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
+++ b/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
+
+ChapterDto _ch(int id, {bool isRead = false}) => Fragment$ChapterDto(
+  id: id,
+  mangaId: 1,
+  name: 'c$id',
+  chapterNumber: id.toDouble(),
+  sourceOrder: id,
+  isRead: isRead,
+  isBookmarked: false,
+  isDownloaded: true,
+  lastPageRead: 0,
+  pageCount: 10,
+  fetchedAt: '$id',
+  uploadDate: '$id',
+  lastReadAt: '0',
+  url: '',
+  meta: const <Fragment$ChapterDto$meta>[],
+);
+
+/// What `_whileReadingTarget` now hands the shared calculation: every chapter,
+/// in source order, whatever the details screen happens to be showing.
+List<ChapterDto> _readingOrder(List<ChapterDto> chapters) =>
+    [...chapters]..sort((a, b) => a.sourceOrder.compareTo(b.sourceOrder));
+
+void main() {
+  group('delete-while-reading targets reading order, not the visible list', () {
+    final library = [
+      _ch(1, isRead: true),
+      _ch(2, isRead: true),
+      _ch(3, isRead: true),
+      _ch(4),
+      _ch(5),
+    ];
+
+    test('slot N targets N-1 chapters behind the one just read', () {
+      final order = _readingOrder(library);
+      expect(chapterIdToDeleteWhileReading(order, true, 3, 1), 3);
+      expect(chapterIdToDeleteWhileReading(order, true, 3, 2), 2);
+      expect(chapterIdToDeleteWhileReading(order, true, 3, 3), 1);
+    });
+
+    test('a newest-first screen makes no difference', () {
+      final asDisplayed = library.reversed.toList(growable: false);
+      expect(
+        chapterIdToDeleteWhileReading(_readingOrder(asDisplayed), true, 3, 2),
+        2,
+      );
+    });
+
+    test('read chapters stay in range, so every slot still resolves', () {
+      final order = _readingOrder(library);
+      for (var slots = 1; slots <= 3; slots++) {
+        expect(
+          chapterIdToDeleteWhileReading(order, true, 3, slots),
+          isNotNull,
+          reason: 'slot $slots must still find chapter 3 once it is read',
+        );
+      }
+    });
+
+    test('slots count chapters, never gaps left by a filtered-out chapter', () {
+      final everything = _readingOrder(library);
+      final asIfFiltered = [_ch(1, isRead: true), _ch(3, isRead: true), _ch(5)];
+      expect(chapterIdToDeleteWhileReading(everything, true, 3, 2), 2);
+      expect(
+        chapterIdToDeleteWhileReading(asIfFiltered, true, 3, 2),
+        1,
+        reason:
+            'the old path counted positions in the visible list, which '
+            'skipped chapter 2 entirely',
+      );
+    });
+  });
+}


### PR DESCRIPTION
"Delete finished chapters while reading" counted its slots against the chapter list as filtered on screen.

With an Unread filter on, the chapter left that list the moment it was marked read, so the target could never be found and nothing was deleted at any setting. With any filter on, "two back" meant two rows back on screen, which can be several chapters back in the manga. It now walks every chapter in source order, so the setting means the same thing whatever the details screen is sorted or filtered by.

Three review rounds found further routes to the same silent no-op, all fixed here: preferred-scanlator dedup could discard the chapter being read; a chapter finished before the list resolved was skipped with no retry; a failure anywhere in the lookup was swallowed without a trace; and both paths acted on a delete setting snapshotted before an unbounded wait.

One test covers it, and each part of the fix is load-bearing under it — removing the dedup pin or the retry makes it find nothing, and removing the sort makes it target a chapter ahead of the reader.

1599 tests pass. Not verified on a device: the reporter's setup is a chapter filter I don't run.

Closes #271