### PR TITLE
Grey out Updates rows for a series you just read

### DIFF
--- a/lib/src/features/manga_book/domain/updates/updates_row_patch.dart
+++ b/lib/src/features/manga_book/domain/updates/updates_row_patch.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:math';
+
+import 'package:flutter/foundation.dart'; // debugPrint
+
+import '../chapter/chapter_model.dart';
+import '../chapter/graphql/__generated__/fragment.graphql.dart';
+
+/// A page holds 50 rows and a newly added series can be all of them, so this
+/// keeps a return from the reader from bursting 50 requests at a home server.
+const int kUpdatesRefreshBatchSize = 8;
+
+/// Fetches [ids] via [fetch], [batchSize] at a time. A failing fetch is dropped
+/// rather than fatal — one unreachable chapter must not sink the whole batch.
+Future<List<ChapterDto>> fetchChaptersInBatches({
+  required List<int> ids,
+  required Future<ChapterDto?> Function(int id) fetch,
+  int batchSize = kUpdatesRefreshBatchSize,
+}) async {
+  final fetched = <ChapterDto>[];
+  for (var start = 0; start < ids.length; start += batchSize) {
+    final batch = ids.sublist(start, min(start + batchSize, ids.length));
+    final results = await Future.wait([
+      for (final id in batch)
+        fetch(id).then<ChapterDto?>(
+          (c) => c,
+          // Failing soft keeps one bad chapter from costing the user the rest,
+          // but a swallowed error already hid a live bug here once, so say so.
+          onError: (Object e, StackTrace _) {
+            debugPrint('Updates row refresh failed for chapter $id: $e');
+            return null;
+          },
+        ),
+    ]);
+    fetched.addAll(results.nonNulls);
+  }
+  return fetched;
+}
+
+/// Rewrites [rows] for [mangaId] from [chapters]; rows the fetch doesn't cover
+/// keep what they had. Read state only moves forward — a lagging refetch must
+/// never flip an already-read row back to unread, which was the original bug.
+List<ChapterWithMangaDto> patchRowsForManga({
+  required List<ChapterWithMangaDto> rows,
+  required int mangaId,
+  required List<ChapterDto> chapters,
+}) {
+  final fresh = {
+    for (final chapter in chapters)
+      if (chapter.mangaId == mangaId) chapter.id: chapter,
+  };
+  final patched = <ChapterWithMangaDto>[];
+  for (final row in rows) {
+    final chapter = row.mangaId == mangaId ? fresh[row.id] : null;
+    patched.add(chapter == null
+        ? row
+        : row.copyWith(
+            isRead: chapter.isRead || row.isRead,
+            isBookmarked: chapter.isBookmarked,
+            isDownloaded: chapter.isDownloaded,
+            lastPageRead: chapter.lastPageRead,
+          ));
+  }
+  return patched;
+}

--- a/lib/src/features/manga_book/presentation/updates/updates_screen.dart
+++ b/lib/src/features/manga_book/presentation/updates/updates_screen.dart
@@ -18,6 +18,7 @@ import '../../../../widgets/emoticons.dart';
 import '../../data/updates/updates_repository.dart';
 import '../../domain/chapter/chapter_model.dart';
 import '../../domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import '../../domain/updates/updates_row_patch.dart';
 import '../../widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart';
 import '../../widgets/update_status_fab.dart';
 import '../../widgets/update_status_popup_menu.dart';
@@ -25,6 +26,18 @@ import '../reader/controller/reader_controller.dart';
 import 'controller/updates_filter_controller.dart';
 import 'widgets/chapter_manga_list_tile.dart';
 import 'widgets/updates_filter.dart';
+
+/// Refetches one chapter, holding its autoDispose provider open so a bare
+/// refresh with nothing listening can't tear it down mid-fetch and throw.
+Future<ChapterDto?> refetchChapter(WidgetRef ref, int chapterId) async {
+  final provider = chapterProvider(chapterId: chapterId);
+  final keepAlive = ref.listenManual(provider, (_, _) {});
+  try {
+    return await ref.refresh(provider.future);
+  } finally {
+    keepAlive.close();
+  }
+}
 
 class UpdatesScreen extends HookConsumerWidget {
   const UpdatesScreen({super.key});
@@ -73,6 +86,9 @@ class UpdatesScreen extends HookConsumerWidget {
     final controller = usePagingController<int, ChapterWithMangaDto>(
       firstPageKey: 0,
     );
+    // The item builder's context belongs to a row that recycles on scroll, so
+    // post-await guards ask this one whether the screen itself is still alive.
+    final screenContext = context;
     final updatesRepository = ref.watch(updatesRepositoryProvider);
     final isUpdatesChecking = ref
         .watch(updatesSocketProvider.select((value) => value.value?.isRunning))
@@ -234,9 +250,7 @@ class UpdatesScreen extends HookConsumerWidget {
                   final chapterTile = ChapterMangaListTile(
                     chapterWithMangaDto: item,
                     updatePair: () async {
-                      final chapter = await ref.refresh(
-                        chapterProvider(chapterId: item.id).future,
-                      );
+                      final chapter = await refetchChapter(ref, item.id);
                       // Locate the row by id, not the captured build-time index —
                       // the list may have changed (paging/refresh) while the reader
                       // was open, so an index-based patch could hit the wrong row.
@@ -252,6 +266,33 @@ class UpdatesScreen extends HookConsumerWidget {
                         lastPageRead: chapter?.lastPageRead,
                       );
                       controller.itemList = list;
+                    },
+                    refreshManga: () async {
+                      final mangaId = item.mangaId;
+                      final startGeneration = generation.value;
+                      final ids = [
+                        for (final row in [...?controller.itemList])
+                          if (row.mangaId == mangaId) row.id,
+                      ];
+                      // Per chapter rather than via mangaChapterList: refreshing
+                      // that one also runs the offline reconcile, and merely
+                      // coming back to this list must never delete a download.
+                      final chapters = await fetchChaptersInBatches(
+                        ids: ids,
+                        fetch: (id) => refetchChapter(ref, id),
+                      );
+                      // Same staleness rule as _fetchPage: a refresh or filter
+                      // change during the fetch leaves these rows describing a
+                      // list that no longer exists.
+                      if (!screenContext.mounted ||
+                          generation.value != startGeneration) {
+                        return;
+                      }
+                      controller.itemList = patchRowsForManga(
+                        rows: [...?controller.itemList],
+                        mangaId: mangaId,
+                        chapters: chapters,
+                      );
                     },
                     isSelected: selectedChapters.value.containsKey(item.id),
                     canTapSelect: selectedChapters.value.isNotEmpty,

--- a/lib/src/features/manga_book/presentation/updates/widgets/chapter_manga_list_tile.dart
+++ b/lib/src/features/manga_book/presentation/updates/widgets/chapter_manga_list_tile.dart
@@ -20,12 +20,14 @@ class ChapterMangaListTile extends StatelessWidget {
     super.key,
     required this.chapterWithMangaDto,
     required this.updatePair,
+    required this.refreshManga,
     required this.toggleSelect,
     this.canTapSelect = false,
     this.isSelected = false,
   });
   final ChapterWithMangaDto chapterWithMangaDto;
   final AsyncCallback updatePair;
+  final AsyncCallback refreshManga;
   final ValueChanged<ChapterWithMangaDto> toggleSelect;
   final bool canTapSelect;
   final bool isSelected;
@@ -50,11 +52,11 @@ class ChapterMangaListTile extends StatelessWidget {
               chapterId: chapterWithMangaDto.id,
               showReaderLayoutAnimation: true,
             ).push(context);
-            // Refresh this row on return so a chapter read in the reader greys
-            // out here (its read state, download, and progress are re-fetched).
-            // Guard mounted: the user may have left Updates while reading.
+            // Refresh the whole series on return, not just this row — the
+            // reader walks on into the next chapters, and those have rows here
+            // too. Guard mounted: the user may have left Updates while reading.
             if (!context.mounted) return;
-            await updatePair();
+            await refreshManga();
           }
         },
         onLongPress: () => toggleSelect(chapterWithMangaDto),
@@ -67,7 +69,19 @@ class ChapterMangaListTile extends StatelessWidget {
                 ClipRRect(
                   borderRadius: KBorderRadius.r8.radius,
                   child: InkWell(
-                    onTap: () => MangaRoute(mangaId: manga.id).push(context),
+                    onTap: () async {
+                      // The cover sits inside the row, so it has to honour
+                      // multi-select too or it navigates away mid-selection.
+                      if (canTapSelect) {
+                        toggleSelect(chapterWithMangaDto);
+                        return;
+                      }
+                      await MangaRoute(mangaId: manga.id).push(context);
+                      if (!context.mounted) return;
+                      // Chapters get read on the details page too, so this row
+                      // is stale the moment we come back.
+                      await refreshManga();
+                    },
                     child: ServerImage(
                       imageUrl: manga.thumbnailUrl ?? "",
                       size: const Size(56, 80),

--- a/test/src/features/manga_book/updates_row_refresh_offline_test.dart
+++ b/test/src/features/manga_book/updates_row_refresh_offline_test.dart
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Follow-up to #308, an offline bug, so these drive the real on-device catalog
+// through the real offline fallback rather than a mock.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/updates/updates_row_patch.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_read_fallback.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+
+import '../../../helpers/offline_test_db.dart';
+
+const _kMangaId = 7;
+
+/// Stands in for the server being unreachable.
+class _OfflineRepo extends MangaBookRepository {
+  _OfflineRepo()
+      : super(GraphQLClient(
+          link: HttpLink('http://localhost:0'),
+          cache: GraphQLCache(),
+        ));
+
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async =>
+      throw Exception('connection refused');
+}
+
+ChapterWithMangaDto _row({required int id, bool isRead = false}) =>
+    Fragment$ChapterWithMangaDto(
+      id: id,
+      chapterNumber: id.toDouble(),
+      fetchedAt: '0',
+      isBookmarked: false,
+      isDownloaded: true,
+      isRead: isRead,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: _kMangaId,
+      name: 'Chapter $id',
+      pageCount: 10,
+      sourceOrder: id,
+      uploadDate: '0',
+      url: '/c/$id',
+      meta: const [],
+      manga: Fragment$MangaBaseDto(
+        id: _kMangaId,
+        genre: const [],
+        inLibrary: true,
+        inLibraryAt: '0',
+        initialized: true,
+        meta: const [],
+        sourceId: '1',
+        status: Enum$MangaStatus.ONGOING,
+        thumbnailUrl: '/thumb',
+        title: 'Series',
+        unreadCount: 2,
+        updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+        url: '/manga/$_kMangaId',
+      ),
+    );
+
+Future<void> _putChapter(
+  OfflineDatabase db, {
+  required int id,
+  bool isRead = false,
+}) =>
+    db.upsertChapterMetadata(
+      id: id,
+      mangaId: _kMangaId,
+      name: 'Chapter $id',
+      chapterIndex: id,
+      isRead: isRead,
+      lastPageRead: 0,
+      isBookmarked: false,
+      serverIsDownloaded: true,
+      pageCount: 10,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(0),
+    );
+
+/// What the Updates screen does on return, with the server down.
+Future<List<ChapterDto>> _refreshOffline(
+  OfflineDatabase db,
+  List<int> ids,
+) =>
+    fetchChaptersInBatches(
+      ids: ids,
+      fetch: (id) => chapterMetaWithOfflineFallback(
+        fetch: () async => throw Exception('connection refused'),
+        db: db,
+        offlineEnabled: true,
+        offlineFirst: true,
+        chapterId: id,
+      ),
+    );
+
+void main() {
+  group('Updates rows offline (#326 / #308 lineage)', () {
+    test('a chapter read with the server down greys its row', () async {
+      final db = testOfflineDatabase();
+      addTearDown(db.close);
+      await _putChapter(db, id: 1);
+      await _putChapter(db, id: 2);
+
+      // Read chapter 1 to the end, offline. This is the same call the reader
+      // makes; the server write fails and the on-device catalog carries it.
+      await recordReadingProgressWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: _OfflineRepo(),
+        chapterId: 1,
+        lastPageRead: 9,
+        isRead: true,
+      );
+
+      final chapters = await _refreshOffline(db, [1, 2]);
+      final rows = patchRowsForManga(
+        rows: [_row(id: 1), _row(id: 2)],
+        mangaId: _kMangaId,
+        chapters: chapters,
+      );
+
+      expect(rows.map((e) => e.isRead), [true, false]);
+    });
+
+    test('a chapter missing from the catalog does not hide the read one',
+        () async {
+      final db = testOfflineDatabase();
+      addTearDown(db.close);
+      await _putChapter(db, id: 1, isRead: true);
+
+      // Chapter 2 was never downloaded, so offline it cannot be resolved at
+      // all — it must not cost chapter 1 its refresh.
+      final chapters = await _refreshOffline(db, [1, 2]);
+      final rows = patchRowsForManga(
+        rows: [_row(id: 1), _row(id: 2)],
+        mangaId: _kMangaId,
+        chapters: chapters,
+      );
+
+      expect(rows.map((e) => e.isRead), [true, false]);
+    });
+  });
+}

--- a/test/src/features/manga_book/updates_row_refresh_test.dart
+++ b/test/src/features/manga_book/updates_row_refresh_test.dart
@@ -1,0 +1,342 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/updates/updates_row_patch.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/updates/updates_screen.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/updates/widgets/chapter_manga_list_tile.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+const _kMangaId = 7;
+
+final _watchedAfterAsyncGap = Provider<int>((ref) => 1);
+
+Fragment$MangaBaseDto _manga({int id = _kMangaId}) => Fragment$MangaBaseDto(
+      id: id,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: const [],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      thumbnailUrl: '/thumb/$id',
+      title: 'Series $id',
+      unreadCount: 3,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/$id',
+    );
+
+ChapterWithMangaDto _row({
+  required int id,
+  int mangaId = _kMangaId,
+  bool isRead = false,
+  bool isDownloaded = false,
+  int lastPageRead = 0,
+}) =>
+    Fragment$ChapterWithMangaDto(
+      id: id,
+      chapterNumber: id.toDouble(),
+      fetchedAt: '0',
+      isBookmarked: false,
+      isDownloaded: isDownloaded,
+      isRead: isRead,
+      lastPageRead: lastPageRead,
+      lastReadAt: '0',
+      mangaId: mangaId,
+      name: 'Chapter $id',
+      pageCount: 10,
+      sourceOrder: id,
+      uploadDate: '0',
+      url: '/c/$id',
+      meta: const [],
+      manga: _manga(id: mangaId),
+    );
+
+ChapterDto _fresh({
+  required int id,
+  int mangaId = _kMangaId,
+  bool isRead = false,
+  bool isBookmarked = false,
+  bool isDownloaded = false,
+  int lastPageRead = 0,
+}) =>
+    Fragment$ChapterDto(
+      id: id,
+      chapterNumber: id.toDouble(),
+      fetchedAt: '0',
+      isBookmarked: isBookmarked,
+      isDownloaded: isDownloaded,
+      isRead: isRead,
+      lastPageRead: lastPageRead,
+      lastReadAt: '0',
+      mangaId: mangaId,
+      name: 'Chapter $id',
+      pageCount: 10,
+      sourceOrder: id,
+      uploadDate: '0',
+      url: '/c/$id',
+      meta: const [],
+    );
+
+void main() {
+  group('patchRowsForManga', () {
+    test('greys out every chapter of the series that was read', () {
+      final rows = [_row(id: 1), _row(id: 2), _row(id: 3)];
+
+      final patched = patchRowsForManga(
+        rows: rows,
+        mangaId: _kMangaId,
+        chapters: [
+          _fresh(id: 1, isRead: true),
+          _fresh(id: 2, isRead: true),
+          _fresh(id: 3),
+        ],
+      );
+
+      expect(patched.map((e) => e.isRead), [true, true, false]);
+    });
+
+    test('leaves other series alone', () {
+      final rows = [_row(id: 1), _row(id: 9, mangaId: 99)];
+
+      final patched = patchRowsForManga(
+        rows: rows,
+        mangaId: _kMangaId,
+        chapters: [_fresh(id: 1, isRead: true), _fresh(id: 9, isRead: true)],
+      );
+
+      expect(patched[1].isRead, isFalse);
+    });
+
+    test('keeps rows the refreshed list no longer covers', () {
+      final rows = [_row(id: 1, isRead: true, lastPageRead: 5)];
+
+      final patched = patchRowsForManga(
+        rows: rows,
+        mangaId: _kMangaId,
+        chapters: [_fresh(id: 2)],
+      );
+
+      expect(patched.single.isRead, isTrue);
+      expect(patched.single.lastPageRead, 5);
+    });
+
+    test('carries download state and progress across', () {
+      final patched = patchRowsForManga(
+        rows: [_row(id: 1)],
+        mangaId: _kMangaId,
+        chapters: [_fresh(id: 1, isDownloaded: true, lastPageRead: 12)],
+      );
+
+      expect(patched.single.isDownloaded, isTrue);
+      expect(patched.single.lastPageRead, 12);
+    });
+
+    test('a lagging refetch cannot un-read a row', () {
+      final patched = patchRowsForManga(
+        rows: [_row(id: 1, isRead: true)],
+        mangaId: _kMangaId,
+        chapters: [_fresh(id: 1)],
+      );
+
+      expect(patched.single.isRead, isTrue);
+    });
+
+    test('a series the fetch could not reach at all is left alone', () {
+      final rows = [_row(id: 1, isRead: true), _row(id: 2)];
+
+      final patched = patchRowsForManga(
+        rows: rows,
+        mangaId: _kMangaId,
+        chapters: const [],
+      );
+
+      expect(patched.map((e) => e.isRead), [true, false]);
+    });
+
+    test('a bookmark set while reading shows on the row', () {
+      final patched = patchRowsForManga(
+        rows: [_row(id: 1)],
+        mangaId: _kMangaId,
+        chapters: [_fresh(id: 1, isBookmarked: true)],
+      );
+
+      expect(patched.single.isBookmarked, isTrue);
+    });
+
+    test('a chapter from another series cannot patch this one', () {
+      final patched = patchRowsForManga(
+        rows: [_row(id: 1)],
+        mangaId: _kMangaId,
+        chapters: [_fresh(id: 1, mangaId: 99, isRead: true)],
+      );
+
+      expect(patched.single.isRead, isFalse);
+    });
+  });
+
+  group('fetchChaptersInBatches', () {
+    test('never has more than the batch size in flight', () async {
+      var inFlight = 0, peak = 0;
+
+      final chapters = await fetchChaptersInBatches(
+        ids: List.generate(20, (i) => i + 1),
+        batchSize: 4,
+        fetch: (id) async {
+          peak = max(peak, ++inFlight);
+          await Future<void>.delayed(Duration.zero);
+          inFlight--;
+          return _fresh(id: id);
+        },
+      );
+
+      expect(peak, lessThanOrEqualTo(4));
+      expect(chapters.length, 20);
+    });
+
+    test('one failing chapter does not sink the rest', () async {
+      final chapters = await fetchChaptersInBatches(
+        ids: [1, 2, 3],
+        batchSize: 4,
+        fetch: (id) async {
+          if (id == 2) throw Exception('not in the on-device catalog');
+          return _fresh(id: id);
+        },
+      );
+
+      expect(chapters.map((e) => e.id), [1, 3]);
+    });
+  });
+
+  group('refetchChapter', () {
+    // chapterProvider is autoDispose: a bare ref.refresh() with nothing
+    // listening tore it down mid-fetch and threw, leaving the row stale.
+    testWidgets('survives the provider auto-disposing mid-fetch',
+        (tester) async {
+      late WidgetRef captured;
+      await tester.pumpWidget(ProviderScope(
+        overrides: [
+          // Mirrors the real provider, which reads its repository off `ref`
+          // after an async gap — that read is what throws once the provider
+          // has been disposed out from under the fetch.
+          chapterProvider(chapterId: 1).overrideWith((ref) async {
+            await Future<void>.delayed(Duration.zero);
+            ref.watch(_watchedAfterAsyncGap);
+            return _fresh(id: 1, isRead: true);
+          }),
+        ],
+        child: Consumer(builder: (context, ref, _) {
+          captured = ref;
+          return const SizedBox();
+        }),
+      ));
+
+      final pending = refetchChapter(captured, 1);
+      await tester.pump(const Duration(milliseconds: 10));
+
+      expect((await pending)?.isRead, isTrue);
+    });
+
+    testWidgets('a failing fetch still releases the provider', (tester) async {
+      late WidgetRef captured;
+      await tester.pumpWidget(ProviderScope(
+        overrides: [
+          chapterProvider(chapterId: 1)
+              .overrideWith((ref) async => throw Exception('server down')),
+        ],
+        child: Consumer(builder: (context, ref, _) {
+          captured = ref;
+          return const SizedBox();
+        }),
+      ));
+
+      Object? caught;
+      await tester.runAsync(() async {
+        try {
+          await refetchChapter(captured, 1);
+        } catch (e) {
+          caught = e;
+        }
+      });
+
+      // Completes rather than hanging, so the finally released the listener.
+      expect(caught, isNotNull);
+    });
+  });
+
+  group('Updates row refresh on return (#326)', () {
+    testWidgets('opening the series from its cover refreshes the row on back',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final sp = await SharedPreferences.getInstance();
+      var refreshes = 0;
+
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => Scaffold(
+              body: ChapterMangaListTile(
+                chapterWithMangaDto: _row(id: 1),
+                updatePair: () async {},
+                refreshManga: () async => refreshes++,
+                toggleSelect: (_) {},
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/manga/:mangaId',
+            builder: (_, _) => const Scaffold(body: Text('details')),
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sp),
+          // The row's download icon and cover would otherwise open real
+          // sockets from the test.
+          graphQlClientProvider.overrideWithValue(
+            GraphQLClient(link: HttpLink('http://localhost'), cache: GraphQLCache()),
+          ),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          routerConfig: router,
+        ),
+      ));
+      await tester.pump();
+
+      // The cover's placeholder spinner never stops, so settle() would hang.
+      await tester.tap(find.byType(ClipRRect).first, warnIfMissed: false);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.text('details'), findsOneWidget);
+
+      router.pop();
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(refreshes, 1);
+    });
+  });
+}


### PR DESCRIPTION
Closes #326

Reported as a follow-up to #308, but it reproduces with the server up: the Updates tab is the one list that isn't provider-backed. It holds its own copy of the rows and patches them by hand, so nothing about reading a chapter reaches it on its own. Exactly one path ever patched anything, and opening a series from its cover was not it.

**Both ways into a series now refresh its rows.** The cover tap pushed the details route fire-and-forget, so a chapter read there left its row sitting in the list as unread. The row tap was too narrow as well: the reader walks on into the next chapters, and those have rows here too, which stayed unread however far you got. Bookmarks ride along with read state now, since both get set in the two places this refresh fires from.

**Read state only moves forward.** A refetch that lands before the server has stored the progress would otherwise flip a just-read row back to unread, which is the bug itself. The cost is that marking a chapter unread elsewhere leaves it greyed here until the list is properly refreshed. That is a deliberate divergence from Mihon, whose Updates screen is bound live to its database, and it is the quieter way to be wrong.

**The refresh goes per chapter, not through the series chapter list.** Refreshing that one also runs the offline reconcile, and coming back to a list is not a reason to delete a download. Requests run eight at a time: a page holds fifty rows and a newly added series arrives as one block, so "every row of this series" can be the whole page, and a burst that size at a home server every time the reader closes is worse than the stale row it fixes. Each request is tolerated on its own, because offline a chapter the on-device catalog doesn't hold throws and one gap must not sink the batch. Write-back respects the same staleness rule the page fetch already uses.

**The interesting failure only appeared on a real device.** `chapterProvider` is autoDispose, and refreshing it with nothing listening tore it down mid-fetch, so the read threw `Cannot use the Ref ... after it has been disposed` and the row silently kept its stale state. It passed on web because the browser build has no on-device catalog, and the offline branch is what touches `ref` after the async gap. The reader path had been getting away with the bare refresh because the reader is itself listening to that chapter. `refetchChapter` now holds a listener open across the read, and the pre-existing single-row refresh behind the download icon, which had the same latent fault, goes through it too.

Also fixes a small pre-existing bug in the same widget: tapping a cover during multi-select navigated away instead of selecting.

Verified on device against a live server, cover path and hardware back: the row greys while the rest of the list is untouched. Offline is covered by tests driving a real on-device catalog through the real fallback rather than a mock, since the Updates list has no offline fetch of its own. 1603 tests pass.
