### PR TITLE
Match the platform's double-tap timing in the paged reader

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -83,7 +83,12 @@ class PagedReaderViewport extends StatefulWidget {
     this.onIdle,
     this.onReachedStartEdge,
     this.onReachedEndEdge,
+    this.clock = DateTime.now,
   });
+
+  /// Wall clock behind the double-tap window. Injectable because the test
+  /// binding's fake clock moves timers but not [DateTime.now].
+  final DateTime Function() clock;
 
   final PagedReaderController controller;
   final PagedDisplayWindow window;
@@ -147,10 +152,15 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   static const double _pageTurnVelocity = 650;
   static const double _panFlingVelocity = 700;
   static const double _panFlingDistanceFactor = 0.2;
-  static const Duration _tapDelay = Duration(milliseconds: 220);
-  // Must stay shorter than _tapDelay: a double-tap has to be recognised before
-  // the single-tap timer fires, or a slow double-tap runs both actions.
-  static const Duration _doubleTapWindow = Duration(milliseconds: 200);
+  // Android's double-tap timeout. Komikku uses the same value.
+  static const int _doubleTapWindowMs = 300;
+  // Must outlast _doubleTapWindow, or a slow double tap fires both actions.
+  static const Duration _tapDelay = Duration(
+    milliseconds: _doubleTapWindowMs + 20,
+  );
+  static const Duration _doubleTapWindow = Duration(
+    milliseconds: _doubleTapWindowMs,
+  );
   static const Duration _longPressDelay = Duration(milliseconds: 480);
   static const Duration _maxSettleDuration = Duration(milliseconds: 180);
   static const Duration _minSettleDuration = Duration(milliseconds: 70);
@@ -174,11 +184,12 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   // re-chunks a chapter's mapping and shifts display indices, and two chapters
   // can share a raw index, so the chapter disambiguates equal raws.
   final Map<({int chapterId, PageUnit unit}), _PageZoomController>
-      _zoomControllers = {};
+  _zoomControllers = {};
 
   /// Decoded pixel sizes per page, under the same key as [_zoomControllers] and
   /// for the same reason.
-  final Map<({int chapterId, PageUnit unit}), Map<int, Size>> _naturalSizes = {};
+  final Map<({int chapterId, PageUnit unit}), Map<int, Size>> _naturalSizes =
+      {};
 
   Offset? _lastSinglePosition;
   Offset _totalDrag = Offset.zero;
@@ -274,6 +285,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     // page the user is reading.
     if (!identical(oldWidget.window, widget.window)) {
       _reanchor(oldWidget.window);
+      _clearPendingTap();
     }
     _syncZoomBounds();
   }
@@ -301,8 +313,10 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
         : null;
     var target = -1;
     if (item is SpreadDisplay) {
-      target =
-          widget.window.chapterRawToDisplay(item.chapterId, item.entry.first.raw);
+      target = widget.window.chapterRawToDisplay(
+        item.chapterId,
+        item.entry.first.raw,
+      );
     } else if (item is TransitionDisplay) {
       // Anchor to the chapter being ENTERED (its first page). For an
       // end-of-window "next chapter" card that doesn't know its target yet, fall
@@ -315,8 +329,9 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
         target = widget.window.lastDisplayOf(item.fromChapterId!);
       }
     }
-    _displayIndex =
-        target >= 0 ? target : _clampDisplay(widget.initialDisplayIndex);
+    _displayIndex = target >= 0
+        ? target
+        : _clampDisplay(widget.initialDisplayIndex);
     _dragOffset = 0;
     // Runs inside didUpdateWidget; a sync emit would setState an ancestor
     // mid-build. Defer (like commitPendingIfAny).
@@ -350,6 +365,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       _emitRawPage();
       return;
     }
+    _clearPendingTap();
     setState(() {
       _displayIndex = target;
       _dragOffset = 0;
@@ -440,12 +456,11 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
 
   _PageZoomController? get _currentZoomOrNull {
     if (_isTransitionSlot(_displayIndex)) return null;
-    return _zoomControllerFor(_displayIndex)
-      ..configure(
-        minMultiplier: _minMultiplier,
-        maxMultiplier: _maxMultiplier,
-        viewport: _viewportSize,
-      );
+    return _zoomControllerFor(_displayIndex)..configure(
+      minMultiplier: _minMultiplier,
+      maxMultiplier: _maxMultiplier,
+      viewport: _viewportSize,
+    );
   }
 
   _PageZoomController _zoomControllerFor(int displayIndex) {
@@ -464,7 +479,8 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     // so the ensuing tap is swallowed (the in-flight turn still commits on
     // cancel, so we must not also fire a second tap action on top of it).
     if (_pointers.isEmpty) {
-      _interruptedByAnimation = _pageAnimation.isAnimating ||
+      _interruptedByAnimation =
+          _pageAnimation.isAnimating ||
           _panAnimation.isAnimating ||
           _zoomAnimation.isAnimating;
     }
@@ -526,9 +542,9 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     final previousOwner = _dragOwner;
 
     if (_longPressActive) {
-      ReaderInputScope.maybeOf(context)?.onLongPressMoveUpdate(
-        event.localPosition,
-      );
+      ReaderInputScope.maybeOf(
+        context,
+      )?.onLongPressMoveUpdate(event.localPosition);
       return;
     }
 
@@ -642,6 +658,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
 
   void _onPointerCancel(PointerCancelEvent event) {
     _pointers.remove(event.pointer);
+    _clearPendingTap();
     _finishLongPress(cancelled: true);
     if (_dragOwner == _DragOwner.pager || _dragOffset != 0) _settleDrag();
     if (_pointers.isNotEmpty) {
@@ -755,6 +772,15 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       ..setScaleAround(scale, focal);
   }
 
+  // A tap left armed across a page change can act on, or zoom, whichever
+  // page replaced the one it landed on.
+  void _clearPendingTap() {
+    _singleTapTimer?.cancel();
+    _singleTapTimer = null;
+    _lastTapAt = null;
+    _lastTapPosition = null;
+  }
+
   void _handleTap(Offset position) {
     // No double-tap-to-zoom → nothing to disambiguate, so act immediately
     // instead of holding every tap for _tapDelay (a felt page-turn latency).
@@ -763,26 +789,29 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       return;
     }
 
-    final now = DateTime.now();
+    final now = widget.clock();
     final previousTapAt = _lastTapAt;
     final previousTapPosition = _lastTapPosition;
-    _lastTapAt = now;
-    _lastTapPosition = position;
+    _clearPendingTap();
 
     if (previousTapAt != null &&
         now.difference(previousTapAt) <= _doubleTapWindow &&
         previousTapPosition != null &&
         (previousTapPosition - position).distance <= _tapSlop * 2) {
-      _singleTapTimer?.cancel();
-      _lastTapAt = null;
-      _lastTapPosition = null;
       _handleDoubleTap(position);
       return;
     }
 
+    // Too far apart to pair: fire the stranded tap now. Must happen before
+    // arming this one, since acting on it can change the page and clear state.
+    if (previousTapAt != null && previousTapPosition != null) {
+      _handleSingleTap(previousTapPosition);
+    }
+
+    _lastTapAt = now;
+    _lastTapPosition = position;
     _singleTapTimer = Timer(_tapDelay, () {
-      _lastTapAt = null;
-      _lastTapPosition = null;
+      _clearPendingTap();
       if (!mounted) return;
       _handleSingleTap(position);
     });
@@ -807,7 +836,9 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   /// Animate a page's zoom to a target scale/offset (double-tap), so it eases
   /// in instead of snapping — matching the webtoon reader's zoom feel.
   void _animateZoomTo(
-      _PageZoomController zoom, ({double scale, Offset offset}) end) {
+    _PageZoomController zoom,
+    ({double scale, Offset offset}) end,
+  ) {
     // reset() drives the controller to `dismissed`, which fires the status
     // listener that clears these tweens — so it has to run BEFORE we build them.
     // A second double-tap arrives with the controller sitting at `completed`, so
@@ -818,10 +849,12 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       ..reset();
     _zoomAnimationTarget = zoom;
     _zoomScaleTween = Tween<double>(begin: zoom.scale, end: end.scale).animate(
-        CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic));
+      CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic),
+    );
     _zoomOffsetTween = Tween<Offset>(begin: zoom.offset, end: end.offset)
         .animate(
-            CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic));
+          CurvedAnimation(parent: _zoomAnimation, curve: Curves.easeOutCubic),
+        );
     _zoomAnimation
       ..duration = _doubleTapZoomDuration
       ..forward();
@@ -847,14 +880,13 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     Offset position,
     Size size,
     ReaderInputCallbacks callbacks,
-  ) =>
-      tapActionForZone(
-        position: position,
-        size: size,
-        layout: callbacks.navigationLayout,
-        tapInvert: callbacks.tapInvert,
-        smallerTapZones: callbacks.smallerTapZones,
-      );
+  ) => tapActionForZone(
+    position: position,
+    size: size,
+    layout: callbacks.navigationLayout,
+    tapInvert: callbacks.tapInvert,
+    smallerTapZones: callbacks.smallerTapZones,
+  );
 
   Offset _releaseVelocity(PointerUpEvent event) {
     if (_velocityPointer != event.pointer) return Offset.zero;
@@ -869,9 +901,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     final signedVelocity = -releaseVelocity * _axisSign;
     if (signedDistance.abs() > _touchSlop &&
         signedVelocity.abs() > _pageTurnVelocity) {
-      _animateToDisplay(
-        _displayIndex + (signedVelocity > 0 ? 1 : -1),
-      );
+      _animateToDisplay(_displayIndex + (signedVelocity > 0 ? 1 : -1));
       return;
     }
 
@@ -962,14 +992,17 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       return;
     }
     final targetOffset = -delta * _axisSign * _axisExtent;
-    _animateOffsetTo(targetOffset, onComplete: () {
-      if (!mounted) return;
-      setState(() {
-        _displayIndex = targetDisplay;
-        _dragOffset = 0;
-      });
-      _emitRawPage();
-    });
+    _animateOffsetTo(
+      targetOffset,
+      onComplete: () {
+        if (!mounted) return;
+        setState(() {
+          _displayIndex = targetDisplay;
+          _dragOffset = 0;
+        });
+        _emitRawPage();
+      },
+    );
   }
 
   void _applyPagerDragDelta(double dragDelta) {
@@ -1012,12 +1045,15 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
 
   Duration _settleDuration(double target) {
     if (!widget.animateTransitions || _axisExtent <= 0) return Duration.zero;
-    final remaining =
-        ((target - _dragOffset).abs() / _axisExtent).clamp(0.0, 1.0);
+    final remaining = ((target - _dragOffset).abs() / _axisExtent).clamp(
+      0.0,
+      1.0,
+    );
     final minMs = _minSettleDuration.inMilliseconds;
     final maxMs = _maxSettleDuration.inMilliseconds;
     return Duration(
-        milliseconds: minMs + ((maxMs - minMs) * remaining).round());
+      milliseconds: minMs + ((maxMs - minMs) * remaining).round(),
+    );
   }
 
   _PanDirection _commandPanDirection(int delta) {
@@ -1044,10 +1080,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     }
     return LayoutBuilder(
       builder: (context, constraints) {
-        final nextViewport = Size(
-          constraints.maxWidth,
-          constraints.maxHeight,
-        );
+        final nextViewport = Size(constraints.maxWidth, constraints.maxHeight);
         final resized = nextViewport != _viewportSize;
         _viewportSize = nextViewport;
         _syncZoomBounds();
@@ -1131,7 +1164,11 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   /// Feeds the decoded page size to its zoom controller, so pan bounds match
   /// the page's real extent instead of an assumed full-viewport size.
   void _recordNaturalSize(
-      int index, SpreadDisplay spread, int raw, Size natural) {
+    int index,
+    SpreadDisplay spread,
+    int raw,
+    Size natural,
+  ) {
     // An already-decoded page reports during build (the image stream fires its
     // listener synchronously on a cache hit); notifying the zoom then would
     // rebuild mid-build. Publish after the frame instead.
@@ -1180,8 +1217,9 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     }
     if (width <= 0 || height <= 0) return;
 
-    _zoomControllerFor(index)
-        .setPageMetrics(content: Size(width, height), baseScale: 1);
+    _zoomControllerFor(
+      index,
+    ).setPageMetrics(content: Size(width, height), baseScale: 1);
   }
 
   void _republishVisibleMetrics() {
@@ -1197,7 +1235,8 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     if (!spread.entry.isPair) {
       return Size(_viewportSize.width, _viewportSize.height);
     }
-    final margin = widget.centerMargin == CenterMarginType.doublePage ||
+    final margin =
+        widget.centerMargin == CenterMarginType.doublePage ||
             widget.centerMargin == CenterMarginType.doubleAndWide
         ? kCenterMargin
         : 0.0;
@@ -1221,8 +1260,9 @@ class _PositionedDisplayEntry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final translation =
-        axis == Axis.horizontal ? Offset(offset, 0) : Offset(0, offset);
+    final translation = axis == Axis.horizontal
+        ? Offset(offset, 0)
+        : Offset(0, offset);
     return Transform.translate(offset: translation, child: child);
   }
 }
@@ -1249,10 +1289,7 @@ class _ZoomedDisplayEntry extends StatelessWidget {
       builder: (context, child) {
         return Transform.translate(
           offset: controller.offset,
-          child: Transform.scale(
-            scale: controller.scale,
-            child: child,
-          ),
+          child: Transform.scale(scale: controller.scale, child: child),
         );
       },
       child: child,
@@ -1349,7 +1386,9 @@ class _PageZoomController extends ChangeNotifier {
   /// The (scale, offset) that [setScaleAround] would land on — without applying
   /// it, so the viewport can animate toward it.
   ({double scale, Offset offset}) scaleAroundTarget(
-      double targetScale, Offset focal) {
+    double targetScale,
+    Offset focal,
+  ) {
     final nextScale = targetScale.clamp(minScale, maxScale).toDouble();
     final scaleRatio = nextScale / _scale;
     final viewportCenter = Offset(_viewport.width / 2, _viewport.height / 2);
@@ -1387,10 +1426,8 @@ class _PageZoomController extends ChangeNotifier {
 
   /// Whether [drag]'s dominant axis is one the page can still travel along.
   bool canPanAlong(Offset drag) => canPanBy(
-        drag.dx.abs() >= drag.dy.abs()
-            ? Offset(drag.dx, 0)
-            : Offset(0, drag.dy),
-      );
+    drag.dx.abs() >= drag.dy.abs() ? Offset(drag.dx, 0) : Offset(0, drag.dy),
+  );
 
   bool canPan(_PanDirection direction) {
     return switch (direction) {
@@ -1444,46 +1481,52 @@ TapAction tapActionForZone({
   required TapInvert tapInvert,
   required bool smallerTapZones,
 }) {
-  final leftAction =
-      tapInvert.invertsHorizontal ? TapAction.next : TapAction.previous;
-  final rightAction =
-      tapInvert.invertsHorizontal ? TapAction.previous : TapAction.next;
-  final topAction =
-      tapInvert.invertsVertical ? TapAction.next : TapAction.previous;
-  final bottomAction =
-      tapInvert.invertsVertical ? TapAction.previous : TapAction.next;
+  final leftAction = tapInvert.invertsHorizontal
+      ? TapAction.next
+      : TapAction.previous;
+  final rightAction = tapInvert.invertsHorizontal
+      ? TapAction.previous
+      : TapAction.next;
+  final topAction = tapInvert.invertsVertical
+      ? TapAction.next
+      : TapAction.previous;
+  final bottomAction = tapInvert.invertsVertical
+      ? TapAction.previous
+      : TapAction.next;
   final edgeWidth = size.width * (smallerTapZones ? 0.25 : 1 / 3);
   final edgeHeight = size.height * (smallerTapZones ? 0.25 : 1 / 3);
 
   return switch (layout) {
-    ReaderNavigationLayout.rightAndLeft => position.dx < edgeWidth
-        ? leftAction
-        : position.dx >= size.width - edgeWidth
-            ? rightAction
-            : TapAction.menu,
+    ReaderNavigationLayout.rightAndLeft =>
+      position.dx < edgeWidth
+          ? leftAction
+          : position.dx >= size.width - edgeWidth
+          ? rightAction
+          : TapAction.menu,
     ReaderNavigationLayout.edge =>
       position.dx < edgeWidth || position.dx >= size.width - edgeWidth
           ? rightAction
           : position.dy >= size.height - edgeHeight
-              ? leftAction
-              : TapAction.menu,
+          ? leftAction
+          : TapAction.menu,
     // Komikku's kindlish layout: menu across the top, left/right below it.
-    ReaderNavigationLayout.kindlish => position.dy < edgeHeight
-        ? TapAction.menu
-        : position.dx < edgeWidth
-            ? leftAction
-            : rightAction,
-    ReaderNavigationLayout.lShaped => position.dy < edgeHeight
-        ? topAction
-        : position.dy >= size.height - edgeHeight
-            ? bottomAction
-            : position.dx < edgeWidth
-                ? leftAction
-                : position.dx >= size.width - edgeWidth
-                    ? rightAction
-                    : TapAction.menu,
+    ReaderNavigationLayout.kindlish =>
+      position.dy < edgeHeight
+          ? TapAction.menu
+          : position.dx < edgeWidth
+          ? leftAction
+          : rightAction,
+    ReaderNavigationLayout.lShaped =>
+      position.dy < edgeHeight
+          ? topAction
+          : position.dy >= size.height - edgeHeight
+          ? bottomAction
+          : position.dx < edgeWidth
+          ? leftAction
+          : position.dx >= size.width - edgeWidth
+          ? rightAction
+          : TapAction.menu,
     ReaderNavigationLayout.defaultNavigation ||
-    ReaderNavigationLayout.disabled =>
-      TapAction.menu,
+    ReaderNavigationLayout.disabled => TapAction.menu,
   };
 }

--- a/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
+++ b/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
@@ -41,25 +41,24 @@ ReaderInputCallbacks _callbacks({
   ValueChanged<Offset>? onLongPressStart,
   VoidCallback? onLongPressEnd,
   VoidCallback? onLongPressCancel,
-}) =>
-    ReaderInputCallbacks(
-      onTap: onTap ?? () {},
-      onLongPressStart: onLongPressStart ?? (_) {},
-      onLongPressMoveUpdate: (_) {},
-      onLongPressEnd: onLongPressEnd ?? () {},
-      onLongPressCancel: onLongPressCancel ?? () {},
-      onNext: () {},
-      onPrevious: () {},
-      onNextBoundary: onNextBoundary ?? () => false,
-      onPreviousBoundary: onPreviousBoundary ?? () => false,
-      // Default to "a chapter exists" so boundary-move tests fire; the
-      // no-adjacent-chapter case passes () => false explicitly.
-      hasNextBoundary: hasNextBoundary ?? () => true,
-      hasPreviousBoundary: hasPreviousBoundary ?? () => true,
-      navigationLayout: ReaderNavigationLayout.disabled,
-      tapInvert: TapInvert.none,
-      smallerTapZones: false,
-    );
+}) => ReaderInputCallbacks(
+  onTap: onTap ?? () {},
+  onLongPressStart: onLongPressStart ?? (_) {},
+  onLongPressMoveUpdate: (_) {},
+  onLongPressEnd: onLongPressEnd ?? () {},
+  onLongPressCancel: onLongPressCancel ?? () {},
+  onNext: () {},
+  onPrevious: () {},
+  onNextBoundary: onNextBoundary ?? () => false,
+  onPreviousBoundary: onPreviousBoundary ?? () => false,
+  // Default to "a chapter exists" so boundary-move tests fire; the
+  // no-adjacent-chapter case passes () => false explicitly.
+  hasNextBoundary: hasNextBoundary ?? () => true,
+  hasPreviousBoundary: hasPreviousBoundary ?? () => true,
+  navigationLayout: ReaderNavigationLayout.disabled,
+  tapInvert: TapInvert.none,
+  smallerTapZones: false,
+);
 
 Future<void> _pumpViewport(
   WidgetTester tester, {
@@ -78,6 +77,7 @@ Future<void> _pumpViewport(
   VoidCallback? onReachedStartEdge,
   VoidCallback? onReachedEndEdge,
   void Function(int chapterId, int raw, bool isWide)? onPageWide,
+  DateTime Function()? clock,
 }) async {
   // The viewport now renders a PagedDisplayWindow instead of a bare
   // mapping+pages pair. These single-chapter tests wrap the mapping in a
@@ -102,6 +102,7 @@ Future<void> _pumpViewport(
       width: 300,
       height: 500,
       child: PagedReaderViewport(
+        clock: clock ?? DateTime.now,
         controller: controller,
         window: window,
         initialDisplayIndex: initialDisplayIndex,
@@ -142,11 +143,9 @@ Future<void> _pumpViewport(
 }
 
 List<double> _transformScales(WidgetTester tester) => [
-      for (final transform in tester.widgetList<Transform>(
-        find.byType(Transform),
-      ))
-        _xyScale(transform.transform.storage),
-    ];
+  for (final transform in tester.widgetList<Transform>(find.byType(Transform)))
+    _xyScale(transform.transform.storage),
+];
 
 double _xyScale(Float64List storage) {
   final scaleX = math.sqrt(storage[0] * storage[0] + storage[1] * storage[1]);
@@ -161,14 +160,9 @@ double _smallestScale(WidgetTester tester) =>
     _transformScales(tester).reduce(math.min);
 
 List<Offset> _transformTranslations(WidgetTester tester) => [
-      for (final transform in tester.widgetList<Transform>(
-        find.byType(Transform),
-      ))
-        Offset(
-          transform.transform.storage[12],
-          transform.transform.storage[13],
-        ),
-    ];
+  for (final transform in tester.widgetList<Transform>(find.byType(Transform)))
+    Offset(transform.transform.storage[12], transform.transform.storage[13]),
+];
 
 double _leftmostTranslation(WidgetTester tester) =>
     _transformTranslations(tester).map((offset) => offset.dx).reduce(math.min);
@@ -236,8 +230,9 @@ void main() {
     expect(reported, [1]);
   });
 
-  testWidgets('next command at the last display hits the end edge',
-      (tester) async {
+  testWidgets('next command at the last display hits the end edge', (
+    tester,
+  ) async {
     // migrated: the viewport no longer performs the chapter move itself (that's
     // the host's job now). At the window's outer end it fires onReachedEndEdge —
     // the new edge signal that replaces the old onNextBoundary handoff.
@@ -269,8 +264,9 @@ void main() {
     expect(endEdgeHits, 1);
   });
 
-  testWidgets('next command lands on the chapter transition first',
-      (tester) async {
+  testWidgets('next command lands on the chapter transition first', (
+    tester,
+  ) async {
     // migrated: the trailing transition card is now an ordinary in-window slot
     // (via transitionBuilder), so the first next() pages onto it and only the
     // next() past it reaches the window's end edge (onReachedEndEdge).
@@ -350,8 +346,9 @@ void main() {
     expect(endEdgeHits, 1);
   });
 
-  testWidgets('window end edge bounces back onto the last page',
-      (tester) async {
+  testWidgets('window end edge bounces back onto the last page', (
+    tester,
+  ) async {
     // migrated: the old model gated the boundary move on hasNextBoundary and had
     // to avoid sliding onto an empty slot. In the new model the window's outer
     // edge ALWAYS bounces (never slides off) and just reports onReachedEndEdge;
@@ -395,8 +392,9 @@ void main() {
     expect(controller.isAtLast, isTrue);
   });
 
-  testWidgets('last display swipe settles on the chapter transition first',
-      (tester) async {
+  testWidgets('last display swipe settles on the chapter transition first', (
+    tester,
+  ) async {
     // migrated: the trailing transition card is an ordinary in-window slot now,
     // so the first fling pages onto it ('Finished') and only the second fling —
     // off the window's outer end — trips onReachedEndEdge.
@@ -445,8 +443,9 @@ void main() {
     expect(endEdgeHits, 1);
   });
 
-  testWidgets('sub-threshold drag does not turn a double-page spread',
-      (tester) async {
+  testWidgets('sub-threshold drag does not turn a double-page spread', (
+    tester,
+  ) async {
     final pages = _localPages(4);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -815,8 +814,9 @@ void main() {
     await gesture.up();
   });
 
-  testWidgets('two-finger hold does not reach ancestor shortcuts',
-      (tester) async {
+  testWidgets('two-finger hold does not reach ancestor shortcuts', (
+    tester,
+  ) async {
     final pages = _localPages(1);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -903,8 +903,9 @@ void main() {
     await first.up();
   });
 
-  testWidgets('same-page seek during a turn settle cannot park mid-turn',
-      (tester) async {
+  testWidgets('same-page seek during a turn settle cannot park mid-turn', (
+    tester,
+  ) async {
     // The seekbar fires jumpToRaw on every drag tick; mid-settle it can target
     // the still-current page, abandoning the turn without restoring the offset.
     final pages = _localPages(2);
@@ -946,10 +947,12 @@ void main() {
     // A settled slot always sits at translation 0; parked mid-turn, every
     // slot is off-grid.
     final slotOffsets = [
-      for (final transform in tester.widgetList<Transform>(find.ancestor(
-        of: find.byType(ClipRect),
-        matching: find.byType(Transform),
-      )))
+      for (final transform in tester.widgetList<Transform>(
+        find.ancestor(
+          of: find.byType(ClipRect),
+          matching: find.byType(Transform),
+        ),
+      ))
         transform.transform.storage[12],
     ];
     expect(
@@ -959,8 +962,9 @@ void main() {
     );
   });
 
-  testWidgets('two-finger tap does not leak into reader tap actions',
-      (tester) async {
+  testWidgets('two-finger tap does not leak into reader tap actions', (
+    tester,
+  ) async {
     final pages = _localPages(1);
     final mapping = buildSpreadMapping(
       pageCount: pages.length,
@@ -993,8 +997,116 @@ void main() {
 
     await second.up();
     await first.up();
-    await tester.pump(const Duration(milliseconds: 300));
+    // Past the single-tap delay, so a leaked tap would have fired by now.
+    await tester.pump(const Duration(milliseconds: 500));
 
     expect(taps, 0);
   });
+
+  /// Drives the double-tap window, which compares wall clock time and so is
+  /// untouched by the test binding's fake clock.
+  Future<void> tapPair(
+    WidgetTester tester,
+    _FakeClock clock,
+    Duration apart, {
+    Offset? secondAt,
+  }) async {
+    final target = find.byType(PagedReaderViewport);
+    await tester.tap(target);
+    clock.advance(apart);
+    await tester.pump(apart);
+    if (secondAt == null) {
+      await tester.tap(target);
+    } else {
+      await tester.tapAt(secondAt);
+    }
+    await tester.pump();
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a 250ms double tap zooms', (tester) async {
+    // Real double taps commonly land 130-235ms apart. 200ms missed them.
+    final clock = _FakeClock();
+    var menuToggles = 0;
+    await _pumpViewport(
+      tester,
+      controller: PagedReaderController(),
+      mapping: _singlePageMapping(),
+      pages: _localPages(1),
+      initialDisplayIndex: 0,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(onTap: () => menuToggles++),
+      clock: clock.now,
+    );
+
+    await tapPair(tester, clock, const Duration(milliseconds: 250));
+
+    expect(_largestScale(tester), greaterThan(1.9));
+    expect(menuToggles, 0);
+  });
+
+  testWidgets('taps beyond the window stay two separate taps', (tester) async {
+    final clock = _FakeClock();
+    var menuToggles = 0;
+    await _pumpViewport(
+      tester,
+      controller: PagedReaderController(),
+      mapping: _singlePageMapping(),
+      pages: _localPages(1),
+      initialDisplayIndex: 0,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(onTap: () => menuToggles++),
+      clock: clock.now,
+    );
+
+    await tapPair(tester, clock, const Duration(milliseconds: 400));
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(_largestScale(tester), lessThan(1.01), reason: 'no zoom');
+    expect(menuToggles, 2);
+  });
+
+  testWidgets('a second tap elsewhere does not swallow the first', (
+    tester,
+  ) async {
+    // Two quick taps far apart are two deliberate page turns, and widening the
+    // window gave the first one longer to be dropped in.
+    final clock = _FakeClock();
+    var taps = 0;
+    await _pumpViewport(
+      tester,
+      controller: PagedReaderController(),
+      mapping: _singlePageMapping(),
+      pages: _localPages(1),
+      initialDisplayIndex: 0,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(onTap: () => taps++),
+      clock: clock.now,
+    );
+
+    final box = tester.getRect(find.byType(PagedReaderViewport));
+    await tester.tapAt(Offset(box.left + 10, box.center.dy));
+    clock.advance(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.tapAt(Offset(box.right - 10, box.center.dy));
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(taps, 2);
+  });
+}
+
+SpreadMapping _singlePageMapping() => buildSpreadMapping(
+  pageCount: 1,
+  doublePages: false,
+  splitWide: false,
+  splitInvert: false,
+  isWide: (_) => false,
+);
+
+/// Wall clock the double-tap window can be driven against.
+class _FakeClock {
+  DateTime _at = DateTime(2026);
+  DateTime now() => _at;
+  void advance(Duration by) => _at = _at.add(by);
 }


### PR DESCRIPTION
Reported in Discord: double tapping to zoom in the paged reader would sometimes open the menu instead, several times in a row, on a Mi A3 running Android 11. It could not be reproduced on a faster phone.

**We called it a double tap only within 200ms.** Android's own timeout is 300ms, which is what Komikku defers to through `ViewConfiguration.getDoubleTapTimeout()`. Measuring the reporter's screen recording frame by frame, his double taps land between 130 and 235ms apart. Ordinary by the platform's reckoning, and several of them missed our window and became two single taps. Two of his gestures three pixels apart, at 200ms and 233ms, gave opposite results, which is why it felt random to him and why nobody tapping faster could reproduce it.

Page turns wait out the window before acting, so they resolve 100ms later than they did. Komikku pays the same cost, taking its taps through `onSingleTapConfirmed`, which fires only after the platform timeout. The long strip reader was already on Flutter's 300ms default, so this only ever affected paged mode.

**Holding a tap for longer exposed two older bugs.** A second tap too far from the first to pair with it dropped the first entirely, because the pointer-down had already cancelled its timer. Tapping one edge and then the other lost a page turn. Separately, a tap left armed across a page change stayed eligible to pair, so it could act on, or zoom, whichever page replaced the one it landed on. Every path that changes the page now drops the pending tap through one helper, since the seek path had no clear at all.

The window compares wall clock time, which the test binding's fake clock does not move. Reaching it from a test took an injected clock.

Verified on device. 1614 tests pass.
