### PR TITLE
Let people back out of global search

### DIFF
--- a/lib/src/features/browse_center/presentation/browse/browse_screen.dart
+++ b/lib/src/features/browse_center/presentation/browse/browse_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../routes/navigation.dart';
 import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../data/extension_store_repository/extension_store_repository.dart';
@@ -53,7 +54,7 @@ class BrowseScreen extends HookConsumerWidget {
           if (tabController.index == 0) ...[
             IconButton(
               tooltip: context.l10n.globalSearch,
-              onPressed: () => const GlobalSearchRoute().push(context),
+              onPressed: () => openGlobalSearch(context),
               icon: const Icon(Icons.travel_explore_rounded),
             ),
             IconButton(

--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -14,6 +14,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../constants/app_sizes.dart';
 import '../../../../constants/enum.dart';
+import '../../../../routes/navigation.dart';
 import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/misc/toast/toast.dart';
@@ -299,9 +300,10 @@ class _DefaultLibraryToggledSearch extends HookConsumerWidget {
                                   tooltip: context.l10n.globalSearch,
                                   onPressed:
                                       ref.watch(libraryQueryProvider).isNotBlank
-                                      ? () => GlobalSearchRoute(
+                                      ? () => openGlobalSearch(
+                                          context,
                                           query: ref.read(libraryQueryProvider),
-                                        ).go(context)
+                                        )
                                       : null,
                                 ),
                               ),
@@ -1123,7 +1125,7 @@ class _LibrarySearchBar extends ConsumerWidget {
           IconButton(
             icon: const Icon(Icons.travel_explore_rounded),
             tooltip: context.l10n.globalSearch,
-            onPressed: () => GlobalSearchRoute(query: query).push(context),
+            onPressed: () => openGlobalSearch(context, query: query),
           ),
       ],
       highlightDsl: true,

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/manga_description.dart
@@ -14,7 +14,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../../constants/app_sizes.dart';
 import '../../../../../graphql/__generated__/schema.graphql.dart';
-import '../../../../../routes/router_config.dart';
+import '../../../../../routes/navigation.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/launch_url_in_web.dart';
 import '../../../../../utils/misc/toast/toast.dart';
@@ -199,7 +199,7 @@ class MangaDescription extends HookConsumerWidget {
                 manga: manga,
                 showBadges: false,
                 onTitleClicked: (query) =>
-                    GlobalSearchRoute(query: query).push(context),
+                    openGlobalSearch(context, query: query),
                 belowStatus: soonWidget,
                 titleMaxLines: null,
               ),

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/tag_actions_menu.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/tag_actions_menu.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../../routes/navigation.dart';
 import '../../../../../routes/router_config.dart';
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../../../utils/misc/toast/toast.dart';
@@ -52,7 +53,7 @@ Future<void> showTagActionsMenu(
       ref.read(libraryQueryProvider.notifier).update(tag);
       const LibraryRoute(categoryId: 0).go(context);
     case 'global':
-      GlobalSearchRoute(query: tag).push(context);
+      openGlobalSearch(context, query: tag);
     case 'copy':
       Clipboard.setData(ClipboardData(text: tag));
       ref.read(toastProvider)?.show(context.l10n.copiedToClipboard);

--- a/lib/src/features/manga_book/presentation/recommends/recommendation_card.dart
+++ b/lib/src/features/manga_book/presentation/recommends/recommendation_card.dart
@@ -7,7 +7,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../constants/app_sizes.dart';
-import '../../../../routes/router_config.dart';
+import '../../../../routes/navigation.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../data/recommendations/recommendation_provider.dart';
 
@@ -26,7 +26,7 @@ class RecommendationCard extends StatelessWidget {
       width: 96,
       child: InkWell(
         borderRadius: KBorderRadius.r8.radius,
-        onTap: () => GlobalSearchRoute(query: rec.title).push(context),
+        onTap: () => openGlobalSearch(context, query: rec.title),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,

--- a/lib/src/features/manga_book/presentation/recommends/recommends_browse_screen.dart
+++ b/lib/src/features/manga_book/presentation/recommends/recommends_browse_screen.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../constants/app_sizes.dart';
-import '../../../../routes/router_config.dart';
+import '../../../../routes/navigation.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../widgets/emoticons.dart';
 import '../../data/recommendations/recommendation_repository.dart';
@@ -66,7 +66,7 @@ class RecommendsBrowseScreen extends ConsumerWidget {
                   return InkWell(
                     borderRadius: KBorderRadius.r8.radius,
                     onTap: () =>
-                        GlobalSearchRoute(query: r.title).push(context),
+                        openGlobalSearch(context, query: r.title),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [

--- a/lib/src/features/quick_open/presentation/unified_search/unified_search_screen.dart
+++ b/lib/src/features/quick_open/presentation/unified_search/unified_search_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../../../routes/navigation.dart';
 import '../../../../routes/router_config.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/platform/platform_runtime.dart';
@@ -161,7 +162,7 @@ class UnifiedSearchScreen extends HookConsumerWidget {
                         } else if (goToHits.isNotEmpty) {
                           goToHits.first.navigate(context);
                         } else if (plainQuery.isNotEmpty) {
-                          GlobalSearchRoute(query: plainQuery).push(context);
+                          openGlobalSearch(context, query: plainQuery);
                         } else {
                           return; // pure operator query, nothing typed to hand off
                         }
@@ -234,7 +235,7 @@ class UnifiedSearchScreen extends HookConsumerWidget {
                             leading: const Icon(Icons.travel_explore_rounded),
                             title: Text(l.unifiedSearchAllSources(plainQuery)),
                             onTap: () {
-                              GlobalSearchRoute(query: plainQuery).push(context);
+                              openGlobalSearch(context, query: plainQuery);
                               close();
                             },
                           ),

--- a/lib/src/routes/navigation.dart
+++ b/lib/src/routes/navigation.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/widgets.dart';
+
+import 'router_config.dart';
+
+/// Global search is a top-level route, so it covers the shell and its bottom
+/// nav. It has to be pushed: `go` replaces the stack, leaving nothing to go
+/// back to and no way off the screen but killing the app (#350). Routed
+/// through here so no caller has to know that.
+void openGlobalSearch(BuildContext context, {String? query}) =>
+    GlobalSearchRoute(query: query).push(context);

--- a/test/src/features/library/global_search_navigation_test.dart
+++ b/test/src/features/library/global_search_navigation_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Regression guard for #350: the library's global-search button replaced the
+// navigation stack, so global search opened with the shell gone and nothing
+// underneath. There was no back entry and no bottom nav, and closing the app
+// was the only way back to the library.
+//
+// The route topology here mirrors the real one: the library lives inside the
+// shell, global search is a top-level sibling of it.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tsumiru/src/routes/navigation.dart';
+
+GoRouter _router() => GoRouter(
+      initialLocation: '/library/0',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) => Scaffold(
+            body: child,
+            bottomNavigationBar: const Text('BOTTOM NAV'),
+          ),
+          routes: [
+            GoRoute(
+              path: '/library/:categoryId',
+              builder: (context, state) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => openGlobalSearch(context, query: 'king'),
+                    child: const Text('global search'),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        GoRoute(
+          path: '/global-search',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('GLOBAL SEARCH'))),
+        ),
+      ],
+    );
+
+void main() {
+  group('opening global search from the library', () {
+    testWidgets('leaves a route to come back to', (tester) async {
+      final router = _router();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('global search'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('GLOBAL SEARCH'), findsOneWidget);
+
+      final navigator = tester.state<NavigatorState>(
+        find.byType(Navigator).last,
+      );
+      expect(navigator.canPop(), isTrue,
+          reason: 'go() would replace the stack and strand the reader here');
+    });
+
+    testWidgets('going back returns to the library and its nav bar',
+        (tester) async {
+      final router = _router();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('global search'));
+      await tester.pumpAndSettle();
+
+      tester.state<NavigatorState>(find.byType(Navigator).last).pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('GLOBAL SEARCH'), findsNothing);
+      expect(find.text('global search'), findsOneWidget);
+      expect(find.text('BOTTOM NAV'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #350

Opening global search from the library left no way back. Global search is a top-level route, so it renders over the shell — and the library's button *replaced* the navigation stack instead of pushing onto it, so it opened with the bottom nav gone and nothing beneath to return to. The only back arrow on screen belongs to the search field and merely clears the text. Force-closing the app was the only way back to the library.

Reproduced in a running build, and confirmed fixed the same way: the route back arrow now appears, and pressing it returns to the library with its nav bar and the search query intact.

### Why it survived #280

#280 fixed this same call in July, but the library has **two** global-search entry points and it only changed one. At that merge commit the file still had `.go(context)` at line 233 alongside the fixed `.push(context)` at line 905. The bug was never gone — just moved out of sight.

So rather than change the second line and leave the same trap for next time, every entry point (library ×2, Browse, unified search, tag menu, description, recommends ×2) now calls `openGlobalSearch()`, which owns the push/replace decision. There is no longer a second call site to overlook.

### Tests

Two regression tests over a router that mirrors the real topology — library inside the shell, global search as a top-level sibling. They assert a back route exists and that popping restores the library and its nav bar. Verified they genuinely guard: reverting the helper to `.go()` fails both.

Full suite green at 1635.