### PR TITLE
Show a new extension's sources without restarting

### DIFF
--- a/lib/src/features/browse_center/presentation/extension/controller/extension_actions.dart
+++ b/lib/src/features/browse_center/presentation/extension/controller/extension_actions.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/widgets.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../../utils/extensions/custom_extensions.dart';
+import '../../../data/extension_repository/extension_repository.dart';
+import '../../source/controller/source_controller.dart';
+import 'extension_controller.dart';
+
+part 'extension_actions.g.dart';
+
+/// The single entry point for installing, updating and uninstalling extensions.
+///
+/// The server registers an extension's sources in the same transaction that
+/// installs it, so the source list is stale the moment the mutation returns.
+/// Browse keeps its tabs alive, so a stale list survives every tab switch and
+/// only clears on restart — route every extension action through here so the
+/// source list can never be left behind again (#344).
+class ExtensionActions {
+  ExtensionActions(this._ref);
+
+  final Ref _ref;
+
+  ExtensionRepository get _repository => _ref.read(extensionRepositoryProvider);
+
+  /// [languageCode] is enabled in the source language filter, so the sources the
+  /// new extension brings aren't filtered straight back out of the Sources tab.
+  Future<void> install(String pkgName, {String? languageCode}) =>
+      _refreshAfter(() async {
+        await _repository.installExtension(pkgName);
+        if (languageCode.isNotBlank) _enableSourceLanguage(languageCode!);
+      });
+
+  Future<void> installFile(BuildContext context, {PlatformFile? file}) =>
+      _refreshAfter(
+        () => _repository.installExtensionFile(context, file: file),
+      );
+
+  Future<void> update(String pkgName) =>
+      _refreshAfter(() => _repository.updateExtension(pkgName));
+
+  Future<void> uninstall(String pkgName) =>
+      _refreshAfter(() => _repository.uninstallExtension(pkgName));
+
+  /// A blank filter means the user turned every language off (the key defaults
+  /// to a populated list), so installing an extension doesn't switch one back on.
+  void _enableSourceLanguage(String code) {
+    final enabled = _ref.read(sourceLanguageFilterProvider);
+    if (enabled.isNotBlank && !enabled!.contains(code)) {
+      _ref
+          .read(sourceLanguageFilterProvider.notifier)
+          .update({...enabled, code}.toList());
+    }
+  }
+
+  Future<void> _refreshAfter(Future<void> Function() mutate) async {
+    await mutate();
+    _ref.invalidate(sourceListProvider);
+    return _ref.refresh(extensionProvider.future);
+  }
+}
+
+/// Kept alive on purpose: callers reach it with `ref.read` inside a button
+/// handler and then await a network round trip. An auto-disposing provider
+/// would be gone before the refresh runs.
+@Riverpod(keepAlive: true)
+ExtensionActions extensionActions(Ref ref) => ExtensionActions(ref);

--- a/lib/src/features/browse_center/presentation/extension/extension_screen.dart
+++ b/lib/src/features/browse_center/presentation/extension/extension_screen.dart
@@ -4,7 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -15,7 +14,6 @@ import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/emoticons.dart';
 import '../../../../widgets/search_field.dart';
-import '../../data/extension_store_repository/extension_store_repository.dart';
 import '../../domain/extension/extension_model.dart';
 import 'controller/extension_controller.dart';
 import 'widgets/extension_list_tile.dart';
@@ -27,7 +25,6 @@ class ExtensionScreen extends HookConsumerWidget {
     Key? key,
     required String title,
     required List<Extension>? extensions,
-    required AsyncCallback refresh,
   }) {
     if (extensions.isBlank) return <Widget>[];
     return [
@@ -42,7 +39,6 @@ class ExtensionScreen extends HookConsumerWidget {
           (context, index) => ExtensionListTile(
             key: ValueKey(extensions[index].pkgName),
             extension: extensions[index],
-            refresh: refresh,
           ),
           childCount: extensions!.length,
         ),
@@ -104,28 +100,24 @@ class ExtensionScreen extends HookConsumerWidget {
                       key: const ValueKey("update"),
                       title: languageMap["update"]?.displayName ?? "",
                       extensions: update,
-                      refresh: refresh,
                     ),
                   if (installed.isNotBlank)
                     ...extensionSet(
                       key: const ValueKey("installed"),
                       title: languageMap["installed"]?.displayName ?? "",
                       extensions: installed,
-                      refresh: refresh,
                     ),
                   if (all.isNotBlank)
                     ...extensionSet(
                       key: const ValueKey("all"),
                       title: languageMap["all"]?.displayName ?? "",
                       extensions: all,
-                      refresh: refresh,
                     ),
                   for (final k in extensionMap.keys)
                     ...extensionSet(
                       key: ValueKey(k),
                       title: languageMap[k]?.displayName ?? k,
                       extensions: extensionMap[k],
-                      refresh: refresh,
                     ),
                 ],
               ),

--- a/lib/src/features/browse_center/presentation/extension/widgets/extension_list_tile.dart
+++ b/lib/src/features/browse_center/presentation/extension/widgets/extension_list_tile.dart
@@ -4,7 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -14,24 +13,20 @@ import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/misc/app_utils.dart';
 import '../../../../../utils/misc/toast/toast.dart';
 import '../../../../../widgets/server_image.dart';
-import '../../../data/extension_repository/extension_repository.dart';
 import '../../../domain/content_rating.dart';
 import '../../../domain/extension/extension_model.dart';
-import '../../source/controller/source_controller.dart';
+import '../controller/extension_actions.dart';
 
 class ExtensionListTile extends HookConsumerWidget {
   const ExtensionListTile({
     super.key,
     required this.extension,
-    required this.refresh,
   });
 
   final Extension extension;
-  final AsyncCallback refresh;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final repository = ref.watch(extensionRepositoryProvider);
     final isLoading = useState(false);
     return ListTile(
       key: key,
@@ -71,10 +66,8 @@ class ExtensionListTile extends HookConsumerWidget {
       ),
       trailing: ExtensionListTileTailing(
         extension: extension,
-        repository: repository,
         isLoading: isLoading,
         ref: ref,
-        refresh: refresh,
       ),
     );
   }
@@ -84,24 +77,39 @@ class ExtensionListTileTailing extends StatelessWidget {
   const ExtensionListTileTailing({
     super.key,
     required this.extension,
-    required this.repository,
     required this.isLoading,
     required this.ref,
-    required this.refresh,
   });
 
   final Extension extension;
-  final ExtensionRepository repository;
   final ValueNotifier<bool> isLoading;
   final WidgetRef ref;
-  final AsyncCallback refresh;
+
+  /// Runs an extension action with the button's spinner and error toast.
+  /// [ExtensionActions] refreshes both the extension and the source list, so no
+  /// caller needs to pass a refresh callback down.
+  Future<void> _run(
+    Future<void> Function(ExtensionActions actions) action,
+  ) async {
+    try {
+      isLoading.value = true;
+      await AppUtils.guard(
+        () => action(ref.read(extensionActionsProvider)),
+        ref.read(toastProvider),
+      );
+      isLoading.value = false;
+    } catch (_) {
+      // The refresh this action triggers can rebuild the list and dispose the
+      // tile out from under the spinner.
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     if (extension.isObsolete.ifNull()) {
       return OutlinedButton(
-        onPressed: extension.isInstalled.ifNull()
-            ? () => repository.uninstallExtension(extension.pkgName)
+        onPressed: extension.isInstalled.ifNull() && !isLoading.value
+            ? () => _run((actions) => actions.uninstall(extension.pkgName))
             : null,
         child: Text(
           context.l10n.obsolete,
@@ -112,30 +120,16 @@ class ExtensionListTileTailing extends StatelessWidget {
       if (extension.isInstalled.ifNull()) {
         final actionButton = TextButton(
           onPressed: (!isLoading.value)
-              ? () async {
-                  try {
-                    isLoading.value = (true);
-                    await AppUtils.guard(
-                      () async {
-                        if (extension.pkgName.isBlank) {
-                          throw context.l10n.errorExtension;
-                        }
-                        if (extension.hasUpdate.ifNull()) {
-                          await repository.updateExtension(extension.pkgName);
-                        } else {
-                          await repository
-                              .uninstallExtension(extension.pkgName);
-                        }
-
-                        await refresh();
-                      },
-                      ref.read(toastProvider),
-                    );
-                    isLoading.value = (false);
-                  } catch (e) {
-                    //
-                  }
-                }
+              ? () => _run((actions) async {
+                    if (extension.pkgName.isBlank) {
+                      throw context.l10n.errorExtension;
+                    }
+                    if (extension.hasUpdate.ifNull()) {
+                      await actions.update(extension.pkgName);
+                    } else {
+                      await actions.uninstall(extension.pkgName);
+                    }
+                  })
               : null,
           child: Text(
             extension.hasUpdate.ifNull()
@@ -160,56 +154,24 @@ class ExtensionListTileTailing extends StatelessWidget {
               icon: const Icon(Icons.delete_outline),
               onPressed: isLoading.value
                   ? null
-                  : () async {
-                      try {
-                        isLoading.value = (true);
-                        await AppUtils.guard(
-                          () async {
-                            await repository
-                                .uninstallExtension(extension.pkgName);
-                            await refresh();
-                          },
-                          ref.read(toastProvider),
-                        );
-                        isLoading.value = (false);
-                      } catch (e) {
-                        //
-                      }
-                    },
+                  : () => _run((actions) => actions.uninstall(
+                        extension.pkgName,
+                      )),
             ),
           ],
         );
       } else {
         return TextButton(
           onPressed: !isLoading.value
-              ? () async {
-                  try {
-                    isLoading.value = (true);
-                    await AppUtils.guard(() async {
-                      if (extension.pkgName.isBlank) {
-                        throw context.l10n.errorExtension;
-                      }
-                      await repository.installExtension(extension.pkgName);
-                      if ((extension.language?.code).isNotBlank) {
-                        final code = extension.language!.code!;
-                        final enabledLanguages =
-                            ref.read(sourceLanguageFilterProvider);
-                        if (enabledLanguages.isNotBlank &&
-                            !enabledLanguages!.contains(code)) {
-                          ref
-                              .read(sourceLanguageFilterProvider.notifier)
-                              .update(
-                                {...enabledLanguages, code}.toList(),
-                              );
-                        }
-                      }
-                      await refresh();
-                    }, ref.read(toastProvider));
-                    isLoading.value = (false);
-                  } catch (e) {
-                    //
-                  }
-                }
+              ? () => _run((actions) async {
+                    if (extension.pkgName.isBlank) {
+                      throw context.l10n.errorExtension;
+                    }
+                    await actions.install(
+                      extension.pkgName,
+                      languageCode: extension.language?.code,
+                    );
+                  })
               : null,
           child: Text(
             isLoading.value ? context.l10n.installing : context.l10n.install,

--- a/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
+++ b/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
@@ -12,8 +12,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/misc/app_utils.dart';
 import '../../../../../utils/misc/toast/toast.dart';
-import '../../../data/extension_repository/extension_repository.dart';
-import '../controller/extension_controller.dart';
+import '../controller/extension_actions.dart';
 
 class InstallExtensionFile extends ConsumerWidget {
   const InstallExtensionFile({super.key});
@@ -34,9 +33,8 @@ class InstallExtensionFile extends ConsumerWidget {
     AppUtils.guard(
       () async {
         await ref
-            .read(extensionRepositoryProvider)
-            .installExtensionFile(context, file: file?.files.single);
-        ref.invalidate(extensionProvider);
+            .read(extensionActionsProvider)
+            .installFile(context, file: file?.files.single);
         if (context.mounted) {
           toast?.show(context.l10n.extensionInstalled, instantShow: true);
         }

--- a/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
+++ b/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/browse_center/data/extension_repository/extension_repository.dart';
+import 'package:tsumiru/src/features/browse_center/data/source_repository/source_repository.dart';
+import 'package:tsumiru/src/features/browse_center/domain/extension/extension_model.dart';
+import 'package:tsumiru/src/features/browse_center/domain/source/source_model.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/extension/controller/extension_actions.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/source/controller/source_controller.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+class _FakeExtensionRepository extends ExtensionRepository {
+  _FakeExtensionRepository() : super(_dummyClient());
+
+  final List<String> installed = <String>[];
+  final List<String> uninstalled = <String>[];
+  final List<String> updated = <String>[];
+  final List<PlatformFile> fileInstalls = <PlatformFile>[];
+
+  @override
+  Future<void> installExtension(String pkgName) async => installed.add(pkgName);
+
+  @override
+  Future<void> uninstallExtension(String pkgName) async =>
+      uninstalled.add(pkgName);
+
+  @override
+  Future<void> updateExtension(String pkgName) async => updated.add(pkgName);
+
+  @override
+  Future<void> installExtensionFile(
+    BuildContext context, {
+    PlatformFile? file,
+  }) async {
+    // The real repository rejects a null pick before it mutates anything, so a
+    // test that passed null would pass even if the file stopped being forwarded.
+    if (file == null) throw Exception('no file picked');
+    fileInstalls.add(file);
+  }
+
+  @override
+  Future<List<Extension>?> getExtensionListStream() async => <Extension>[];
+}
+
+class _CountingSourceRepository extends SourceRepository {
+  _CountingSourceRepository() : super(_dummyClient());
+
+  int listCalls = 0;
+
+  @override
+  Future<List<SourceDto>?> getSourceList() async {
+    listCalls++;
+    return <SourceDto>[];
+  }
+}
+
+void main() {
+  late _FakeExtensionRepository extensions;
+  late _CountingSourceRepository sources;
+  late ProviderContainer container;
+
+  setUp(() async {
+    extensions = _FakeExtensionRepository();
+    sources = _CountingSourceRepository();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    container = ProviderContainer(overrides: [
+      extensionRepositoryProvider.overrideWithValue(extensions),
+      sourceRepositoryProvider.overrideWithValue(sources),
+      sharedPreferencesProvider
+          .overrideWithValue(await SharedPreferences.getInstance()),
+    ]);
+    // Browse keeps the Sources tab alive behind the Extensions tab, so the
+    // source list holds a listener for the whole session. That's what made the
+    // stale list survive every tab switch (#344).
+    container.listen(sourceListProvider, (previous, next) {});
+    container.listen(sourceLanguageFilterProvider, (previous, next) {});
+  });
+
+  tearDown(() => container.dispose());
+
+  Future<int> sourceFetchesAfter(Future<void> Function() action) async {
+    await container.read(sourceListProvider.future);
+    final before = sources.listCalls;
+    await action();
+    await container.read(sourceListProvider.future);
+    return sources.listCalls - before;
+  }
+
+  test('installing an extension refetches the source list', () async {
+    final actions = container.read(extensionActionsProvider);
+    final refetches =
+        await sourceFetchesAfter(() => actions.install('com.example.ext'));
+
+    expect(extensions.installed, <String>['com.example.ext']);
+    expect(refetches, 1,
+        reason: 'the installed extension registers new sources server-side');
+  });
+
+  test('uninstalling an extension refetches the source list', () async {
+    final actions = container.read(extensionActionsProvider);
+    final refetches =
+        await sourceFetchesAfter(() => actions.uninstall('com.example.ext'));
+
+    expect(extensions.uninstalled, <String>['com.example.ext']);
+    expect(refetches, 1,
+        reason: "the removed extension's sources have to disappear too");
+  });
+
+  test('updating an extension refetches the source list', () async {
+    final actions = container.read(extensionActionsProvider);
+    final refetches =
+        await sourceFetchesAfter(() => actions.update('com.example.ext'));
+
+    expect(extensions.updated, <String>['com.example.ext']);
+    expect(refetches, 1,
+        reason: 'an update can add or drop sources within the extension');
+  });
+
+  test("installing enables the extension's language in the source filter",
+      () async {
+    expect(container.read(sourceLanguageFilterProvider), isNot(contains('ko')));
+
+    await container
+        .read(extensionActionsProvider)
+        .install('com.example.ext', languageCode: 'ko');
+
+    // Without this the new sources land in a language group the Sources tab is
+    // filtering out, so the fix would look like it hadn't worked.
+    expect(container.read(sourceLanguageFilterProvider), contains('ko'));
+  });
+
+  test('installing leaves an emptied language filter empty', () async {
+    container.read(sourceLanguageFilterProvider.notifier).update(<String>[]);
+
+    await container
+        .read(extensionActionsProvider)
+        .install('com.example.ext', languageCode: 'ko');
+
+    expect(container.read(sourceLanguageFilterProvider), isEmpty);
+  });
+
+  test('a failed install leaves the source list alone', () async {
+    final failing = ProviderContainer(overrides: [
+      extensionRepositoryProvider.overrideWithValue(_ThrowingRepository()),
+      sourceRepositoryProvider.overrideWithValue(sources),
+    ]);
+    addTearDown(failing.dispose);
+    failing.listen(sourceListProvider, (previous, next) {});
+    await failing.read(sourceListProvider.future);
+    final before = sources.listCalls;
+
+    await expectLater(
+      failing.read(extensionActionsProvider).install('com.example.ext'),
+      throwsA(isA<Exception>()),
+    );
+
+    expect(sources.listCalls, before);
+  });
+
+  testWidgets('installing from a file refetches the source list',
+      (tester) async {
+    // Only a BuildContext to hand to the picker call. The container stays
+    // detached from the tree: attaching it makes Riverpod defer refreshes to a
+    // frame that a bare `await` never pumps.
+    final apk = PlatformFile(name: 'source.apk', size: 4);
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(builder: (context) {
+          capturedContext = context;
+          return const SizedBox.shrink();
+        }),
+      ),
+    );
+
+    // runAsync puts this on the real event loop. The widget tester's fake clock
+    // never advances the timers the container refreshes on, so a bare await here
+    // waits forever.
+    await tester.runAsync(() async {
+      await container.read(sourceListProvider.future);
+      final before = sources.listCalls;
+
+      await container
+          .read(extensionActionsProvider)
+          .installFile(capturedContext, file: apk);
+      await container.read(sourceListProvider.future);
+
+      expect(extensions.fileInstalls.single.name, 'source.apk');
+      expect(sources.listCalls, before + 1);
+    });
+  });
+}
+
+class _ThrowingRepository extends ExtensionRepository {
+  _ThrowingRepository() : super(_dummyClient());
+
+  @override
+  Future<void> installExtension(String pkgName) async =>
+      throw Exception('install failed');
+
+  @override
+  Future<List<Extension>?> getExtensionListStream() async => <Extension>[];
+}


### PR DESCRIPTION
Installing an extension registered its sources on the server, but the app only refreshed the extension list. The Sources tab kept showing the set it had loaded at launch, and since Browse keeps its tabs alive, switching back to Sources revealed that stale copy instead of rebuilding it. Only restarting the app cleared it.

Global search and the Migrate picker read the same list, so a newly installed extension wasn't searchable or migratable either. Uninstalling had the mirror problem: the removed extension's sources lingered.

## What changed

Every extension action — install, install from an APK, update, uninstall, and the Obsolete button — now goes through `ExtensionActions`, which refreshes the extension list and invalidates the source list together. Adding a new extension action in future can't silently skip the source refresh.

The Obsolete button was also uninstalling with no refresh, no spinner and no error toast at all; it now behaves like every other action.

Suwayomi-WebUI handles this the same way, evicting its cached `sources` field after every `updateExtension` mutation.

## Why a plain refetch is enough

`installExtension` writes the new `SourceTable` rows inside the same transaction that installs the extension, so the sources exist by the time the mutation resolves. There's no timing window to work around.

## Notes

- `extensionActionsProvider` is `keepAlive` deliberately: callers reach it with `ref.read` inside a button handler and then await a network round trip, so an auto-disposing provider would be gone before the refresh ran.
- The language-filter step moved into `install` unchanged, including leaving an emptied filter alone.

## Testing

- 7 new tests: install, uninstall, update, install-from-file, a rejected install leaving the source list untouched, and both language-filter branches.
- Full suite green (1621 tests).
- Verified on device: installing an extension surfaces its sources in Sources immediately, and uninstalling removes them, with no restart.

Closes #344
