### PR TITLE
Keep the download queue's pause control reachable

### DIFF
--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -95,7 +95,8 @@ class DownloadsMap extends _$DownloadsMap {
   /// out, so the answer in flight is already incomplete and has to be redone.
   /// An ordinary message is not a reason to restart it.
   Future<void> _reconcileQueue({bool moreDropped = false}) async {
-    if (moreDropped) _consecutiveFailures = 0;
+    // A newly dropped batch means the read is needed again, not that the
+    // server has recovered, so it does not clear the failure backoff.
     if (_consecutiveFailures >= _maxReconcileFailures) return;
     if (_reconciling) {
       if (moreDropped) _restartRequested = true;

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -42,27 +42,38 @@ class DownloadsMap extends _$DownloadsMap {
       }
     }
     if (stateOrNull != null) {
-      state = currState;
-      _changedSinceFetch = true;
+      _publish(currState);
     }
   }
 
   bool _reconciling = false;
-  bool _changedSinceFetch = false;
+  bool _restartRequested = false;
+
+  /// Bumped by every queue write. A re-read that started before the current
+  /// generation is older than what we already have, whatever its source.
+  int _generation = 0;
+
+  void _publish(Map<int, DownloadDto> queue) {
+    state = queue;
+    _generation++;
+  }
+
+  static const _maxReconcileAttempts = 3;
 
   /// Re-read the whole queue after the server drops deltas past `maxUpdates`.
-  /// Single-flight, and repeats if deltas landed while the request was out —
-  /// applying a snapshot older than those deltas would resurrect a chapter the
-  /// queue has already lost (#313).
+  /// Single-flight, and re-reads rather than applying a snapshot that anything
+  /// else has since moved past — a clear or a reorder landing mid-flight would
+  /// otherwise be undone by the older answer (#313, and the #73 symptom).
   Future<void> _reconcileQueue() async {
     if (_reconciling) {
-      _changedSinceFetch = true;
+      _restartRequested = true;
       return;
     }
     _reconciling = true;
     try {
-      do {
-        _changedSinceFetch = false;
+      for (var attempt = 0; attempt < _maxReconcileAttempts; attempt++) {
+        _restartRequested = false;
+        final generation = _generation;
         DownloadStatusDto? fresh;
         try {
           fresh =
@@ -72,8 +83,13 @@ class DownloadsMap extends _$DownloadsMap {
           return;
         }
         if (!ref.mounted) return;
-        if (!_changedSinceFetch) state = getStateFromUpdates(fresh);
-      } while (_changedSinceFetch);
+        if (generation == _generation && !_restartRequested) {
+          _publish(getStateFromUpdates(fresh));
+          return;
+        }
+      }
+      // Still losing the race after several tries; leave it to the next
+      // message rather than hammering a server that is clearly busy.
     } finally {
       _reconciling = false;
     }
@@ -98,6 +114,9 @@ class DownloadsMap extends _$DownloadsMap {
       });
     });
     final downloadStatusDto = ref.watch(downloadStatusProvider).value;
+    // A rebuild replaces the queue too, so an in-flight re-read must not
+    // outrank it.
+    _generation++;
     return getStateFromUpdates(downloadStatusDto);
   }
 
@@ -115,7 +134,7 @@ class DownloadsMap extends _$DownloadsMap {
         .read(downloadsRepositoryProvider)
         .reorderDownload(chapterId, to);
     if (!ref.mounted) return;
-    state = getStateFromUpdates(downloadStatusDto);
+    _publish(getStateFromUpdates(downloadStatusDto));
   }
 
   /// Clear the whole server download queue and empty the local map immediately.
@@ -127,7 +146,7 @@ class DownloadsMap extends _$DownloadsMap {
   Future<void> clearAll() async {
     await ref.read(downloadsRepositoryProvider).clearDownloads();
     if (!ref.mounted) return;
-    state = {};
+    _publish({});
     ref.invalidate(downloadStatusProvider);
   }
 }

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -21,27 +21,37 @@ class DownloadsMap extends _$DownloadsMap {
   void updateDownloadStatus(Fragment$DownloadUpdatesDto? downloadStatusDto) {
     final currState = {...?stateOrNull};
     // Progress ticks arrive about once a second while anything is downloading.
-    // They move no chapter in or out, so they must not count as a change that
-    // outranks an in-flight re-read — otherwise a round-trip slower than the
-    // tick rate can never win the race and the queue stays stale for good.
+    // A tick that only moves a percentage must not outrank an in-flight
+    // re-read, or a round-trip slower than the tick rate could never land and
+    // the queue would stay stale for good. A tick that adds a chapter or moves
+    // one, though, is a real change and does outrank it.
     var structural = downloadStatusDto?.initial?.isNotEmpty ?? false;
     for (final element in [...?downloadStatusDto?.initial]) {
       currState[element.chapter.id] = element;
     }
     for (final element in [...?downloadStatusDto?.updates]) {
-      if (element.type != DownloadUpdateType.PROGRESS) structural = true;
+      final chapterId = element.download.chapter.id;
       switch (element.type) {
         case DownloadUpdateType.DEQUEUED:
         case DownloadUpdateType.FINISHED:
-          currState.remove(element.download.chapter.id);
+          structural = true;
+          currState.remove(chapterId);
+          break;
+        case DownloadUpdateType.PROGRESS:
+          final previous = currState[chapterId];
+          if (previous == null ||
+              previous.position != element.download.position) {
+            structural = true;
+          }
+          currState[chapterId] = element.download;
           break;
         case DownloadUpdateType.QUEUED:
-        case DownloadUpdateType.PROGRESS:
         case DownloadUpdateType.POSITION:
         case DownloadUpdateType.PAUSED:
         case DownloadUpdateType.ERROR:
         case DownloadUpdateType.STOPPED:
-          currState[element.download.chapter.id] = element.download;
+          structural = true;
+          currState[chapterId] = element.download;
           break;
         case DownloadUpdateType.$unknown:
           throw UnimplementedError();
@@ -71,6 +81,11 @@ class DownloadsMap extends _$DownloadsMap {
   }
 
   static const _maxReconcileAttempts = 3;
+  static const _maxReconcileFailures = 3;
+
+  /// A queue that keeps losing the race is worth retrying on every message; a
+  /// server that keeps refusing the read is not, so failures back off instead.
+  int _consecutiveFailures = 0;
 
   /// Re-read the whole queue after the server drops deltas past `maxUpdates`.
   /// Single-flight, and re-reads rather than applying a snapshot that anything
@@ -80,6 +95,8 @@ class DownloadsMap extends _$DownloadsMap {
   /// out, so the answer in flight is already incomplete and has to be redone.
   /// An ordinary message is not a reason to restart it.
   Future<void> _reconcileQueue({bool moreDropped = false}) async {
+    if (moreDropped) _consecutiveFailures = 0;
+    if (_consecutiveFailures >= _maxReconcileFailures) return;
     if (_reconciling) {
       if (moreDropped) _restartRequested = true;
       return;
@@ -94,11 +111,15 @@ class DownloadsMap extends _$DownloadsMap {
           fresh =
               await ref.read(downloadsRepositoryProvider).getDownloadStatus();
         } catch (_) {
-          return; // _reconcileNeeded stays set, so the next message retries.
+          // _reconcileNeeded stays set, so the next message retries — until
+          // the failures say the server, not the race, is the problem.
+          _consecutiveFailures++;
+          return;
         }
         if (!ref.mounted) return;
         if (generation == _generation && !_restartRequested) {
           _publish(getStateFromUpdates(fresh));
+          _consecutiveFailures = 0;
           _reconcileNeeded = false;
           return;
         }
@@ -132,8 +153,10 @@ class DownloadsMap extends _$DownloadsMap {
     });
     final downloadStatusDto = ref.watch(downloadStatusProvider).value;
     // A rebuild replaces the queue too, so an in-flight re-read must not
-    // outrank it.
+    // outrank it. It's also the user's way back in after a run of failures
+    // (pull-to-refresh, re-entering the screen), so clear the backoff.
     _generation++;
+    _consecutiveFailures = 0;
     return getStateFromUpdates(downloadStatusDto);
   }
 

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -43,6 +43,39 @@ class DownloadsMap extends _$DownloadsMap {
     }
     if (stateOrNull != null) {
       state = currState;
+      _changedSinceFetch = true;
+    }
+  }
+
+  bool _reconciling = false;
+  bool _changedSinceFetch = false;
+
+  /// Re-read the whole queue after the server drops deltas past `maxUpdates`.
+  /// Single-flight, and repeats if deltas landed while the request was out —
+  /// applying a snapshot older than those deltas would resurrect a chapter the
+  /// queue has already lost (#313).
+  Future<void> _reconcileQueue() async {
+    if (_reconciling) {
+      _changedSinceFetch = true;
+      return;
+    }
+    _reconciling = true;
+    try {
+      do {
+        _changedSinceFetch = false;
+        DownloadStatusDto? fresh;
+        try {
+          fresh =
+              await ref.read(downloadsRepositoryProvider).getDownloadStatus();
+        } catch (_) {
+          // Transient; the next update message reconciles again.
+          return;
+        }
+        if (!ref.mounted) return;
+        if (!_changedSinceFetch) state = getStateFromUpdates(fresh);
+      } while (_changedSinceFetch);
+    } finally {
+      _reconciling = false;
     }
   }
 
@@ -58,12 +91,7 @@ class DownloadsMap extends _$DownloadsMap {
         // which any mass en/dequeue trips (#313). Refetch in place rather than
         // invalidating, so the queue doesn't blank out while it reloads.
         if (next.value?.omittedUpdates ?? false) {
-          ref
-              .read(downloadsRepositoryProvider)
-              .getDownloadStatus()
-              .then((fresh) {
-            if (ref.mounted) state = getStateFromUpdates(fresh);
-          });
+          _reconcileQueue();
           return;
         }
         updateDownloadStatus(next.value);

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -1,7 +1,6 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../data/downloads/downloads_repository.dart';
 import '../../../domain/downloads/downloads_model.dart';
 import '../../../domain/downloads/graphql/__generated__/fragment.graphql.dart';
@@ -54,7 +53,20 @@ class DownloadsMap extends _$DownloadsMap {
     // app-wide. Defer the write off the current frame.
     ref.listen(downloadUpdatesProvider, (_, next) {
       Future.microtask(() {
-        if (ref.mounted) updateDownloadStatus(next.value);
+        if (!ref.mounted) return;
+        // Past `maxUpdates` the server drops the deltas and expects a re-fetch,
+        // which any mass en/dequeue trips (#313). Refetch in place rather than
+        // invalidating, so the queue doesn't blank out while it reloads.
+        if (next.value?.omittedUpdates ?? false) {
+          ref
+              .read(downloadsRepositoryProvider)
+              .getDownloadStatus()
+              .then((fresh) {
+            if (ref.mounted) state = getStateFromUpdates(fresh);
+          });
+          return;
+        }
+        updateDownloadStatus(next.value);
       });
     });
     final downloadStatusDto = ref.watch(downloadStatusProvider).value;
@@ -103,20 +115,17 @@ List<int> downloadsChapterIds(Ref ref) {
   return downloads.map((d) => d.chapter.id).toList();
 }
 
+/// Anything queued must be pausable or resumable. Reading the feed's delta list
+/// instead hid the control on a fresh subscribe and on any queue that had
+/// stopped changing, failed ones included (#313).
 @riverpod
-AsyncValue<DownloaderState?> downloaderState(Ref ref) {
-  return ref.watch(downloadUpdatesProvider
-      .select((value) => value.copyWithData((data) => data?.state)));
-}
+bool showDownloadsFAB(Ref ref) => ref.watch(downloadsMapProvider).isNotEmpty;
 
+/// Best-known run state. The feed only speaks when something changes, so a
+/// paused queue leaves it with no answer — fall back to the query (#313).
 @riverpod
-bool showDownloadsFAB(Ref ref) {
-  final downloads = ref.watch(downloadUpdatesProvider);
-  return downloads.value?.state == DownloaderState.STARTED ||
-      (downloads.value?.updates).isNotBlank &&
-          downloads.value!.updates.any(
-            (element) =>
-                element.download.state != DownloadState.ERROR ||
-                element.download.tries != 3,
-          );
+DownloaderState? downloaderRunState(Ref ref) {
+  final live = ref.watch(downloadUpdatesProvider).value?.state;
+  final queried = ref.watch(downloadStatusProvider).value?.state;
+  return live ?? queried;
 }

--- a/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
+++ b/lib/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart
@@ -20,10 +20,16 @@ Future<DownloadStatusDto?> downloadStatus(Ref ref) =>
 class DownloadsMap extends _$DownloadsMap {
   void updateDownloadStatus(Fragment$DownloadUpdatesDto? downloadStatusDto) {
     final currState = {...?stateOrNull};
+    // Progress ticks arrive about once a second while anything is downloading.
+    // They move no chapter in or out, so they must not count as a change that
+    // outranks an in-flight re-read — otherwise a round-trip slower than the
+    // tick rate can never win the race and the queue stays stale for good.
+    var structural = downloadStatusDto?.initial?.isNotEmpty ?? false;
     for (final element in [...?downloadStatusDto?.initial]) {
       currState[element.chapter.id] = element;
     }
     for (final element in [...?downloadStatusDto?.updates]) {
+      if (element.type != DownloadUpdateType.PROGRESS) structural = true;
       switch (element.type) {
         case DownloadUpdateType.DEQUEUED:
         case DownloadUpdateType.FINISHED:
@@ -42,20 +48,26 @@ class DownloadsMap extends _$DownloadsMap {
       }
     }
     if (stateOrNull != null) {
-      _publish(currState);
+      _publish(currState, structural: structural);
     }
   }
 
   bool _reconciling = false;
   bool _restartRequested = false;
 
-  /// Bumped by every queue write. A re-read that started before the current
-  /// generation is older than what we already have, whatever its source.
+  /// Set once the server tells us it dropped updates, cleared only when a full
+  /// re-read has actually landed. Ordinary messages don't carry what was lost,
+  /// so until then the queue is known-incomplete and every message retries.
+  bool _reconcileNeeded = false;
+
+  /// Bumped by every write that changes which chapters are queued or where.
+  /// A re-read that started before the current generation is older than what
+  /// we already have, whatever its source.
   int _generation = 0;
 
-  void _publish(Map<int, DownloadDto> queue) {
+  void _publish(Map<int, DownloadDto> queue, {bool structural = true}) {
     state = queue;
-    _generation++;
+    if (structural) _generation++;
   }
 
   static const _maxReconcileAttempts = 3;
@@ -64,9 +76,12 @@ class DownloadsMap extends _$DownloadsMap {
   /// Single-flight, and re-reads rather than applying a snapshot that anything
   /// else has since moved past — a clear or a reorder landing mid-flight would
   /// otherwise be undone by the older answer (#313, and the #73 symptom).
-  Future<void> _reconcileQueue() async {
+  /// [moreDropped] means the server dropped another batch while this read was
+  /// out, so the answer in flight is already incomplete and has to be redone.
+  /// An ordinary message is not a reason to restart it.
+  Future<void> _reconcileQueue({bool moreDropped = false}) async {
     if (_reconciling) {
-      _restartRequested = true;
+      if (moreDropped) _restartRequested = true;
       return;
     }
     _reconciling = true;
@@ -79,17 +94,17 @@ class DownloadsMap extends _$DownloadsMap {
           fresh =
               await ref.read(downloadsRepositoryProvider).getDownloadStatus();
         } catch (_) {
-          // Transient; the next update message reconciles again.
-          return;
+          return; // _reconcileNeeded stays set, so the next message retries.
         }
         if (!ref.mounted) return;
         if (generation == _generation && !_restartRequested) {
           _publish(getStateFromUpdates(fresh));
+          _reconcileNeeded = false;
           return;
         }
       }
-      // Still losing the race after several tries; leave it to the next
-      // message rather than hammering a server that is clearly busy.
+      // Kept losing the race. Stop for now rather than hammering a busy
+      // server; _reconcileNeeded is still set, so the next message tries again.
     } finally {
       _reconciling = false;
     }
@@ -106,11 +121,13 @@ class DownloadsMap extends _$DownloadsMap {
         // Past `maxUpdates` the server drops the deltas and expects a re-fetch,
         // which any mass en/dequeue trips (#313). Refetch in place rather than
         // invalidating, so the queue doesn't blank out while it reloads.
-        if (next.value?.omittedUpdates ?? false) {
-          _reconcileQueue();
-          return;
+        final dropped = next.value?.omittedUpdates ?? false;
+        if (dropped) {
+          _reconcileNeeded = true;
+        } else {
+          updateDownloadStatus(next.value);
         }
-        updateDownloadStatus(next.value);
+        if (_reconcileNeeded) _reconcileQueue(moreDropped: dropped);
       });
     });
     final downloadStatusDto = ref.watch(downloadStatusProvider).value;

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -16,6 +16,7 @@ import '../../../offline/data/offline_download_providers.dart';
 import '../../../offline/data/offline_settings_providers.dart';
 import '../../../offline/presentation/offline_files_view.dart';
 import '../../domain/downloads/downloads_model.dart';
+import '../../domain/downloads_queue/downloads_queue_model.dart';
 import 'controller/downloads_controller.dart';
 import 'widgets/download_progress_list_tile.dart';
 import 'widgets/downloads_fab.dart';
@@ -26,7 +27,8 @@ class DownloadsScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final downloadsChapterIds = ref.watch(downloadsChapterIdsProvider);
-    final downloadsGlobalStatus = ref.watch(downloaderStateProvider);
+    final queueStatus = ref.watch(downloadStatusProvider);
+    final downloaderRunState = ref.watch(downloaderRunStateProvider);
     final showDownloadsFAB = ref.watch(showDownloadsFABProvider);
     // Own the tab controller so the FAB can be tab-contextual: the server queue
     // pause on the Server tab, the on-device pause on the On-device tab.
@@ -56,19 +58,21 @@ class DownloadsScreen extends HookConsumerWidget {
             ),
         ],
       ),
+      // Defaulting to STOPPED (i.e. offering Resume) keeps the recovery action
+      // reachable when the run state is unknown: starting an already-running
+      // downloader is a no-op, being unable to restart a stalled one is not.
       floatingActionButton: onDeviceTab
           ? const OfflineDownloadsFab()
           : (showDownloadsFAB
               ? DownloadsFab(
-                  status: downloadsGlobalStatus.value ??
-                      DownloaderState.STARTED)
+                  status: downloaderRunState ?? DownloaderState.STOPPED)
               : null),
       body: TabBarView(
         controller: tabController,
         children: [
           _ServerDownloads(
             downloadsChapterIds: downloadsChapterIds,
-            downloadsGlobalStatus: downloadsGlobalStatus,
+            queueStatus: queueStatus,
           ),
           const OfflineFilesView(),
         ],
@@ -102,16 +106,19 @@ class OfflineDownloadsFab extends ConsumerWidget {
 class _ServerDownloads extends ConsumerWidget {
   const _ServerDownloads({
     required this.downloadsChapterIds,
-    required this.downloadsGlobalStatus,
+    required this.queueStatus,
   });
 
   final List<int> downloadsChapterIds;
-  final AsyncValue<DownloaderState?> downloadsGlobalStatus;
+
+  /// The queue query, not the live feed: the feed can go silent for minutes
+  /// under a mass enqueue, and the tab shouldn't blank out when it does.
+  final AsyncValue<DownloadStatusDto?> queueStatus;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final toast = ref.watch(toastProvider);
-    return downloadsGlobalStatus.showUiWhenData(
+    return queueStatus.showUiWhenData(
         context,
         (data) {
           if (data == null) {

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -118,7 +118,14 @@ class _ServerDownloads extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final toast = ref.watch(toastProvider);
-    return queueStatus.showUiWhenData(
+    // With nothing to show, a dead feed is still worth reporting — otherwise a
+    // broken socket over a working connection reads as an empty queue.
+    final feed = ref.watch(downloadUpdatesProvider);
+    final effectiveStatus = downloadsChapterIds.isBlank && feed.hasError
+        ? AsyncValue<DownloadStatusDto?>.error(
+            feed.error!, feed.stackTrace ?? StackTrace.current)
+        : queueStatus;
+    return effectiveStatus.showUiWhenData(
         context,
         (data) {
           if (data == null) {
@@ -146,6 +153,10 @@ class _ServerDownloads extends ConsumerWidget {
               ),
             );
           }
+        },
+        refresh: () {
+          ref.invalidate(downloadStatusProvider);
+          ref.invalidate(downloadUpdatesProvider);
         },
         showGenericError: true,
     );

--- a/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/data/downloads/downloads_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/downloads/downloads_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/downloads_queue/downloads_queue_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart';
+
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+/// Serves a canned queue and counts how often it was asked for one.
+class _FakeRepo extends DownloadsRepository {
+  _FakeRepo(this.status) : super(_dummyClient(), _dummyClient());
+
+  final DownloadStatusDto status;
+  int fetches = 0;
+
+  @override
+  Future<DownloadStatusDto?> getDownloadStatus() async {
+    fetches++;
+    return status;
+  }
+}
+
+Map<String, dynamic> _queueItem({
+  required int chapterId,
+  required int position,
+  String state = 'QUEUED',
+  int tries = 0,
+}) =>
+    {
+      'chapter': {
+        'id': chapterId,
+        'name': 'Ch. $chapterId',
+        'sourceOrder': position,
+        'isDownloaded': false,
+        '__typename': 'ChapterType',
+      },
+      'manga': {
+        'id': 1,
+        'title': 'Series',
+        'downloadCount': 0,
+        'thumbnailUrl': null,
+        '__typename': 'MangaType',
+      },
+      'progress': 0.0,
+      'state': state,
+      'tries': tries,
+      'position': position,
+      '__typename': 'DownloadType',
+    };
+
+DownloadStatusDto _status(
+  String downloaderState,
+  List<Map<String, dynamic>> queue,
+) =>
+    DownloadStatusDto.fromJson({
+      'state': downloaderState,
+      'queue': queue,
+      '__typename': 'DownloadStatus',
+    });
+
+/// A container where the live download feed never speaks — the real shape when
+/// the queue is paused (nothing changes, so no deltas) or when the server drops
+/// updates under a mass enqueue.
+Future<ProviderContainer> _silentFeed(DownloadStatusDto status) async {
+  final container = ProviderContainer(overrides: [
+    downloadStatusProvider.overrideWith((ref) => Future.value(status)),
+    downloadUpdatesProvider
+        .overrideWith((ref) => const Stream<DownloadUpdatesDto?>.empty()),
+  ]);
+  addTearDown(container.dispose);
+  await container.read(downloadStatusProvider.future);
+  return container;
+}
+
+void main() {
+  group('showDownloadsFAB', () {
+    test('shows for a queue the live feed has said nothing about', () async {
+      // The regression (#313): the queue arrives via the subscription's
+      // `initial` snapshot with an empty delta list, and the old gate read only
+      // the deltas — so a paused queue rendered rows with no way to restart it.
+      final container = await _silentFeed(_status('STOPPED', [
+        _queueItem(chapterId: 10, position: 0),
+        _queueItem(chapterId: 11, position: 1),
+      ]));
+
+      expect(container.read(downloadsChapterIdsProvider), [10, 11]);
+      expect(container.read(showDownloadsFABProvider), isTrue);
+    });
+
+    test('shows when every item has permanently failed', () async {
+      // The old gate excluded items errored at tries == 3, hiding the control
+      // for a wholly-failed queue — the case where restarting matters most.
+      final container = await _silentFeed(_status('STOPPED', [
+        _queueItem(chapterId: 10, position: 0, state: 'ERROR', tries: 3),
+        _queueItem(chapterId: 11, position: 1, state: 'ERROR', tries: 3),
+      ]));
+
+      expect(container.read(showDownloadsFABProvider), isTrue);
+    });
+
+    test('hides for an empty queue', () async {
+      final container = await _silentFeed(_status('STOPPED', const []));
+      expect(container.read(showDownloadsFABProvider), isFalse);
+    });
+  });
+
+  group('omitted updates', () {
+    test('re-fetches the queue without blanking it', () async {
+      // The server drops deltas past `maxUpdates` on a mass enqueue and expects
+      // a re-fetch. The queue must survive that reload — an empty frame would
+      // take the control down with it, which is the bug all over again.
+      final status = _status('STARTED', [
+        _queueItem(chapterId: 10, position: 0),
+        _queueItem(chapterId: 11, position: 1),
+      ]);
+      final repo = _FakeRepo(status);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+      expect(container.read(downloadsChapterIdsProvider), [10, 11]);
+      expect(repo.fetches, 1);
+
+      // Record every queue length published from here on: the reload must not
+      // pass through an empty frame.
+      final seen = <int>[];
+      container.listen(
+        downloadsChapterIdsProvider,
+        (_, next) => seen.add(next.length),
+      );
+
+      feed.add(DownloadUpdatesDto.fromJson({
+        'state': 'STARTED',
+        'omittedUpdates': true,
+        'updates': const [],
+        'initial': null,
+        '__typename': 'DownloadUpdates',
+      }));
+      await pumpEventQueue();
+
+      expect(repo.fetches, 2, reason: 'the dropped batch forces a re-fetch');
+      expect(container.read(downloadsChapterIdsProvider), [10, 11]);
+      expect(seen, isNot(contains(0)),
+          reason: 'the queue never went empty mid-reload');
+    });
+  });
+
+  group('downloaderRunState', () {
+    test('falls back to the queue query when the feed is silent', () async {
+      final container = await _silentFeed(_status('STOPPED', [
+        _queueItem(chapterId: 10, position: 0),
+      ]));
+
+      expect(container.read(downloaderRunStateProvider),
+          DownloaderState.STOPPED);
+    });
+
+    test('prefers the live feed once it speaks', () async {
+      final container = ProviderContainer(overrides: [
+        // Query says stopped, feed says started: the feed is newer.
+        downloadStatusProvider.overrideWith(
+            (ref) => Future.value(_status('STOPPED', const []))),
+        downloadUpdatesProvider.overrideWith((ref) =>
+            Stream.value(DownloadUpdatesDto.fromJson({
+              'state': 'STARTED',
+              'omittedUpdates': false,
+              'updates': const [],
+              'initial': const [],
+              '__typename': 'DownloadUpdates',
+            }))),
+      ]);
+      addTearDown(container.dispose);
+      // Hold both alive across the awaits; they're autoDispose, and in the app
+      // the screen is what keeps them subscribed.
+      container.listen(downloadUpdatesProvider, (_, _) {});
+      container.listen(downloaderRunStateProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+      await container.read(downloadUpdatesProvider.future);
+
+      expect(container.read(downloaderRunStateProvider),
+          DownloaderState.STARTED);
+    });
+  });
+}

--- a/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
@@ -313,9 +313,11 @@ void main() {
       feed.add(_feedMessage(omitted: true));
       await pumpEventQueue();
 
-      // Ten ordinary messages would be ten more requests without a backoff.
+      // Ten more messages would be ten more requests without a backoff. Half
+      // report further dropped batches, which re-arm the need for a read but
+      // must not be read as the server having recovered.
       for (var i = 0; i < 10; i++) {
-        feed.add(_feedMessage());
+        feed.add(_feedMessage(omitted: i.isEven));
         await pumpEventQueue();
       }
 

--- a/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
@@ -35,6 +35,15 @@ class _FakeRepo extends DownloadsRepository {
     fetches++;
     return response();
   }
+
+  @override
+  Future<void> clearDownloads() async {}
+
+  DownloadStatusDto? reorderResult;
+
+  @override
+  Future<DownloadStatusDto?> reorderDownload(int chapterId, int to) async =>
+      reorderResult;
 }
 
 Map<String, dynamic> _dequeued(Map<String, dynamic> item) => {
@@ -251,7 +260,92 @@ void main() {
       await pumpEventQueue();
 
       // No unhandled async error, and the last known queue survives.
+      expect(repo.fetches, 2, reason: 'the re-fetch was attempted');
       expect(container.read(downloadsChapterIdsProvider), [10]);
+    });
+
+    test('a reorder mid-flight is not undone by the re-fetch', () async {
+      // reorder writes the queue without a rebuild, so its write is the one
+      // the generation counter has to catch on its own.
+      final both = [
+        _queueItem(chapterId: 10, position: 0),
+        _queueItem(chapterId: 11, position: 1),
+      ];
+      final swapped = [
+        _queueItem(chapterId: 11, position: 0),
+        _queueItem(chapterId: 10, position: 1),
+      ];
+      final slow = Completer<DownloadStatusDto?>();
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', both),
+        () => slow.future,
+        () async => _status('STARTED', swapped),
+      ])
+        ..reorderResult = _status('STARTED', swapped);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+      expect(container.read(downloadsChapterIdsProvider), [10, 11]);
+
+      feed.add(_feedMessage(omitted: true));
+      await pumpEventQueue();
+
+      container.read(downloadsMapProvider.notifier).reorder(11, 0);
+      await pumpEventQueue();
+      expect(container.read(downloadsChapterIdsProvider), [11, 10]);
+
+      slow.complete(_status('STARTED', both));
+      await pumpEventQueue();
+
+      expect(container.read(downloadsChapterIdsProvider), [11, 10],
+          reason: 'the stale snapshot must not undo the reorder');
+    });
+
+    test('clearing the queue mid-flight is not undone by the re-fetch',
+        () async {
+      // #73 all over again if this breaks: the user empties the queue, the
+      // in-flight snapshot lands, and all of it comes back. (clearAll also
+      // invalidates the status query, so the rebuild guards this too.)
+      final both = [
+        _queueItem(chapterId: 10, position: 0),
+        _queueItem(chapterId: 11, position: 1),
+      ];
+      final slow = Completer<DownloadStatusDto?>();
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', both),
+        () => slow.future,
+        () async => _status('STOPPED', const []),
+      ]);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+
+      feed.add(_feedMessage(omitted: true));
+      await pumpEventQueue();
+
+      await container.read(downloadsMapProvider.notifier).clearAll();
+      await pumpEventQueue();
+      expect(container.read(downloadsChapterIdsProvider), isEmpty);
+
+      slow.complete(_status('STARTED', both));
+      await pumpEventQueue();
+
+      expect(container.read(downloadsChapterIdsProvider), isEmpty,
+          reason: 'the cleared queue must stay cleared');
     });
   });
 

--- a/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
@@ -22,6 +22,9 @@ GraphQLClient _dummyClient() =>
 class _FakeRepo extends DownloadsRepository {
   _FakeRepo.scripted(this.responses) : super(_dummyClient(), _dummyClient());
 
+  /// Mirrors `_maxReconcileFailures` in the controller.
+  static const maxFailures = 3;
+
   final List<Future<DownloadStatusDto?> Function()> responses;
   int fetches = 0;
 
@@ -242,6 +245,83 @@ void main() {
       expect(container.read(downloadsChapterIdsProvider), [10, 11],
           reason: 'the re-read still lands despite the progress tick');
       expect(repo.fetches, 2, reason: 'no pointless second re-read');
+    });
+
+    test('a progress tick that adds a chapter does outrank the re-read',
+        () async {
+      // PROGRESS is an upsert: a tick for a chapter we don't have adds it. That
+      // is a membership change, so a snapshot taken before it must not win.
+      final one = _queueItem(chapterId: 10, position: 0);
+      final slow = Completer<DownloadStatusDto?>();
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', [one]),
+        () => slow.future,
+        () async => _status('STARTED', [
+              one,
+              _queueItem(chapterId: 11, position: 1),
+            ]),
+      ]);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+
+      feed.add(_feedMessage(omitted: true));
+      await pumpEventQueue();
+
+      feed.add(_feedMessage(updates: [
+        {
+          'type': 'PROGRESS',
+          'download': _queueItem(chapterId: 11, position: 1),
+          '__typename': 'DownloadUpdate',
+        }
+      ]));
+      await pumpEventQueue();
+      expect(container.read(downloadsChapterIdsProvider), [10, 11]);
+
+      slow.complete(_status('STARTED', [one]));
+      await pumpEventQueue();
+
+      expect(container.read(downloadsChapterIdsProvider), [10, 11],
+          reason: 'the older snapshot must not drop chapter 11 again');
+    });
+
+    test('a server that keeps refusing the read is left alone', () async {
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', [
+              _queueItem(chapterId: 10, position: 0),
+            ]),
+        () async => throw Exception('server unreachable'),
+      ]);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+
+      feed.add(_feedMessage(omitted: true));
+      await pumpEventQueue();
+
+      // Ten ordinary messages would be ten more requests without a backoff.
+      for (var i = 0; i < 10; i++) {
+        feed.add(_feedMessage());
+        await pumpEventQueue();
+      }
+
+      expect(repo.fetches, greaterThan(1), reason: 'it does retry at first');
+      expect(repo.fetches, lessThanOrEqualTo(1 + _FakeRepo.maxFailures),
+          reason: 'but stops rather than issuing one per feed message');
     });
 
     test('a slow re-fetch cannot resurrect a chapter dequeued mid-flight',

--- a/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
@@ -20,10 +20,6 @@ GraphQLClient _dummyClient() =>
 /// Answers each queue fetch from a script, so a test can delay one response or
 /// make it fail. The last entry repeats once the script runs out.
 class _FakeRepo extends DownloadsRepository {
-  _FakeRepo.constant(DownloadStatusDto status)
-      : responses = [() async => status],
-        super(_dummyClient(), _dummyClient());
-
   _FakeRepo.scripted(this.responses) : super(_dummyClient(), _dummyClient());
 
   final List<Future<DownloadStatusDto?> Function()> responses;
@@ -153,11 +149,19 @@ void main() {
       // The server drops deltas past `maxUpdates` on a mass enqueue and expects
       // a re-fetch. The queue must survive that reload — an empty frame would
       // take the control down with it, which is the bug all over again.
-      final status = _status('STARTED', [
-        _queueItem(chapterId: 10, position: 0),
-        _queueItem(chapterId: 11, position: 1),
+      // The re-read returns a queue that has moved on, so the assertions can
+      // tell "applied" apart from "fetched and thrown away".
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', [
+              _queueItem(chapterId: 10, position: 0),
+              _queueItem(chapterId: 11, position: 1),
+            ]),
+        () async => _status('STARTED', [
+              _queueItem(chapterId: 10, position: 0),
+              _queueItem(chapterId: 11, position: 1),
+              _queueItem(chapterId: 12, position: 2),
+            ]),
       ]);
-      final repo = _FakeRepo.constant(status);
       final feed = StreamController<DownloadUpdatesDto?>();
       addTearDown(feed.close);
 
@@ -190,9 +194,54 @@ void main() {
       await pumpEventQueue();
 
       expect(repo.fetches, 2, reason: 'the dropped batch forces a re-fetch');
-      expect(container.read(downloadsChapterIdsProvider), [10, 11]);
+      expect(container.read(downloadsChapterIdsProvider), [10, 11, 12],
+          reason: 'the re-read is applied, not discarded');
       expect(seen, isNot(contains(0)),
           reason: 'the queue never went empty mid-reload');
+    });
+
+    test('a progress tick does not outrank an in-flight re-read', () async {
+      // The feed publishes roughly once a second while downloading. If those
+      // ticks counted as changes, a round-trip slower than the tick rate could
+      // never land and the queue would stay stale for good.
+      final one = _queueItem(chapterId: 10, position: 0);
+      final slow = Completer<DownloadStatusDto?>();
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', [one]),
+        () => slow.future,
+      ]);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+
+      feed.add(_feedMessage(omitted: true));
+      await pumpEventQueue();
+
+      feed.add(_feedMessage(updates: [
+        {
+          'type': 'PROGRESS',
+          'download': _queueItem(chapterId: 10, position: 0),
+          '__typename': 'DownloadUpdate',
+        }
+      ]));
+      await pumpEventQueue();
+
+      slow.complete(_status('STARTED', [
+        one,
+        _queueItem(chapterId: 11, position: 1),
+      ]));
+      await pumpEventQueue();
+
+      expect(container.read(downloadsChapterIdsProvider), [10, 11],
+          reason: 'the re-read still lands despite the progress tick');
+      expect(repo.fetches, 2, reason: 'no pointless second re-read');
     });
 
     test('a slow re-fetch cannot resurrect a chapter dequeued mid-flight',

--- a/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
@@ -17,19 +17,43 @@ import 'package:tsumiru/src/features/manga_book/presentation/downloads/controlle
 GraphQLClient _dummyClient() =>
     GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
 
-/// Serves a canned queue and counts how often it was asked for one.
+/// Answers each queue fetch from a script, so a test can delay one response or
+/// make it fail. The last entry repeats once the script runs out.
 class _FakeRepo extends DownloadsRepository {
-  _FakeRepo(this.status) : super(_dummyClient(), _dummyClient());
+  _FakeRepo.constant(DownloadStatusDto status)
+      : responses = [() async => status],
+        super(_dummyClient(), _dummyClient());
 
-  final DownloadStatusDto status;
+  _FakeRepo.scripted(this.responses) : super(_dummyClient(), _dummyClient());
+
+  final List<Future<DownloadStatusDto?> Function()> responses;
   int fetches = 0;
 
   @override
-  Future<DownloadStatusDto?> getDownloadStatus() async {
+  Future<DownloadStatusDto?> getDownloadStatus() {
+    final response = responses[fetches.clamp(0, responses.length - 1)];
     fetches++;
-    return status;
+    return response();
   }
 }
+
+Map<String, dynamic> _dequeued(Map<String, dynamic> item) => {
+      'type': 'DEQUEUED',
+      'download': item,
+      '__typename': 'DownloadUpdate',
+    };
+
+DownloadUpdatesDto _feedMessage({
+  bool omitted = false,
+  List<Map<String, dynamic>> updates = const [],
+}) =>
+    DownloadUpdatesDto.fromJson({
+      'state': 'STARTED',
+      'omittedUpdates': omitted,
+      'updates': updates,
+      'initial': null,
+      '__typename': 'DownloadUpdates',
+    });
 
 Map<String, dynamic> _queueItem({
   required int chapterId,
@@ -124,7 +148,7 @@ void main() {
         _queueItem(chapterId: 10, position: 0),
         _queueItem(chapterId: 11, position: 1),
       ]);
-      final repo = _FakeRepo(status);
+      final repo = _FakeRepo.constant(status);
       final feed = StreamController<DownloadUpdatesDto?>();
       addTearDown(feed.close);
 
@@ -160,6 +184,74 @@ void main() {
       expect(container.read(downloadsChapterIdsProvider), [10, 11]);
       expect(seen, isNot(contains(0)),
           reason: 'the queue never went empty mid-reload');
+    });
+
+    test('a slow re-fetch cannot resurrect a chapter dequeued mid-flight',
+        () async {
+      // Refetch goes out holding [10, 11]; a DEQUEUED delta drops 11 while it
+      // is still in the air. Applying the stale snapshot on arrival would put
+      // 11 back — so the snapshot is discarded and the queue re-read.
+      final both = [
+        _queueItem(chapterId: 10, position: 0),
+        _queueItem(chapterId: 11, position: 1),
+      ];
+      final slow = Completer<DownloadStatusDto?>();
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', both),
+        () => slow.future,
+        () async => _status('STARTED', [both.first]),
+      ]);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+      expect(container.read(downloadsChapterIdsProvider), [10, 11]);
+
+      feed.add(_feedMessage(omitted: true));
+      await pumpEventQueue();
+      expect(repo.fetches, 2, reason: 'the re-fetch is in flight');
+
+      feed.add(_feedMessage(updates: [_dequeued(both[1])]));
+      await pumpEventQueue();
+      expect(container.read(downloadsChapterIdsProvider), [10]);
+
+      slow.complete(_status('STARTED', both));
+      await pumpEventQueue();
+
+      expect(container.read(downloadsChapterIdsProvider), [10],
+          reason: 'the stale snapshot must not bring chapter 11 back');
+      expect(repo.fetches, 3, reason: 'it re-reads instead of applying stale');
+    });
+
+    test('a failed re-fetch leaves the queue intact', () async {
+      final repo = _FakeRepo.scripted([
+        () async => _status('STARTED', [
+              _queueItem(chapterId: 10, position: 0),
+            ]),
+        () async => throw Exception('server unreachable'),
+      ]);
+      final feed = StreamController<DownloadUpdatesDto?>();
+      addTearDown(feed.close);
+
+      final container = ProviderContainer(overrides: [
+        downloadsRepositoryProvider.overrideWithValue(repo),
+        downloadUpdatesProvider.overrideWith((ref) => feed.stream),
+      ]);
+      addTearDown(container.dispose);
+      container.listen(downloadsChapterIdsProvider, (_, _) {});
+      await container.read(downloadStatusProvider.future);
+
+      feed.add(_feedMessage(omitted: true));
+      await pumpEventQueue();
+
+      // No unhandled async error, and the last known queue survives.
+      expect(container.read(downloadsChapterIdsProvider), [10]);
     });
   });
 


### PR DESCRIPTION
The pause/resume control on Downloads → Server could disappear, leaving a queue with no way to restart it.

Its visibility came from the subscription's delta list, which is empty on a fresh subscribe (the queue arrives in `initial`) and stays empty for a queue that has stopped changing. So a paused queue rendered rows with no control, and it never came back, because a paused queue produces no further deltas. The gate also excluded items errored at three tries, hiding the button exactly when the whole queue had failed and restarting was the only thing left to do.

Visibility now follows the queue itself, the same data the list renders, so the two can't disagree. Pause vs Resume comes from the live feed when it has spoken and the status query otherwise, defaulting to Resume when neither has: starting an already-running downloader is a no-op, being unable to restart a stalled one is not.

`omittedUpdates` is also honored now. We ask the server for `maxUpdates: 150` and then ignored the flag telling us it had dropped deltas past that cap, which any mass enqueue trips — a library update queueing new chapters is exactly that. The queue could silently drift stale as a result.

### Reconciling safely

Re-reading the queue turned out to be the delicate part, and most of the commits here are about getting it right:

- Single-flight, so two dropped batches can't complete out of order.
- A generation counter on every write, so a re-read that started before a dequeue, reorder, clear or rebuild is discarded rather than undoing it.
- Progress ticks don't count as changes, since they arrive about once a second while downloading and would otherwise stop any slower round-trip from ever landing. A tick that adds a chapter or moves one does count, because progress updates are upserts.
- Failed reads back off after a few attempts instead of retrying at the feed's message rate; reconnecting or pulling to refresh clears it.

The Server tab also reports a dead live feed again when there is nothing to show, and its error state offers a retry.

### Testing

13 provider tests covering visibility, the run-state fallback, and each reconciliation race. Each was checked against the unfixed code first and fails there.

Verified against a live server holding the failure state from the report: 63 chapters errored at three tries with the downloader stopped, where the control was previously absent.

Closes #313
