### PR TITLE
Keep badge settings and badge corners intact after the library revamp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ import 'src/features/auth/data/auth_coordinator.dart';
 import 'src/features/auth/data/auth_credentials_store.dart';
 import 'src/features/auth/data/basic_auth_migration.dart';
 import 'src/features/auth/data/secure_credentials_provider.dart';
+import 'src/features/library/data/badge_preference_migration.dart';
 import 'src/features/migration/controller/bulk_migration_providers.dart';
 import 'src/features/notifications/controller/notifications_controller.dart';
 import 'src/features/notifications/data/background/notification_background_entry.dart';
@@ -202,6 +203,14 @@ Future<void> _startApp() async {
     }
   } catch (e, st) {
     debugPrint('request timeout migration failed: $e\n$st');
+  }
+
+  // 3.7) One-time: the badge revamp replaced three preference keys. Seed the
+  //    new ones from the old so an upgrade keeps the badges the user picked.
+  try {
+    await migrateBadgePreferences(sharedPreferences);
+  } catch (e, st) {
+    debugPrint('badge preference migration failed: $e\n$st');
   }
 
   // 4) Preload both auth providers BEFORE the first frame so synchronous reads

--- a/lib/src/features/library/data/badge_preference_migration.dart
+++ b/lib/src/features/library/data/badge_preference_migration.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../constants/enum.dart';
+
+/// Set once the seeding below has run, so a later deliberate change by the user
+/// survives the next launch.
+const kBadgePrefsMigratedKey = 'badgePrefsRevampMigrated';
+
+const _kLegacyUnreadBadge = 'unreadBadge';
+const _kLegacyLocalBadge = 'localBadge';
+const _kLegacyUseLangIcon = 'useLangIcon';
+
+/// Carries pre-revamp badge settings onto the keys that replaced them, so an
+/// upgrade doesn't read as the app forgetting them.
+///
+/// * `unreadBadge` off becomes [UnreadBadgeMode.hidden]. Everyone else is
+///   already covered by the new key's own default.
+/// * `localBadge` folded into `sourceBadge`, which now draws the Local Source
+///   folder glyph itself. Turning it on is the only way to keep that badge; it
+///   also brings source icons the user didn't ask for, which beats silently
+///   dropping a badge they did.
+/// * `useLangIcon` put a source icon in the language slot. The language slot
+///   now always draws a flag, so the source icon moves to `sourceBadge` and the
+///   language badge turns off — the same single icon on the cover as before.
+Future<void> migrateBadgePreferences(SharedPreferences prefs) async {
+  if (prefs.getBool(kBadgePrefsMigratedKey) == true) return;
+
+  if (prefs.getBool(_kLegacyUnreadBadge) == false &&
+      prefs.getInt(DBKeys.unreadBadgeMode.name) == null) {
+    await prefs.setInt(
+      DBKeys.unreadBadgeMode.name,
+      UnreadBadgeMode.hidden.index,
+    );
+  }
+
+  // Only meaningful while the language badge was actually on: the old settings
+  // page nested this switch under it, and the renderer gated on it too.
+  final langIconStandsIn = prefs.getBool(_kLegacyUseLangIcon) == true &&
+      prefs.getBool(DBKeys.languageBadge.name) == true;
+
+  if (langIconStandsIn || prefs.getBool(_kLegacyLocalBadge) == true) {
+    await prefs.setBool(DBKeys.sourceBadge.name, true);
+  }
+  if (langIconStandsIn) {
+    await prefs.setBool(DBKeys.languageBadge.name, false);
+  }
+
+  await prefs.setBool(kBadgePrefsMigratedKey, true);
+}

--- a/lib/src/widgets/manga_cover/widgets/manga_badges.dart
+++ b/lib/src/widgets/manga_cover/widgets/manga_badges.dart
@@ -42,6 +42,11 @@ double _stripHeight(BuildContext context) {
 /// padding, no slant inset) — for artwork that should bleed to the diagonal.
 typedef _Segment = ({Decoration decoration, Widget child, bool fill});
 
+/// Badge corners are physical: the layout editor offers "top-left" and
+/// "top-right", not "start" and "end". Every row that places a cluster pins
+/// this, or an RTL locale mirrors the clusters onto the wrong corners.
+const _kPhysical = TextDirection.ltr;
+
 class MangaBadgesRow extends ConsumerWidget {
   const MangaBadgesRow({
     super.key,
@@ -67,6 +72,7 @@ class MangaBadgesRow extends ConsumerWidget {
         padding: padding ?? KEdgeInsets.a8.size,
         child: Row(
           mainAxisSize: MainAxisSize.min,
+          textDirection: _kPhysical,
           children: [
             _BadgeStrip(
               height: height,
@@ -212,6 +218,7 @@ class MangaBadgesRow extends ConsumerWidget {
           if (!constraints.hasBoundedWidth) {
             return Row(
               mainAxisSize: MainAxisSize.min,
+              textDirection: _kPhysical,
               children: [
                 if (left.isNotEmpty) leftStrip,
                 if (left.isNotEmpty && right.isNotEmpty)
@@ -225,6 +232,7 @@ class MangaBadgesRow extends ConsumerWidget {
           // Capping each at half the width lets its own clip shave the excess.
           return Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            textDirection: _kPhysical,
             children: [
               Flexible(
                 child: left.isEmpty ? const SizedBox.shrink() : leftStrip,

--- a/test/src/features/library/badge_preference_migration_test.dart
+++ b/test/src/features/library/badge_preference_migration_test.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2022 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/library/data/badge_preference_migration.dart';
+
+Future<SharedPreferences> _migrated(Map<String, Object> initial) async {
+  SharedPreferences.setMockInitialValues(initial);
+  final prefs = await SharedPreferences.getInstance();
+  await migrateBadgePreferences(prefs);
+  return prefs;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('unreadBadge → unreadBadgeMode', () {
+    test('off stays off, as Hidden', () async {
+      final prefs = await _migrated({'unreadBadge': false});
+      expect(prefs.getInt('unreadBadgeMode'), UnreadBadgeMode.hidden.index);
+    });
+
+    test('on leaves the new key alone, so it keeps its Count default',
+        () async {
+      final prefs = await _migrated({'unreadBadge': true});
+      expect(prefs.getInt('unreadBadgeMode'), isNull);
+    });
+
+    test('never set leaves the new key alone', () async {
+      final prefs = await _migrated({});
+      expect(prefs.getInt('unreadBadgeMode'), isNull);
+    });
+
+    test('a mode the user already chose is not overwritten', () async {
+      final prefs = await _migrated({
+        'unreadBadge': false,
+        'unreadBadgeMode': UnreadBadgeMode.dot.index,
+      });
+      expect(prefs.getInt('unreadBadgeMode'), UnreadBadgeMode.dot.index);
+    });
+  });
+
+  group('localBadge → sourceBadge', () {
+    test('Local Source badge on keeps a badge, via the source badge', () async {
+      final prefs = await _migrated({'localBadge': true, 'sourceBadge': false});
+      expect(prefs.getBool('sourceBadge'), isTrue);
+    });
+
+    test('Local Source badge off changes nothing', () async {
+      final prefs = await _migrated({'localBadge': false, 'sourceBadge': false});
+      expect(prefs.getBool('sourceBadge'), isFalse);
+    });
+  });
+
+  group('useLangIcon → sourceBadge', () {
+    test('the source icon moves out of the language slot', () async {
+      final prefs = await _migrated({
+        'languageBadge': true,
+        'useLangIcon': true,
+        'sourceBadge': false,
+      });
+      expect(prefs.getBool('sourceBadge'), isTrue);
+      // The slot now always draws a flag, which is not what they picked.
+      expect(prefs.getBool('languageBadge'), isFalse);
+    });
+
+    test('a plain language badge keeps drawing a language badge', () async {
+      final prefs = await _migrated({
+        'languageBadge': true,
+        'useLangIcon': false,
+      });
+      expect(prefs.getBool('languageBadge'), isTrue);
+      expect(prefs.getBool('sourceBadge'), isNull);
+    });
+
+    test('inert when the language badge itself was off', () async {
+      final prefs = await _migrated({
+        'languageBadge': false,
+        'useLangIcon': true,
+      });
+      expect(prefs.getBool('languageBadge'), isFalse);
+      expect(prefs.getBool('sourceBadge'), isNull);
+    });
+  });
+
+  test('a fresh install is left entirely alone', () async {
+    final prefs = await _migrated({});
+    expect(prefs.getInt('unreadBadgeMode'), isNull);
+    expect(prefs.getBool('sourceBadge'), isNull);
+    expect(prefs.getBool('languageBadge'), isNull);
+  });
+
+  test('a later deliberate change survives the next launch', () async {
+    final prefs = await _migrated({'unreadBadge': false, 'localBadge': true});
+    expect(prefs.getInt('unreadBadgeMode'), UnreadBadgeMode.hidden.index);
+
+    // The user turns both back the other way, then relaunches.
+    await prefs.setInt('unreadBadgeMode', UnreadBadgeMode.count.index);
+    await prefs.setBool('sourceBadge', false);
+    await migrateBadgePreferences(prefs);
+
+    expect(prefs.getInt('unreadBadgeMode'), UnreadBadgeMode.count.index);
+    expect(prefs.getBool('sourceBadge'), isFalse);
+  });
+}

--- a/test/src/features/library/badge_preference_migration_test.dart
+++ b/test/src/features/library/badge_preference_migration_test.dart
@@ -69,6 +69,18 @@ void main() {
       expect(prefs.getBool('languageBadge'), isFalse);
     });
 
+    test('the source icon is not left drawn twice', () async {
+      // This combination drew the same icon in both slots before the revamp.
+      // Collapsing it to one is the intent, not a dropped badge.
+      final prefs = await _migrated({
+        'languageBadge': true,
+        'useLangIcon': true,
+        'sourceBadge': true,
+      });
+      expect(prefs.getBool('sourceBadge'), isTrue);
+      expect(prefs.getBool('languageBadge'), isFalse);
+    });
+
     test('a plain language badge keeps drawing a language badge', () async {
       final prefs = await _migrated({
         'languageBadge': true,

--- a/test/src/widgets/manga_cover/manga_badges_test.dart
+++ b/test/src/widgets/manga_cover/manga_badges_test.dart
@@ -10,6 +10,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tsumiru/src/constants/enum.dart';
 import 'package:tsumiru/src/features/browse_center/domain/source/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/library/data/badge_preference_migration.dart';
 import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
 import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
@@ -67,6 +68,7 @@ Future<void> _pumpBadges(
   Map<String, Object> prefs = const {},
   Fragment$MangaDto? manga,
   bool onDevice = true,
+  bool migrate = false,
 }) async {
   SharedPreferences.setMockInitialValues({
     'onDeviceBadge': true,
@@ -77,6 +79,9 @@ Future<void> _pumpBadges(
     ...prefs,
   });
   final sp = await SharedPreferences.getInstance();
+  // Stand in for the boot-time upgrade path, so a test can seed the pre-revamp
+  // keys and assert on what the user ends up seeing.
+  if (migrate) await migrateBadgePreferences(sp);
   await tester.pumpWidget(ProviderScope(
     overrides: [
       sharedPreferencesProvider.overrideWithValue(sp),
@@ -208,6 +213,25 @@ void main() {
       expect(find.byIcon(Icons.offline_pin_rounded), findsOneWidget);
       expect(find.text('🇯🇵'), findsOneWidget);
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('an upgrade keeps the badges the user had set', (tester) async {
+      // The point of the migration: what it writes is what the renderer reads.
+      // Pre-revamp keys in, the same cover out.
+      await _pumpBadges(
+        tester,
+        prefs: {
+          'unreadBadge': false,
+          'localBadge': true,
+          'sourceBadge': false,
+        },
+        migrate: true,
+        manga: _manga(lang: 'localsourcelang'),
+      );
+
+      expect(find.text('4'), findsNothing, reason: 'unread badge stayed off');
+      expect(find.byIcon(Icons.folder_rounded), findsOneWidget,
+          reason: 'the Local Source badge survived as the source badge');
     });
 
     testWidgets('nothing enabled renders nothing at all', (tester) async {

--- a/test/src/widgets/manga_cover/manga_badges_test.dart
+++ b/test/src/widgets/manga_cover/manga_badges_test.dart
@@ -68,7 +68,9 @@ Future<void> _pumpBadges(
   Map<String, Object> prefs = const {},
   Fragment$MangaDto? manga,
   bool onDevice = true,
+  TextDirection textDirection = TextDirection.ltr,
   bool migrate = false,
+  bool showCountBadges = true,
 }) async {
   SharedPreferences.setMockInitialValues({
     'onDeviceBadge': true,
@@ -90,14 +92,17 @@ Future<void> _pumpBadges(
     ],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
-      home: Scaffold(
-        body: Align(
-          alignment: Alignment.topLeft,
-          child: SizedBox(
-            width: 160,
-            child: MangaBadgesRow(
-              manga: manga ?? _manga(),
-              showCountBadges: true,
+      home: Directionality(
+        textDirection: textDirection,
+        child: Scaffold(
+          body: Align(
+            alignment: Alignment.topLeft,
+            child: SizedBox(
+              width: 160,
+              child: MangaBadgesRow(
+                manga: manga ?? _manga(),
+                showCountBadges: showCountBadges,
+              ),
             ),
           ),
         ),
@@ -213,6 +218,42 @@ void main() {
       expect(find.byIcon(Icons.offline_pin_rounded), findsOneWidget);
       expect(find.text('🇯🇵'), findsOneWidget);
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('the left cluster stays on the left in an RTL locale',
+        (tester) async {
+      // The corners the layout editor offers are physical, so an RTL locale
+      // must not mirror them. Unread sits left by default, language right.
+      await _pumpBadges(tester, textDirection: TextDirection.rtl);
+      expect(
+        tester.getCenter(find.text('4')).dx,
+        lessThan(tester.getCenter(find.text('🇯🇵')).dx),
+      );
+    });
+
+    testWidgets('an RTL locale still reaches both physical corners',
+        (tester) async {
+      await _pumpBadges(tester, textDirection: TextDirection.rtl);
+      final row = tester.getRect(find.byType(MangaBadgesRow));
+      // Each cluster hugs its own corner, inside the row's 8px padding.
+      expect(tester.getTopLeft(find.text('4')).dx, lessThan(row.center.dx));
+      expect(
+        tester.getTopRight(find.text('🇯🇵')).dx,
+        greaterThan(row.center.dx),
+      );
+    });
+
+    testWidgets('the Browse in-library marker stays left in an RTL locale',
+        (tester) async {
+      // Browse and global-search covers take their own path through the row.
+      await _pumpBadges(
+        tester,
+        showCountBadges: false,
+        textDirection: TextDirection.rtl,
+      );
+      final row = tester.getRect(find.byType(MangaBadgesRow));
+      final marker = find.byIcon(Icons.collections_bookmark_rounded);
+      expect(tester.getCenter(marker).dx, lessThan(row.center.dx));
     });
 
     testWidgets('an upgrade keeps the badges the user had set', (tester) async {

--- a/test/src/widgets/manga_cover/manga_badges_test.dart
+++ b/test/src/widgets/manga_cover/manga_badges_test.dart
@@ -323,6 +323,42 @@ void main() {
       expect(find.text('4'), findsOneWidget);
       expect(find.text('🇯🇵'), findsOneWidget);
     });
+
+    testWidgets('the unbounded path keeps its cluster order in RTL',
+        (tester) async {
+      // The list tiles take the min-width branch, which orders the two clusters
+      // itself rather than pinning them to corners — RTL would swap them.
+      SharedPreferences.setMockInitialValues({
+        'onDeviceBadge': true,
+        'downloadedBadge': true,
+        'languageBadge': true,
+      });
+      final sp = await SharedPreferences.getInstance();
+      await tester.pumpWidget(ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sp),
+          offlineDeviceMangaIdsProvider.overrideWith((ref) async => {_kMangaId}),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: Row(
+                children: [
+                  MangaBadgesRow(manga: _manga(), showCountBadges: true),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      expect(
+        tester.getCenter(find.text('4')).dx,
+        lessThan(tester.getCenter(find.text('🇯🇵')).dx),
+      );
+    });
   });
 
   group('badge height', () {


### PR DESCRIPTION
Two follow-ups from the library revamp (#273), both fixed here.

## Badge settings were forgotten on upgrade

The revamp replaced three preference keys and nothing carried the old values across, so the app read empty keys and fell back to defaults. It looked like it had forgotten your setup:

- The unread badge came back as a count for anyone who had turned it off.
- A Local Source badge with the source badge off simply vanished.

A one-time seeding step now runs at startup, behind a guard key so it happens once and never overrides a later deliberate change:

- Unread badge off stays off, as the new Hidden mode.
- Local Source badge survives as the source badge, which draws that folder glyph itself now.
- "Use source icon for language" really meant "put a source icon in the language slot". That slot always draws a flag now, so the source icon moves to the source badge and the language badge turns off, leaving the same single icon on the cover.

One combination changes on purpose: with the language badge, the source icon substitution, and the source badge all on, the old renderer drew the same icon twice. That collapses to one.

## Badges landed on the wrong corner in right-to-left locales

The badge layout editor offers top-left and top-right, but the clusters were positioned by a row that follows the reading direction, so an Arabic reader saw every badge on the opposite corner from the one they set. The Browse "in library" marker mirrored the same way.

The three rows that place a cluster are now pinned to a physical direction. Every segment is a digit, a flag, an icon or an image, so none of them read differently laid out this way.

## Tests

- Migration mapping, including idempotency and the combinations that would otherwise lose a badge.
- RTL placement across all three paths: the library grid, the list tiles, and the Browse marker. Each was checked against the unfixed renderer to confirm it fails without the change.
- An end-to-end case that seeds pre-revamp keys, runs the migration and asserts on the rendered cover, so the keys the migration writes and the keys the renderer reads cannot drift apart.

Full suite green, no new analyzer findings. Verified on device.

Closes #291
Closes #290