### PR TITLE
Never let the paged reader rest between two pages

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -344,6 +344,9 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
         ? -1
         : widget.window.chapterRawToDisplay(chapterId, rawIndex);
     if (target < 0 || target == _displayIndex) {
+      // _abandonMotion may have killed a settle whose commit never ran; a jump
+      // resolving to the current page must still land the pager back on it.
+      if (_dragOffset != 0) setState(() => _dragOffset = 0);
       _emitRawPage();
       return;
     }
@@ -608,6 +611,13 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       if (!_interruptedByAnimation && !_suppressTap) {
         _handleTap(event.localPosition);
       }
+    }
+    // A page-owned gesture (or swallowed tap) can end with the pager still
+    // displaced by an abandoned turn — never let it rest between slots.
+    if (_dragOwner != _DragOwner.pager &&
+        _dragOffset != 0 &&
+        !_pageAnimation.isAnimating) {
+      _settleDrag();
     }
 
     _resetGesture();

--- a/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
+++ b/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
@@ -903,6 +903,62 @@ void main() {
     await first.up();
   });
 
+  testWidgets('same-page seek during a turn settle cannot park mid-turn',
+      (tester) async {
+    // The seekbar fires jumpToRaw on every drag tick; mid-settle it can target
+    // the still-current page, abandoning the turn without restoring the offset.
+    final pages = _localPages(2);
+    final mapping = buildSpreadMapping(
+      pageCount: pages.length,
+      doublePages: false,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    );
+    final controller = PagedReaderController();
+
+    await _pumpViewport(
+      tester,
+      controller: controller,
+      mapping: mapping,
+      pages: pages,
+      initialDisplayIndex: 0,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(),
+      animateTransitions: true,
+    );
+
+    // Slow drag past the turn threshold, then release to start the settle.
+    final center = tester.getCenter(find.byType(PagedReaderViewport));
+    final turn = await tester.startGesture(center);
+    for (var i = 0; i < 4; i++) {
+      await turn.moveBy(const Offset(-60, 0));
+      await tester.pump(const Duration(milliseconds: 40));
+    }
+    await turn.up();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 40));
+
+    // Mid-settle the seekbar reports the current page (raw 0).
+    controller.jumpToRaw(0);
+    await tester.pumpAndSettle();
+
+    // A settled slot always sits at translation 0; parked mid-turn, every
+    // slot is off-grid.
+    final slotOffsets = [
+      for (final transform in tester.widgetList<Transform>(find.ancestor(
+        of: find.byType(ClipRect),
+        matching: find.byType(Transform),
+      )))
+        transform.transform.storage[12],
+    ];
+    expect(
+      slotOffsets.where((dx) => dx.abs() < 0.1),
+      isNotEmpty,
+      reason: 'pager rested between slots: $slotOffsets',
+    );
+  });
+
   testWidgets('two-finger tap does not leak into reader tap actions',
       (tester) async {
     final pages = _localPages(1);


### PR DESCRIPTION
A page turn settles over a 70-180ms animation. If `jumpToRaw` lands during that window with a target that resolves to the current display index, `_abandonMotion` kills the settle and skips its commit (generation bump), and the early return leaves `_dragOffset` frozen mid-turn. The pager is left parked between two slots, showing the current page and its neighbor side by side.

The seekbar is the trigger: it fires `jumpToRaw` on every tap and drag tick, and its thumb points at the still-current page until a turn commits, so touching it mid-settle produces exactly the same-target call.

It only ever showed up zoomed because taps and drags on a zoomed page become pans (navigate-to-pan returns before any pager motion), so the parked state persists. Unzoomed, the next tap runs `_animateToDisplay` and realigns the grid invisibly.

The fix has two layers:

- The same-page jump now snaps `_dragOffset` back to 0, which fixes this bug directly.
- Gesture release settles any leftover pager displacement (`_onPointerUp` fallback), so no future abandon path can strand the reader off-grid.

The regression test replays the sequence: drag past the turn threshold, release, then a same-page `jumpToRaw` mid-settle. It fails on the old code (pager left off-grid) and passes with the fix.

Closes #314
