### PR TITLE
Hold auto-deletes until the reader closes, and let just-read chapters survive the keep rule

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -140,21 +140,16 @@ class ReaderScreen extends HookConsumerWidget {
         toast?.showError(context.l10n.errorSomethingWentWrong);
       }
 
-      // Delete the on-device copy once read, if the user opted in.
-      // On a new read, auto-delete behind the reader — both the on-device copy
-      // and (per the server settings) the server copy. Each no-ops if its own
-      // setting is off.
+      // Auto-delete waits for reader exit (Komikku's timing): finishing a
+      // chapter resolves and queues its delete; the PopScope flush runs it.
+      // Awaited so a chapter completed by the pop-time flush still lands in
+      // the queue before that same pop drains it.
       if (isReadingCompleted && context.mounted) {
-        unawaited(maybeDeleteOnReadLocal(
+        await noteChapterFinishedInReader(
           ref,
           mangaId: mangaId,
-          readChapterId: chapterValue.id,
-        ));
-        unawaited(maybeDeleteOnReadServer(
-          ref,
-          mangaId: mangaId,
-          readChapterId: chapterValue.id,
-        ));
+          chapterId: chapterValue.id,
+        );
       }
 
       // Invalidate history to refresh the reading progress. Defer past the
@@ -316,6 +311,10 @@ class ReaderScreen extends HookConsumerWidget {
               await updateLastRead(latestPage.value);
             }
           } finally {
+            // Deferred while-reading deletes run now — leaving the reader is
+            // the point where the just-read chapters may be deleted. Container-
+            // driven: the server round-trip outlives this route's ref.
+            unawaited(flushPendingReadDeletes(providerContainer));
             // The write above lands first (awaited); defer the list refreshes
             // past this frame — invalidating during the pop's build phase trips
             // the Riverpod-3 modify-during-build assert.

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -286,17 +286,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           ),
         );
         unawaited(
-          maybeDeleteOnReadLocal(
+          noteChapterFinishedInReader(
             ref,
             mangaId: manga.id,
-            readChapterId: chapterId,
-          ),
-        );
-        unawaited(
-          maybeDeleteOnReadServer(
-            ref,
-            mangaId: manga.id,
-            readChapterId: chapterId,
+            chapterId: chapterId,
           ),
         );
       }
@@ -1360,21 +1353,13 @@ void _markChapterRead(
           manual: false,
         ),
       );
-      // The chapter just crossed is behind the reader now → auto-delete it (both
-      // the on-device copy and, per the server settings, the server copy). Each
-      // no-ops if its own setting is off.
+      // The chapter just crossed is behind the reader now — queue its
+      // auto-delete for reader exit (Komikku's timing).
       unawaited(
-        maybeDeleteOnReadLocal(
+        noteChapterFinishedInReader(
           ref,
           mangaId: mangaId,
-          readChapterId: chapter.id,
-        ),
-      );
-      unawaited(
-        maybeDeleteOnReadServer(
-          ref,
-          mangaId: mangaId,
-          readChapterId: chapter.id,
+          chapterId: chapter.id,
         ),
       );
     }),

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -246,10 +246,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         completedChapterIds.value = {...completedChapterIds.value, chapterId};
         unawaited(maybeTrackProgressOnReadFetch(ref,
             mangaId: manga.id, isRead: true, manual: false));
-        unawaited(maybeDeleteOnReadLocal(ref,
-            mangaId: manga.id, readChapterId: chapterId));
-        unawaited(maybeDeleteOnReadServer(ref,
-            mangaId: manga.id, readChapterId: chapterId));
+        unawaited(noteChapterFinishedInReader(ref,
+            mangaId: manga.id, chapterId: chapterId));
       }
       // Fired off a scroll/visibility notification — defer past the frame or
       // it trips the Riverpod-3 modify-during-build assert.
@@ -759,15 +757,10 @@ void _markChapterRead(
       isRead: true,
       manual: false,
     ));
-    unawaited(maybeDeleteOnReadLocal(
+    unawaited(noteChapterFinishedInReader(
       ref,
       mangaId: mangaId,
-      readChapterId: chapter.id,
-    ));
-    unawaited(maybeDeleteOnReadServer(
-      ref,
-      mangaId: mangaId,
-      readChapterId: chapter.id,
+      chapterId: chapter.id,
     ));
   }));
   // Deliberately do NOT invalidate chapterProvider / mangaChapterList here —

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -437,21 +437,20 @@ Future<bool> recordReadState(
 /// isn't loaded.
 @visibleForTesting
 Future<int?> whileReadingDeleteTarget(
-    WidgetRef ref, int mangaId, int readChapterId, int slots) async {
+    _Read read, int mangaId, int readChapterId, int slots) async {
   try {
     // Not the filtered/on-screen list: a filter can drop the just-read chapter
     // or turn "N back" into counting gaps instead of chapters.
     final listProvider = mangaChapterListProvider(mangaId: mangaId);
-    var chapters = ref.read(listProvider).value;
+    var chapters = read(listProvider).value;
     // A chapter finished before the list resolves would otherwise be skipped
     // with no second chance.
-    chapters ??= await ref.read(listProvider.future);
+    chapters ??= await read(listProvider.future);
     if (chapters == null) return null;
 
-    final preferred =
-        ref.read(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+    final preferred = read(mangaPreferredScanlatorsProvider(mangaId: mangaId));
     final showAll =
-        ref.read(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+        read(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
     // Pinned to the chapter actually being read: without it dedup can keep a
     // different group's copy of that number and drop this id from the list.
     final deduped = preferred.isEmpty || showAll
@@ -479,34 +478,140 @@ Future<int?> whileReadingDeleteTarget(
 
 /// The server delete settings, loaded from the server (null offline / on error,
 /// so the server delete simply doesn't run — it needs a connection anyway).
-Future<DeleteChaptersSettings?> _serverDeleteSettings(WidgetRef ref) async {
+Future<DeleteChaptersSettings?> _serverDeleteSettings(_Read read) async {
   try {
-    return await ref.read(deleteChaptersSettingsControllerProvider.future);
+    return await read(deleteChaptersSettingsControllerProvider.future);
   } catch (_) {
     return null;
   }
 }
 
-// --- on-device (local) ------------------------------------------------------
+/// Lets the delete chain run off a WidgetRef mid-read or the root
+/// [ProviderContainer] at reader exit, where the route's ref is already gone.
+typedef _Read = T Function<T>(ProviderListenable<T> provider);
 
-/// Delete THIS phone's copy of the chapter N slots behind the one just read.
-Future<void> maybeDeleteOnReadLocal(
+/// Chapters finished this session — shields them from keep-rule eviction
+/// until next launch, so closing the reader doesn't yank one off the device.
+final sessionReadChaptersProvider =
+    NotifierProvider<SessionReadChapters, Set<int>>(SessionReadChapters.new);
+
+class SessionReadChapters extends Notifier<Set<int>> {
+  @override
+  Set<int> build() => {};
+
+  void record(int chapterId) {
+    if (state.contains(chapterId)) return;
+    state = {...state, chapterId};
+  }
+}
+
+/// A while-reading delete, resolved to its target but not yet executed.
+typedef PendingReadDelete = ({int mangaId, int chapterId, bool server});
+
+/// While-reading deletes deferred until the reader closes — Komikku queues on
+/// chapter finish and deletes in onActivityFinish, never mid-read.
+final pendingReadDeletesProvider =
+    NotifierProvider<PendingReadDeletes, Set<PendingReadDelete>>(
+        PendingReadDeletes.new);
+
+class PendingReadDeletes extends Notifier<Set<PendingReadDelete>> {
+  final Set<Future<void>> _resolving = {};
+
+  @override
+  Set<PendingReadDelete> build() => {};
+
+  void enqueue(PendingReadDelete entry) {
+    if (state.contains(entry)) return;
+    state = {...state, entry};
+  }
+
+  /// Track a finish-time target resolution, so an exit flush can wait for
+  /// entries still being computed instead of draining past them.
+  void trackResolution(Future<void> work) {
+    _resolving.add(work);
+    work.whenComplete(() => _resolving.remove(work));
+  }
+
+  Future<void> get resolutionsSettled => Future.wait({..._resolving});
+
+  Set<PendingReadDelete> drain() {
+    final drained = state;
+    state = {};
+    return drained;
+  }
+}
+
+/// Shields the chapter from keep-rule eviction and queues its while-reading
+/// deletes. Targets resolve NOW, not at exit — the list/dedup state can shift
+/// by then and pick the wrong chapter.
+Future<void> noteChapterFinishedInReader(
   WidgetRef ref, {
   required int mangaId,
-  required int readChapterId,
-}) async {
-  if (!ref.read(offlineActiveProvider)) return;
-  final s = ref.read(localDeleteSettingsProvider);
-  if (s.deleteWhileReading <= 0) return;
-  final targetId = await whileReadingDeleteTarget(
-      ref, mangaId, readChapterId, s.deleteWhileReading);
-  if (targetId == null) return;
-  // The wait above is unbounded: a setting changed while it ran would leave
-  // targetId computed from a slot count that no longer applies.
-  final now = ref.read(localDeleteSettingsProvider);
-  if (now.deleteWhileReading != s.deleteWhileReading) return;
-  await _deleteDeviceCopyIfDeletable(ref, targetId, now.deleteWithBookmark);
+  required int chapterId,
+}) {
+  ref.read(sessionReadChaptersProvider.notifier).record(chapterId);
+  final pending = ref.read(pendingReadDeletesProvider.notifier);
+  final work =
+      _resolveReadDeletes(ref, pending, mangaId: mangaId, chapterId: chapterId);
+  pending.trackResolution(work);
+  return work;
 }
+
+Future<void> _resolveReadDeletes(
+  WidgetRef ref,
+  PendingReadDeletes pending, {
+  required int mangaId,
+  required int chapterId,
+}) async {
+  try {
+    if (ref.read(offlineActiveProvider)) {
+      final s = ref.read(localDeleteSettingsProvider);
+      if (s.deleteWhileReading > 0) {
+        final target = await whileReadingDeleteTarget(
+            ref.read, mangaId, chapterId, s.deleteWhileReading);
+        if (target != null) {
+          pending.enqueue((mangaId: mangaId, chapterId: target, server: false));
+        }
+      }
+    }
+
+    final serverSettings = await _serverDeleteSettings(ref.read);
+    if (serverSettings != null && serverSettings.deleteWhileReading > 0) {
+      final target = await whileReadingDeleteTarget(
+          ref.read, mangaId, chapterId, serverSettings.deleteWhileReading);
+      if (target != null) {
+        pending.enqueue((mangaId: mangaId, chapterId: target, server: true));
+      }
+    }
+  } catch (e) {
+    // A finish racing the reader's teardown can lose its ref mid-resolve;
+    // skipping the delete is the safe side.
+    logger.w('Offline: resolving while-reading deletes failed: $e');
+  }
+}
+
+/// Runs the deferred while-reading deletes. The bookmark gate re-reads
+/// settings now, so a bookmark added after finish still blocks the delete.
+Future<void> flushPendingReadDeletes(ProviderContainer container) async {
+  final notifier = container.read(pendingReadDeletesProvider.notifier);
+  // A chapter finished right at exit may still be resolving its target; the
+  // drain would strand that entry until some future reader session.
+  await notifier.resolutionsSettled;
+  final pending = notifier.drain();
+  for (final p in pending) {
+    if (p.server) {
+      final s = await _serverDeleteSettings(container.read);
+      await _deleteServerCopyIfDeletable(
+          container.read, p.mangaId, p.chapterId, s?.deleteWithBookmark ?? false);
+    } else {
+      final allow =
+          container.read(localDeleteSettingsProvider).deleteWithBookmark;
+      await _deleteDeviceCopyIfDeletable(container.read, p.chapterId, allow);
+    }
+  }
+}
+
+// --- on-device (local) ------------------------------------------------------
 
 /// Delete THIS phone's copy when a chapter is manually marked read.
 Future<void> maybeDeleteOnManualLocal(
@@ -516,7 +621,7 @@ Future<void> maybeDeleteOnManualLocal(
   if (!ref.read(offlineActiveProvider)) return;
   final s = ref.read(localDeleteSettingsProvider);
   if (!s.deleteManuallyMarkedRead) return;
-  await _deleteDeviceCopyIfDeletable(ref, chapterId, s.deleteWithBookmark);
+  await _deleteDeviceCopyIfDeletable(ref.read, chapterId, s.deleteWithBookmark);
 }
 
 /// Delete a chapter's device copy iff it's downloaded and the bookmark gate
@@ -524,16 +629,16 @@ Future<void> maybeDeleteOnManualLocal(
 /// un-pinned (via [deleteChapterFromDevice]) so the reconciler doesn't just
 /// re-download it; the server copy is untouched.
 Future<void> _deleteDeviceCopyIfDeletable(
-  WidgetRef ref,
+  _Read read,
   int chapterId,
   bool allowBookmarked,
 ) async {
   try {
-    if (ref.read(offlineDownloadManagerProvider) == null) return;
-    final c = await ref.read(offlineRepositoryProvider).chapterById(chapterId);
+    if (read(offlineDownloadManagerProvider) == null) return;
+    final c = await read(offlineRepositoryProvider).chapterById(chapterId);
     if (c == null || c.deviceState != OfflineDeviceState.downloaded) return;
     if (c.isBookmarked && !allowBookmarked) return;
-    await deleteChapterFromDevice(ref, chapterId);
+    await _deleteChapterFromDeviceRead(read, chapterId);
   } catch (e) {
     // Best-effort — a failed auto-delete must never surface during reading.
     logger.e('Offline: on-device delete-on-read failed for $chapterId: $e');
@@ -545,25 +650,6 @@ Future<void> _deleteDeviceCopyIfDeletable(
 /// Tell the SERVER to delete its copy of the chapter N slots behind the one just
 /// read (per the WebUI's delete-while-reading). The cascade then drops the
 /// device copy too.
-Future<void> maybeDeleteOnReadServer(
-  WidgetRef ref, {
-  required int mangaId,
-  required int readChapterId,
-}) async {
-  final s = await _serverDeleteSettings(ref);
-  if (s == null || s.deleteWhileReading <= 0) return;
-  final targetId = await whileReadingDeleteTarget(
-      ref, mangaId, readChapterId, s.deleteWhileReading);
-  if (targetId == null) return;
-  // Both waits above are unbounded, so re-resolve rather than reading .value —
-  // this controller autoDisposes and would come back as loading, reading null
-  // and cancelling a delete the setting still calls for.
-  final now = await _serverDeleteSettings(ref);
-  if (now == null || now.deleteWhileReading != s.deleteWhileReading) return;
-  await _deleteServerCopyIfDeletable(
-      ref, mangaId, targetId, now.deleteWithBookmark);
-}
-
 /// Tell the SERVER to delete its copy when a chapter is manually marked read.
 Future<void> maybeDeleteOnManualServer(
   WidgetRef ref, {
@@ -571,10 +657,10 @@ Future<void> maybeDeleteOnManualServer(
   required int chapterId,
 }) async {
   if (mangaId == null) return;
-  final s = await _serverDeleteSettings(ref);
+  final s = await _serverDeleteSettings(ref.read);
   if (s == null || !s.deleteManuallyMarkedRead) return;
   await _deleteServerCopyIfDeletable(
-      ref, mangaId, chapterId, s.deleteWithBookmark);
+      ref.read, mangaId, chapterId, s.deleteWithBookmark);
 }
 
 /// Delete a chapter's SERVER copy iff downloaded and the bookmark gate allows
@@ -583,27 +669,29 @@ Future<void> maybeDeleteOnManualServer(
 /// bookmark gate also honours a bookmark made offline that hasn't reached the
 /// server yet.
 Future<void> _deleteServerCopyIfDeletable(
-  WidgetRef ref,
+  _Read read,
   int mangaId,
   int chapterId,
   bool allowBookmarked,
 ) async {
   try {
+    final listProvider = mangaChapterListProvider(mangaId: mangaId);
+    // Running at reader exit, the list may be mid-refetch — wait for it rather
+    // than silently skipping the delete on a null .value.
     final chapters =
-        ref.read(mangaChapterListProvider(mangaId: mangaId)).value;
+        read(listProvider).value ?? await read(listProvider.future);
     final idx = chapters?.indexWhere((e) => e.id == chapterId) ?? -1;
     if (chapters == null || idx < 0) return;
     final c = chapters[idx];
     if (!c.isDownloaded) return;
     var isBookmarked = c.isBookmarked;
-    if (ref.read(offlineActiveProvider)) {
-      final row =
-          await ref.read(offlineRepositoryProvider).chapterById(chapterId);
+    if (read(offlineActiveProvider)) {
+      final row = await read(offlineRepositoryProvider).chapterById(chapterId);
       if (row?.isBookmarked ?? false) isBookmarked = true;
     }
     if (isBookmarked && !allowBookmarked) return;
-    await ref.read(mangaBookRepositoryProvider).deleteChapters([chapterId]);
-    await cascadeServerDeleteToDevice(ref, [chapterId]);
+    await read(mangaBookRepositoryProvider).deleteChapters([chapterId]);
+    await _cascadeServerDeleteToDeviceRead(read, [chapterId]);
   } catch (e) {
     // Best-effort — a failed server auto-delete must never surface mid-read.
     logger.e('Offline: server delete-on-read failed for $chapterId: $e');
@@ -742,25 +830,32 @@ Future<void> pushPendingProgress(
 /// Enforce device ⊆ server: when chapters are deleted on the server, drop any
 /// device copies too. Silent; no-op when offline is unavailable.
 Future<void> cascadeServerDeleteToDevice(
-    WidgetRef ref, List<int> chapterIds) async {
-  if (ref.read(offlineDownloadManagerProvider) == null) return;
+    WidgetRef ref, List<int> chapterIds) =>
+    _cascadeServerDeleteToDeviceRead(ref.read, chapterIds);
+
+Future<void> _cascadeServerDeleteToDeviceRead(
+    _Read read, List<int> chapterIds) async {
+  if (read(offlineDownloadManagerProvider) == null) return;
   for (final id in chapterIds) {
-    await deleteChapterFromDevice(ref, id);
+    await _deleteChapterFromDeviceRead(read, id);
   }
 }
 
 /// Remove a chapter's device copy (widget entry).
-Future<void> deleteChapterFromDevice(WidgetRef ref, int chapterId) async {
-  final manager = ref.read(offlineDownloadManagerProvider);
+Future<void> deleteChapterFromDevice(WidgetRef ref, int chapterId) =>
+    _deleteChapterFromDeviceRead(ref.read, chapterId);
+
+Future<void> _deleteChapterFromDeviceRead(_Read read, int chapterId) async {
+  final manager = read(offlineDownloadManagerProvider);
   if (manager == null) return;
   await _deleteChapterFromDeviceCore(
     manager: manager,
-    db: ref.read(offlineDatabaseProvider),
-    repo: ref.read(offlineRepositoryProvider),
+    db: read(offlineDatabaseProvider),
+    repo: read(offlineRepositoryProvider),
     coordinator:
-        _useBgService ? null : ref.read(offlineDownloadCoordinatorProvider),
+        _useBgService ? null : read(offlineDownloadCoordinatorProvider),
     bgController:
-        _useBgService ? ref.read(backgroundDownloadControllerProvider) : null,
+        _useBgService ? read(backgroundDownloadControllerProvider) : null,
     chapterId: chapterId,
   );
 }
@@ -1088,10 +1183,12 @@ Future<void> reconcileMangaCore({
   required int mangaId,
   Future<void> Function(List<int> chapterIds)? enqueueServerDownload,
   Future<void> Function(int chapterId)? removeFromWorker,
+  Set<int> sessionProtected = const {},
 }) {
   return OfflineReconciler(
     db: db,
     nets: nets,
+    sessionProtected: sessionProtected,
     now: DateTime.now(),
     // Only QUEUE chapters here; starting the download is the caller's job (via
     // downloadStarterProvider) so the Ref-less launch path and tests stay in
@@ -1146,6 +1243,7 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
     coordinator: coordinator,
     nets: ref.read(safetyNetConfigProvider),
     mangaId: mangaId,
+    sessionProtected: ref.read(sessionReadChaptersProvider),
     enqueueServerDownload: (ids) => ref
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),
@@ -1174,6 +1272,7 @@ Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
     coordinator: coordinator,
     nets: ref.read(safetyNetConfigProvider),
     mangaId: mangaId,
+    sessionProtected: ref.read(sessionReadChaptersProvider),
     enqueueServerDownload: (ids) => ref
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),
@@ -1206,6 +1305,7 @@ Future<void> reconcileMangaContainer(
     coordinator: coordinator,
     nets: container.read(safetyNetConfigProvider),
     mangaId: mangaId,
+    sessionProtected: container.read(sessionReadChaptersProvider),
     enqueueServerDownload: (ids) => container
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),

--- a/lib/src/features/offline/data/offline_reconciler.dart
+++ b/lib/src/features/offline/data/offline_reconciler.dart
@@ -27,6 +27,7 @@ class OfflineReconciler {
     required this.onEvict,
     required this.now,
     this.onServerDownload,
+    this.sessionProtected = const {},
   });
 
   final OfflineDatabase db;
@@ -34,6 +35,10 @@ class OfflineReconciler {
   final Future<void> Function(int chapterId) onDownload;
   final Future<void> Function(int chapterId) onEvict;
   final DateTime now;
+
+  /// Chapters read this session — shielded from rule eviction so finishing a
+  /// chapter doesn't remove it from the device until the next launch.
+  final Set<int> sessionProtected;
 
   /// Called with chapters the keep-rule wants but the SERVER hasn't downloaded
   /// yet — enqueue a server download (server-client model: the server fetches
@@ -69,6 +74,7 @@ class OfflineReconciler {
       desired: desired,
       nets: nets,
       now: now,
+      protected: sessionProtected,
     );
 
     // Merge orphaned ids into the evict set.

--- a/lib/src/features/offline/data/reconcile_logic.dart
+++ b/lib/src/features/offline/data/reconcile_logic.dart
@@ -30,17 +30,23 @@ Set<int> desiredChapterIds(
 
 /// Decide evictions over the currently-downloaded set, honoring precedence:
 /// pinned > safety-nets > rule. Pinned chapters are never evicted.
+/// [protected] chapters (read this session) dodge the rule eviction only —
+/// the time and storage nets still apply, since those exist for space
+/// pressure, not the rolling unread window.
 ({Set<int> evict, bool overCapWarning}) applySafetyNets({
   required List<OfflineChapter> downloaded,
   required Set<int> desired,
   required SafetyNetConfig nets,
   required DateTime now,
+  Set<int> protected = const {},
 }) {
   final evict = <int>{};
 
   // 1) Not wanted by any rule and not pinned.
   for (final c in downloaded) {
-    if (!c.pinned && !desired.contains(c.id)) evict.add(c.id);
+    if (!c.pinned && !desired.contains(c.id) && !protected.contains(c.id)) {
+      evict.add(c.id);
+    }
   }
 
   // 2) Time-net: non-pinned older than keepDays.

--- a/test/src/features/offline/data/pending_read_deletes_test.dart
+++ b/test/src/features/offline/data/pending_read_deletes_test.dart
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/features/settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+ChapterDto _ch(int id, {required int sourceOrder, bool isRead = false}) =>
+    Fragment$ChapterDto(
+      id: id,
+      mangaId: 1,
+      name: 'c$id',
+      chapterNumber: id.toDouble(),
+      sourceOrder: sourceOrder,
+      scanlator: null,
+      isRead: isRead,
+      isBookmarked: false,
+      isDownloaded: true,
+      lastPageRead: 0,
+      pageCount: 10,
+      fetchedAt: '0',
+      uploadDate: '0',
+      lastReadAt: '0',
+      url: '',
+      meta: const <Fragment$ChapterDto$meta>[],
+    );
+
+class _FixedChapterList extends MangaChapterList {
+  _FixedChapterList(this.chapters);
+  final List<ChapterDto> chapters;
+
+  @override
+  Future<List<ChapterDto>?> build({required int mangaId}) async => chapters;
+}
+
+void main() {
+  test('while-reading deletes queue up and drain once', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final pending = container.read(pendingReadDeletesProvider.notifier);
+
+    const entry = (mangaId: 1, chapterId: 10, server: false);
+    pending.enqueue(entry);
+    pending.enqueue((mangaId: 1, chapterId: 11, server: true));
+    // Finishing the same chapter twice (re-read after scroll-back) must not
+    // queue a second delete.
+    pending.enqueue(entry);
+
+    expect(container.read(pendingReadDeletesProvider), hasLength(2));
+    expect(pending.drain(), hasLength(2));
+    // Drained: the reader-exit flush must not run these twice.
+    expect(pending.drain(), isEmpty);
+  });
+
+  test('session-read set accumulates without draining', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final session = container.read(sessionReadChaptersProvider.notifier);
+
+    session.record(10);
+    session.record(11);
+    session.record(10);
+
+    expect(container.read(sessionReadChaptersProvider), {10, 11});
+  });
+
+  testWidgets(
+      'finishing a chapter queues the RESOLVED delete target, not the finished '
+      'chapter', (tester) async {
+    final (captured, container) = await _pumpFinishHarness(tester);
+
+    await noteChapterFinishedInReader(captured, mangaId: 1, chapterId: 3);
+
+    expect(container.read(sessionReadChaptersProvider), {3},
+        reason: 'the finished chapter is shielded from rule eviction');
+    final queued = container.read(pendingReadDeletesProvider);
+    expect(queued.where((p) => !p.server).map((p) => p.chapterId), [2],
+        reason: 'the device delete stores the resolved 2-slots-back target');
+  });
+
+  testWidgets('exit flush waits for a resolution still in flight',
+      (tester) async {
+    final (captured, container) = await _pumpFinishHarness(tester);
+
+    // Deliberately NOT awaited — the reader's call sites fire and forget, and
+    // exiting right after a finish must not strand the late entry.
+    final resolution =
+        noteChapterFinishedInReader(captured, mangaId: 1, chapterId: 3);
+    await flushPendingReadDeletes(container);
+
+    expect(container.read(pendingReadDeletesProvider), isEmpty,
+        reason: 'the flush drained the entry the resolution added, so nothing '
+            'is left for a future session');
+    await resolution;
+    expect(container.read(pendingReadDeletesProvider), isEmpty,
+        reason: 'nothing lands after the flush that waited');
+  });
+}
+
+/// Chapters 1..3 in reading order, delete-while-reading at 2 slots, offline
+/// active: finishing chapter 3 resolves a device delete for chapter 2.
+Future<(WidgetRef, ProviderContainer)> _pumpFinishHarness(
+    WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues(const {});
+  final prefs = await SharedPreferences.getInstance();
+  final chapters = [
+    _ch(3, sourceOrder: 3),
+    _ch(2, sourceOrder: 2, isRead: true),
+    _ch(1, sourceOrder: 1, isRead: true),
+  ];
+
+  late WidgetRef captured;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        localDeleteSettingsProvider.overrideWithValue(
+          const DeleteChaptersSettings(
+            deleteWhileReading: 2,
+            deleteManuallyMarkedRead: false,
+            deleteWithBookmark: false,
+          ),
+        ),
+        mangaChapterListProvider(mangaId: 1)
+            .overrideWith(() => _FixedChapterList(chapters)),
+      ],
+      child: Consumer(
+        builder: (context, ref, _) {
+          captured = ref;
+          return const SizedBox();
+        },
+      ),
+    ),
+  );
+  final container =
+      ProviderScope.containerOf(tester.element(find.byType(SizedBox)));
+  return (captured, container);
+}

--- a/test/src/features/offline/data/reconcile_eviction_test.dart
+++ b/test/src/features/offline/data/reconcile_eviction_test.dart
@@ -30,6 +30,28 @@ void main() {
     expect(r.overCapWarning, false);
   });
 
+  test('session-read chapters dodge rule eviction', () {
+    final r = applySafetyNets(
+      downloaded: [dl(1), dl(2)], desired: {1}, nets: SafetyNetConfig.off,
+      now: now, protected: {2});
+    expect(r.evict, isEmpty,
+        reason: 'a chapter read this session must survive its manga\'s '
+            'keep-rule until the next launch');
+  });
+
+  test('storage cap still evicts session-read chapters', () {
+    final nets = SafetyNetConfig(timeEvictEnabled: false, keepDays: 30,
+        storageCapEnabled: true, storageCapBytes: 150);
+    final r = applySafetyNets(
+      downloaded: [
+        dl(1, bytes: 100, at: DateTime(2026, 1, 1)),
+        dl(2, bytes: 100, at: DateTime(2026, 1, 2)),
+      ],
+      desired: {2}, nets: nets, now: now, protected: {1});
+    expect(r.evict, {1},
+        reason: 'session protection yields to space pressure');
+  });
+
   test('never evicts pinned, even if not desired', () {
     final r = applySafetyNets(
       downloaded: [dl(1, pinned: true)], desired: {}, nets: SafetyNetConfig.off, now: now);

--- a/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
+++ b/test/src/features/settings/presentation/downloads/delete_while_reading_direction_test.dart
@@ -100,7 +100,7 @@ void main() {
         ),
       );
 
-      final pending = whileReadingDeleteTarget(captured, 1, 33, 2);
+      final pending = whileReadingDeleteTarget(captured.read, 1, 33, 2);
       slow.gate.complete(chapters);
       await tester.pump();
 


### PR DESCRIPTION
This fixes two deletion-timing problems from the report in #309, one in the while-reading path and one in the keep-rule path.

**While-reading deletes now wait for reader exit.** The slot math was right, but the delete ran the moment the last page was reached, so with the setting on, a chapter could vanish while still on screen. Komikku queues the delete on finish and runs the queue in `onActivityFinish`; the reader now does the same. The target chapter is still resolved at finish time, against the chapter list and scanlator-dedup state the reader is showing — resolving at exit could pick a different chapter once the list refreshes or the autoDispose dedup providers reset. The flush runs off the root container so the server round-trip survives the route being disposed, and it waits for any in-flight target resolution before draining. The bookmark permission is read at execution time, so revoking "delete bookmarked chapters" between finish and exit is honored.

**Just-read chapters survive the keep rule until next launch.** The keep-N-unread window rolls forward when a chapter is read, so exiting the reader reconciled and evicted the chapter that was just finished. Chapters read in the current session are now shielded from rule eviction; the time and storage safety nets still evict them, since those exist for space pressure. Launch reconciliation deliberately runs unshielded, which is what bounds the protection to one session.

One known residual remains, accepted because Komikku has the same window: a chapter finished in the same instant the reader exits can have its queued delete slip to the next reading session (the finish-side progress write is still in flight when the exit flush drains). The worst case is a delete landing one session late; the target chapter was already resolved at finish, so the delay cannot change which chapter gets deleted.

Tests pin the resolved-target-at-finish behavior, the flush waiting on in-flight resolutions, the queue drain semantics, and the eviction shield (including the storage cap overriding it).

Closes #309
