### PR TITLE
Use the desktop portal for the Linux file picker

### DIFF
--- a/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
+++ b/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:graphql/client.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -39,8 +40,13 @@ class ExtensionRepository {
         .mutate$InstallExternalExtension(
           Options$Mutation$InstallExternalExtension(
             variables: Variables$Mutation$InstallExternalExtension(
-              extensionFile: await http.MultipartFile.fromPath(
-                  "extensionFile", file.path!),
+              // Web picks carry bytes and a blob URL rather than a real path,
+              // so fromPath can't open them.
+              extensionFile: kIsWeb
+                  ? http.MultipartFile.fromBytes("extensionFile", file.bytes!,
+                      filename: file.name)
+                  : await http.MultipartFile.fromPath(
+                      "extensionFile", file.path!),
             ),
           ),
         )

--- a/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
+++ b/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
@@ -5,6 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -19,9 +20,11 @@ class InstallExtensionFile extends ConsumerWidget {
 
   void extensionFilePicker(WidgetRef ref, BuildContext context) async {
     final toast = ref.read(toastProvider);
-    final file = await FilePicker.platform.pickFiles(
+    final file = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['apk'],
+      // Web has no file paths, so the bytes have to come back with the pick.
+      withData: kIsWeb,
     );
     if ((file?.files).isNotBlank) {
       if (context.mounted) {

--- a/lib/src/utils/misc/file_picker_utils.dart
+++ b/lib/src/utils/misc/file_picker_utils.dart
@@ -12,9 +12,11 @@ abstract class FilePickerUtils {
     BuildContext? context,
     List<String>? extensions,
   }) async {
-    final pickedFiles = await FilePicker.platform.pickFiles(
+    final pickedFiles = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: extensions,
+      // Web has no file paths, so the bytes have to come back with the pick.
+      withData: kIsWeb,
     );
     final file = pickedFiles?.files.first;
     if (context != null && context.mounted) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -381,10 +381,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.7"
+    version: "11.0.2"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   cupertino_icons: ^1.0.5
   drift: ^2.32.0
   extension_type_unions: ^1.0.10
-  file_picker: ^8.0.0+1
+  file_picker: ^11.0.0
   flex_color_picker: 3.8.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
Moves file_picker from 8.3.x to 11.0.2 so the Linux picker uses the desktop portal.

## Why

On 8.x the Linux picker drew its dialog by running a helper program from inside the flatpak sandbox, so the dialog only saw what the sandbox saw. Since the flatpak grants no filesystem access, that meant an empty folder and no way to reach any of the user's files. Restoring a backup and installing an extension from a file were both unusable on the flatpak build.

11.x talks to the XDG desktop portal over D-Bus instead. The dialog runs outside the sandbox, so it shows the real file system, uses the desktop's file chooser, and returns only the picked file. No filesystem grant had to be added to the manifest.

## withData on web

The v11 entry point is static and forwards `withData` explicitly, defaulting it to false. We previously called the web implementation directly, which defaults it to true. Bumping the version alone would give web callers a `PlatformFile` with null bytes and break backup restore on web. Nothing in the type system or the test suite catches it.

Both call sites now pass `withData: kIsWeb`: `file_picker_utils.dart` for backup restore and `install_extension_file.dart` for extension install.

The other two majors in the range don't touch us. v10 changed two image-compression defaults we never set, and v9's change is the web blob behavior above.

## Web extension install

Requesting bytes on web exposed that installing an extension from a file could never have worked there: the upload used `MultipartFile.fromPath`, and web picks carry a blob URL rather than a real path. The web branch now sends the bytes the picker already returns. The native branch is unchanged.

## Verification

Built the Linux flatpak locally, installed it, and ran a backup restore. The picker opens the desktop's file chooser, and the home directory shows the real files.

`flutter analyze` reports no errors. All 1627 tests pass.

Not tested on Windows, macOS, or web.

Closes #306
