### PR TITLE
Let the macOS release launch again

### DIFF
--- a/lib/src/features/auth/data/secure_credentials_provider.dart
+++ b/lib/src/features/auth/data/secure_credentials_provider.dart
@@ -27,4 +27,10 @@ FlutterSecureStorage secureStorage(Ref ref) => const FlutterSecureStorage(
       aOptions: AndroidOptions(
         migrateWithBackup: true,
       ),
+      // The data-protection keychain needs a restricted entitlement, and macOS
+      // refuses to launch an ad-hoc-signed build that carries one. The login
+      // keychain works unsigned.
+      mOptions: MacOsOptions(
+        usesDataProtectionKeychain: false,
+      ),
     );

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,7 +12,5 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,7 +8,5 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
-	<key>keychain-access-groups</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
The macOS 1.1.4 build never starts. The keychain-access-groups entitlement added for login persistence is on Apple's restricted list, and macOS refuses to run an ad-hoc-signed binary that carries one. The app is killed before Flutter starts.

This drops the entitlement and stores credentials in the classic login keychain on macOS instead of the data-protection keychain. The login keychain needs no entitlement, so unsigned release builds launch and keep logins again.

One caveat to verify on hardware: ad-hoc signatures have no stable identity, so macOS may ask for keychain access again after an update.

Closes #360