### PR TITLE
Bump version to 1.1.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 1.1.2+48
+version: 1.1.3+49
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
Bugfix release: the Updates read-state fix (#326), the cross-device delete fix (#325), and the paged reader's double-tap timing.