### PR TITLE
Apply the delete-while-reading setting to every deletion path

### DIFF
--- a/lib/src/features/migration/controller/bulk_migration_providers.dart
+++ b/lib/src/features/migration/controller/bulk_migration_providers.dart
@@ -20,6 +20,7 @@ import '../../manga_book/domain/chapter/chapter_model.dart';
 import '../../offline/data/offline_background_downloads.dart';
 import '../../offline/data/offline_download_providers.dart';
 import '../../offline/data/offline_repository.dart';
+import '../../settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
 import '../data/bulk_migration_runner.dart';
 import '../data/migration_journal.dart';
 import '../data/migration_repository.dart';
@@ -139,6 +140,8 @@ Future<void> migrateOfflineLocalState(
         coordinator: coordinator,
         nets: container.read(safetyNetConfigProvider),
         mangaId: id,
+        deleteWhileReadingSlots:
+            container.read(localDeleteSettingsProvider).deleteWhileReading,
         enqueueServerDownload: (ids) => container
             .read(downloadsRepositoryProvider)
             .addChaptersBatchToDownloadQueue(ids),

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -18,6 +18,7 @@ import '../../manga_book/data/downloads/downloads_repository.dart';
 import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../manga_book/data/updates/updates_repository.dart';
 import '../../manga_book/presentation/downloads/controller/downloads_controller.dart';
+import '../../settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
 import 'background/background_download_controller_shim.dart';
 import 'background/background_download_lock.dart';
 import 'background/catchup_spec_writer.dart';
@@ -299,6 +300,8 @@ Future<bool> _reconcileTracked(
     nets: container.read(safetyNetConfigProvider),
     mangaId: mangaId,
     sessionProtected: container.read(sessionReadChaptersProvider),
+    deleteWhileReadingSlots:
+        container.read(localDeleteSettingsProvider).deleteWhileReading,
     enqueueServerDownload: (ids) async {
       try {
         await container

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -1191,11 +1191,13 @@ Future<void> reconcileMangaCore({
   Future<void> Function(List<int> chapterIds)? enqueueServerDownload,
   Future<void> Function(int chapterId)? removeFromWorker,
   Set<int> sessionProtected = const {},
+  int deleteWhileReadingSlots = 0,
 }) {
   return OfflineReconciler(
     db: db,
     nets: nets,
     sessionProtected: sessionProtected,
+    deleteWhileReadingSlots: deleteWhileReadingSlots,
     now: DateTime.now(),
     // Only QUEUE chapters here; starting the download is the caller's job (via
     // downloadStarterProvider) so the Ref-less launch path and tests stay in
@@ -1251,6 +1253,8 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
     nets: ref.read(safetyNetConfigProvider),
     mangaId: mangaId,
     sessionProtected: ref.read(sessionReadChaptersProvider),
+    deleteWhileReadingSlots:
+        ref.read(localDeleteSettingsProvider).deleteWhileReading,
     enqueueServerDownload: (ids) => ref
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),
@@ -1280,6 +1284,8 @@ Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
     nets: ref.read(safetyNetConfigProvider),
     mangaId: mangaId,
     sessionProtected: ref.read(sessionReadChaptersProvider),
+    deleteWhileReadingSlots:
+        ref.read(localDeleteSettingsProvider).deleteWhileReading,
     enqueueServerDownload: (ids) => ref
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),
@@ -1313,6 +1319,8 @@ Future<void> reconcileMangaContainer(
     nets: container.read(safetyNetConfigProvider),
     mangaId: mangaId,
     sessionProtected: container.read(sessionReadChaptersProvider),
+    deleteWhileReadingSlots:
+        container.read(localDeleteSettingsProvider).deleteWhileReading,
     enqueueServerDownload: (ids) => container
         .read(downloadsRepositoryProvider)
         .addChaptersBatchToDownloadQueue(ids),
@@ -1345,6 +1353,8 @@ Future<void> reconcileAllAtLaunch(ProviderContainer container) async {
         coordinator: coordinator,
         nets: nets,
         mangaId: m.id,
+        deleteWhileReadingSlots:
+            container.read(localDeleteSettingsProvider).deleteWhileReading,
         enqueueServerDownload: (ids) => container
             .read(downloadsRepositoryProvider)
             .addChaptersBatchToDownloadQueue(ids),

--- a/lib/src/features/offline/data/offline_reconciler.dart
+++ b/lib/src/features/offline/data/offline_reconciler.dart
@@ -28,6 +28,7 @@ class OfflineReconciler {
     required this.now,
     this.onServerDownload,
     this.sessionProtected = const {},
+    this.deleteWhileReadingSlots = 0,
   });
 
   final OfflineDatabase db;
@@ -39,6 +40,10 @@ class OfflineReconciler {
   /// Chapters read this session — shielded from rule eviction so finishing a
   /// chapter doesn't remove it from the device until the next launch.
   final Set<int> sessionProtected;
+
+  /// The user's "delete finished chapters while reading" slot count. Every path
+  /// that deletes a download has to honour it, not just the reader.
+  final int deleteWhileReadingSlots;
 
   /// Called with chapters the keep-rule wants but the SERVER hasn't downloaded
   /// yet — enqueue a server download (server-client model: the server fetches
@@ -74,7 +79,10 @@ class OfflineReconciler {
       desired: desired,
       nets: nets,
       now: now,
-      protected: sessionProtected,
+      protected: {
+        ...sessionProtected,
+        ...readChaptersInDeleteWindow(chapters, deleteWhileReadingSlots),
+      },
     );
 
     // Merge orphaned ids into the evict set.

--- a/lib/src/features/offline/data/reconcile_logic.dart
+++ b/lib/src/features/offline/data/reconcile_logic.dart
@@ -28,6 +28,30 @@ Set<int> desiredChapterIds(
   return ruleSet..addAll(pinned);
 }
 
+/// Read chapters the "finished chapters to keep" setting still wants kept.
+/// Slot N targets the chapter N-1 behind the one just finished, so the N-1
+/// most recently read chapters are the ones the user asked to hold on to.
+///
+/// Ordered by the server's read timestamp, not chapter order: someone who
+/// dips back to an early chapter has just-finished it, and ranking by chapter
+/// number would protect wherever they got furthest instead. Rows synced before
+/// per-chapter timestamps existed carry none, so they fall back to reading
+/// order.
+Set<int> readChaptersInDeleteWindow(List<OfflineChapter> chapters, int slots) {
+  if (slots <= 1) return const {};
+  int readAt(OfflineChapter c) => int.tryParse(c.lastReadAt ?? '') ?? 0;
+  final read = chapters.where((c) => c.isRead).toList()
+    ..sort((a, b) {
+      final byTime = readAt(b).compareTo(readAt(a));
+      if (byTime != 0) return byTime;
+      final byOrder = b.chapterIndex.compareTo(a.chapterIndex);
+      // Duplicate scanlator copies share a chapter index; id keeps the pick
+      // stable instead of letting sort order decide.
+      return byOrder != 0 ? byOrder : b.id.compareTo(a.id);
+    });
+  return read.take(slots - 1).map((c) => c.id).toSet();
+}
+
 /// Decide evictions over the currently-downloaded set, honoring precedence:
 /// pinned > safety-nets > rule. Pinned chapters are never evicted.
 /// [protected] chapters (read this session) dodge the rule eviction only —

--- a/test/src/features/offline/data/offline_reconciler_test.dart
+++ b/test/src/features/offline/data/offline_reconciler_test.dart
@@ -207,4 +207,27 @@ void main() {
     expect(r2.toDownload, isEmpty);
     expect(r2.toEvict, isEmpty);
   });
+
+  test('a chapter read on another device survives the keep rule (#325)',
+      () async {
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.nUnread, 2);
+    // Read elsewhere, so nothing is in this device's reading session.
+    await seedChapter(1, 1, read: true, dev: OfflineDeviceState.downloaded);
+    await seedChapter(2, 2, read: true, dev: OfflineDeviceState.downloaded);
+    await seedChapter(3, 3, dev: OfflineDeviceState.downloaded);
+
+    final evicted = <int>[];
+    await OfflineReconciler(
+      db: db,
+      nets: SafetyNetConfig.off,
+      onDownload: (id) async {},
+      onEvict: (id) async => evicted.add(id),
+      now: DateTime(2026, 3, 1),
+      deleteWhileReadingSlots: 2,
+    ).reconcileManga(1);
+
+    expect(evicted, [1],
+        reason: 'the keep window has to reach the reconciler, not just exist');
+  });
 }

--- a/test/src/features/offline/data/reconcile_read_window_test.dart
+++ b/test/src/features/offline/data/reconcile_read_window_test.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_logic.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_types.dart';
+
+OfflineChapter _ch(int id, {bool isRead = false, String? readAt}) =>
+    OfflineChapter(
+      id: id,
+      mangaId: 1,
+      name: 'c$id',
+      chapterIndex: id,
+      isRead: isRead,
+      lastPageRead: 0,
+      isBookmarked: false,
+      serverIsDownloaded: true,
+      deviceState: OfflineDeviceState.downloaded,
+      pageCount: 1,
+      bytes: 100,
+      pinned: false,
+      downloadedAt: DateTime(2026, 1, 1),
+      progressDirty: false,
+      bookmarkDirty: false,
+      readStateDirty: false,
+      syncedIsRead: false,
+      lastReadAt: readAt,
+      updatedAt: DateTime(2026),
+      downloadGeneration: 0,
+    );
+
+void main() {
+  group('readChaptersInDeleteWindow', () {
+    test('a window of one keeps only the most recently read chapter', () {
+      final chapters = [
+        _ch(1, isRead: true),
+        _ch(2, isRead: true),
+        _ch(3, isRead: true),
+        _ch(4),
+      ];
+
+      expect(readChaptersInDeleteWindow(chapters, 2), {3});
+    });
+
+    test('a wider window keeps more of the recently read chapters', () {
+      final chapters = [
+        _ch(1, isRead: true),
+        _ch(2, isRead: true),
+        _ch(3, isRead: true),
+        _ch(4),
+      ];
+
+      expect(readChaptersInDeleteWindow(chapters, 4), {1, 2, 3});
+    });
+
+    test('a window of none keeps nothing', () {
+      expect(readChaptersInDeleteWindow([_ch(1, isRead: true)], 1), isEmpty);
+    });
+
+    test('the setting being off keeps nothing', () {
+      expect(readChaptersInDeleteWindow([_ch(1, isRead: true)], 0), isEmpty);
+    });
+
+    test('dipping back to an early chapter keeps that one, not the furthest',
+        () {
+      final chapters = [
+        _ch(1, isRead: true, readAt: '2000'),
+        _ch(2, isRead: true, readAt: '3000'),
+        _ch(50, isRead: true, readAt: '1000'),
+      ];
+
+      expect(readChaptersInDeleteWindow(chapters, 2), {2},
+          reason: 'chapter 2 was read most recently even though 50 is further '
+              'along');
+    });
+
+    test('chapters with no read timestamp fall back to reading order', () {
+      final chapters = [_ch(1, isRead: true), _ch(9, isRead: true)];
+
+      expect(readChaptersInDeleteWindow(chapters, 2), {9});
+    });
+  });
+
+  test('a chapter read on another device survives the keep rule (#325)', () {
+    final chapters = [
+      _ch(1, isRead: true),
+      _ch(2, isRead: true),
+      _ch(3),
+      _ch(4),
+    ];
+    // "keep 2 unread" wants only the unread ones, and nothing was read in this
+    // session — which is exactly how the other device's sync wiped the lot.
+    final desired = desiredChapterIds(chapters, OfflineKeepRule.nUnread, 2);
+
+    final r = applySafetyNets(
+      downloaded: chapters,
+      desired: desired,
+      nets: SafetyNetConfig.off,
+      now: DateTime(2026, 3, 1),
+      protected: readChaptersInDeleteWindow(chapters, 2),
+    );
+
+    expect(r.evict, {1},
+        reason: 'chapter 2 is inside the keep window and must survive '
+            'regardless of which device read it');
+  });
+}


### PR DESCRIPTION
Closes #325

Follow-up to #309. The reporter has "Delete finished chapters while reading" set to "second to last read chapter" and found that reading on his other device deleted every read chapter instead of the one he asked for.

**Two things delete on-device downloads. Only the reader checked this setting.** The cleanup pass that enforces a series' keep rule works purely from the rule, so with "keep N unread" a chapter that is no longer unread is no longer wanted, and it goes.

That held while the reader was the only thing marking chapters read. The reporter's second device did the marking without it, so read state arrived with no finish event, only the cleanup ran, and it ran against every chapter that was no longer unread.

**The fix takes the keep window from read state rather than from a reading session,** so it holds on whichever device is doing the cleanup and survives a restart. #317 added an in-memory shield for this, which only ever helped the device doing the reading and was lost on the next launch. That shield stays, since it covers the chapter being read right now, which is not yet inside the window.

The window ranks by the server's read timestamp rather than by chapter order. Someone who dips back to an early chapter has just finished that one, and counting by chapter number would protect wherever they got furthest instead. Duplicate scanlator copies share a chapter number, so ties resolve by id rather than by whatever order the sort happens to produce.

Storage and age limits still override the window, exactly as they already did for the session shield. Those exist for space pressure, not for the rolling read window.

The regression test drives a real on-device catalog through the reconciler rather than calling the helper directly, so pulling the wiring back out fails it. 1596 tests pass.
