### PR TITLE
Never leave the paged reader resting between two pages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'src/features/tracking/domain/tracker_oauth_helpers.dart';
 import 'src/global_providers/global_providers.dart';
 import 'src/sorayomi.dart';
 import 'src/utils/crash/crash_log.dart';
+import 'src/utils/crash/diagnostics.dart';
 import 'src/utils/crash/redact_tokens.dart';
 import 'src/utils/desktop/desktop_window.dart';
 import 'src/utils/hive/graphql_cache_guard.dart';
@@ -398,6 +399,7 @@ void _logBoot(String stage) {
 /// crash startup.
 Future<void> _setUpCrashReporting() async {
   _crashLogPath = await initCrashLog();
+  setDiagnosticSink((line) => writeCrashLog(_crashLogPath, line));
   FlutterError.onError = (details) {
     FlutterError.presentError(details);
     _logCrash(details.exception, details.stack);

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart
@@ -13,6 +13,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../../../constants/enum.dart';
+import '../../../../../../utils/crash/diagnostics.dart';
 import '../../../../../../widgets/custom_circular_progress_indicator.dart';
 import '../reader_wrapper.dart';
 import 'double_page_view.dart';
@@ -20,6 +21,39 @@ import 'paged_display_window.dart';
 import 'paged_spread_mapping.dart';
 
 enum _DragOwner { page, pager }
+
+/// Captured at the drop, not reconstructed later: a settle writes its
+/// intermediate positions into `_dragOffset`, so the resting offset alone can't
+/// tell an abandoned turn from an unsettled drag.
+class _StrandRecord {
+  const _StrandRecord({
+    required this.target,
+    required this.offset,
+    required this.extent,
+    required this.generation,
+    required this.owner,
+    required this.stop,
+    required this.interrupted,
+    required this.at,
+  });
+
+  final double target;
+  final double offset;
+  final double extent;
+  final int generation;
+  final String owner;
+  final String stop;
+  final bool interrupted;
+  final DateTime at;
+
+  String describe() {
+    final fraction = extent > 0 ? (target / extent) : 0;
+    return 'stop=$stop owner=$owner gen=$generation '
+        'targetPages=${fraction.toStringAsFixed(2)} '
+        'atProgress=${(extent > 0 ? offset / extent : 0).toStringAsFixed(3)} '
+        'interrupted=$interrupted';
+  }
+}
 
 enum _PanDirection { left, right, up, down }
 
@@ -44,6 +78,12 @@ class PagedReaderController {
   bool get isAtFirst => _state?.isAtFirstDisplay ?? false;
 
   bool get isAtLast => _state?.isAtLastDisplay ?? false;
+
+  /// Strands the pager [progress] of a turn from its slot. Test-only, and the
+  /// only way in: every reachable path that abandons a turn now re-rests the
+  /// pager, which is why the reported stranding has never been traced.
+  @visibleForTesting
+  void debugStrand(double progress) => _state?._debugStrand(progress);
 }
 
 /// Continuous multi-chapter paged viewport.
@@ -168,6 +208,14 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   static const Duration _doubleTapZoomDuration = Duration(milliseconds: 200);
   static const Curve _settleCurve = Curves.easeOutCubic;
 
+  /// Far above [_pageTurnThreshold] on purpose: that one reads release intent,
+  /// which a stranding gives no evidence of. Below this we snap back — repeating
+  /// a page is recoverable, skipping one is not.
+  static const double _restCommitThreshold = 0.9;
+
+  static const Duration _diagnosticInterval = Duration(seconds: 5);
+  static const int _maxDiagnosticsPerSession = 20;
+
   late int _displayIndex;
   late final AnimationController _pageAnimation;
   late final AnimationController _panAnimation;
@@ -178,6 +226,18 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   /// Bumped whenever a turn in flight is abandoned, so its completion can't
   /// commit a target that no longer matches where the pager ended up.
   int _motionGeneration = 0;
+
+  /// Set while a settle owes a completion. Between an animation ending and its
+  /// completion microtask the pager legitimately sits a full page from its slot,
+  /// and the rest guard would pre-empt the commit.
+  bool _commitPending = false;
+
+  /// Recorded at each stop rather than inferred: the touch path stops the
+  /// animation directly, not via [_abandonMotion], so one guess goes stale.
+  String _lastMotionStop = 'none';
+  _StrandRecord? _strand;
+  DateTime? _lastDiagnosticAt;
+  int _diagnosticCount = 0;
   Size _viewportSize = Size.zero;
   final Map<int, Offset> _pointers = {};
   // Keyed by (chapterId, page identity), not display index — a late wide page
@@ -306,7 +366,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
 
   void _reanchor(PagedDisplayWindow oldWindow) {
     // In-flight motion still targets the OLD window.
-    _abandonMotion();
+    _abandonMotion('reanchor');
 
     final item = (_displayIndex >= 0 && _displayIndex < oldWindow.length)
         ? oldWindow.items[_displayIndex]
@@ -344,8 +404,12 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   /// left running writes its old position over wherever we land next, then
   /// finishes by committing the page IT was aiming at; a zoom left running
   /// keeps scaling a page that is no longer the one on screen.
-  void _abandonMotion() {
+  void _abandonMotion(String reason) {
     _motionGeneration++;
+    // Nothing takes over here, so no completion is owed — leaving this set would
+    // mute the rest guard for good.
+    _commitPending = false;
+    _lastMotionStop = reason;
     _pageAnimation.stop();
     _pageTween = null;
     _stopPanAnimation();
@@ -353,7 +417,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
   }
 
   void jumpToRaw(int rawIndex) {
-    _abandonMotion();
+    _abandonMotion('seek');
     final chapterId = _currentChapterId();
     final target = chapterId == null
         ? -1
@@ -375,7 +439,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
 
   void moveByCommand(int delta) {
     if (delta == 0 || _pageAnimation.isAnimating) return;
-    _abandonMotion();
+    _abandonMotion('command');
     if (widget.navigateToPan && _panCurrentPage(_commandPanDirection(delta))) {
       return;
     }
@@ -484,6 +548,7 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
           _panAnimation.isAnimating ||
           _zoomAnimation.isAnimating;
     }
+    if (_pageAnimation.isAnimating) _lastMotionStop = 'touch';
     _pageAnimation.stop();
     _stopPanAnimation();
     _stopZoomAnimation();
@@ -598,6 +663,8 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
     _pointers.remove(event.pointer);
     if (_longPressActive) {
       _finishLongPress();
+      // This return skips the displaced-pager net further down.
+      _enforcePagerRest();
       return;
     }
     _longPressTimer?.cancel();
@@ -1033,14 +1100,103 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
       begin: _dragOffset,
       end: target,
     ).animate(CurvedAnimation(parent: _pageAnimation, curve: _settleCurve));
+    _commitPending = true;
     _pageAnimation.forward().whenCompleteOrCancel(() {
-      if (!mounted || generation != _motionGeneration) return;
+      if (generation != _motionGeneration) {
+        // Only a strand if nothing took over: a turn superseded by the next one
+        // is ordinary, and logging it would bury the real event.
+        if (!_commitPending && _dragOffset != 0) {
+          _recordStrand(target: target, generation: generation);
+          _scheduleRestCheck();
+        }
+        return;
+      }
+      _commitPending = false;
+      if (!mounted) return;
       onComplete?.call();
       if (target == 0) {
         setState(() => _dragOffset = 0);
         _notifyIdle();
       }
     });
+  }
+
+  @visibleForTesting
+  void _debugStrand(double progress) {
+    _motionGeneration++;
+    _commitPending = false;
+    _lastMotionStop = 'debug';
+    _pageAnimation.stop();
+    _pageTween = null;
+    setState(() => _dragOffset = -progress * _axisSign * _axisExtent);
+  }
+
+  void _recordStrand({required double target, required int generation}) {
+    _strand = _StrandRecord(
+      target: target,
+      offset: _dragOffset,
+      extent: _axisExtent,
+      generation: generation,
+      owner: _dragOwner?.name ?? 'none',
+      stop: _lastMotionStop,
+      interrupted: _interruptedByAnimation,
+      at: DateTime.now(),
+    );
+  }
+
+  void _scheduleRestCheck() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _enforcePagerRest();
+    });
+  }
+
+  /// The pager must never come to rest between two slots. Enforced here rather
+  /// than at each site that can abandon a turn, so a stranding heals whatever
+  /// caused it — including causes we have not found.
+  void _enforcePagerRest() {
+    if (_dragOffset == 0) return;
+    if (_pointers.isNotEmpty) return;
+    if (_pageAnimation.isAnimating) return;
+    if (_commitPending) return;
+
+    if (_axisExtent <= 0) {
+      // Keeping a pixel offset with no extent lets a later, narrower layout read
+      // it as a much larger fraction of a page.
+      _logRestRecovery(progress: 0, action: 'zero-extent');
+      setState(() => _dragOffset = 0);
+      return;
+    }
+
+    final progress = -_dragOffset * _axisSign / _axisExtent;
+    if (progress.abs() >= _restCommitThreshold) {
+      _logRestRecovery(progress: progress, action: 'commit');
+      _animateToDisplay(_displayIndex + (progress > 0 ? 1 : -1));
+      return;
+    }
+    _logRestRecovery(progress: progress, action: 'snapback');
+    _animateOffsetTo(0);
+  }
+
+  void _logRestRecovery({required double progress, required String action}) {
+    final now = DateTime.now();
+    final last = _lastDiagnosticAt;
+    if (_diagnosticCount >= _maxDiagnosticsPerSession) return;
+    if (last != null && now.difference(last) < _diagnosticInterval) return;
+    _lastDiagnosticAt = now;
+    _diagnosticCount++;
+
+    final strand = _strand;
+    final held = strand == null
+        ? -1
+        : now.difference(strand.at).inMilliseconds;
+    recordDiagnostic(
+      '[${now.toIso8601String()}] reader-rest: action=$action '
+      'progress=${progress.toStringAsFixed(3)} '
+      'index=$_displayIndex axis=${widget.axis.name} '
+      'reverse=${widget.reverse} zoom=${_currentZoomOrNull?.isActive ?? false} '
+      'spread=${widget.window.items[_clampDisplay(_displayIndex)] is SpreadDisplay} '
+      'heldMs=$held ${strand?.describe() ?? 'strand=none'}\n',
+    );
   }
 
   Duration _settleDuration(double target) {
@@ -1085,6 +1241,8 @@ class _PagedReaderViewportState extends State<PagedReaderViewport>
         _viewportSize = nextViewport;
         _syncZoomBounds();
         if (resized) _republishVisibleMetrics();
+        // Catch-all: a stranding from a path we never found heals next frame.
+        if (_dragOffset != 0) _scheduleRestCheck();
         return GestureDetector(
           behavior: HitTestBehavior.opaque,
           onLongPress: _claimLongPressArena,

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2634,12 +2634,12 @@
     "@serverUnreachableAction": {
         "description": "Button that opens the connection settings screen"
     },
-    "clearCrashLog": "Clear crash log",
-    "copyCrashLog": "Copy crash log",
-    "copyCrashLogSubtitle": "For bug reports — copies the latest error log to the clipboard",
-    "crashLogCleared": "Crash log cleared",
-    "crashLogCopied": "Crash log copied to clipboard",
-    "noCrashLog": "No crash log found",
+    "clearCrashLog": "Clear debug log",
+    "copyCrashLog": "Copy debug log",
+    "copyCrashLogSubtitle": "For bug reports — copies recent errors and reader diagnostics",
+    "crashLogCleared": "Debug log cleared",
+    "crashLogCopied": "Debug log copied to clipboard",
+    "noCrashLog": "No debug log found",
     "serverUrl": "Server URL",
     "serverUrlHintText": "Server url",
     "serverVersion": "Server version",

--- a/lib/src/utils/crash/diagnostics.dart
+++ b/lib/src/utils/crash/diagnostics.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// Breadcrumbs for non-fatal faults, written into the same log the crash
+/// handlers use so Settings' copy action picks them up.
+///
+/// A sink rather than a direct write: the log path resolves once at startup and
+/// callers deep in the widget tree can't await it. Tests swap it to capture.
+typedef DiagnosticSink = void Function(String line);
+
+DiagnosticSink? _sink;
+
+void setDiagnosticSink(DiagnosticSink? sink) => _sink = sink;
+
+void recordDiagnostic(String line) => _sink?.call(line);

--- a/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
+++ b/test/src/features/manga_book/reader/paged_reader_viewport_test.dart
@@ -16,6 +16,7 @@ import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/read
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_spread_mapping.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart';
+import 'package:tsumiru/src/utils/crash/diagnostics.dart';
 
 const _png1x1 =
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
@@ -960,6 +961,194 @@ void main() {
       isNotEmpty,
       reason: 'pager rested between slots: $slotOffsets',
     );
+  });
+
+  Future<List<double>> strandAndSettle(
+    WidgetTester tester,
+    PagedReaderController controller,
+    double progress,
+  ) async {
+    controller.debugStrand(progress);
+    await tester.pumpAndSettle();
+    return [
+      for (final transform in tester.widgetList<Transform>(
+        find.ancestor(
+          of: find.byType(ClipRect),
+          matching: find.byType(Transform),
+        ),
+      ))
+        transform.transform.storage[12],
+    ];
+  }
+
+  testWidgets('a pager stranded mid-turn comes to rest on a slot', (
+    tester,
+  ) async {
+    final pages = _localPages(3);
+    final mapping = buildSpreadMapping(
+      pageCount: pages.length,
+      doublePages: false,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    );
+    final controller = PagedReaderController();
+    await _pumpViewport(
+      tester,
+      controller: controller,
+      mapping: mapping,
+      pages: pages,
+      initialDisplayIndex: 0,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(),
+    );
+
+    final offsets = await strandAndSettle(tester, controller, 0.4);
+    expect(
+      offsets.where((dx) => dx.abs() < 0.1),
+      isNotEmpty,
+      reason: 'pager left resting between slots: $offsets',
+    );
+  });
+
+  testWidgets('a barely-started turn snaps back instead of skipping a page', (
+    tester,
+  ) async {
+    // 0.19 clears the 0.18 turn threshold, so recovering through the normal
+    // settle logic would advance the page.
+    final pages = _localPages(3);
+    final mapping = buildSpreadMapping(
+      pageCount: pages.length,
+      doublePages: false,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    );
+    final controller = PagedReaderController();
+    final seen = <int>[];
+    await _pumpViewport(
+      tester,
+      controller: controller,
+      mapping: mapping,
+      pages: pages,
+      initialDisplayIndex: 0,
+      onRawPageChanged: seen.add,
+      callbacks: _callbacks(),
+    );
+    seen.clear();
+
+    await strandAndSettle(tester, controller, 0.19);
+
+    expect(seen, isEmpty, reason: 'recovery moved the reader off the page');
+  });
+
+  testWidgets('an all-but-finished turn is committed, not thrown away', (
+    tester,
+  ) async {
+    final pages = _localPages(3);
+    final mapping = buildSpreadMapping(
+      pageCount: pages.length,
+      doublePages: false,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    );
+    final controller = PagedReaderController();
+    final seen = <int>[];
+    await _pumpViewport(
+      tester,
+      controller: controller,
+      mapping: mapping,
+      pages: pages,
+      initialDisplayIndex: 0,
+      onRawPageChanged: seen.add,
+      callbacks: _callbacks(),
+    );
+    seen.clear();
+
+    final offsets = await strandAndSettle(tester, controller, 0.95);
+
+    expect(seen.last, 1, reason: 'the turn the user made was dropped');
+    expect(offsets.where((dx) => dx.abs() < 0.1), isNotEmpty);
+  });
+
+  testWidgets('recovering records a diagnostic naming what it did', (
+    tester,
+  ) async {
+    final lines = <String>[];
+    setDiagnosticSink(lines.add);
+    addTearDown(() => setDiagnosticSink(null));
+
+    final pages = _localPages(3);
+    final mapping = buildSpreadMapping(
+      pageCount: pages.length,
+      doublePages: false,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    );
+    final controller = PagedReaderController();
+    await _pumpViewport(
+      tester,
+      controller: controller,
+      mapping: mapping,
+      pages: pages,
+      initialDisplayIndex: 0,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(),
+    );
+
+    await strandAndSettle(tester, controller, 0.4);
+
+    expect(lines, hasLength(1));
+    expect(lines.single, contains('reader-rest:'));
+    expect(lines.single, contains('action=snapback'));
+    expect(lines.single, contains('progress=0.400'));
+    expect(lines.single, contains('axis=horizontal'));
+  });
+
+  testWidgets('the guard leaves a drag in progress alone', (tester) async {
+    final pages = _localPages(3);
+    final mapping = buildSpreadMapping(
+      pageCount: pages.length,
+      doublePages: false,
+      splitWide: false,
+      splitInvert: false,
+      isWide: (_) => false,
+    );
+    final controller = PagedReaderController();
+    await _pumpViewport(
+      tester,
+      controller: controller,
+      mapping: mapping,
+      pages: pages,
+      initialDisplayIndex: 0,
+      onRawPageChanged: (_) {},
+      callbacks: _callbacks(),
+    );
+
+    final center = tester.getCenter(find.byType(PagedReaderViewport));
+    final drag = await tester.startGesture(center);
+    await drag.moveBy(const Offset(-60, 0));
+    await tester.pump(const Duration(milliseconds: 40));
+    await tester.pump(const Duration(milliseconds: 40));
+
+    // Mid-drag every slot is legitimately off-grid; snapping here would fight
+    // the finger.
+    final offsets = [
+      for (final transform in tester.widgetList<Transform>(
+        find.ancestor(
+          of: find.byType(ClipRect),
+          matching: find.byType(Transform),
+        ),
+      ))
+        transform.transform.storage[12],
+    ];
+    expect(offsets.every((dx) => dx.abs() >= 0.1), isTrue,
+        reason: 'the guard snapped the pager while a finger was down');
+
+    await drag.up();
+    await tester.pumpAndSettle();
   });
 
   testWidgets('two-finger tap does not leak into reader tap actions', (


### PR DESCRIPTION
Readers keep reporting two pages drawn side by side in the paged reader, still on v1.1.3. The reporter's screenshot decodes as the pager **resting between two slots** — a page at base fit on one side of a clean vertical seam, a different page zoomed on the other — rather than pages composited on top of each other. That's the signature from #314.

Three fixes have already shipped against this symptom and all three are in v1.1.3 (checked against the tags): #185, #285 and #315. Each closed one specific route to it. The reports continue, so the remaining route is one that reading the code has not found — an audit of every path that can abandon a page turn came back clean.

## Enforce the rule centrally

The invariant "the pager never rests between two pages" has been asserted twice in comments and enforced only at whichever call sites we thought of at the time. This enforces it in one place: when the pager is resting off a slot with nothing animating, no commit owed and nobody touching the screen, land it. A stranding heals whatever caused it, including causes we haven't identified.

It deliberately does **not** reuse the drag settle logic. That commits a turn at 18% of a swipe because it is reading a user's release intent, which a stranding gives no evidence of — recovering through it would have silently skipped pages. Recovery only completes a turn that had all but finished (90%+), and otherwise returns to the page being read. Repeating a page is recoverable; skipping one is not.

A `_commitPending` flag covers the gap between an animation ending and its completion running, where the pager legitimately sits a full page from its slot. Without it the guard would pre-empt the commit and eat the turn.

## Make the next report useful

Each recovery appends one line to the log Settings can already copy: how far off-boundary, what last stopped the turn, that turn's target, drag owner, zoom state, axis, and how long it sat. Capped at one line per 5 s and 20 per session; the file already self-trims at 256 KB. Nothing is written when nothing goes wrong.

This is what ends the loop. Recoveries logged means we finally have the trigger. **No recoveries logged while pages still overlap proves it was never a stranded pager**, and that the whole family we've fixed three times is the wrong tree — which nothing before this could rule out.

The Settings tile is renamed from "Copy crash log" to "Copy debug log" in a separate commit: it's where someone goes after something went wrong, but it only advertised crashes, so nobody reporting a visual glitch would think to open it. String keys are unchanged.

## Testing

- 5 new tests: a stranded pager comes to rest; a 19% strand snaps back **without** moving the page (pins the skipped-page regression the design review caught); a 95% strand commits the turn; the guard leaves a drag in progress alone; a recovery records a diagnostic.
- Because no reachable path strands the pager any more, tests reach it through a `@visibleForTesting` hook — otherwise the recovery would ship untested.
- Full suite green (1619). Analyzer clean.
- Device-verified: normal reading, zooming, slider scrubbing and chapter transitions show no spurious page turns.

Follow-on: #346 tracks the underlying architectural debt — Komikku, WebUI, Catalyst and mangayomi all delegate settling to a real pager, and we're the only one of the four that owns it.
