### PR TITLE
Fall back to offline for gateway errors, and offer View offline on every library failure

### DIFF
--- a/lib/src/features/offline/data/offline_background_downloads.dart
+++ b/lib/src/features/offline/data/offline_background_downloads.dart
@@ -23,6 +23,7 @@ import 'offline_database.dart';
 import 'offline_download_coordinator.dart';
 import 'offline_download_providers.dart';
 import 'offline_repository.dart';
+import 'server_reachability.dart';
 import 'offline_settings_providers.dart';
 
 part 'offline_background_downloads.g.dart';
@@ -98,6 +99,12 @@ OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
     measureChapterBytes: store.chapterBytes,
     persistedPaused: () =>
         prefs.getBool(DBKeys.offlineDownloadsPaused.name) ?? false,
+    // Deferred: the pump can hit this mid-provider-build.
+    onServerUnreachable: () => Future(() {
+      try {
+        ref.read(serverUnreachableProvider.notifier).set(true);
+      } catch (_) {}
+    }),
   );
 }
 

--- a/lib/src/features/offline/data/offline_download_coordinator.dart
+++ b/lib/src/features/offline/data/offline_download_coordinator.dart
@@ -30,12 +30,19 @@ class OfflineDownloadCoordinator {
     required this.engine,
     required this.measureChapterBytes,
     this.persistedPaused,
+    this.onServerUnreachable,
   });
 
   final OfflineDatabase db;
   final PageUrlsResolver resolvePages;
   final ChapterDownloadEngine engine;
   final ChapterBytesMeasurer measureChapterBytes;
+
+  /// Reports "the server is unreachable" upward when a resolve fails on a
+  /// connection error. Without it the pump can park during a background-only
+  /// outage that no UI read ever notices, and the reconnect listener (which
+  /// needs a true->false transition) would never fire to unpark it.
+  void Function()? onServerUnreachable;
 
   /// Reads the persisted "downloads paused" flag (injected so a restart
   /// survives with the pause intact, without depending on SharedPreferences
@@ -265,7 +272,12 @@ class OfflineDownloadCoordinator {
       final cause = e is OperationMessageException ? e.exception : e;
       if (isConnectionError(cause)) {
         // Page-list resolve hit a dead network, not a real chapter failure:
-        // leave it downloading so the next pump resumes it (Android worker parity).
+        // leave it downloading so the next pump resumes it (Android worker
+        // parity). Park the pump too — a proxy answering 502 fails in
+        // milliseconds, and re-picking the same row would hot-loop for the
+        // whole outage.
+        _pausedForOffline = true;
+        onServerUnreachable?.call();
         logger.i('Offline: chapter ${chapter.id} paused (resolve offline); '
             'leaving downloading for resume');
       } else {

--- a/lib/src/features/offline/presentation/server_unreachable_banner.dart
+++ b/lib/src/features/offline/presentation/server_unreachable_banner.dart
@@ -9,6 +9,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../routes/router_config.dart';
 import '../../../utils/extensions/custom_extensions.dart';
+import '../../library/presentation/category/controller/edit_category_controller.dart';
+import '../data/offline_repository.dart';
 import '../data/server_reachability.dart';
 
 /// Inline banner shown in the library while the server can't be reached.
@@ -32,6 +34,16 @@ class ServerUnreachableBanner extends ConsumerWidget {
         TextButton(
           onPressed: () => const ConnectionRoute().push(context),
           child: Text(context.l10n.serverUnreachableAction),
+        ),
+        TextButton(
+          // Same contract as the library's refresh gestures: drop both pins,
+          // then genuinely re-ask the server.
+          onPressed: () {
+            ref.read(viewOfflineNowProvider.notifier).set(false);
+            ref.read(serverUnreachableProvider.notifier).set(false);
+            ref.invalidate(categoryControllerProvider);
+          },
+          child: Text(context.l10n.refresh),
         ),
       ],
     );

--- a/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
@@ -45,9 +45,10 @@ extension AsyncValueExtensions<T> on AsyncValue<T> {
     // true to keep the previous data on screen.
     bool skipLoadingOnReload = false,
     Widget? loadingWidget,
-    // Offer "View offline" on the unreachable view. Only for screens that
-    // actually honor the offline pin (the library) — elsewhere the button
-    // would flip a switch this screen ignores.
+    // Offer "View offline" on every failure view, unreachable or not — the
+    // error stays on screen, the pin is the user's bypass. Only for screens
+    // that actually honor the offline pin (the library) — elsewhere the
+    // button would flip a switch this screen ignores.
     bool offlineEscapeHatch = false,
   }) {
     if (addScaffoldWrapper) {
@@ -75,12 +76,27 @@ extension AsyncValueExtensions<T> on AsyncValue<T> {
               title: showGenericError
                   ? context.l10n.errorSomethingWentWrong
                   : error.toString(),
-              button: refresh != null
-                  ? TextButton(
-                      onPressed: refresh,
-                      child: Text(context.l10n.refresh),
-                    )
-                  : null,
+              // Null when there's nothing to show — an empty Column still
+              // costs Emoticons' spacing slot. The pin self-gates on the
+              // catalog (no ref here); its shrunk state trails the column,
+              // where the dead spacing lands below the last visible button.
+              // Accepted edge: hatch set, no refresh, no catalog reserves one
+              // phantom slot — no current caller hits it (the library always
+              // passes refresh).
+              button: (refresh == null && !offlineEscapeHatch)
+                  ? null
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      spacing: 8,
+                      children: [
+                        if (refresh != null)
+                          TextButton(
+                            onPressed: refresh,
+                            child: Text(context.l10n.refresh),
+                          ),
+                        if (offlineEscapeHatch) const ViewOfflineButton(),
+                      ],
+                    ),
             ));
       },
       loading: () => AppUtils.wrapOn(

--- a/lib/src/utils/network/graphql_errors.dart
+++ b/lib/src/utils/network/graphql_errors.dart
@@ -33,13 +33,26 @@ Map<String, dynamic>? tsumiruHttpResponseDecoder(http.Response response) {
   }
 }
 
-/// True only when the request never reached a responding server (no
-/// connectivity) — the one case where falling back to the offline cache is
-/// right. A server that answered with an error (500/parse/auth) is not this.
+/// True only when the request never reached the Suwayomi server — the one
+/// case where falling back to the offline cache is right. The server itself
+/// answering with an error (500/parse/auth) is not this, but a reverse proxy
+/// answering FOR an unreachable upstream (502/503/504) is: the user's server
+/// is down, only the middleman is talking.
 bool isConnectionError(Object error) {
   if (error is OperationException) {
     final link = error.linkException;
+    if (link is HttpLinkServerException &&
+        _isGatewayStatus(link.response.statusCode)) {
+      // A gateway status is the middleman speaking for a dead origin even
+      // when its body happens to parse (some balancers emit JSON errors).
+      return true;
+    }
     if (link is ServerException && link.parsedResponse == null) {
+      return _isSocketLike(link.originalException);
+    }
+    // A response-decoder throw (our ServerNotJsonException) arrives wrapped
+    // in the PARSER exception, a sibling of ServerException — not inside it.
+    if (link is ResponseFormatException) {
       return _isSocketLike(link.originalException);
     }
     return false;
@@ -51,4 +64,12 @@ bool _isSocketLike(Object? e) =>
     e is SocketException ||
     e is TimeoutException ||
     e is HandshakeException ||
-    e is http.ClientException;
+    e is http.ClientException ||
+    (e is ServerNotJsonException && _isGatewayStatus(e.statusCode));
+
+// A proxy answering for a dead origin: 502/503/504, plus Cloudflare's
+// origin-down codes. 520/525/526 stay surfaced — the origin is alive but
+// misbehaving there, which the user must see to fix.
+bool _isGatewayStatus(int status) =>
+    status == 502 || status == 503 || status == 504 ||
+    (status >= 521 && status <= 524);

--- a/lib/src/widgets/server_unreachable_view.dart
+++ b/lib/src/widgets/server_unreachable_view.dart
@@ -33,9 +33,8 @@ class ServerUnreachableView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // The escape hatch belongs here as much as on the loading screen — a retry
-    // that fails lands on this view, and without it the user is stuck waiting
-    // out network windows with a perfectly good catalog on disk.
+    // Gated here, not inside the button: a shrunk child still costs the
+    // Column's spacing, doubling the gap between its neighbours.
     final hasCatalog =
         ref.watch(offlineCatalogAvailableProvider).value ?? false;
     return Emoticons(
@@ -51,17 +50,31 @@ class ServerUnreachableView extends ConsumerWidget {
             icon: const Icon(Icons.settings_ethernet_rounded),
             label: Text(context.l10n.serverUnreachableAction),
           ),
-          if (offlineEscape && hasCatalog)
-            TextButton.icon(
-              icon: const Icon(Icons.cloud_off_rounded),
-              label: Text(context.l10n.viewOffline),
-              onPressed: () =>
-                  ref.read(viewOfflineNowProvider.notifier).set(true),
-            ),
+          if (offlineEscape && hasCatalog) const ViewOfflineButton(),
           if (onRetry != null)
             TextButton(onPressed: onRetry, child: Text(context.l10n.refresh)),
         ],
       ),
+    );
+  }
+}
+
+/// The "View offline" pin. The error it accompanies stays visible — this is
+/// the user's bypass, never an automatic mask. Self-gates on the catalog for
+/// callers without a ref; ref-having parents should gate externally so a
+/// shrunk child doesn't eat Column spacing.
+class ViewOfflineButton extends ConsumerWidget {
+  const ViewOfflineButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final hasCatalog =
+        ref.watch(offlineCatalogAvailableProvider).value ?? false;
+    if (!hasCatalog) return const SizedBox.shrink();
+    return TextButton.icon(
+      icon: const Icon(Icons.cloud_off_rounded),
+      label: Text(context.l10n.viewOffline),
+      onPressed: () => ref.read(viewOfflineNowProvider.notifier).set(true),
     );
   }
 }

--- a/test/src/utils/async_value_connection_error_test.dart
+++ b/test/src/utils/async_value_connection_error_test.dart
@@ -10,11 +10,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:http/http.dart' as http;
+import 'package:tsumiru/src/utils/network/graphql_errors.dart';
 import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
 import 'package:tsumiru/src/utils/extensions/custom_extensions.dart';
 import 'package:tsumiru/src/widgets/server_unreachable_view.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
 
-Widget _host(AsyncValue<int> async, {VoidCallback? refresh}) => ProviderScope(
+Widget _host(AsyncValue<int> async,
+        {VoidCallback? refresh,
+        bool escapeHatch = false,
+        bool catalogAvailable = false}) =>
+    ProviderScope(
+    overrides: [
+      offlineCatalogAvailableProvider
+          .overrideWith((ref) async => catalogAvailable),
+    ],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -22,7 +33,7 @@ Widget _host(AsyncValue<int> async, {VoidCallback? refresh}) => ProviderScope(
         body: Builder(
           builder: (context) =>
               async.showUiWhenData(context, (d) => Text('data $d'),
-                  refresh: refresh),
+                  refresh: refresh, offlineEscapeHatch: escapeHatch),
         ),
       ),
     ));
@@ -59,5 +70,55 @@ void main() {
 
     expect(find.byType(ServerUnreachableView), findsNothing);
     expect(find.text('boom'), findsOneWidget);
+  });
+
+  // The live 3:03 failure, end to end: proxy answers 502 HTML for a dead
+  // upstream -> parser wraps the decoder throw -> the app treats it as
+  // unreachable and offers the offline library.
+  testWidgets('a proxied 502 lands on the unreachable view with View offline',
+      (tester) async {
+    final e = OperationMessageException(OperationException(
+      linkException: HttpLinkParserException(
+        originalException: const ServerNotJsonException(502, '<html>'),
+        originalStackTrace: StackTrace.empty,
+        response: http.Response('<html>', 502),
+      ),
+    ));
+    await tester.pumpWidget(_host(
+      AsyncError<int>(e, StackTrace.current),
+      refresh: () {},
+      escapeHatch: true,
+      catalogAvailable: true,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ServerUnreachableView), findsOneWidget);
+    expect(find.text('View offline'), findsOneWidget);
+  });
+
+  // The error must stay on screen; the pin is a bypass, never a mask.
+  testWidgets(
+      'a generic error offers View offline when the screen honors the pin '
+      'and a catalog exists', (tester) async {
+    await tester.pumpWidget(_host(
+      AsyncError<int>('boom', StackTrace.current),
+      escapeHatch: true,
+      catalogAvailable: true,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('boom'), findsOneWidget);
+    expect(find.text('View offline'), findsOneWidget);
+  });
+
+  testWidgets('no View offline on a generic error without a catalog',
+      (tester) async {
+    await tester.pumpWidget(_host(
+      AsyncError<int>('boom', StackTrace.current),
+      escapeHatch: true,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('View offline'), findsNothing);
   });
 }

--- a/test/src/utils/network/graphql_errors_test.dart
+++ b/test/src/utils/network/graphql_errors_test.dart
@@ -18,6 +18,41 @@ void main() {
     test('a plain Exception is not (ambiguous -> surface)', () {
       expect(isConnectionError(Exception('boom')), isFalse);
     });
+    // A reverse proxy answering for a dead upstream is a connection loss:
+    // the user's server never spoke, only the middleman did. The decoder's
+    // throw arrives wrapped in the PARSER exception (gql_http_link wraps
+    // httpResponseDecoder throws in HttpLinkParserException, a SIBLING of
+    // ServerException) — pin the real chain: a fabricated ServerException
+    // wrapper made an earlier version of this pass while production failed.
+    test('gateway statuses through the real parser-exception chain fall back',
+        () {
+      for (final status in [502, 503, 504, 521, 524]) {
+        final e = OperationException(
+            linkException: HttpLinkParserException(
+                originalException: ServerNotJsonException(status, "<html>"),
+                originalStackTrace: StackTrace.empty,
+                response: http.Response('<html>', status)));
+        expect(isConnectionError(e), isTrue, reason: 'HTTP $status');
+      }
+    });
+    test('non-gateway error pages still surface (500, captive-portal 200)',
+        () {
+      for (final status in [500, 200, 520, 525]) {
+        final e = OperationException(
+            linkException: HttpLinkParserException(
+                originalException: ServerNotJsonException(status, "<html>"),
+                originalStackTrace: StackTrace.empty,
+                response: http.Response('<html>', status)));
+        expect(isConnectionError(e), isFalse, reason: 'HTTP $status');
+      }
+    });
+    test('a gateway status with a JSON body still counts as unreachable', () {
+      final e = OperationException(
+          linkException: HttpLinkServerException(
+              response: http.Response('{"errors":[]}', 502),
+              parsedResponse: const Response(response: {}, errors: [])));
+      expect(isConnectionError(e), isTrue);
+    });
     test('ServerException wrapping a socket error (no parsed response) is', () {
       final e = OperationException(
           linkException: ServerException(


### PR DESCRIPTION
Closes #331

Found live during server maintenance: a reverse proxy answering 502 for the stopped server produced a raw error screen with no route to the on-device library, while airplane mode fell back correctly.

**Gateway answers are connection losses.** A proxy speaking for a dead origin (502/503/504, plus Cloudflare's origin-down 521-524) now routes to the offline fallback exactly like an unplugged network. The classifier distinguishes the middleman from the origin: a genuine 500 from Suwayomi, a captive portal's 200, and Cloudflare's origin-misbehaving codes (520/525+) still surface, because those need the user's attention, not masking. Balancers that emit parseable JSON error bodies on gateway statuses are classified by status, not body shape.

Getting the classification to actually fire took two attempts, and the failure mode is worth recording: the response decoder's throw arrives wrapped in the HTTP link's parser exception, a sibling of the server exception the first attempt checked - dead code that passed its tests because they pinned a hand-built chain. The tests now construct the exact production chain (verified against the link package's source), including an end-to-end widget test of the proxied-502 screenshot scenario.

**Every library failure offers the bypass.** Errors that rightly stay on screen now carry the View offline button whenever the device has a catalog - the error stays visible, the button is the user's escape hatch. The unreachable banner gained a Refresh action with the same contract as the library's refresh gestures (drop both offline pins, genuinely re-ask the server), so recovery after an outage is one tap on the banner that's already showing.

**The download pump respects outages.** A resolve failing on a connection error now parks the pump (a proxy 502 fails in milliseconds; re-picking the same chapter would hot-loop for the whole outage) and reports unreachability upward, so the existing reconnect listener can unpark it even when no UI read ever noticed the outage.

Verified live on device: server stopped behind the proxy -> library falls back to the offline catalog with the banner; server restarted -> banner's Refresh reconnects in one tap. 1588 tests pass.