### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 1.1.0+46
+version: 1.1.1+47
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
Version 1.1.1+47 for the next release. Ten PRs since v1.1.0: the long strip Original size and Maximum width options (#323), offline covers and faster fallback (#312), auto-download after library updates (#318), delete timing (#317), and fixes across library sort and filters, the paged reader, the download queue, and the Linux file picker.