### PR TITLE
Give the Discord announcement a user agent

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -335,7 +335,7 @@ jobs:
           # The channel's usual format: role ping + bare link, and Discord's
           # own unfurl draws the release card. A custom embed would suppress it.
           python3 - "$url" <<'PY'
-          import json, os, sys, urllib.request
+          import json, os, sys, urllib.error, urllib.request
           role = os.environ.get('PING_ROLE', '')
           ping = f'<@&{role}>\n' if role else ''
           payload = {
@@ -345,6 +345,18 @@ jobs:
           req = urllib.request.Request(
               os.environ['WEBHOOK'],
               data=json.dumps(payload).encode(),
-              headers={'Content-Type': 'application/json'})
-          urllib.request.urlopen(req)
+              headers={
+                  'Content-Type': 'application/json',
+                  # Cloudflare turns urllib's default agent away with a 403
+                  # before Discord ever sees the request.
+                  'User-Agent': 'Tsumiru-Release (+https://tsumiru.app)',
+              })
+          try:
+              urllib.request.urlopen(req)
+          except urllib.error.HTTPError as e:
+              # Discord says why in the body; the bare traceback only shows the
+              # status, which is what made the Cloudflare block look like a bad
+              # webhook.
+              sys.exit(f'Discord rejected the announcement: {e.code} '
+                       f'{e.read().decode("utf-8", "replace")}')
           PY


### PR DESCRIPTION
The v1.1.3 release announcement never appeared. The step ran with the secret present and failed with `HTTP 403`, which read like a bad webhook.

**It was Cloudflare, not Discord.** The body carried `error code: 1010`, a browser-signature block against urllib's default `Python-urllib/3.12` agent. The request never reached Discord's API.

Confirmable without the real webhook. The same POST to a made-up webhook URL gives:

- default agent: `403`, `error code: 1010`
- any explicit agent: `404 {"message": "Unknown Webhook"}`

The second one proves it reached the API and was correctly rejected on the fake token, so the agent is the only difference that matters.

Failures now print what Discord actually said. The old code let the `HTTPError` propagate, so the log showed a traceback ending in `403: Forbidden` and nothing about the cause, which is what made this look like a credentials problem.

Verified by running the patched script against a fake webhook: it now reports `404 {"message": "Unknown Webhook", "code": 10015}` and exits non-zero. It stays best-effort, so a future failure still cannot block a release.