### PR TITLE
Keep the offline category mirror honest, and stop covers re-decoding on tab switches

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,6 +50,7 @@ import 'src/utils/crash/redact_tokens.dart';
 import 'src/utils/desktop/desktop_window.dart';
 import 'src/utils/hive/graphql_cache_guard.dart';
 import 'src/utils/misc/toast/toast.dart';
+import 'src/utils/soft_clear_image_cache.dart';
 import 'src/utils/platform/is_android_native.dart';
 import 'src/widgets/app_error_app.dart';
 
@@ -62,6 +63,22 @@ String? _crashLogPath;
 /// error (log only; keep the app running). See [_onFatalError].
 bool _appRendered = false;
 
+/// Stock binding except the image cache survives memory-pressure signals
+/// with a working set intact (see [SoftClearImageCache]) — Android sends one
+/// for plain backgrounding, and the default clear-to-zero re-faded every
+/// cover on return.
+class _TsumiruWidgetsBinding extends WidgetsFlutterBinding {
+  @override
+  ImageCache createImageCache() => SoftClearImageCache(floorBytes: 64 << 20);
+
+  static WidgetsBinding ensureInitialized() {
+    // First thing in main, so no binding exists yet; constructing a second
+    // one would assert, which is the alarm we'd want if that ever lied.
+    _TsumiruWidgetsBinding();
+    return WidgetsBinding.instance;
+  }
+}
+
 void main() {
   // Run everything inside a guarded zone so a fatal error — sync, async, or
   // framework — is caught, written to a log file, and shown as a readable
@@ -70,7 +87,10 @@ void main() {
 }
 
 Future<void> _startApp() async {
-  WidgetsFlutterBinding.ensureInitialized();
+  _TsumiruWidgetsBinding.ensureInitialized();
+  // 100 MB default is too small even for tile-sized covers — evicted covers
+  // re-shimmer on every tab switch. A cap, not an allocation.
+  PaintingBinding.instance.imageCache.maximumSizeBytes = 256 << 20;
   await _setUpCrashReporting();
   // Initialise the foreground-task plugin (Android-only; no-op elsewhere) before
   // any download service is started. Must run after the binding is ready.

--- a/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
+++ b/lib/src/features/library/presentation/category/controller/edit_category_controller.dart
@@ -13,6 +13,7 @@ import '../../../../../features/offline/data/offline_read_fallback.dart';
 import '../../../../../features/offline/data/offline_repository.dart';
 import '../../../../../features/offline/data/server_reachability.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/network/graphql_errors.dart';
 import '../../../data/category_repository.dart';
 import '../../../domain/category/category_model.dart';
 import '../../library/controller/library_controller.dart';
@@ -81,25 +82,52 @@ class CategoryController extends _$CategoryController {
   }
 
   /// Hide/show a category from the Library tabs. Stored as a server-side
-  /// category meta flag so it persists and syncs across devices.
-  Future<AsyncValue<void>> setHidden(int categoryId, bool hidden) async {
+  /// category meta flag so it persists and syncs across devices. Offline,
+  /// the change lands on the device's mirror instead — downloads in a hidden
+  /// category must stay reachable — and the server's flag reasserts on the
+  /// next online sync.
+  Future<AsyncValue<CategoryVisibilityOutcome>> setHidden(
+      int categoryId, bool hidden) async {
+    // Captured before the awaits: this provider auto-disposes (see build).
     final repo = ref.read(categoryRepositoryProvider);
-    final response = await AsyncValue.guard(
-      () => hidden
-          ? repo.setCategoryMeta(
-              categoryId: categoryId,
-              key: kCategoryHiddenMetaKey,
-              value: 'true',
-            )
-          : repo.deleteCategoryMeta(
-              categoryId: categoryId,
-              key: kCategoryHiddenMetaKey,
-            ),
+    final offlineDb = ref.read(offlineReadDatabaseProvider);
+    final response = await AsyncValue.guard<CategoryVisibilityOutcome>(
+      () async {
+        hidden
+            ? await repo.setCategoryMeta(
+                categoryId: categoryId,
+                key: kCategoryHiddenMetaKey,
+                value: 'true',
+              )
+            : await repo.deleteCategoryMeta(
+                categoryId: categoryId,
+                key: kCategoryHiddenMetaKey,
+              );
+        return CategoryVisibilityOutcome.synced;
+      },
     );
+    // The repository throws OperationMessageException wrapping the link
+    // error — unwrap before classifying, same as _shouldFallBack.
+    if (response case AsyncError(:final error)
+        when isConnectionError(
+              error is OperationMessageException ? error.exception : error,
+            ) &&
+            offlineDb != null) {
+      // A mirror without this row (never synced online) can't honor the
+      // change — fall through to the error rather than claim success.
+      if (await offlineDb.setCategoryHidden(categoryId, hidden)) {
+        ref.invalidateSelf();
+        return const AsyncData(CategoryVisibilityOutcome.deviceOnly);
+      }
+    }
     ref.invalidateSelf();
     return response;
   }
 }
+
+/// How a category visibility change landed: on the server (permanent,
+/// cross-device) or only on this device's offline mirror (until reconnect).
+enum CategoryVisibilityOutcome { synced, deviceOnly }
 
 @riverpod
 List<CategoryDto>? categoryListQuery(

--- a/lib/src/features/library/presentation/category/widgets/category_tile.dart
+++ b/lib/src/features/library/presentation/category/widgets/category_tile.dart
@@ -9,6 +9,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../../constants/app_sizes.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../../../utils/misc/toast/toast.dart';
+import '../../../../../utils/network/graphql_errors.dart';
 import '../../../../../widgets/popup_widgets/pop_button.dart';
 import '../../../domain/category/category_model.dart';
 import '../controller/edit_category_controller.dart';
@@ -87,9 +89,32 @@ class CategoryTile extends HookConsumerWidget {
               tooltip: isHidden
                   ? context.l10n.showCategory
                   : context.l10n.hideCategory,
-              onPressed: () => ref
-                  .read(categoryControllerProvider.notifier)
-                  .setHidden(category.id, !isHidden),
+              // The flag lives on the server; offline the change lands on the
+              // device mirror instead (a hidden category's downloads must stay
+              // reachable), and the server's flag returns on reconnect.
+              onPressed: () async {
+                final result = await ref
+                    .read(categoryControllerProvider.notifier)
+                    .setHidden(category.id, !isHidden);
+                if (!context.mounted) return;
+                switch (result) {
+                  case AsyncData(
+                      value: CategoryVisibilityOutcome.deviceOnly
+                    ):
+                    ref.read(toastProvider)?.show(
+                          context.l10n.categoryVisibilityDeviceOnly,
+                        );
+                  case AsyncError(:final error):
+                    ref.read(toastProvider)?.showError(
+                          isConnectionError(error is OperationMessageException
+                                  ? error.exception
+                                  : error)
+                              ? context.l10n.needsServerConnection
+                              : context.l10n.errorSomethingWentWrong,
+                        );
+                  default:
+                }
+              },
               icon: Icon(
                 isHidden
                     ? Icons.visibility_rounded
@@ -103,20 +128,37 @@ class CategoryTile extends HookConsumerWidget {
               onPressed: !isDefault
                   ? () => showDialog(
                         context: context,
-                        builder: (context) => AlertDialog(
-                          title: Text(context.l10n.deleteCategoryTitle),
-                          content:
-                              Text(context.l10n.deleteCategoryDescription),
+                        builder: (dialogContext) => AlertDialog(
+                          title:
+                              Text(dialogContext.l10n.deleteCategoryTitle),
+                          content: Text(
+                              dialogContext.l10n.deleteCategoryDescription),
                           actions: [
                             const PopButton(),
                             ElevatedButton(
-                              onPressed: () {
-                                ref
+                              onPressed: () async {
+                                Navigator.pop(dialogContext);
+                                final result = await ref
                                     .read(categoryControllerProvider.notifier)
                                     .deleteCategory(category.id);
-                                Navigator.pop(context);
+                                // Deliberately the TILE's context: the dialog
+                                // unmounts with the pop, and this resolves
+                                // long after on the failure paths.
+                                if (result is AsyncError && context.mounted) {
+                                  final error = result.error;
+                                  final cause =
+                                      error is OperationMessageException
+                                          ? error.exception
+                                          : error;
+                                  ref.read(toastProvider)?.showError(
+                                        isConnectionError(cause)
+                                            ? context.l10n.needsServerConnection
+                                            : context
+                                                .l10n.errorSomethingWentWrong,
+                                      );
+                                }
                               },
-                              child: Text(context.l10n.delete),
+                              child: Text(dialogContext.l10n.delete),
                             ),
                           ],
                         ),

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -145,6 +145,9 @@ class OfflineCategories extends Table {
   IntColumn get id => integer()();
   TextColumn get name => text()();
   IntColumn get sortOrder => integer().withDefault(const Constant(0))();
+  // Mirrors the server's tsumiru.hidden category meta, so hidden tabs stay
+  // hidden offline.
+  BoolColumn get isHidden => boolean().withDefault(const Constant(false))();
 
   @override
   Set<Column> get primaryKey => {id};
@@ -183,7 +186,7 @@ class OfflineDatabase extends _$OfflineDatabase {
   OfflineDatabase(super.e);
 
   @override
-  int get schemaVersion => 13;
+  int get schemaVersion => 14;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -360,6 +363,22 @@ class OfflineDatabase extends _$OfflineDatabase {
           'UPDATE offline_chapters SET synced_is_read = is_read',
         );
       }
+      if (from < 14) {
+        // onCreate only runs for brand-new databases, so an upgrade from a
+        // version without these tables has to create them itself.
+        if (await _hasTable(offlineCategories)) {
+          await _addColumnIfMissing(
+            m,
+            offlineCategories,
+            offlineCategories.isHidden,
+          );
+        } else {
+          await m.createTable(offlineCategories);
+        }
+        if (!await _hasTable(offlineMangaCategories)) {
+          await m.createTable(offlineMangaCategories);
+        }
+      }
     },
   );
 
@@ -497,14 +516,75 @@ class OfflineDatabase extends _$OfflineDatabase {
     ),
   );
 
-  Future<void> upsertCategory(int id, String name, int sortOrder) =>
+  Future<void> upsertCategory(
+    int id,
+    String name,
+    int sortOrder, {
+    required bool isHidden,
+  }) =>
       into(offlineCategories).insertOnConflictUpdate(
         OfflineCategoriesCompanion(
           id: Value(id),
           name: Value(name),
           sortOrder: Value(sortOrder),
+          isHidden: Value(isHidden),
         ),
       );
+
+  /// Device-local visibility override while offline. The next online
+  /// [OfflineSync.syncCategories] reasserts the server's flag. False when no
+  /// mirrored row matched — callers must not report success then.
+  Future<bool> setCategoryHidden(int id, bool hidden) async {
+    final rows =
+        await (update(offlineCategories)..where((t) => t.id.equals(id))).write(
+      OfflineCategoriesCompanion(isHidden: Value(hidden)),
+    );
+    return rows > 0;
+  }
+
+  /// Drop categories the server no longer has, membership rows included.
+  /// Callers guard against an empty [serverIds] — a failed fetch must never
+  /// wipe the mirror.
+  Future<void> pruneRemovedCategories(Set<int> serverIds) => transaction(
+        () async {
+          await (delete(offlineMangaCategories)
+                ..where((t) => t.categoryId.isNotIn(serverIds)))
+              .go();
+          await (delete(offlineCategories)
+                ..where((t) => t.id.isNotIn(serverIds)))
+              .go();
+        },
+      );
+
+  /// Downloaded-library manga per category, for the offline tab counts.
+  /// Membership rows outside [mangaIds] don't count.
+  Future<Map<int, int>> mangaCountByCategory(Set<int> mangaIds) async {
+    final rows = await select(offlineMangaCategories).get();
+    final counts = <int, int>{};
+    for (final row in rows) {
+      if (mangaIds.contains(row.mangaId)) {
+        counts[row.categoryId] = (counts[row.categoryId] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }
+
+  /// Of [mangaIds], the ones with no membership in a STORED category — these
+  /// render under Default. A row pointing at a pruned/unmirrored category
+  /// doesn't count either; the mapper's inner join drops it the same way.
+  Future<Set<int>> uncategorizedOf(Set<int> mangaIds) async {
+    final rows = await (select(offlineMangaCategories).join([
+      innerJoin(
+        offlineCategories,
+        offlineCategories.id.equalsExp(offlineMangaCategories.categoryId),
+      ),
+    ]))
+        .get();
+    final categorized = {
+      for (final row in rows) row.readTable(offlineMangaCategories).mangaId,
+    };
+    return mangaIds.difference(categorized);
+  }
 
   /// Replace a manga's full category membership atomically (delete-then-insert).
   /// Safe to call with an empty list — just removes all memberships.

--- a/lib/src/features/offline/data/offline_read_fallback.dart
+++ b/lib/src/features/offline/data/offline_read_fallback.dart
@@ -228,14 +228,25 @@ Future<List<CategoryDto>?> categoriesWithOfflineFallback({
 }) async {
   Future<List<CategoryDto>?> serveCatalog() async {
     final downloadedIds = await db!.mangaIdsWithDeviceDownloads();
-    final count = (await db.libraryManga())
+    final downloadedInLibrary = (await db.libraryManga())
         .where((m) => downloadedIds.contains(m.id))
-        .length;
-    if (count == 0) return null;
+        .map((m) => m.id)
+        .toSet();
+    if (downloadedInLibrary.isEmpty) return null;
     final storedCats = await db.allOfflineCategories();
-    if (storedCats.isNotEmpty) {
-      return [
-        for (final cat in storedCats)
+    if (storedCats.isEmpty) {
+      return [offlineDefaultCategoryDto(downloadedInLibrary.length)];
+    }
+    // Real per-tab counts, so empty tabs drop the same way they do online
+    // (nonZeroCategoryList). Manga with no membership rows live in the
+    // server's default category, which their DTOs don't list.
+    final counts = await db.mangaCountByCategory(downloadedInLibrary);
+    final uncategorized = await db.uncategorizedOf(downloadedInLibrary);
+    int countFor(OfflineCategory cat) =>
+        (counts[cat.id] ?? 0) + (cat.id == 0 ? uncategorized.length : 0);
+    final tabs = [
+      for (final cat in storedCats)
+        if (countFor(cat) > 0)
           Fragment$CategoryDto(
             defaultCategory: cat.id == 0,
             id: cat.id,
@@ -243,12 +254,27 @@ Future<List<CategoryDto>?> categoriesWithOfflineFallback({
             includeInUpdate: Enum$IncludeOrExclude.UNSET,
             name: cat.name,
             order: cat.sortOrder,
-            mangas: Fragment$CategoryDto$mangas(totalCount: count),
-            meta: const <Fragment$CategoryDto$meta>[],
+            mangas: Fragment$CategoryDto$mangas(totalCount: countFor(cat)),
+            // Mirrored so hidden tabs stay hidden offline.
+            meta: [
+              if (cat.isHidden)
+                Fragment$CategoryDto$meta(
+                  key: kCategoryHiddenMetaKey,
+                  value: 'true',
+                ),
+            ],
           ),
-      ];
+    ];
+    // Downloads with no home tab (uncategorizedOf already covers orphaned
+    // memberships) get a synthetic Default.
+    final defaultCovered = tabs.any((t) => t.id == 0);
+    if (!defaultCovered && uncategorized.isNotEmpty) {
+      tabs.insert(0, offlineDefaultCategoryDto(uncategorized.length));
     }
-    return [offlineDefaultCategoryDto(count)];
+    if (tabs.isEmpty) {
+      return [offlineDefaultCategoryDto(downloadedInLibrary.length)];
+    }
+    return tabs;
   }
 
   Future<bool> canServe() async =>

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -192,10 +192,24 @@ class OfflineSync {
     await onSynced?.call();
   }
 
+  /// Full mirror, not an accumulate: categories deleted on the server must
+  /// stop haunting the offline tabs. Empty is ignored for the same reason as
+  /// [pruneRemovedLibraryManga] — a failed fetch must never wipe the mirror.
   Future<void> syncCategories(List<CategoryDto> categories) async {
-    for (final cat in categories) {
-      await _db.upsertCategory(cat.id, cat.name, cat.order);
-    }
+    if (categories.isEmpty) return;
+    // One transaction: overlapping syncs (fired unawaited on every category
+    // rebuild) must not interleave an old upsert after a newer prune.
+    await _db.transaction(() async {
+      for (final cat in categories) {
+        await _db.upsertCategory(
+          cat.id,
+          cat.name,
+          cat.order,
+          isHidden: cat.isHidden,
+        );
+      }
+      await _db.pruneRemovedCategories({for (final c in categories) c.id});
+    });
     await onSynced?.call();
   }
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1492,6 +1492,10 @@
     "@categoryTabs": {
         "description": "Library Group checkbox to show or hide the category tab bar in Tabs mode"
     },
+    "categoryVisibilityDeviceOnly": "Changed on this device only until you reconnect",
+    "@categoryVisibilityDeviceOnly": {
+        "description": "Toast when hiding or showing a category offline: the change lives on the device mirror and the server setting returns on the next online sync"
+    },
     "sectionHeadersShowAllCategories": "Show all categories",
     "@sectionHeadersShowAllCategories": {
         "description": "Library Group checkbox to scroll all sections together in Section headers mode"
@@ -2193,6 +2197,10 @@
     },
     "noCategoriesFound": "You don't have any Categories. \n(Tip: Tap the Plus button to create one for organizing your library)",
     "noCategoriesFoundAlt": "You don't have any Categories. \nCreate one in settings for organizing your library",
+    "needsServerConnection": "Needs a connection to the server",
+    "@needsServerConnection": {
+        "description": "Error toast when a server-stored setting is changed while the server is unreachable"
+    },
     "noCategoryMangaFound": "No manga found in this Category. \n(Tip: Check your search & filters!)",
     "noChaptersFound": "No Chapters found",
     "noDownloads": "No Downloads",

--- a/lib/src/utils/soft_clear_image_cache.dart
+++ b/lib/src/utils/soft_clear_image_cache.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/painting.dart';
+
+/// ImageCache whose [clear] evicts down to [floorBytes] instead of emptying.
+///
+/// Flutter answers every Android memory-pressure signal — including the one
+/// sent for plain backgrounding — by clearing the decoded-image cache to
+/// zero, so returning to the app re-decoded (and re-faded) every library
+/// cover. Coil keeps a working set on that signal and only empties when the
+/// app is queued to be killed. Keeping a floor is that behavior: an app
+/// switch stays warm, and a genuine low-memory event still frees everything
+/// above the floor.
+class SoftClearImageCache extends ImageCache {
+  SoftClearImageCache({required this.floorBytes});
+
+  final int floorBytes;
+
+  // Unlike a real clear, in-flight loads survive — deliberately: pending
+  // images are covers entering the screen right now, and cancelling them
+  // would only re-request the same bytes. Known cost: hot-reloaded asset
+  // edits can serve stale (dev-only, and everything here is network-fetched).
+  @override
+  void clear() {
+    final budget = maximumSizeBytes;
+    if (budget <= floorBytes) {
+      super.clear();
+      return;
+    }
+    // Shrinking the budget evicts LRU entries to fit; restoring it keeps
+    // the survivors.
+    maximumSizeBytes = floorBytes;
+    maximumSizeBytes = budget;
+  }
+}

--- a/lib/src/widgets/custom_circular_progress_indicator.dart
+++ b/lib/src/widgets/custom_circular_progress_indicator.dart
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 
@@ -22,6 +24,44 @@ class CenterSorayomiShimmerIndicator extends StatelessWidget {
           width: context.width * .35,
           child: const SorayomiShimmerIndicator(),
         ),
+      );
+}
+
+/// Stays invisible for [delay] so a fast resolve (a cached cover re-decoding)
+/// never flashes a loading state. Sized like the shimmer from the start so
+/// layout doesn't shift.
+class DelayedShimmer extends StatefulWidget {
+  const DelayedShimmer({super.key, this.delay = const Duration(milliseconds: 200)});
+
+  final Duration delay;
+
+  @override
+  State<DelayedShimmer> createState() => _DelayedShimmerState();
+}
+
+class _DelayedShimmerState extends State<DelayedShimmer> {
+  bool _visible = false;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer(widget.delay, () {
+      if (mounted) setState(() => _visible = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => AnimatedOpacity(
+        opacity: _visible ? 1 : 0,
+        duration: const Duration(milliseconds: 150),
+        child: const CenterSorayomiShimmerIndicator(),
       );
 }
 

--- a/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
+++ b/lib/src/widgets/manga_cover/grid/manga_cover_grid_tile.dart
@@ -333,13 +333,24 @@ class MangaCoverGridTile extends StatelessWidget {
               )
             : null,
       ),
-      child: ServerImage(
-        imageUrl: manga.thumbnailUrl ?? "",
-        // A freeform tile is only as tall as its cover, so a screen-relative
-        // shimmer would make the grid lurch once the art lands.
-        progressIndicatorBuilder: freeform
-            ? (context, url, progress) => const _FreeformCoverPlaceholder()
-            : null,
+      // Decode at tile size, not source size: full-res covers overflow
+      // Flutter's decoded-image budget after a few dozen tiles, so every tab
+      // switch re-decoded (and re-shimmered) the whole grid.
+      child: LayoutBuilder(
+        builder: (context, constraints) => ServerImage(
+          imageUrl: manga.thumbnailUrl ?? "",
+          memCacheWidth: constraints.hasBoundedWidth
+              ? (constraints.maxWidth *
+                      MediaQuery.devicePixelRatioOf(context))
+                  .round()
+                  .clamp(1, 1 << 16)
+              : null,
+          // A freeform tile is only as tall as its cover, so a screen-relative
+          // shimmer would make the grid lurch once the art lands.
+          progressIndicatorBuilder: freeform
+              ? (context, url, progress) => const _FreeformCoverPlaceholder()
+              : null,
+        ),
       ),
     );
     if (!freeform) return image;

--- a/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
+++ b/lib/src/widgets/manga_cover/list/manga_cover_list_tile.dart
@@ -65,6 +65,12 @@ class MangaCoverListTile extends StatelessWidget {
               borderRadius: KBorderRadius.r8.radius,
               child: ServerImage(
                 imageUrl: manga.thumbnailUrl ?? "",
+                // Decode at display size — see the grid tile.
+                memCacheWidth: (kCompactCoverWidth *
+                        scale *
+                        MediaQuery.devicePixelRatioOf(context))
+                    .round()
+                    .clamp(1, 1 << 16),
                 size: Size(
                   kCompactCoverWidth * scale,
                   mangaCoverBoxHeight(kCompactCoverWidth * scale,

--- a/lib/src/widgets/server_image.dart
+++ b/lib/src/widgets/server_image.dart
@@ -297,12 +297,18 @@ class ServerImage extends HookConsumerWidget {
       renderMethod = ImageRenderMethodForWeb.HtmlImage;
     }
 
+    // Covers re-decode from disk within a few frames after any cache clear
+    // (tab switch under pressure, background trim). Delaying the shimmer
+    // hides those near-instant reloads while real network loads still show one.
+    final defaultIndicator = isCoverImagePath(imageUrl)
+        ? const DelayedShimmer()
+        : const CenterSorayomiShimmerIndicator();
     finalProgressIndicatorBuilder(
             BuildContext context, String url, DownloadProgress progress) =>
         AppUtils.wrapOn(
           wrapper,
           progressIndicatorBuilder?.call(context, url, progress) ??
-              const CenterSorayomiShimmerIndicator(),
+              defaultIndicator,
         );
 
     Widget errorWidget(BuildContext context, String error, stackTrace) {
@@ -397,6 +403,10 @@ class ServerImage extends HookConsumerWidget {
       httpHeaders: httpHeaders,
       width: size?.width,
       fit: fit ?? BoxFit.cover,
+      // Package defaults linger the placeholder a full second after the image
+      // is ready.
+      fadeOutDuration: const Duration(milliseconds: 150),
+      fadeInDuration: const Duration(milliseconds: 150),
       memCacheWidth: imageBuilder == null ? cacheWidth : null,
       memCacheHeight: imageBuilder == null ? cacheHeight : null,
       imageRenderMethodForWeb: renderMethod,

--- a/test/src/features/offline/data/offline_category_mirror_test.dart
+++ b/test/src/features/offline/data/offline_category_mirror_test.dart
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/library/domain/category/category_model.dart';
+import 'package:tsumiru/src/features/library/domain/category/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_read_fallback.dart';
+import 'package:tsumiru/src/features/offline/data/offline_sync.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+CategoryDto cat(int id, String name, {int order = 0, bool hidden = false}) =>
+    Fragment$CategoryDto(
+      defaultCategory: id == 0,
+      id: id,
+      includeInDownload: Enum$IncludeOrExclude.UNSET,
+      includeInUpdate: Enum$IncludeOrExclude.UNSET,
+      name: name,
+      order: order,
+      mangas: Fragment$CategoryDto$mangas(totalCount: 0),
+      meta: [
+        if (hidden)
+          Fragment$CategoryDto$meta(
+            key: kCategoryHiddenMetaKey,
+            value: 'true',
+          ),
+      ],
+    );
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seedDownloadedManga(int mangaId, List<int> categories) async {
+    await db.upsertMangaMetadata(
+      id: mangaId,
+      title: 'M$mangaId',
+      updatedAt: DateTime(2026),
+    );
+    await db.replaceMangaCategories(mangaId, categories);
+    await db.upsertChapterMetadata(
+      id: 100 + mangaId,
+      mangaId: mangaId,
+      name: 'c',
+      chapterIndex: 1,
+      isRead: false,
+      lastPageRead: 0,
+      isBookmarked: false,
+      serverIsDownloaded: true,
+      pageCount: 1,
+      updatedAt: DateTime(2026),
+    );
+    await db.setChapterDeviceState(
+      100 + mangaId,
+      OfflineDeviceState.downloaded,
+      bytes: 1,
+    );
+  }
+
+  group('syncCategories', () {
+    test('prunes categories the server no longer has', () async {
+      final sync = OfflineSync(db);
+      await sync.syncCategories([cat(1, 'A'), cat(2, 'B')]);
+      await seedDownloadedManga(10, [2]);
+
+      await sync.syncCategories([cat(1, 'A')]);
+
+      final stored = await db.allOfflineCategories();
+      expect(stored.map((c) => c.id), [1]);
+      // Membership rows of the pruned category go with it.
+      expect(await db.categoriesForManga(10), isEmpty);
+    });
+
+    test('an empty server list never wipes the mirror', () async {
+      final sync = OfflineSync(db);
+      await sync.syncCategories([cat(1, 'A')]);
+
+      await sync.syncCategories(const []);
+
+      expect((await db.allOfflineCategories()).length, 1);
+    });
+
+    test('mirrors the hidden flag both ways', () async {
+      final sync = OfflineSync(db);
+      await sync.syncCategories([cat(1, 'A', hidden: true)]);
+      expect((await db.allOfflineCategories()).single.isHidden, isTrue);
+
+      await sync.syncCategories([cat(1, 'A')]);
+      expect((await db.allOfflineCategories()).single.isHidden, isFalse);
+    });
+
+    test('a device-local visibility flip yields to the server on re-sync',
+        () async {
+      final sync = OfflineSync(db);
+      await sync.syncCategories([cat(1, 'A', hidden: true)]);
+
+      // Offline unhide: the mirror flips so downloads stay reachable...
+      await db.setCategoryHidden(1, false);
+      expect((await db.allOfflineCategories()).single.isHidden, isFalse);
+
+      // ...and the server's flag reasserts on the next online sync.
+      await sync.syncCategories([cat(1, 'A', hidden: true)]);
+      expect((await db.allOfflineCategories()).single.isHidden, isTrue);
+    });
+  });
+
+  group('categoriesWithOfflineFallback catalog serve', () {
+    Future<Never> boom() async => throw const SocketException('unreachable');
+
+    test(
+        'serves per-category counts, keeps hidden meta, drops empty tabs, '
+        'and homes uncategorized manga in Default', () async {
+      final sync = OfflineSync(db);
+      await sync.syncCategories([
+        cat(1, 'Visible', order: 1),
+        cat(2, 'Empty', order: 2),
+        cat(3, 'Hidden', order: 3, hidden: true),
+      ]);
+      await seedDownloadedManga(10, [1]);
+      await seedDownloadedManga(11, [3]);
+      await seedDownloadedManga(12, []); // default category only
+
+      final tabs = await categoriesWithOfflineFallback(
+        fetch: boom,
+        db: db,
+        offlineEnabled: true,
+      );
+
+      expect(tabs, isNotNull);
+      final byId = {for (final t in tabs!) t.id: t};
+      // Default synthesized for the uncategorized download.
+      expect(byId[0]?.mangas.totalCount, 1);
+      expect(byId[1]?.mangas.totalCount, 1);
+      // No downloaded manga -> no tab, same as nonZeroCategoryList online.
+      expect(byId.containsKey(2), isFalse);
+      // Hidden flag survives the round trip into the synthetic DTO.
+      expect(byId[3]?.isHidden, isTrue);
+    });
+
+    test(
+        'orphaned membership rows (category never mirrored or pruned '
+        'mid-state) still count their manga into Default', () async {
+      final sync = OfflineSync(db);
+      await sync.syncCategories([cat(1, 'A')]);
+      await seedDownloadedManga(10, [1]);
+      // Membership points at a category the mirror has never stored.
+      await seedDownloadedManga(11, [99]);
+
+      final tabs = await categoriesWithOfflineFallback(
+        fetch: boom,
+        db: db,
+        offlineEnabled: true,
+      );
+
+      final byId = {for (final t in tabs!) t.id: t};
+      // The mapper's inner join drops the orphan membership, so the manga
+      // renders under Default -- the count must agree.
+      expect(byId[0]?.mangas.totalCount, 1);
+      expect(byId[1]?.mangas.totalCount, 1);
+    });
+
+    test('deleted category stops appearing offline after a re-sync', () async {
+      final sync = OfflineSync(db);
+      await sync.syncCategories([cat(1, 'A'), cat(2, 'Doomed')]);
+      await seedDownloadedManga(10, [1]);
+      await seedDownloadedManga(11, [2]);
+
+      // Server deleted category 2; next online category load re-syncs.
+      await sync.syncCategories([cat(1, 'A')]);
+
+      final tabs = await categoriesWithOfflineFallback(
+        fetch: boom,
+        db: db,
+        offlineEnabled: true,
+      );
+      expect(tabs!.map((t) => t.id), isNot(contains(2)));
+      // Its manga did not vanish -- it re-homes into Default.
+      expect(tabs.firstWhere((t) => t.id == 0).mangas.totalCount, 1);
+    });
+  });
+}

--- a/test/src/features/offline/data/offline_chapter_number_schema_test.dart
+++ b/test/src/features/offline/data/offline_chapter_number_schema_test.dart
@@ -74,7 +74,7 @@ void main() {
     });
     tearDown(() => tmp.delete(recursive: true));
 
-    test('adds the columns, preserves rows, lands on version 13', () async {
+    test('adds the columns, preserves rows, lands on version 14', () async {
       final dbPath = p.join(tmp.path, 'test.db');
 
       // Build a genuine v8 file: the chapters table WITHOUT the new columns,
@@ -148,7 +148,12 @@ void main() {
           .customSelect('PRAGMA user_version')
           .getSingle()
           .then((r) => r.read<int>('user_version'));
-      expect(version, 13);
+      expect(version, 14);
+      // v14 must create both category tables on an upgrade from before they
+      // existed — onCreate only runs for fresh files.
+      await db.upsertCategory(1, 'A', 0, isHidden: false);
+      await db.replaceMangaCategories(1, [1]);
+      expect((await db.categoriesForManga(1)).single.name, 'A');
       await db.close();
     });
   });

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -16,8 +16,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 13', () {
-    expect(db.schemaVersion, 13);
+  test('opens at schema version 14', () {
+    expect(db.schemaVersion, 14);
   });
 
   test('inserts and reads a manga', () async {

--- a/test/src/features/offline/data/offline_dto_mappers_test.dart
+++ b/test/src/features/offline/data/offline_dto_mappers_test.dart
@@ -106,8 +106,8 @@ void main() {
 
   test('full metadata survives upsert → read', () async {
     // Arrange – persist categories first (FK-free but order matters semantically)
-    await db.upsertCategory(2, 'Action', 0);
-    await db.upsertCategory(5, 'Romance', 1);
+    await db.upsertCategory(2, 'Action', 0, isHidden: false);
+    await db.upsertCategory(5, 'Romance', 1, isHidden: false);
 
     // Persist a manga with all new fields
     await db.upsertMangaMetadata(
@@ -170,8 +170,8 @@ void main() {
   });
 
   test('allOfflineCategories returns persisted categories', () async {
-    await db.upsertCategory(1, 'Shonen', 0);
-    await db.upsertCategory(2, 'Seinen', 1);
+    await db.upsertCategory(1, 'Shonen', 0, isHidden: false);
+    await db.upsertCategory(2, 'Seinen', 1, isHidden: false);
     final all = await db.allOfflineCategories();
     expect(all.map((c) => c.id).toSet(), {1, 2});
   });

--- a/test/src/features/offline/data/offline_fallback_bounded_fetch_test.dart
+++ b/test/src/features/offline/data/offline_fallback_bounded_fetch_test.dart
@@ -26,7 +26,7 @@ void main() {
 
   Future<void> seedCatalog() async {
     await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
-    await db.upsertCategory(3, 'Shelf', 0);
+    await db.upsertCategory(3, 'Shelf', 0, isHidden: false);
     await db.replaceMangaCategories(1, [3]);
     // The offline library only lists series with files on this device.
     await db.upsertChapterMetadata(

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 13', () {
-    expect(db.schemaVersion, 13);
+  test('opens at schema version 14', () {
+    expect(db.schemaVersion, 14);
   });
 
   test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',

--- a/test/src/utils/network/graphql_errors_test.dart
+++ b/test/src/utils/network/graphql_errors_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:http/http.dart' as http;
+import 'package:tsumiru/src/utils/extensions/custom_extensions.dart';
 import 'package:tsumiru/src/utils/network/graphql_errors.dart';
 
 void main() {
@@ -28,6 +29,29 @@ void main() {
       final e = OperationException(
           graphqlErrors: const [GraphQLError(message: 'Unauthorized')]);
       expect(isConnectionError(e), isFalse);
+    });
+
+    // The repository layer throws OperationMessageException AROUND the
+    // OperationException — the shape every UI mutation actually sees.
+    // isConnectionError does not see through it (importing the wrapper here
+    // would cycle), so call sites MUST unwrap first; this pair pins both
+    // halves of that contract.
+    test('wrapped OperationMessageException is NOT recognized directly', () {
+      final wrapped = OperationMessageException(OperationException(
+          linkException: ServerException(
+              originalException: const SocketException('down'),
+              parsedResponse: null)));
+      expect(isConnectionError(wrapped), isFalse);
+    });
+    test('call-site unwrap of OperationMessageException classifies right', () {
+      final Object wrapped = OperationMessageException(OperationException(
+          linkException: ServerException(
+              originalException: const SocketException('down'),
+              parsedResponse: null)));
+      final cause = wrapped is OperationMessageException
+          ? wrapped.exception
+          : wrapped;
+      expect(isConnectionError(cause), isTrue);
     });
   });
 

--- a/test/src/utils/soft_clear_image_cache_test.dart
+++ b/test/src/utils/soft_clear_image_cache_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/utils/soft_clear_image_cache.dart';
+
+Future<ui.Image> _decodeOnePixel() {
+  final recorder = ui.PictureRecorder();
+  ui.Canvas(recorder).drawRect(
+    const ui.Rect.fromLTWH(0, 0, 1, 1),
+    ui.Paint()..color = const ui.Color(0xFF000000),
+  );
+  return recorder.endRecording().toImage(1, 1);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> put(ImageCache cache, int key, ui.Image image) async {
+    final completer = OneFrameImageStreamCompleter(
+      Future.value(ImageInfo(image: image.clone())),
+    );
+    cache.putIfAbsent(key, () => completer);
+    // Let the completer's future deliver so the entry lands in the cache.
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  test('clear keeps the newest entries down to the floor', () async {
+    final image = await _decodeOnePixel();
+    final perImage = image.height * image.width * 4;
+    final cache = SoftClearImageCache(floorBytes: perImage * 2)
+      ..maximumSizeBytes = perImage * 10;
+    for (var key = 0; key < 4; key++) {
+      await put(cache, key, image);
+    }
+    expect(cache.currentSize, 4);
+
+    cache.clear();
+
+    // Floor holds the two most recent; budget is restored for new decodes.
+    expect(cache.currentSize, 2);
+    expect(cache.containsKey(3), isTrue);
+    expect(cache.containsKey(2), isTrue);
+    expect(cache.maximumSizeBytes, perImage * 10);
+  });
+
+  test('clear empties fully when the budget is at or below the floor',
+      () async {
+    final image = await _decodeOnePixel();
+    final perImage = image.height * image.width * 4;
+    final cache = SoftClearImageCache(floorBytes: perImage * 10)
+      ..maximumSizeBytes = perImage * 4;
+    await put(cache, 1, image);
+    expect(cache.currentSize, 1);
+
+    cache.clear();
+
+    expect(cache.currentSize, 0);
+  });
+}


### PR DESCRIPTION
Closes #327
Closes #328

Three user reports, one subsystem.

**Offline categories (#327).** The offline category mirror was upsert-only — no code path anywhere removed a category, so server-side deletions haunted the offline tabs forever. `syncCategories` is now a true mirror: it prunes categories absent from the server's list (guarded against empty fetches so a failed load can't wipe the mirror, transactional so overlapping syncs can't interleave an old upsert after a newer prune), and it carries the `tsumiru.hidden` meta into a new `isHidden` column (schema v14, with a create-table guard for databases predating the category tables — `onCreate` only runs for fresh files). The offline tab list now shows real per-category counts instead of the grand total everywhere, drops empty categories the way `nonZeroCategoryList` does online, and re-homes uncategorized or orphan-membership downloads into Default so nothing becomes unreachable.

**Offline visibility (#327).** Hiding/unhiding a category is a server-meta write that used to fail silently offline and snap back. It now lands on the device's mirror instead, with a toast saying the change lives on this device until reconnect — downloads in a hidden category must stay reachable offline — and the server's flag reasserts on the next online sync. Category deletion stays server-only and reports honestly when it needs a connection. One trap this surfaced, now pinned by a test: repository-layer errors arrive wrapped in `OperationMessageException`, and `isConnectionError` does not see through the wrapper — call sites must unwrap first (centralizing the unwrap would create an import cycle).

**Covers (#328).** Library covers decoded at source resolution, so a few dozen filled the decoded-image budget and every tab switch re-decoded (and re-shimmered) the grid even with all bytes on disk. Covers now decode at tile size, and the budget rises to 256 MB. Backgrounding was the worse half: Flutter answers Android's memory-trim signal — sent for plain backgrounding — by clearing the decoded-image cache to zero, where Coil keeps a working set and only empties when the app is queued to die. A custom `ImageCache` now evicts to a 64 MB floor on that signal instead of emptying (in-flight loads deliberately survive; they're covers entering the screen). Perception fixes on top: the cover shimmer waits 200 ms before appearing so fast disk re-decodes show nothing at all, and the placeholder crossfade drops from the package's 1000/500 ms defaults to 150 ms.

Verified on device (Pixel 9 Pro, debug build): offline hide/unhide with the device-only toast, ghost-category pruning, and the backgrounding cycle with no cover fades. Cache behavior measured live via the VM service: ~310 KB per decoded cover with the cap active, budget registered. 1582 tests pass, including new coverage for the mirror semantics (prune, empty-guard, hidden round-trip, per-tab counts, orphan re-homing, yield-to-server), the soft-clear floor, and the wrapped-error contract.