### PR TITLE
Filter the Updates and History lists

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -84,6 +84,13 @@ enum DBKeys {
   chapterFilterDownloaded(null),
   chapterFilterUnread(null),
   chapterFilterBookmarked(null),
+  updatesFilterDownloaded(null),
+  updatesFilterUnread(null),
+  updatesFilterStarted(null),
+  updatesFilterBookmarked(null),
+  historyFilterUnfinishedSeries(null),
+  historyFilterUnread(null),
+  historyFilterInLibrary(null),
   mangaSort(MangaSort.lastRead),
   // Default descending so the default Last-Read sort opens newest-read first
   // (last-read-descending). asc=true, dsc=false.

--- a/lib/src/features/history/data/history_repository.dart
+++ b/lib/src/features/history/data/history_repository.dart
@@ -30,8 +30,9 @@ class HistoryRepository {
     DateTime? fromDate,
     DateTime? toDate,
   }) async {
+    // No inLibrary gate: history covers anything you've read, and the
+    // "Library" filter decides whether non-library entries are shown.
     final filter = Input$ChapterFilterInput(
-      inLibrary: Input$BooleanFilterInput(equalTo: true),
       lastReadAt: Input$LongFilterInput(
         isNull: false,
         greaterThan:

--- a/lib/src/features/history/data/history_repository.dart
+++ b/lib/src/features/history/data/history_repository.dart
@@ -29,10 +29,15 @@ class HistoryRepository {
     String? searchQuery,
     DateTime? fromDate,
     DateTime? toDate,
+    bool? inLibrary,
   }) async {
-    // No inLibrary gate: history covers anything you've read, and the
-    // "Library" filter decides whether non-library entries are shown.
+    // Library membership is pushed to the server rather than filtered on the
+    // result: this fetch is one bounded window, so spending it on rows that are
+    // about to be discarded would cut how far back the history reaches.
     final filter = Input$ChapterFilterInput(
+      inLibrary: inLibrary == null
+          ? null
+          : Input$BooleanFilterInput(equalTo: inLibrary),
       lastReadAt: Input$LongFilterInput(
         isNull: false,
         greaterThan:

--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -20,8 +20,10 @@ part 'history_controller.g.dart';
 class ReadingHistory extends _$ReadingHistory {
   @override
   Future<List<HistoryItemDto>?> build() async {
-    final items =
-        await ref.watch(historyRepositoryProvider).getReadingHistory();
+    final inLibrary = ref.watch(historyFilterInLibraryProvider);
+    final items = await ref
+        .watch(historyRepositoryProvider)
+        .getReadingHistory(inLibrary: inLibrary);
     // Guard the post-await ref use: the provider may have been disposed during
     // the fetch, and keepAlive() on a dead ref throws UnmountedRefException.
     if (ref.mounted) ref.keepAlive();
@@ -32,8 +34,11 @@ class ReadingHistory extends _$ReadingHistory {
     // Don't reset to AsyncLoading — that blanks the list to a full-screen
     // spinner on pull-to-refresh. Keep the current items visible until fresh
     // data lands (the RefreshIndicator already shows the pull spinner).
+    final inLibrary = ref.read(historyFilterInLibraryProvider);
     final result = await AsyncValue.guard(
-      () => ref.read(historyRepositoryProvider).getReadingHistory(),
+      () => ref
+          .read(historyRepositoryProvider)
+          .getReadingHistory(inLibrary: inLibrary),
     );
     if (!ref.mounted) return;
     final items = result.asData?.value;

--- a/lib/src/features/history/presentation/history_controller.dart
+++ b/lib/src/features/history/presentation/history_controller.dart
@@ -62,9 +62,75 @@ class MangaReadingHistory extends _$MangaReadingHistory {
   }
 }
 
+/// The History list filters, as one value; a record so equality is structural.
+typedef HistoryFilter = ({
+  bool? unfinishedSeries,
+  bool? unread,
+  bool? inLibrary,
+});
+
+const HistoryFilter kNoHistoryFilter = (
+  unfinishedSeries: null,
+  unread: null,
+  inLibrary: null,
+);
+
+@riverpod
+class HistoryFilterUnfinishedSeries extends _$HistoryFilterUnfinishedSeries
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.historyFilterUnfinishedSeries);
+}
+
+@riverpod
+class HistoryFilterUnread extends _$HistoryFilterUnread
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.historyFilterUnread);
+}
+
+@riverpod
+class HistoryFilterInLibrary extends _$HistoryFilterInLibrary
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.historyFilterInLibrary);
+}
+
+@riverpod
+HistoryFilter historyFilter(Ref ref) => (
+      unfinishedSeries: ref.watch(historyFilterUnfinishedSeriesProvider),
+      unread: ref.watch(historyFilterUnreadProvider),
+      inLibrary: ref.watch(historyFilterInLibraryProvider),
+    );
+
+@riverpod
+bool historyHasActiveFilters(Ref ref) =>
+    ref.watch(historyFilterProvider) != kNoHistoryFilter;
+
+/// Applies [filter] to one row. Each filter is tri-state: null passes
+/// everything, true keeps matches, false keeps non-matches.
+bool historyItemMatchesFilter(HistoryItemDto item, HistoryFilter filter) {
+  final unfinishedSeries = filter.unfinishedSeries;
+  if (unfinishedSeries != null &&
+      unfinishedSeries != (item.manga.unreadCount > 0)) {
+    return false;
+  }
+  final unread = filter.unread;
+  if (unread != null && unread != !item.isRead) return false;
+  final inLibrary = filter.inLibrary;
+  if (inLibrary != null && inLibrary != item.manga.inLibrary) return false;
+  return true;
+}
+
 @riverpod
 List<HistoryGroup> historyGroupedByDate(Ref ref) {
-  final historyItems = ref.watch(readingHistoryProvider).value ?? [];
+  final allItems = ref.watch(readingHistoryProvider).value ?? [];
+  final filter = ref.watch(historyFilterProvider);
+  final historyItems = filter == kNoHistoryFilter
+      ? allItems
+      : allItems
+          .where((item) => historyItemMatchesFilter(item, filter))
+          .toList();
 
   if (historyItems.isEmpty) return [];
 

--- a/lib/src/features/history/presentation/history_screen.dart
+++ b/lib/src/features/history/presentation/history_screen.dart
@@ -12,6 +12,7 @@ import '../../../utils/extensions/custom_extensions.dart';
 import '../../../widgets/emoticons.dart';
 import '../../../widgets/search_field.dart';
 import 'history_controller.dart';
+import 'widgets/history_filter.dart';
 import 'widgets/history_group_widget.dart';
 
 class HistoryScreen extends ConsumerWidget {
@@ -23,11 +24,28 @@ class HistoryScreen extends ConsumerWidget {
     final historyGroups = ref.watch(filteredHistoryGroupsProvider);
     final historyState = ref.watch(readingHistoryProvider);
     final searchQuery = ref.watch(historySearchQueryProvider);
+    final hasActiveFilters = ref.watch(historyHasActiveFiltersProvider);
 
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.history),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.filter_list_rounded),
+            tooltip: l10n.filter,
+            // Tinted while filtered, so a short list reads as "filtered" rather
+            // than "nothing read". Komikku uses amber; ours comes from the theme.
+            color: hasActiveFilters ? context.theme.colorScheme.primary : null,
+            onPressed: () => showModalBottomSheet(
+              context: context,
+              isScrollControlled: true,
+              shape: RoundedRectangleBorder(
+                borderRadius: KBorderRadius.rT16.radius,
+              ),
+              clipBehavior: Clip.hardEdge,
+              builder: (_) => const HistoryFilterSheet(),
+            ),
+          ),
           IconButton(
             onPressed: () =>
                 ref.read(readingHistoryProvider.notifier).refresh(),
@@ -68,7 +86,10 @@ class HistoryScreen extends ConsumerWidget {
                   return const HistoryEmptyState();
                 }
 
-                if (historyGroups.isEmpty && searchQuery.isNotBlank) {
+                // Filters can empty the list just as a search can; without this
+                // the builder below renders a blank page with no explanation.
+                if (historyGroups.isEmpty &&
+                    (searchQuery.isNotBlank || hasActiveFilters)) {
                   return const HistoryNoSearchResults();
                 }
 

--- a/lib/src/features/history/presentation/widgets/history_filter.dart
+++ b/lib/src/features/history/presentation/widgets/history_filter.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../utils/extensions/custom_extensions.dart';
+import '../../../../widgets/tri_state_filter_tile.dart';
+import '../history_controller.dart';
+
+/// Filter rows for the History list, matching Komikku's three: unfinished
+/// series, unfinished chapter, and library membership.
+class HistoryFilterSheet extends ConsumerWidget {
+  const HistoryFilterSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      top: false,
+      child: ListView(
+        shrinkWrap: true,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
+            child: Text(
+              context.l10n.filter,
+              style: context.textTheme.titleMedium,
+            ),
+          ),
+          TriStateFilterTile(
+            header: context.l10n.filterHeaderSeries,
+            provider: historyFilterUnfinishedSeriesProvider,
+            onChanged: ref
+                .read(historyFilterUnfinishedSeriesProvider.notifier)
+                .update,
+            includedLabel: context.l10n.filterOptionUnfinished,
+            excludedLabel: context.l10n.filterOptionFinished,
+          ),
+          TriStateFilterTile(
+            header: context.l10n.filterHeaderReadStatus,
+            provider: historyFilterUnreadProvider,
+            onChanged: ref.read(historyFilterUnreadProvider.notifier).update,
+            includedLabel: context.l10n.filterOptionUnread,
+            excludedLabel: context.l10n.filterOptionRead,
+          ),
+          TriStateFilterTile(
+            header: context.l10n.filterHeaderLibrary,
+            provider: historyFilterInLibraryProvider,
+            onChanged: ref.read(historyFilterInLibraryProvider.notifier).update,
+            includedLabel: context.l10n.filterOptionInLibrary,
+            excludedLabel: context.l10n.filterOptionNotInLibrary,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/manga_book/data/updates/updates_repository.dart
+++ b/lib/src/features/manga_book/data/updates/updates_repository.dart
@@ -13,9 +13,37 @@ import '../../../../graphql/__generated__/schema.graphql.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../domain/chapter_page/chapter_page_model.dart';
 import '../../domain/update_status/update_status_model.dart';
+import '../../domain/updates/updates_filter.dart';
 import './graphql/__generated__/query.graphql.dart';
 
 part 'updates_repository.g.dart';
+
+/// Rows per page. The offset step must match, or pages overlap and the list
+/// repeats rows.
+const int updatesPageSize = 50;
+
+Input$BooleanFilterInput? _equals(bool? value) =>
+    value == null ? null : Input$BooleanFilterInput(equalTo: value);
+
+Input$ChapterFilterInput updatesFilterInput(UpdatesFilter filter) =>
+    Input$ChapterFilterInput(
+      inLibrary: Input$BooleanFilterInput(equalTo: true),
+      isDownloaded: _equals(filter.downloaded),
+      isRead: filter.unread == null ? null : _equals(!filter.unread!),
+      isBookmarked: _equals(filter.bookmarked),
+      // Komikku treats a finished chapter as neither started nor not-started, so
+      // both sides of this filter also require unread (updatesView.sq).
+      and: filter.started == null
+          ? null
+          : [
+              Input$ChapterFilterInput(isRead: _equals(false)),
+              Input$ChapterFilterInput(
+                lastPageRead: filter.started!
+                    ? Input$IntFilterInput(greaterThan: 0)
+                    : Input$IntFilterInput(equalTo: 0),
+              ),
+            ],
+    );
 
 class UpdatesRepository {
   const UpdatesRepository(this.client, this.subscriptionClient);
@@ -27,16 +55,15 @@ class UpdatesRepository {
   // Updates
   Future<ChapterPageWithMangaDto?> getRecentChaptersPage({
     int pageNo = 0,
+    UpdatesFilter filter = kNoUpdatesFilter,
   }) =>
       client
           .query$GetChapterWithMangaPage(
             Options$Query$GetChapterWithMangaPage(
               variables: Variables$Query$GetChapterWithMangaPage(
-                filter: Input$ChapterFilterInput(
-                  inLibrary: Input$BooleanFilterInput(equalTo: true),
-                ),
-                first: 50,
-                offset: pageNo * 30,
+                filter: updatesFilterInput(filter),
+                first: updatesPageSize,
+                offset: pageNo * updatesPageSize,
                 order: [
                   Input$ChapterOrderInput(
                     by: Enum$ChapterOrderBy.FETCHED_AT,

--- a/lib/src/features/manga_book/domain/updates/updates_filter.dart
+++ b/lib/src/features/manga_book/domain/updates/updates_filter.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// The Updates list filters, as one value. A record so equality is structural —
+/// the screen compares it between builds to decide whether to refetch.
+typedef UpdatesFilter = ({
+  bool? downloaded,
+  bool? unread,
+  bool? started,
+  bool? bookmarked,
+});
+
+const UpdatesFilter kNoUpdatesFilter = (
+  downloaded: null,
+  unread: null,
+  started: null,
+  bookmarked: null,
+);

--- a/lib/src/features/manga_book/presentation/updates/controller/updates_filter_controller.dart
+++ b/lib/src/features/manga_book/presentation/updates/controller/updates_filter_controller.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../constants/db_keys.dart';
+import '../../../../../utils/mixin/shared_preferences_client_mixin.dart';
+import '../../../domain/updates/updates_filter.dart';
+
+export '../../../domain/updates/updates_filter.dart';
+
+part 'updates_filter_controller.g.dart';
+
+@riverpod
+class UpdatesFilterDownloaded extends _$UpdatesFilterDownloaded
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.updatesFilterDownloaded);
+}
+
+@riverpod
+class UpdatesFilterUnread extends _$UpdatesFilterUnread
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.updatesFilterUnread);
+}
+
+@riverpod
+class UpdatesFilterStarted extends _$UpdatesFilterStarted
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.updatesFilterStarted);
+}
+
+@riverpod
+class UpdatesFilterBookmarked extends _$UpdatesFilterBookmarked
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.updatesFilterBookmarked);
+}
+
+@riverpod
+UpdatesFilter updatesFilter(Ref ref) => (
+      downloaded: ref.watch(updatesFilterDownloadedProvider),
+      unread: ref.watch(updatesFilterUnreadProvider),
+      started: ref.watch(updatesFilterStartedProvider),
+      bookmarked: ref.watch(updatesFilterBookmarkedProvider),
+    );
+
+@riverpod
+bool updatesHasActiveFilters(Ref ref) =>
+    ref.watch(updatesFilterProvider) != kNoUpdatesFilter;

--- a/lib/src/features/manga_book/presentation/updates/updates_screen.dart
+++ b/lib/src/features/manga_book/presentation/updates/updates_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
+import '../../../../constants/app_sizes.dart';
 import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/hooks/paging_controller_hook.dart';
@@ -21,7 +22,9 @@ import '../../widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
 import '../../widgets/update_status_fab.dart';
 import '../../widgets/update_status_popup_menu.dart';
 import '../reader/controller/reader_controller.dart';
+import 'controller/updates_filter_controller.dart';
 import 'widgets/chapter_manga_list_tile.dart';
+import 'widgets/updates_filter.dart';
 
 class UpdatesScreen extends HookConsumerWidget {
   const UpdatesScreen({super.key});
@@ -30,9 +33,10 @@ class UpdatesScreen extends HookConsumerWidget {
     UpdatesRepository repository,
     PagingController<int, ChapterWithMangaDto> controller,
     int pageKey,
+    UpdatesFilter filter,
   ) async {
     AsyncValue.guard(
-      () => repository.getRecentChaptersPage(pageNo: pageKey),
+      () => repository.getRecentChaptersPage(pageNo: pageKey, filter: filter),
     ).then(
       (value) => value.whenOrNull(
         data: (recentChaptersPage) {
@@ -66,12 +70,35 @@ class UpdatesScreen extends HookConsumerWidget {
         .ifNull();
     final lastUpdated = ref.watch(libraryLastUpdatedProvider).value;
     final selectedChapters = useState<Map<int, ChapterDto>>({});
+    final filter = ref.watch(updatesFilterProvider);
+    final hasActiveFilters = ref.watch(updatesHasActiveFiltersProvider);
+    // The page listener is registered once, so it can't close over `filter` —
+    // it reads the latest value through this holder instead.
+    final latestFilter = useRef(filter);
+    latestFilter.value = filter;
     useEffect(() {
       controller.addPageRequestListener(
-        (pageKey) => _fetchPage(updatesRepository, controller, pageKey),
+        (pageKey) => _fetchPage(
+          updatesRepository,
+          controller,
+          pageKey,
+          latestFilter.value,
+        ),
       );
       return;
     }, []);
+    // Filtering happens server-side, so a changed filter invalidates every page
+    // already loaded. Skip the mount run or page 0 would be fetched twice.
+    final isFilterMount = useRef(true);
+    useEffect(() {
+      if (isFilterMount.value) {
+        isFilterMount.value = false;
+        return null;
+      }
+      selectedChapters.value = ({});
+      controller.refresh();
+      return null;
+    }, [filter]);
     useEffect(() {
       if (!isUpdatesChecking) {
         try {
@@ -104,6 +131,25 @@ class UpdatesScreen extends HookConsumerWidget {
               // which is where Mihon keeps it.
               title: Text(context.l10n.updates),
               actions: [
+                IconButton(
+                  icon: const Icon(Icons.filter_list_rounded),
+                  tooltip: context.l10n.filter,
+                  // Tinted while filtered, so a short list reads as "filtered"
+                  // rather than "nothing new". Komikku uses amber here; ours
+                  // comes from the theme.
+                  color: hasActiveFilters
+                      ? context.theme.colorScheme.primary
+                      : null,
+                  onPressed: () => showModalBottomSheet(
+                    context: context,
+                    isScrollControlled: true,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: KBorderRadius.rT16.radius,
+                    ),
+                    clipBehavior: Clip.hardEdge,
+                    builder: (_) => const UpdatesFilterSheet(),
+                  ),
+                ),
                 IconButton(
                   icon: const Icon(Icons.calendar_month_rounded),
                   tooltip: context.l10n.upcoming,

--- a/lib/src/features/manga_book/presentation/updates/updates_screen.dart
+++ b/lib/src/features/manga_book/presentation/updates/updates_screen.dart
@@ -34,12 +34,18 @@ class UpdatesScreen extends HookConsumerWidget {
     PagingController<int, ChapterWithMangaDto> controller,
     int pageKey,
     UpdatesFilter filter,
+    int generation,
+    ValueGetter<int> currentGeneration,
   ) async {
     AsyncValue.guard(
       () => repository.getRecentChaptersPage(pageNo: pageKey, filter: filter),
     ).then(
       (value) => value.whenOrNull(
         data: (recentChaptersPage) {
+          // A refresh or filter change while this request was in flight leaves
+          // it describing a list that no longer exists; appending its rows would
+          // interleave two different result sets and skew the next page key.
+          if (generation != currentGeneration()) return;
           try {
             if (recentChaptersPage != null) {
               if (recentChaptersPage.pageInfo.hasNextPage) {
@@ -54,7 +60,10 @@ class UpdatesScreen extends HookConsumerWidget {
             //
           }
         },
-        error: (error, stackTrace) => controller.error = error,
+        error: (error, stackTrace) {
+          if (generation != currentGeneration()) return;
+          controller.error = error;
+        },
       ),
     );
   }
@@ -76,6 +85,14 @@ class UpdatesScreen extends HookConsumerWidget {
     // it reads the latest value through this holder instead.
     final latestFilter = useRef(filter);
     latestFilter.value = filter;
+    // Bumped by every reset of the list, so replies from the previous one can be
+    // recognised as stale and dropped.
+    final generation = useRef(0);
+    final resetList = useCallback(() {
+      generation.value++;
+      selectedChapters.value = ({});
+      controller.refresh();
+    }, []);
     useEffect(() {
       controller.addPageRequestListener(
         (pageKey) => _fetchPage(
@@ -83,6 +100,8 @@ class UpdatesScreen extends HookConsumerWidget {
           controller,
           pageKey,
           latestFilter.value,
+          generation.value,
+          () => generation.value,
         ),
       );
       return;
@@ -95,15 +114,13 @@ class UpdatesScreen extends HookConsumerWidget {
         isFilterMount.value = false;
         return null;
       }
-      selectedChapters.value = ({});
-      controller.refresh();
+      resetList();
       return null;
     }, [filter]);
     useEffect(() {
       if (!isUpdatesChecking) {
         try {
-          selectedChapters.value = ({});
-          controller.refresh();
+          resetList();
         } catch (e) {
           //
         }
@@ -161,14 +178,11 @@ class UpdatesScreen extends HookConsumerWidget {
       bottomSheet: selectedChapters.value.isNotEmpty
           ? MultiChaptersActionsBottomAppBar(
               selectedChapters: selectedChapters,
-              afterOptionSelected: () async => controller.refresh(),
+              afterOptionSelected: () async => resetList(),
             )
           : null,
       body: RefreshIndicator(
-        onRefresh: () async {
-          selectedChapters.value = ({});
-          controller.refresh();
-        },
+        onRefresh: () async => resetList(),
         child: CustomScrollView(
           slivers: [
             if (lastUpdated != null && (int.tryParse(lastUpdated) ?? 0) > 0)
@@ -197,14 +211,14 @@ class UpdatesScreen extends HookConsumerWidget {
                 firstPageErrorIndicatorBuilder: (context) => Emoticons(
                   title: controller.error.toString(),
                   button: TextButton(
-                    onPressed: () => controller.refresh(),
+                    onPressed: () => resetList(),
                     child: Text(context.l10n.retry),
                   ),
                 ),
                 noItemsFoundIndicatorBuilder: (context) => Emoticons(
                   title: context.l10n.noUpdatesFound,
                   button: TextButton(
-                    onPressed: () => controller.refresh(),
+                    onPressed: () => resetList(),
                     child: Text(context.l10n.refresh),
                   ),
                 ),

--- a/lib/src/features/manga_book/presentation/updates/widgets/updates_filter.dart
+++ b/lib/src/features/manga_book/presentation/updates/widgets/updates_filter.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../widgets/tri_state_filter_tile.dart';
+import '../controller/updates_filter_controller.dart';
+
+/// Filter rows for the Updates list. Same order Komikku uses — Downloaded,
+/// Unread, Started, Bookmarked — and the same pills the library organizer uses.
+class UpdatesFilterSheet extends ConsumerWidget {
+  const UpdatesFilterSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      top: false,
+      child: ListView(
+        shrinkWrap: true,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
+            child: Text(
+              context.l10n.filter,
+              style: context.textTheme.titleMedium,
+            ),
+          ),
+          TriStateFilterTile(
+            header: context.l10n.filterHeaderDownloadStatus,
+            provider: updatesFilterDownloadedProvider,
+            onChanged: ref.read(updatesFilterDownloadedProvider.notifier).update,
+            includedLabel: context.l10n.filterOptionDownloaded,
+            excludedLabel: context.l10n.filterOptionNotDownloaded,
+          ),
+          TriStateFilterTile(
+            header: context.l10n.filterHeaderReadStatus,
+            provider: updatesFilterUnreadProvider,
+            onChanged: ref.read(updatesFilterUnreadProvider.notifier).update,
+            includedLabel: context.l10n.filterOptionUnread,
+            excludedLabel: context.l10n.filterOptionRead,
+          ),
+          TriStateFilterTile(
+            header: context.l10n.filterHeaderProgress,
+            provider: updatesFilterStartedProvider,
+            onChanged: ref.read(updatesFilterStartedProvider.notifier).update,
+            includedLabel: context.l10n.filterOptionStarted,
+            excludedLabel: context.l10n.filterOptionNotStarted,
+          ),
+          TriStateFilterTile(
+            header: context.l10n.filterHeaderBookmarks,
+            provider: updatesFilterBookmarkedProvider,
+            onChanged: ref.read(updatesFilterBookmarkedProvider.notifier).update,
+            includedLabel: context.l10n.filterOptionBookmarked,
+            excludedLabel: context.l10n.filterOptionNotBookmarked,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/offline/presentation/keep_rule_picker.dart
+++ b/lib/src/features/offline/presentation/keep_rule_picker.dart
@@ -22,31 +22,37 @@ Future<({OfflineKeepRule rule, int count})?> pickOfflineKeepRule(
   return showModalBottomSheet<({OfflineKeepRule rule, int count})>(
     context: context,
     showDragHandle: true,
+    // Scroll-controlled and scrollable: a default sheet is capped at 9/16 of
+    // the space it is given, and the "Updating library" strip is a sibling of
+    // the page content, so it shrinks that space from under it.
+    isScrollControlled: true,
     builder: (sheetContext) => SafeArea(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          for (final n in kOfflineBufferSizes)
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final n in kOfflineBufferSizes)
+              ListTile(
+                leading: const Icon(Icons.bookmark_add_outlined),
+                title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+                onTap: () => Navigator.pop(
+                    sheetContext, (rule: OfflineKeepRule.nUnread, count: n)),
+              ),
             ListTile(
-              leading: const Icon(Icons.bookmark_add_outlined),
-              title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+              leading: const Icon(Icons.menu_book_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAllUnread),
               onTap: () => Navigator.pop(
-                  sheetContext, (rule: OfflineKeepRule.nUnread, count: n)),
+                  sheetContext, (rule: OfflineKeepRule.allUnread, count: 3)),
             ),
-          ListTile(
-            leading: const Icon(Icons.menu_book_outlined),
-            title: Text(sheetContext.l10n.keepOfflineAllUnread),
-            onTap: () => Navigator.pop(
-                sheetContext, (rule: OfflineKeepRule.allUnread, count: 3)),
-          ),
-          ListTile(
-            leading: const Icon(Icons.library_books_outlined),
-            title: Text(sheetContext.l10n.keepOfflineAll),
-            onTap: () => Navigator.pop(
-                sheetContext, (rule: OfflineKeepRule.all, count: 3)),
-          ),
-        ],
+            ListTile(
+              leading: const Icon(Icons.library_books_outlined),
+              title: Text(sheetContext.l10n.keepOfflineAll),
+              onTap: () => Navigator.pop(
+                  sheetContext, (rule: OfflineKeepRule.all, count: 3)),
+            ),
+          ],
+        ),
       ),
     ),
   );

--- a/lib/src/features/offline/presentation/offline_files_view.dart
+++ b/lib/src/features/offline/presentation/offline_files_view.dart
@@ -195,72 +195,78 @@ class OfflineFilesView extends HookConsumerWidget {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
+      // Scroll-controlled and scrollable: a default sheet is capped at 9/16
+      // of the space it is given, and the "Updating library" strip is a
+      // sibling of the page content, so it shrinks that space from under it.
+      isScrollControlled: true,
       builder: (sheetContext) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            for (final n in _bufferSizes)
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final n in _bufferSizes)
+                ListTile(
+                  leading: const Icon(Icons.bookmark_add_outlined),
+                  title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+                  trailing: (manga.keepRule == OfflineKeepRule.nUnread &&
+                          manga.keepUnreadCount == n)
+                      ? const Icon(Icons.check_rounded)
+                      : null,
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    changeKeepRule(ref, manga.id, OfflineKeepRule.nUnread, n);
+                  },
+                ),
               ListTile(
-                leading: const Icon(Icons.bookmark_add_outlined),
-                title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
-                trailing: (manga.keepRule == OfflineKeepRule.nUnread &&
-                        manga.keepUnreadCount == n)
+                leading: const Icon(Icons.menu_book_outlined),
+                title: Text(sheetContext.l10n.keepOfflineAllUnread),
+                trailing: manga.keepRule == OfflineKeepRule.allUnread
                     ? const Icon(Icons.check_rounded)
                     : null,
                 onTap: () {
                   Navigator.pop(sheetContext);
-                  changeKeepRule(ref, manga.id, OfflineKeepRule.nUnread, n);
+                  changeKeepRule(ref, manga.id, OfflineKeepRule.allUnread,
+                      manga.keepUnreadCount);
                 },
               ),
-            ListTile(
-              leading: const Icon(Icons.menu_book_outlined),
-              title: Text(sheetContext.l10n.keepOfflineAllUnread),
-              trailing: manga.keepRule == OfflineKeepRule.allUnread
-                  ? const Icon(Icons.check_rounded)
-                  : null,
-              onTap: () {
-                Navigator.pop(sheetContext);
-                changeKeepRule(ref, manga.id, OfflineKeepRule.allUnread,
-                    manga.keepUnreadCount);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.library_books_outlined),
-              title: Text(sheetContext.l10n.keepOfflineAll),
-              trailing: manga.keepRule == OfflineKeepRule.all
-                  ? const Icon(Icons.check_rounded)
-                  : null,
-              onTap: () {
-                Navigator.pop(sheetContext);
-                changeKeepRule(
-                    ref, manga.id, OfflineKeepRule.all, manga.keepUnreadCount);
-              },
-            ),
-            const Divider(height: 1),
-            ListTile(
-              leading: const Icon(Icons.bookmark_remove_outlined),
-              title: Text(sheetContext.l10n.manageDownloadsStopKeep),
-              onTap: () {
-                Navigator.pop(sheetContext);
-                detachKeepRule(ref, manga.id);
-              },
-            ),
-            ListTile(
-              leading: Icon(Icons.delete_outline_rounded,
-                  color: sheetContext.theme.colorScheme.error),
-              title: Text(sheetContext.l10n.manageDownloadsStopDelete,
-                  style:
-                      TextStyle(color: sheetContext.theme.colorScheme.error)),
-              onTap: () async {
-                final ok = await _confirm(sheetContext,
-                    sheetContext.l10n.manageDownloadsDeleteConfirm(1));
-                if (!sheetContext.mounted) return;
-                Navigator.pop(sheetContext);
-                if (ok) await removeKeepRuleAndDelete(ref, manga.id);
-              },
-            ),
-          ],
+              ListTile(
+                leading: const Icon(Icons.library_books_outlined),
+                title: Text(sheetContext.l10n.keepOfflineAll),
+                trailing: manga.keepRule == OfflineKeepRule.all
+                    ? const Icon(Icons.check_rounded)
+                    : null,
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  changeKeepRule(
+                      ref, manga.id, OfflineKeepRule.all, manga.keepUnreadCount);
+                },
+              ),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.bookmark_remove_outlined),
+                title: Text(sheetContext.l10n.manageDownloadsStopKeep),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  detachKeepRule(ref, manga.id);
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.delete_outline_rounded,
+                    color: sheetContext.theme.colorScheme.error),
+                title: Text(sheetContext.l10n.manageDownloadsStopDelete,
+                    style:
+                        TextStyle(color: sheetContext.theme.colorScheme.error)),
+                onTap: () async {
+                  final ok = await _confirm(sheetContext,
+                      sheetContext.l10n.manageDownloadsDeleteConfirm(1));
+                  if (!sheetContext.mounted) return;
+                  Navigator.pop(sheetContext);
+                  if (ok) await removeKeepRuleAndDelete(ref, manga.id);
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/offline/presentation/series_offline_button.dart
+++ b/lib/src/features/offline/presentation/series_offline_button.dart
@@ -74,80 +74,86 @@ class SeriesOfflineButton extends ConsumerWidget {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
+      // Scroll-controlled and scrollable: a default sheet is capped at 9/16
+      // of the space it is given, and the "Updating library" strip is a
+      // sibling of the page content, so it shrinks that space from under it.
+      isScrollControlled: true,
       builder: (sheetContext) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Explain what this sheet does — offline (device) copies, distinct
-            // from the server download up top.
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 4, 20, 14),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    sheetContext.l10n.offlineSheetTitle,
-                    style: sheetContext.textTheme.titleMedium
-                        ?.copyWith(fontWeight: FontWeight.w600),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    sheetContext.l10n.offlineSheetSubtitle,
-                    style: TextStyle(
-                      color: sheetContext.theme.colorScheme.onSurfaceVariant,
-                      fontSize: 13,
-                      height: 1.3,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Explain what this sheet does — offline (device) copies, distinct
+              // from the server download up top.
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 4, 20, 14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      sheetContext.l10n.offlineSheetTitle,
+                      style: sheetContext.textTheme.titleMedium
+                          ?.copyWith(fontWeight: FontWeight.w600),
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 6),
+                    Text(
+                      sheetContext.l10n.offlineSheetSubtitle,
+                      style: TextStyle(
+                        color: sheetContext.theme.colorScheme.onSurfaceVariant,
+                        fontSize: 13,
+                        height: 1.3,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            const Divider(height: 1),
-            // Rolling forward buffer: keep the next N unread downloaded, topped
-            // up as you read. Distinct buffer sizes.
-            for (final n in const [5, 10, 25])
+              const Divider(height: 1),
+              // Rolling forward buffer: keep the next N unread downloaded, topped
+              // up as you read. Distinct buffer sizes.
+              for (final n in const [5, 10, 25])
+                ListTile(
+                  leading: const Icon(Icons.bookmark_add_outlined),
+                  title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
+                  trailing: (rule == OfflineKeepRule.nUnread && config.count == n)
+                      ? const Icon(Icons.check_rounded)
+                      : null,
+                  onTap: () =>
+                      _apply(sheetContext, ref, OfflineKeepRule.nUnread, n),
+                ),
               ListTile(
-                leading: const Icon(Icons.bookmark_add_outlined),
-                title: Text(sheetContext.l10n.keepOfflineNextUnread(n)),
-                trailing: (rule == OfflineKeepRule.nUnread && config.count == n)
+                leading: const Icon(Icons.menu_book_outlined),
+                title: Text(sheetContext.l10n.keepOfflineAllUnread),
+                trailing: rule == OfflineKeepRule.allUnread
+                    ? const Icon(Icons.check_rounded)
+                    : null,
+                onTap: () => _apply(
+                    sheetContext, ref, OfflineKeepRule.allUnread, config.count),
+              ),
+              ListTile(
+                leading: const Icon(Icons.library_books_outlined),
+                title: Text(sheetContext.l10n.keepOfflineAll),
+                trailing: rule == OfflineKeepRule.all
                     ? const Icon(Icons.check_rounded)
                     : null,
                 onTap: () =>
-                    _apply(sheetContext, ref, OfflineKeepRule.nUnread, n),
+                    _apply(sheetContext, ref, OfflineKeepRule.all, config.count),
               ),
-            ListTile(
-              leading: const Icon(Icons.menu_book_outlined),
-              title: Text(sheetContext.l10n.keepOfflineAllUnread),
-              trailing: rule == OfflineKeepRule.allUnread
-                  ? const Icon(Icons.check_rounded)
-                  : null,
-              onTap: () => _apply(
-                  sheetContext, ref, OfflineKeepRule.allUnread, config.count),
-            ),
-            ListTile(
-              leading: const Icon(Icons.library_books_outlined),
-              title: Text(sheetContext.l10n.keepOfflineAll),
-              trailing: rule == OfflineKeepRule.all
-                  ? const Icon(Icons.check_rounded)
-                  : null,
-              onTap: () =>
-                  _apply(sheetContext, ref, OfflineKeepRule.all, config.count),
-            ),
-            if (onDevice || rule != OfflineKeepRule.off) ...[
-              const Divider(height: 1),
-              ListTile(
-                leading: Icon(Icons.delete_outline_rounded,
-                    color: sheetContext.theme.colorScheme.error),
-                title: Text(
-                  sheetContext.l10n.offlineRemoveSeries,
-                  style: TextStyle(
+              if (onDevice || rule != OfflineKeepRule.off) ...[
+                const Divider(height: 1),
+                ListTile(
+                  leading: Icon(Icons.delete_outline_rounded,
                       color: sheetContext.theme.colorScheme.error),
+                  title: Text(
+                    sheetContext.l10n.offlineRemoveSeries,
+                    style: TextStyle(
+                        color: sheetContext.theme.colorScheme.error),
+                  ),
+                  onTap: () => _removeAll(sheetContext, ref),
                 ),
-                onTap: () => _removeAll(sheetContext, ref),
-              ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1798,6 +1798,30 @@
     "@filterOptionNotBookmarked": {
         "description": "Bookmarks filter chip: only entries with no bookmarked chapter"
     },
+    "filterHeaderSeries": "Series",
+    "@filterHeaderSeries": {
+        "description": "Section label for the series-progress filter chip row"
+    },
+    "filterOptionUnfinished": "Unfinished",
+    "@filterOptionUnfinished": {
+        "description": "Series filter chip: only series with chapters left to read"
+    },
+    "filterOptionFinished": "Finished",
+    "@filterOptionFinished": {
+        "description": "Series filter chip: only series with every chapter read"
+    },
+    "filterHeaderLibrary": "Library",
+    "@filterHeaderLibrary": {
+        "description": "Section label for the library-membership filter chip row"
+    },
+    "filterOptionInLibrary": "In library",
+    "@filterOptionInLibrary": {
+        "description": "Library filter chip: only entries saved to the library"
+    },
+    "filterOptionNotInLibrary": "Not in library",
+    "@filterOptionNotInLibrary": {
+        "description": "Library filter chip: only entries not saved to the library"
+    },
     "filterHeaderPublicationStatus": "Publication Status",
     "@filterHeaderPublicationStatus": {
         "description": "Section label for the completed filter chip row"

--- a/test/src/features/history/history_filter_test.dart
+++ b/test/src/features/history/history_filter_test.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/history/domain/history_item.dart';
+import 'package:tsumiru/src/features/history/presentation/history_controller.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+
+HistoryItemDto _item({
+  bool isRead = false,
+  int unreadCount = 3,
+  bool inLibrary = true,
+}) =>
+    Fragment$ChapterWithMangaDto(
+      id: 1,
+      chapterNumber: 1,
+      fetchedAt: '0',
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: isRead,
+      lastPageRead: isRead ? 10 : 4,
+      lastReadAt: '1700000000',
+      mangaId: 7,
+      name: 'Chapter 1',
+      pageCount: 10,
+      sourceOrder: 1,
+      uploadDate: '0',
+      url: '/c/1',
+      meta: const [],
+      manga: Fragment$MangaBaseDto(
+        id: 7,
+        genre: const [],
+        inLibrary: inLibrary,
+        inLibraryAt: '0',
+        initialized: true,
+        meta: const [],
+        sourceId: '1',
+        status: Enum$MangaStatus.ONGOING,
+        title: 'Series',
+        unreadCount: unreadCount,
+        updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+        url: '/manga/7',
+      ),
+    );
+
+void main() {
+  group('historyItemMatchesFilter', () {
+    test('no filter keeps everything', () {
+      expect(historyItemMatchesFilter(_item(), kNoHistoryFilter), isTrue);
+      expect(
+        historyItemMatchesFilter(
+          _item(isRead: true, unreadCount: 0, inLibrary: false),
+          kNoHistoryFilter,
+        ),
+        isTrue,
+      );
+    });
+
+    test('unfinished series keys off remaining unread chapters', () {
+      const unfinished =
+          (unfinishedSeries: true, unread: null, inLibrary: null);
+      expect(historyItemMatchesFilter(_item(unreadCount: 3), unfinished), isTrue);
+      expect(
+        historyItemMatchesFilter(_item(unreadCount: 0), unfinished),
+        isFalse,
+      );
+
+      const finished = (unfinishedSeries: false, unread: null, inLibrary: null);
+      expect(historyItemMatchesFilter(_item(unreadCount: 0), finished), isTrue);
+      expect(historyItemMatchesFilter(_item(unreadCount: 3), finished), isFalse);
+    });
+
+    test('unread keys off the chapter itself, not the series', () {
+      const unread = (unfinishedSeries: null, unread: true, inLibrary: null);
+      expect(historyItemMatchesFilter(_item(isRead: false), unread), isTrue);
+      expect(historyItemMatchesFilter(_item(isRead: true), unread), isFalse);
+
+      const read = (unfinishedSeries: null, unread: false, inLibrary: null);
+      expect(historyItemMatchesFilter(_item(isRead: true), read), isTrue);
+      expect(historyItemMatchesFilter(_item(isRead: false), read), isFalse);
+    });
+
+    test('library membership filters both ways', () {
+      const inLibrary = (unfinishedSeries: null, unread: null, inLibrary: true);
+      expect(historyItemMatchesFilter(_item(inLibrary: true), inLibrary), isTrue);
+      expect(
+        historyItemMatchesFilter(_item(inLibrary: false), inLibrary),
+        isFalse,
+      );
+
+      const notInLibrary =
+          (unfinishedSeries: null, unread: null, inLibrary: false);
+      expect(
+        historyItemMatchesFilter(_item(inLibrary: false), notInLibrary),
+        isTrue,
+      );
+      expect(
+        historyItemMatchesFilter(_item(inLibrary: true), notInLibrary),
+        isFalse,
+      );
+    });
+
+    test('filters combine, so all must pass', () {
+      const filter = (unfinishedSeries: true, unread: true, inLibrary: true);
+      expect(historyItemMatchesFilter(_item(), filter), isTrue);
+      // Fails on library membership alone.
+      expect(
+        historyItemMatchesFilter(_item(inLibrary: false), filter),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/src/features/manga_book/updates_filter_test.dart
+++ b/test/src/features/manga_book/updates_filter_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/data/updates/updates_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/updates/updates_filter.dart';
+
+void main() {
+  group('updatesFilterInput', () {
+    test('always scopes to the library', () {
+      final input = updatesFilterInput(kNoUpdatesFilter);
+      expect(input.inLibrary?.equalTo, true);
+    });
+
+    test('leaves every field unset when nothing is filtered', () {
+      final input = updatesFilterInput(kNoUpdatesFilter);
+      expect(input.isDownloaded, isNull);
+      expect(input.isRead, isNull);
+      expect(input.isBookmarked, isNull);
+      expect(input.and, isNull);
+    });
+
+    test('maps downloaded and bookmarked straight through', () {
+      final included = updatesFilterInput(
+        (downloaded: true, unread: null, started: null, bookmarked: true),
+      );
+      expect(included.isDownloaded?.equalTo, true);
+      expect(included.isBookmarked?.equalTo, true);
+
+      final excluded = updatesFilterInput(
+        (downloaded: false, unread: null, started: null, bookmarked: false),
+      );
+      expect(excluded.isDownloaded?.equalTo, false);
+      expect(excluded.isBookmarked?.equalTo, false);
+    });
+
+    test('inverts unread into the server isRead field', () {
+      final unread = updatesFilterInput(
+        (downloaded: null, unread: true, started: null, bookmarked: null),
+      );
+      expect(unread.isRead?.equalTo, false);
+
+      final read = updatesFilterInput(
+        (downloaded: null, unread: false, started: null, bookmarked: null),
+      );
+      expect(read.isRead?.equalTo, true);
+    });
+
+    // Komikku's updatesView.sq requires read = 0 on BOTH sides of started, so a
+    // finished chapter is neither started nor not-started.
+    test('started keeps only unread chapters with progress', () {
+      final input = updatesFilterInput(
+        (downloaded: null, unread: null, started: true, bookmarked: null),
+      );
+      expect(input.and, hasLength(2));
+      expect(input.and!.first.isRead?.equalTo, false);
+      expect(input.and!.last.lastPageRead?.greaterThan, 0);
+    });
+
+    test('not-started keeps only unread chapters without progress', () {
+      final input = updatesFilterInput(
+        (downloaded: null, unread: null, started: false, bookmarked: null),
+      );
+      expect(input.and, hasLength(2));
+      expect(input.and!.first.isRead?.equalTo, false);
+      expect(input.and!.last.lastPageRead?.equalTo, 0);
+    });
+  });
+}


### PR DESCRIPTION
Neither the Updates nor the History screen could be narrowed down, so finding the oldest unread update meant scrolling past everything already read.

Both now get filter chips, in the same style and order the library organizer uses. Every label already existed from that work, so only the History pair needed new strings.

**Updates** — downloaded, unread, started, bookmarked. Filtering runs on the server, so the paged list stays correct. Started follows Komikku and treats a finished chapter as neither started nor not-started (`updatesView.sq` requires `read = 0` on both branches).

**History** — unfinished series, unread chapter, library membership. History was also quietly restricted to library entries, so chapters read from a series since removed never appeared at all; that restriction is lifted. History is one bounded fetch rather than a paged list, so library membership is applied server-side — filtering it afterwards spent the window on rows that were then discarded and cut how far back the screen reached.

Also in here:

- The Updates pager asked for 50 rows but advanced the offset by 30, repeating 20 rows on every page after the first.
- Changing a filter clears the list, but a request already in flight still appended its rows into the new one and pushed the next-page key past them. Every reset now bumps a counter that late replies are checked against, shared by all the refresh paths.
- The offline keep-rule sheets overflowed while a library refresh was running: they lay their rows out in a fixed column, and a sheet that isn't scroll-controlled only gets 9/16 of the space it's handed, which the "Updating library" strip takes a slice of. All three now size to their content and scroll if the room runs out.

Filters verified against a live server; new tests cover the filter translation on both screens.

Closes #261
Closes #297
Closes #298