### PR TITLE
Open the reader on the page, and badge Browse with waiting extension updates

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -102,7 +102,10 @@ enum DBKeys {
   sourceDisplayMode(DisplayMode.grid),
   globalSearchSourceFilter(GlobalSearchSourceFilter.pinned),
   gridMangaCoverWidth(192.0),
-  readerOverlay(true),
+  // Off, like Mihon/Komikku (ReaderViewModel: `menuVisible = false`): a reader
+  // opens on the page, not on the chrome. Anyone who wants the title and quick
+  // settings up front can turn it back on in Settings > Reader.
+  readerOverlay(false),
   // Show the continuous-reader feedback snackbars ("loading next chapter",
   // "no more chapters", etc.). Off = a quiet reading experience.
   readerFeedbackToasts(true),

--- a/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
+++ b/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
@@ -86,6 +86,20 @@ class ExtensionRepository {
       )
       .getData((data) => null);
 
+  /// How many installed extensions have an update waiting.
+  ///
+  /// A plain query, unlike [getExtensionListStream] — that one is a mutation
+  /// that sends the server out to the extension repos, which is far too much to
+  /// do for a number on a navigation bar.
+  Future<int> getExtensionUpdateCount() => client
+      .query$ExtensionUpdateCount(
+        Options$Query$ExtensionUpdateCount(
+          fetchPolicy: FetchPolicy.networkOnly,
+        ),
+      )
+      .getData((data) => data.extensions.totalCount)
+      .then((value) => value ?? 0);
+
   Future<List<Extension>?> getExtensionListStream() =>
       client.mutate$FetchExtensionListStore().getData((data) => data
           .fetchExtensions?.extensions

--- a/lib/src/features/browse_center/data/extension_repository/graphql/query.graphql
+++ b/lib/src/features/browse_center/data/extension_repository/graphql/query.graphql
@@ -19,3 +19,12 @@ mutation InstallExternalExtension($extensionFile: Upload!) {
     }
   }
 }
+
+# Read-only count for the Browse nav badge. Deliberately NOT the fetchExtensions
+# mutation the extensions screen uses: that sends the server out to the repos,
+# and the nav shell is built on every launch.
+query ExtensionUpdateCount {
+  extensions(condition: {hasUpdate: true, isInstalled: true}) {
+    totalCount
+  }
+}

--- a/lib/src/features/browse_center/presentation/extension/controller/extension_update_badge.dart
+++ b/lib/src/features/browse_center/presentation/extension/controller/extension_update_badge.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../offline/data/server_reachability.dart';
+import '../../../data/extension_repository/extension_repository.dart';
+
+part 'extension_update_badge.g.dart';
+
+/// How many installed extensions have an update waiting, for the Browse nav
+/// badge (Mihon/Komikku do the same, `HomeScreen.kt`).
+///
+/// Extension updates were only discoverable by opening Browse and noticing a
+/// section, so people ran old extensions without knowing. A notification for
+/// this exists but is off by default and is a heavier interruption than a
+/// number on a tab.
+///
+/// Kept deliberately cheap: one count query, and none at all while the server
+/// is unreachable. The nav shell is built on every launch, so anything
+/// expensive here is paid constantly and by everyone.
+@riverpod
+Future<int> extensionUpdateBadgeCount(Ref ref) async {
+  if (ref.watch(serverUnreachableProvider)) return 0;
+  try {
+    return await ref
+        .watch(extensionRepositoryProvider)
+        .getExtensionUpdateCount();
+  } catch (_) {
+    // A badge is not worth surfacing an error for; it simply doesn't show.
+    return 0;
+  }
+}

--- a/lib/src/widgets/shell/big_screen_navigation_bar.dart
+++ b/lib/src/widgets/shell/big_screen_navigation_bar.dart
@@ -9,17 +9,20 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../constants/gen/assets.gen.dart';
 import '../../constants/navigation_bar_data.dart';
+import '../../features/browse_center/presentation/extension/controller/extension_update_badge.dart';
 import '../../features/offline/data/offline_nav_status.dart';
 import '../../routes/router_config.dart';
 import '../../utils/extensions/custom_extensions.dart';
 import 'animated_nav_icon.dart';
+import 'nav_badges.dart';
 import 'sidebar_expanded.dart';
 
 class BigScreenNavigationBar extends ConsumerWidget {
-  const BigScreenNavigationBar(
-      {super.key,
-      required this.selectedIndex,
-      required this.onDestinationSelected});
+  const BigScreenNavigationBar({
+    super.key,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+  });
 
   final int selectedIndex;
   final ValueChanged<int> onDestinationSelected;
@@ -29,12 +32,16 @@ class BigScreenNavigationBar extends ConsumerWidget {
   /// left-align (the rail's Column centers a narrower leading child).
   static const double _extendedWidth = 256;
 
-  NavigationRailDestination getNavigationRailDestination(BuildContext context,
-      NavigationBarData data, bool selected, bool downloadsPaused) {
-    final badged = downloadsPaused && data.icon == Icons.download_outlined;
+  NavigationRailDestination getNavigationRailDestination(
+    BuildContext context,
+    NavigationBarData data,
+    bool selected,
+    bool downloadsPaused,
+    int extensionUpdates,
+  ) {
     final icon = AnimatedNavIcon(vector: data.animatedIcon, selected: selected);
     return NavigationRailDestination(
-      icon: badged ? Badge(child: icon) : icon,
+      icon: badgedNavIcon(icon, data, downloadsPaused, extensionUpdates),
       label: Text(data.label(context)),
     );
   }
@@ -42,6 +49,8 @@ class BigScreenNavigationBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final downloadsPaused = ref.watch(downloadsPausedBadgeProvider);
+    final extensionUpdates =
+        ref.watch(extensionUpdateBadgeCountProvider).value ?? 0;
     final navList = NavigationBarData.getNavList(context);
     // The rail shows on any wide screen (width >= 600), which includes a phone
     // in landscape (short side < 600). There the height is tight, so drop the
@@ -56,7 +65,10 @@ class BigScreenNavigationBar extends ConsumerWidget {
     void toggleSidebar() =>
         ref.read(sidebarExpandedProvider.notifier).update(!expanded);
 
-    final logoIcon = ImageIcon(AssetImage(Assets.icons.darkIcon.path), size: 48);
+    final logoIcon = ImageIcon(
+      AssetImage(Assets.icons.darkIcon.path),
+      size: 48,
+    );
 
     final Widget leadingIcon;
     if (showExtended) {
@@ -121,21 +133,26 @@ class BigScreenNavigationBar extends ConsumerWidget {
             child: NavigationRail(
               useIndicator: true,
               elevation: 5,
-      extended: showExtended,
-      minExtendedWidth: _extendedWidth,
-      // Extended shows labels beside icons; otherwise keep them UNDER the icons
-      // (collapsed desktop + tablet) rather than dropping them.
-      labelType: showExtended
-          ? NavigationRailLabelType.none
-          : NavigationRailLabelType.all,
-      leading: isPhone ? null : leadingIcon,
-      destinations: [
-        for (var i = 0; i < navList.length; i++)
-          getNavigationRailDestination(
-              context, navList[i], i == selectedIndex, downloadsPaused),
-      ],
-      selectedIndex: selectedIndex,
-      onDestinationSelected: onDestinationSelected,
+              extended: showExtended,
+              minExtendedWidth: _extendedWidth,
+              // Extended shows labels beside icons; otherwise keep them UNDER the icons
+              // (collapsed desktop + tablet) rather than dropping them.
+              labelType: showExtended
+                  ? NavigationRailLabelType.none
+                  : NavigationRailLabelType.all,
+              leading: isPhone ? null : leadingIcon,
+              destinations: [
+                for (var i = 0; i < navList.length; i++)
+                  getNavigationRailDestination(
+                    context,
+                    navList[i],
+                    i == selectedIndex,
+                    downloadsPaused,
+                    extensionUpdates,
+                  ),
+              ],
+              selectedIndex: selectedIndex,
+              onDestinationSelected: onDestinationSelected,
             ),
           ),
         ),

--- a/lib/src/widgets/shell/nav_badges.dart
+++ b/lib/src/widgets/shell/nav_badges.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+
+import '../../constants/navigation_bar_data.dart';
+
+/// Wraps a nav icon in whatever badge its tab has earned.
+///
+/// Downloads carries a dot when downloading is paused with work still waiting.
+/// Browse carries a count of extensions with updates, which are otherwise only
+/// discoverable by opening the tab and noticing a section (Mihon and Komikku
+/// badge the same tab, `HomeScreen.kt`).
+Widget badgedNavIcon(
+  Widget icon,
+  NavigationBarData data,
+  bool downloadsPaused,
+  int extensionUpdates,
+) {
+  if (data.icon == Icons.download_outlined && downloadsPaused) {
+    return Badge(child: icon);
+  }
+  if (data.icon == Icons.explore_outlined && extensionUpdates > 0) {
+    return Badge(label: Text('$extensionUpdates'), child: icon);
+  }
+  return icon;
+}

--- a/lib/src/widgets/shell/small_screen_navigation_bar.dart
+++ b/lib/src/widgets/shell/small_screen_navigation_bar.dart
@@ -8,8 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../constants/navigation_bar_data.dart';
+import '../../features/browse_center/presentation/extension/controller/extension_update_badge.dart';
 import '../../features/offline/data/offline_nav_status.dart';
 import 'animated_nav_icon.dart';
+import 'nav_badges.dart';
 
 class SmallScreenNavigationBar extends ConsumerWidget {
   const SmallScreenNavigationBar({
@@ -21,12 +23,16 @@ class SmallScreenNavigationBar extends ConsumerWidget {
   final int selectedIndex;
   final void Function(int) onDestinationSelected;
 
-  NavigationDestination getNavigationDestination(BuildContext context,
-      NavigationBarData data, bool selected, bool downloadsPaused) {
-    final badged = downloadsPaused && data.icon == Icons.download_outlined;
+  NavigationDestination getNavigationDestination(
+    BuildContext context,
+    NavigationBarData data,
+    bool selected,
+    bool downloadsPaused,
+    int extensionUpdates,
+  ) {
     final icon = AnimatedNavIcon(vector: data.animatedIcon, selected: selected);
     return NavigationDestination(
-      icon: badged ? Badge(child: icon) : icon,
+      icon: badgedNavIcon(icon, data, downloadsPaused, extensionUpdates),
       label: data.label(context),
       tooltip: data.label(context),
     );
@@ -35,6 +41,8 @@ class SmallScreenNavigationBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final downloadsPaused = ref.watch(downloadsPausedBadgeProvider);
+    final extensionUpdates =
+        ref.watch(extensionUpdateBadgeCountProvider).value ?? 0;
     final navList = NavigationBarData.getNavList(context);
     return NavigationBarTheme(
       data: NavigationBarThemeData(
@@ -48,7 +56,12 @@ class SmallScreenNavigationBar extends ConsumerWidget {
         destinations: [
           for (var i = 0; i < navList.length; i++)
             getNavigationDestination(
-                context, navList[i], i == selectedIndex, downloadsPaused),
+              context,
+              navList[i],
+              i == selectedIndex,
+              downloadsPaused,
+              extensionUpdates,
+            ),
         ],
       ),
     );

--- a/test/src/features/manga_book/reader/auto_scroll_drag_test.dart
+++ b/test/src/features/manga_book/reader/auto_scroll_drag_test.dart
@@ -119,7 +119,11 @@ Future<ProviderContainer> _pumpReader(WidgetTester tester) async {
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.reset);
 
-  SharedPreferences.setMockInitialValues(const {});
+  // Chrome visible on purpose. The step-based auto-scroll timer only runs while
+  // chrome is hidden, and it stops at the last loaded page — with a 12-page
+  // fixture that fires immediately and ends auto-scroll for a reason that has
+  // nothing to do with the drag this test is about.
+  SharedPreferences.setMockInitialValues(const {'flutter.readerOverlay': true});
   final prefs = await SharedPreferences.getInstance();
   final chapter = _chapter();
 

--- a/test/src/widgets/shell/nav_badges_test.dart
+++ b/test/src/widgets/shell/nav_badges_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// The bar and the rail badge through one helper so the two layouts can't drift
+// apart, and a badge on the wrong tab is worse than no badge at all.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/animated_nav_vectors.dart';
+import 'package:tsumiru/src/constants/navigation_bar_data.dart';
+import 'package:tsumiru/src/widgets/shell/nav_badges.dart';
+
+const _marker = SizedBox.shrink();
+
+NavigationBarData _tab(IconData icon) => NavigationBarData(
+  icon: icon,
+  activeIcon: icon,
+  animatedIcon: AnimatedNavVectors.browse,
+  label: (_) => 'tab',
+);
+
+void main() {
+  final browse = _tab(Icons.explore_outlined);
+  final downloads = _tab(Icons.download_outlined);
+  final library = _tab(Icons.collections_bookmark_outlined);
+
+  test('Browse carries the count of extensions with updates', () {
+    final badged = badgedNavIcon(_marker, browse, false, 3);
+    expect(badged, isA<Badge>());
+    expect(((badged as Badge).label as Text).data, '3');
+  });
+
+  test('no updates means no badge', () {
+    expect(badgedNavIcon(_marker, browse, false, 0), same(_marker));
+  });
+
+  test('the extension count never lands on another tab', () {
+    expect(badgedNavIcon(_marker, library, false, 5), same(_marker));
+    // Downloads shows its own paused dot, and it must stay a dot — a count of
+    // extension updates on the Downloads tab would be actively misleading.
+    final pausedDownloads = badgedNavIcon(_marker, downloads, true, 5);
+    expect((pausedDownloads as Badge).label, isNull);
+  });
+
+  test('Downloads badges only while paused', () {
+    expect(badgedNavIcon(_marker, downloads, true, 0), isA<Badge>());
+    expect(badgedNavIcon(_marker, downloads, false, 0), same(_marker));
+  });
+}


### PR DESCRIPTION
Two changes off the back of #351, where both requested features turned out to already exist.

## The reader opens on the page

A chapter opened with the title bar and quick settings showing, so every read started by dismissing them. On a phone that is real visual noise.

Mihon and Tachiyomi both open clean (`ReaderViewModel: menuVisible = false`), and that is what people coming from them expect. The setting already existed as **Settings → Reader → Reader initial overlay**; only the default was backwards. Anyone who wants the chrome up front still has the toggle.

Note this reaches existing users too, not just new installs: an untouched preference falls through to the default.

Flipping it exposed a test that had been passing for the wrong reason. The step-based auto-scroll timer only runs while chrome is hidden, so with the old default it never started and nothing could stop auto-scroll mid-test. That test now states which chrome mode it exercises instead of inheriting whatever the global default happens to be.

## The Browse tab badges waiting extension updates

Extension updates were only discoverable by opening Browse and noticing a section, so people ran old extensions without knowing. A notification for this exists but is off by default, and it is a heavier interruption than a number on a tab. Mihon and Komikku badge the same tab.

The count is a plain query rather than the `fetchExtensions` mutation the extensions screen uses. That mutation sends the server out to the extension repos, which is far too much work for a navigation bar that is built on every launch, and is the same shape of mistake as #354. It also asks for nothing while the server is unreachable.

The bar and the rail now badge through one helper so the two layouts cannot drift apart. Tests cover the count landing on Browse, never landing on another tab, and Downloads keeping its paused dot rather than inheriting a number.

## Testing

1641 tests, analyzer clean. The badge was checked on screen with a forced count, since no extension currently has an update pending.
