### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 1.1.1+47
+version: 1.1.2+48
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
Version 1.1.2+48. One PR since v1.1.1: the offline category mirror fixes and cover decode/animation work (#329).