### PR TITLE
Auto-download new chapters for keep-rule manga after a library update

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,6 +31,7 @@ import 'src/features/offline/data/background/background_download_controller_shim
 import 'src/features/offline/data/server_reachability.dart';
 import 'src/features/offline/data/offline_background_downloads.dart';
 import 'src/features/offline/data/offline_bootstrap.dart';
+import 'src/features/offline/data/offline_chapter_catchup.dart';
 import 'src/features/offline/data/offline_download_providers.dart';
 import 'src/features/offline/data/offline_repository.dart';
 import 'src/features/offline/data/offline_server_identity_repository.dart';
@@ -308,6 +309,9 @@ Future<void> _startApp() async {
       if (!container.read(offlineActiveProvider)) return;
       await pushPendingProgress(container);
       await reconcileAllAtLaunch(container);
+      // New-chapter catch-up for keep-rule manga (#310): launch pass now, then
+      // re-runs when an update finishes or the server download queue drains.
+      initChapterCatchUp(container);
       // One-time sweep of phantom (browsed-not-added) catalog entries.
       if (sharedPreferences.getBool('offlinePhantomCleanupDone') != true) {
         try {

--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -152,6 +152,11 @@ enum DBKeys {
   // download starters to gate every restart path.
   offlineDownloadsPaused(false),
   offlineCatalogServerId(null),
+  // Newest chapter fetchedAt the catch-up pass has processed (epoch seconds).
+  offlineCatchUpWatermark(0),
+  // Manga ids still owed a device pull once the server finishes downloading —
+  // persisted because the watermark has already moved past their chapters.
+  offlineCatchUpAwaitingPull(null),
   offlineLastServerId(null),
   offlineLastServerAddress(null),
   offlineServerMismatchDismissedList(null),

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../global_providers/global_providers.dart';
+import '../../../utils/logger/logger.dart';
+import '../../manga_book/data/downloads/downloads_repository.dart';
+import '../../manga_book/data/manga_book/manga_book_repository.dart';
+import '../../manga_book/data/updates/updates_repository.dart';
+import '../../manga_book/presentation/downloads/controller/downloads_controller.dart';
+import 'background/background_download_controller_shim.dart';
+import 'offline_background_downloads.dart';
+import 'offline_database.dart';
+import 'offline_download_providers.dart';
+import 'offline_repository.dart';
+import 'offline_types.dart';
+
+/// Closes the #310 gap: a library update told the SERVER to find new chapters,
+/// but nothing on the client synced or downloaded them for keep-rule manga —
+/// the full fetch→mirror→reconcile chain only ran on a manga-details visit.
+
+/// Feed pages scanned per pass. Running out of budget before reaching the
+/// watermark falls back to a full keep-rule pass, so the cap trades feed
+/// queries for chapter-list fetches rather than dropping anything.
+const _maxCatchUpPages = 3;
+
+bool _running = false;
+
+/// Manga whose reconcile had to ask the SERVER to download chapters first.
+/// Their device pull can only happen after those finish — see
+/// [pullAfterServerDownloads].
+final Set<int> _awaitingServerDownloads = {};
+
+/// Called once from app bootstrap, after the offline engine is up.
+void initChapterCatchUp(ProviderContainer container) {
+  // Restore the second-hop obligations — the watermark has already moved past
+  // these manga, so losing the set to a restart would strand their pulls.
+  _awaitingServerDownloads.addAll(container
+          .read(sharedPreferencesProvider)
+          .getStringList(DBKeys.offlineCatchUpAwaitingPull.name)
+          ?.map(int.tryParse)
+          .whereType<int>() ??
+      const []);
+  // A finished server update run is the moment new chapters exist to pull.
+  container.listen(updateRunningSocketProvider, (previous, next) {
+    final wasRunning = previous?.value ?? false;
+    final isRunning = next.value ?? wasRunning;
+    if (wasRunning && !isRunning) {
+      unawaited(runKeepRuleCatchUp(container));
+    }
+  });
+  // The server's download queue draining is the moment chapters queued by a
+  // catch-up reconcile become pullable to the device.
+  container.listen(downloadsMapProvider, (previous, next) {
+    if ((previous?.isNotEmpty ?? false) && next.isEmpty) {
+      unawaited(pullAfterServerDownloads(container));
+    }
+  });
+  // Catch anything the server found while the app was closed.
+  unawaited(runKeepRuleCatchUp(container));
+}
+
+/// Single-flight: a trigger landing mid-pass is dropped, since its chapters
+/// are newer than the watermark and the next pass (launch or update-finish)
+/// will pick them up.
+Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
+  if (_running) return;
+  if (!container.read(offlineActiveProvider)) return;
+  _running = true;
+  try {
+    final keepRuleManga = {
+      for (final m in await container.read(offlineDatabaseProvider).libraryManga())
+        if (m.keepRule != OfflineKeepRule.off) m.id,
+    };
+    if (keepRuleManga.isEmpty) return;
+
+    final prefs = container.read(sharedPreferencesProvider);
+    final watermark = prefs.getInt(DBKeys.offlineCatchUpWatermark.name) ?? 0;
+
+    final scan = await touchedSinceWatermark(
+      fetchPage: (pageNo) async {
+        final page = await container
+            .read(updatesRepositoryProvider)
+            .getRecentChaptersPage(pageNo: pageNo);
+        final nodes = page?.nodes;
+        if (nodes == null) return null;
+        return [
+          for (final n in nodes)
+            (mangaId: n.mangaId, fetchedAt: int.tryParse(n.fetchedAt) ?? 0),
+        ];
+      },
+      keepRuleManga: keepRuleManga,
+      watermark: watermark,
+    );
+    // Didn't reach the watermark (or this is the first pass, with none yet)?
+    // Fall back to every keep-rule manga instead of skipping the tail.
+    final touched = scan.sawWatermark ? scan.touched : keepRuleManga;
+    final allSynced = await _syncAndReconcile(container, touched);
+
+    // Only a fully-processed pass may advance the watermark — a skipped manga
+    // must stay newer than it so the next pass retries. syncChapters is
+    // idempotent, so re-processing the rest is just cheap.
+    if (allSynced && scan.newestFetchedAt > watermark) {
+      await prefs.setInt(
+          DBKeys.offlineCatchUpWatermark.name, scan.newestFetchedAt);
+    }
+    if (touched.isNotEmpty) {
+      await container.read(downloadStarterProvider)();
+    }
+    // Manga still waiting on server-side downloads get retried here too — the
+    // queue-drain edge alone can be missed when downloads finish faster than
+    // the subscription reports them.
+    await _pullAwaiting(container);
+  } catch (e) {
+    logger.w('Offline: chapter catch-up pass failed: $e');
+  } finally {
+    _running = false;
+  }
+}
+
+/// Second hop: chapters the server had to download from the source first.
+/// Once its queue drains, re-run the chain for the manga that were waiting so
+/// the device copies get pulled. Single-flight with the catch-up pass, whose
+/// own tail retry covers a drain edge that lands mid-pass.
+Future<void> pullAfterServerDownloads(ProviderContainer container) async {
+  if (_running) return;
+  _running = true;
+  try {
+    await _pullAwaiting(container);
+  } finally {
+    _running = false;
+  }
+}
+
+Future<void> _pullAwaiting(ProviderContainer container) async {
+  if (_awaitingServerDownloads.isEmpty) return;
+  if (!container.read(offlineActiveProvider)) return;
+  // One obligation at a time, persisted after each: a crash mid-loop keeps
+  // the unprocessed rest, and a batch clear would lose them.
+  for (final mangaId in {..._awaitingServerDownloads}) {
+    _awaitingServerDownloads.remove(mangaId);
+    // The reconcile may re-add this manga (a NEW server enqueue) — that is a
+    // fresh obligation, not the one being consumed, so it must survive.
+    final ok = await _syncAndReconcile(container, {mangaId});
+    if (!ok) _awaitingServerDownloads.add(mangaId);
+    await _persistAwaiting(container);
+  }
+  await container.read(downloadStarterProvider)();
+}
+
+Future<void> _persistAwaiting(ProviderContainer container) =>
+    container.read(sharedPreferencesProvider).setStringList(
+          DBKeys.offlineCatchUpAwaitingPull.name,
+          [for (final id in _awaitingServerDownloads) '$id'],
+        );
+
+/// Scans the feed for keep-rule manga touched since [watermark]. Boundary
+/// entries (same second as watermark) are re-included since a resync is
+/// idempotent but a missed chapter isn't; [sawWatermark] false means the
+/// scan hit its page budget first, so the tail is unknown, not empty.
+@visibleForTesting
+Future<({Set<int> touched, int newestFetchedAt, bool sawWatermark})>
+    touchedSinceWatermark({
+  required Future<List<({int mangaId, int fetchedAt})>?> Function(int pageNo)
+      fetchPage,
+  required Set<int> keepRuleManga,
+  required int watermark,
+}) async {
+  final touched = <int>{};
+  var newest = watermark;
+  // First run has no watermark to reach: one page seeds it (the caller falls
+  // back to a full keep-rule pass), instead of paging a library's whole
+  // backlog as if it were new.
+  final pageBudget = watermark == 0 ? 1 : _maxCatchUpPages;
+  for (var page = 0; page < pageBudget; page++) {
+    final nodes = await fetchPage(page);
+    if (nodes == null) break;
+    if (nodes.isEmpty) {
+      // The feed genuinely ended — nothing older remains unseen.
+      return (touched: touched, newestFetchedAt: newest, sawWatermark: true);
+    }
+    for (final node in nodes) {
+      if (node.fetchedAt < watermark) {
+        return (touched: touched, newestFetchedAt: newest, sawWatermark: true);
+      }
+      newest = math.max(newest, node.fetchedAt);
+      if (keepRuleManga.contains(node.mangaId)) touched.add(node.mangaId);
+    }
+    if (nodes.length < updatesPageSize) {
+      return (touched: touched, newestFetchedAt: newest, sawWatermark: true);
+    }
+  }
+  return (touched: touched, newestFetchedAt: newest, sawWatermark: false);
+}
+
+/// The manga-details chain, minus the screen: stored chapters from the server,
+/// mirrored into drift, then reconciled. Sequential on purpose — an update can
+/// touch much of a library, and this runs behind the UI.
+Future<bool> _syncAndReconcile(
+    ProviderContainer container, Set<int> mangaIds) async {
+  var allSynced = true;
+  for (final mangaId in mangaIds) {
+    try {
+      final chapters = await container
+          .read(mangaBookRepositoryProvider)
+          .getStoredChapterList(mangaId);
+      final sync = container.read(offlineSyncProvider);
+      if (chapters == null || sync == null) {
+        allSynced = false;
+        continue;
+      }
+      await sync.syncChapters(chapters);
+      if (!await _reconcileTracked(container, mangaId)) allSynced = false;
+    } catch (e) {
+      // Never reconcile on a failed fetch — evictions must not run against a
+      // list the server didn't actually give us.
+      allSynced = false;
+      logger.w('Offline: catch-up skipped manga $mangaId: $e');
+    }
+  }
+  return allSynced;
+}
+
+/// Like [reconcileMangaContainer], but also records server-download enqueues
+/// so the queue-drain trigger knows which manga still owe a device pull.
+/// Returns false on a failed enqueue (reconcileMangaCore swallows the error)
+/// so the pass won't advance the watermark past an unqueued chapter.
+Future<bool> _reconcileTracked(
+    ProviderContainer container, int mangaId) async {
+  final manager = container.read(offlineDownloadManagerProvider);
+  final coordinator = container.read(offlineDownloadCoordinatorProvider);
+  if (manager == null || coordinator == null) return false;
+  var enqueueFailed = false;
+  await reconcileMangaCore(
+    db: container.read(offlineDatabaseProvider),
+    repo: container.read(offlineRepositoryProvider),
+    manager: manager,
+    coordinator: coordinator,
+    nets: container.read(safetyNetConfigProvider),
+    mangaId: mangaId,
+    sessionProtected: container.read(sessionReadChaptersProvider),
+    enqueueServerDownload: (ids) async {
+      try {
+        await container
+            .read(downloadsRepositoryProvider)
+            .addChaptersBatchToDownloadQueue(ids);
+        // Recorded only on success: a failed enqueue produces no queue
+        // activity, so no drain edge would ever retry the waiting entry.
+        _awaitingServerDownloads.add(mangaId);
+      } catch (_) {
+        enqueueFailed = true;
+        rethrow;
+      }
+    },
+    removeFromWorker: (id) async {
+      final ctrl = container.read(backgroundDownloadControllerProvider);
+      await ctrl.onRemoved(id);
+      final gen =
+          await container.read(offlineDatabaseProvider).bumpChapterGeneration(id);
+      await ctrl.recordChapterDeleted(id, gen);
+    },
+  );
+  await _persistAwaiting(container);
+  return !enqueueFailed;
+}

--- a/test/src/features/offline/data/offline_chapter_catchup_test.dart
+++ b/test/src/features/offline/data/offline_chapter_catchup_test.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_chapter_catchup.dart';
+
+typedef _Node = ({int mangaId, int fetchedAt});
+
+void main() {
+  test('collects keep-rule manga newer than the watermark, stops at it',
+      () async {
+    final calls = <int>[];
+    Future<List<_Node>?> fetch(int page) async {
+      calls.add(page);
+      return [
+        (mangaId: 1, fetchedAt: 300),
+        (mangaId: 2, fetchedAt: 250),
+        (mangaId: 3, fetchedAt: 200),
+        (mangaId: 1, fetchedAt: 100), // at the watermark — scan ends here
+        (mangaId: 4, fetchedAt: 50),
+      ];
+    }
+
+    final scan = await touchedSinceWatermark(
+        fetchPage: fetch, keepRuleManga: {1, 3, 4}, watermark: 100);
+    expect(scan.touched, {1, 3},
+        reason: 'manga 2 has no keep rule, manga 4 is behind the watermark; '
+            'manga 1 at the boundary second is re-included');
+    expect(scan.newestFetchedAt, 300);
+    expect(scan.sawWatermark, isTrue);
+    expect(calls, [0], reason: 'the sub-watermark entry ends the scan');
+  });
+
+  test('entries sharing the boundary second are not dropped', () async {
+    Future<List<_Node>?> fetch(int page) async => [
+          (mangaId: 5, fetchedAt: 100),
+          (mangaId: 6, fetchedAt: 100),
+          (mangaId: 7, fetchedAt: 99),
+        ];
+
+    final scan = await touchedSinceWatermark(
+        fetchPage: fetch, keepRuleManga: {5, 6, 7}, watermark: 100);
+    expect(scan.touched, {5, 6},
+        reason: 'both boundary-second manga are re-processed, the strictly '
+            'older one is not');
+    expect(scan.sawWatermark, isTrue);
+  });
+
+  test('first run reads a single page instead of the whole feed', () async {
+    final calls = <int>[];
+    // A full page (50) would normally request the next one.
+    Future<List<_Node>?> fetch(int page) async {
+      calls.add(page);
+      return [
+        for (var i = 0; i < 50; i++) (mangaId: i, fetchedAt: 1000 - i),
+      ];
+    }
+
+    final scan = await touchedSinceWatermark(
+        fetchPage: fetch, keepRuleManga: {1, 2}, watermark: 0);
+    expect(calls, [0]);
+    expect(scan.newestFetchedAt, 1000);
+    expect(scan.sawWatermark, isFalse,
+        reason: 'a first run reports the tail unknown, so the caller falls '
+            'back to a full keep-rule pass');
+  });
+
+  test('a full page continues to the next, a short page ends the scan',
+      () async {
+    final calls = <int>[];
+    Future<List<_Node>?> fetch(int page) async {
+      calls.add(page);
+      if (page == 0) {
+        return [
+          for (var i = 0; i < 50; i++) (mangaId: 1, fetchedAt: 2000 - i),
+        ];
+      }
+      return [(mangaId: 2, fetchedAt: 1500)];
+    }
+
+    final scan = await touchedSinceWatermark(
+        fetchPage: fetch, keepRuleManga: {1, 2}, watermark: 10);
+    expect(calls, [0, 1]);
+    expect(scan.touched, {1, 2});
+    expect(scan.newestFetchedAt, 2000);
+    expect(scan.sawWatermark, isTrue, reason: 'a short page ends the feed');
+  });
+
+  test('feed scan is bounded even when every page is full', () async {
+    final calls = <int>[];
+    Future<List<_Node>?> fetch(int page) async {
+      calls.add(page);
+      return [
+        for (var i = 0; i < 50; i++)
+          (mangaId: page * 50 + i, fetchedAt: 100000 - page * 50 - i),
+      ];
+    }
+
+    final scan = await touchedSinceWatermark(
+        fetchPage: fetch, keepRuleManga: {1}, watermark: 10);
+    expect(calls, hasLength(3),
+        reason: 'the page budget caps a stale-watermark scan');
+    expect(scan.sawWatermark, isFalse,
+        reason: 'an exhausted budget must not pass off the unseen tail as '
+            'covered — the caller falls back to a full keep-rule pass');
+  });
+}


### PR DESCRIPTION
This closes the gap reported in #310: a library update told the server to find new chapters, but the client never mirrored or downloaded them for keep-rule manga. The full fetch, mirror, reconcile chain only ran when a manga's details screen was opened, so keep rules silently did nothing until each series was visited.

A catch-up pass now scans the recent-chapters feed for keep-rule manga with chapters newer than a stored watermark and runs that same chain per touched series. It fires on three existing signals:

- when an update run finishes (the running-status subscription's falling edge)
- at app launch, covering updates the server ran while the app was closed
- when the server's download queue drains, which is when source-fetched chapters become pullable to the device

The pass holds a few correctness properties, most of them added during review:

- An oversized update (more new chapters than the scan budget covers) falls back to processing every keep-rule manga instead of silently dropping the tail past the watermark.
- Chapters sharing the watermark's boundary second are re-included: syncing a chapter twice is harmless, but one missed at the boundary would never be picked up.
- The watermark only advances after a fully-processed pass, so a failed fetch retries next pass, and a pass never reconciles a manga whose fetch failed (evictions must not run against a list the server didn't give us).
- A failed server-download enqueue holds the watermark and is not recorded as a pending pull, since it would produce no queue activity to retry on.
- The pending-pull set persists across restarts and is consumed one manga at a time, so a crash mid-recovery cannot lose the remainder.
- The first pass on an existing install is bounded to one feed page plus a full keep-rule pass, so it never walks the library's whole backlog.

Session-read chapters keep their eviction shield from #317 during catch-up reconciles. On Android the queued downloads run through the existing foreground-service engine. Running the detection itself while the app is closed (the background worker) is deliberately out of scope here and tracked as follow-up work.

Closes #310
