### PR TITLE
Fix macOS UI login credential persistence

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
macOS UI login could not persist or read credentials because the Runner entitlements did not declare a Keychain access group. macOS reported OSStatus -34018 from secd when the app accessed the Keychain.

Add the empty keychain-access-groups entitlement to both DebugProfile and Release so credential storage works for Debug and Release builds without changing the existing sandbox permissions.