### PR TITLE
Stop asking the server for chapters on every launch

### DIFF
--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -1337,6 +1337,16 @@ Future<void> reconcileMangaContainer(
 }
 
 /// Launch entry point (main.dart holds a ProviderContainer, not a Ref).
+///
+/// Deliberately passes no `enqueueServerDownload`: asking the server for a
+/// chapter it doesn't have sends it out to the source, and doing that for the
+/// whole library on every start re-issued the same request forever whenever the
+/// server was behind — a permanent CPU load and an endless challenge-solving
+/// storm for sources the reader never opened (#354). Filling the server is the
+/// server's own job (`autoDownloadNewChapters`, bounded by
+/// `autoDownloadNewChaptersLimit`); the request belongs to the moment a reader
+/// asks for a series, not to the app starting. Everything else here is local:
+/// evicting orphans and pulling chapters the server already holds.
 Future<void> reconcileAllAtLaunch(ProviderContainer container) async {
   if (!container.read(offlineActiveProvider)) return;
   final manager = container.read(offlineDownloadManagerProvider);
@@ -1355,9 +1365,6 @@ Future<void> reconcileAllAtLaunch(ProviderContainer container) async {
         mangaId: m.id,
         deleteWhileReadingSlots:
             container.read(localDeleteSettingsProvider).deleteWhileReading,
-        enqueueServerDownload: (ids) => container
-            .read(downloadsRepositoryProvider)
-            .addChaptersBatchToDownloadQueue(ids),
         removeFromWorker: (id) async {
           final ctrl = container.read(backgroundDownloadControllerProvider);
           await ctrl.onRemoved(id);

--- a/test/src/features/offline/data/launch_reconcile_server_request_test.dart
+++ b/test/src/features/offline/data/launch_reconcile_server_request_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Regression guard for #354. Asking the server to fetch a chapter sends it out
+// to the source, so it must follow a user's decision, not the app starting.
+// Launch reconcile swept the whole library and re-issued that request every
+// start, which pinned the CPU and kept FlareSolverr solving challenges for
+// sources the reader never opened.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_reconciler.dart';
+import 'package:tsumiru/src/features/offline/data/reconcile_types.dart';
+import '../../../../helpers/offline_test_db.dart';
+
+void main() {
+  late OfflineDatabase db;
+  setUp(() => db = testOfflineDatabase());
+  tearDown(() => db.close());
+
+  Future<void> seed() async {
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.all, 3);
+    // Wanted by the rule, but the server hasn't fetched it from the source yet.
+    await db.upsertChapterMetadata(
+      id: 1, mangaId: 1, name: 'c1', chapterIndex: 1, isRead: false,
+      lastPageRead: 0, isBookmarked: false, serverIsDownloaded: false,
+      pageCount: 1, updatedAt: DateTime(2026),
+    );
+  }
+
+  test('a launch-shaped reconcile asks the server for nothing', () async {
+    await seed();
+    final asked = <int>[];
+    await OfflineReconciler(
+      db: db,
+      nets: SafetyNetConfig.off,
+      onDownload: (_) async {},
+      onEvict: (_) async {},
+      now: DateTime(2026, 3, 1),
+      // Launch passes no handler: filling the server is the server's job, and
+      // it already does it on its own schedule within its own limit.
+    ).reconcileManga(1);
+
+    expect(asked, isEmpty, reason: 'launch must not generate source traffic');
+  });
+
+  test('a user-initiated reconcile still asks the server', () async {
+    await seed();
+    final asked = <int>[];
+    await OfflineReconciler(
+      db: db,
+      nets: SafetyNetConfig.off,
+      onDownload: (_) async {},
+      onEvict: (_) async {},
+      now: DateTime(2026, 3, 1),
+      onServerDownload: (ids) async => asked.addAll(ids),
+    ).reconcileManga(1);
+
+    expect(asked, [1],
+        reason: 'setting a keep rule must still top up the server');
+  });
+}


### PR DESCRIPTION
Closes #354

Every launch, Tsumiru walked the whole library and — for each chapter a keep rule wanted that the server didn't have — told the server to go fetch it. That request sends the server out to the source, so a server that was behind got the same instruction on every single start, forever.

Reported by Primrula: constant 10-12% CPU and app-wide lag on Windows and Android, with FlareSolverr solving challenges continuously for sources they had never browsed, and **no downloads running**. Closing the app stopped it. Their own test is what identified it — Settings → Downloads → On device → Remove all Downloads made the lag vanish *even with nothing downloaded on the device*, because that path clears the keep rules the launch sweep was acting on.

### Why it stayed hidden

A fully-downloaded server produces an empty request set on every pass, so the bug is invisible there. It only appears when the server is still missing chapters a keep rule wants — the normal state for anyone filling their library.

### What changes

Launch reconcile no longer passes `enqueueServerDownload`. Filling the server is the server's own job and it already does it inside a limit the user sets (`autoDownloadNewChapters` / `autoDownloadNewChaptersLimit`). Komikku draws the same line: its update job downloads what an update just discovered, never a desired state re-derived from scratch, and it runs on an interval rather than at launch.

The request now belongs to the moments a reader actually asks for a series — setting a keep rule, opening it, migrating — all of which still pass the handler. Launch keeps its local work: evicting orphans and pulling chapters the server already holds, neither of which touches a source.

### Not included

The CPU cost of downloading itself is a separate problem with a separate cause (an fsync per page). A fix was prototyped and dropped: it needs the download path to commit per chapter rather than per page, which is designed but not built. Kept out deliberately rather than shipped as an interim change.