### PR TITLE
Fix offline chapter catch-up missing downloads (#371)

### DIFF
--- a/lib/src/features/offline/data/offline_awaiting_server_downloads.dart
+++ b/lib/src/features/offline/data/offline_awaiting_server_downloads.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../constants/db_keys.dart';
+import '../../../global_providers/global_providers.dart';
+
+/// Sendable read signature shared by `Ref.read`, `WidgetRef.read`, and
+/// `ProviderContainer.read` — lets the functions below stay agnostic of which
+/// kind of reader the caller has.
+typedef OfflineRead = T Function<T>(ProviderListenable<T> provider);
+
+/// Manga whose reconcile had to ask the SERVER to download chapters first —
+/// their device pull can only happen after those finish.
+///
+/// Shared by EVERY reconcile entry point: the automatic keep-rule catch-up
+/// pass (`offline_chapter_catchup.dart`'s `runKeepRuleCatchUp`/
+/// `pullAfterServerDownloads`) and the manga-details-triggered entry points
+/// (`reconcileManga`/`reconcileMangaWidget`/`reconcileMangaContainer` in
+/// `offline_download_providers.dart`). Only the catch-up pass used to
+/// register here — a manga-details-triggered download that needed a server
+/// fetch first silently missed the progressive
+/// pull-as-soon-as-the-server-queue-drains mechanism
+/// (`offline_chapter_catchup.dart`'s `downloadsMapProvider` listener) and sat
+/// waiting for the next full-library sync instead. Registering from every
+/// entry point here closes that gap.
+final Set<int> awaitingServerDownloads = {};
+
+/// Persists the current [awaitingServerDownloads] set so a crash/restart
+/// before the next drain doesn't lose the obligation.
+Future<void> persistAwaitingServerDownloads(OfflineRead read) =>
+    read(sharedPreferencesProvider).setStringList(
+      DBKeys.offlineCatchUpAwaitingPull.name,
+      [for (final id in awaitingServerDownloads) '$id'],
+    );

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -23,6 +23,7 @@ import 'background/background_download_controller_shim.dart';
 import 'background/background_download_lock.dart';
 import 'background/catchup_spec_writer.dart';
 import 'background/catchup_work_spec.dart';
+import 'offline_awaiting_server_downloads.dart';
 import 'offline_background_downloads.dart';
 import 'offline_database.dart';
 import 'offline_download_providers.dart';
@@ -47,24 +48,20 @@ bool _running = false;
 /// until the next update cycle.
 bool _drainMissedDuringPass = false;
 
-/// Manga whose reconcile had to ask the SERVER to download chapters first.
-/// Their device pull can only happen after those finish — see
-/// [pullAfterServerDownloads].
-final Set<int> _awaitingServerDownloads = {};
-
-/// Resets all module-private state. The three globals above persist across
-/// `test()` cases in the same file (one isolate per file), so every test
-/// exercising this module must call this in `setUp`.
+/// Resets all module-private state, PLUS the cross-module
+/// [awaitingServerDownloads] set. These globals persist across `test()` cases
+/// in the same file (one isolate per file), so every test exercising this
+/// module must call this in `setUp`.
 @visibleForTesting
 void resetChapterCatchUpStateForTest() {
   _running = false;
   _drainMissedDuringPass = false;
-  _awaitingServerDownloads.clear();
+  awaitingServerDownloads.clear();
 }
 
 @visibleForTesting
 void seedAwaitingServerDownloadsForTest(Iterable<int> mangaIds) {
-  _awaitingServerDownloads
+  awaitingServerDownloads
     ..clear()
     ..addAll(mangaIds);
 }
@@ -85,7 +82,7 @@ void simulateQueueDrainForTest(ProviderContainer container) {
 void initChapterCatchUp(ProviderContainer container) {
   // Restore the second-hop obligations — the watermark has already moved past
   // these manga, so losing the set to a restart would strand their pulls.
-  _awaitingServerDownloads.addAll(
+  awaitingServerDownloads.addAll(
     container
             .read(sharedPreferencesProvider)
             .getStringList(DBKeys.offlineCatchUpAwaitingPull.name)
@@ -145,8 +142,8 @@ Future<void> _adoptWorkerObligations(ProviderContainer container) async {
       final lockedStore = await CatchupStateStore.open();
       final fresh = lockedStore.readLedger(catalogServerId);
       if (fresh.pendingServerFetch.isEmpty) return;
-      _awaitingServerDownloads.addAll(fresh.pendingServerFetch.values);
-      await _persistAwaiting(container);
+      awaitingServerDownloads.addAll(fresh.pendingServerFetch.values);
+      await persistAwaitingServerDownloads(container.read);
       await lockedStore.writeLedger(
         catalogServerId,
         fresh.copyWith(
@@ -211,7 +208,7 @@ Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
     // miss them — always give them a fresh sync attempt.
     final touched = {
       ...feedTouched,
-      ..._awaitingServerDownloads.where(keepRuleManga.contains),
+      ...awaitingServerDownloads.where(keepRuleManga.contains),
     };
     final allSynced = await _syncAndReconcile(container, touched);
 
@@ -268,26 +265,20 @@ Future<void> pullAfterServerDownloads(ProviderContainer container) async {
 }
 
 Future<void> _pullAwaiting(ProviderContainer container) async {
-  if (_awaitingServerDownloads.isEmpty) return;
+  if (awaitingServerDownloads.isEmpty) return;
   if (!container.read(offlineActiveProvider)) return;
   // One obligation at a time, persisted after each: a crash mid-loop keeps
   // the unprocessed rest, and a batch clear would lose them.
-  for (final mangaId in {..._awaitingServerDownloads}) {
-    _awaitingServerDownloads.remove(mangaId);
+  for (final mangaId in {...awaitingServerDownloads}) {
+    awaitingServerDownloads.remove(mangaId);
     // The reconcile may re-add this manga (a NEW server enqueue) — that is a
     // fresh obligation, not the one being consumed, so it must survive.
     final ok = await _syncAndReconcile(container, {mangaId});
-    if (!ok) _awaitingServerDownloads.add(mangaId);
-    await _persistAwaiting(container);
+    if (!ok) awaitingServerDownloads.add(mangaId);
+    await persistAwaitingServerDownloads(container.read);
   }
   await container.read(downloadStarterProvider)();
 }
-
-Future<void> _persistAwaiting(ProviderContainer container) =>
-    container.read(sharedPreferencesProvider).setStringList(
-      DBKeys.offlineCatchUpAwaitingPull.name,
-      [for (final id in _awaitingServerDownloads) '$id'],
-    );
 
 /// Scans the feed for keep-rule manga touched since [watermark]. Boundary
 /// entries (same second as watermark) are re-included since a resync is
@@ -385,7 +376,7 @@ Future<bool> _reconcileTracked(ProviderContainer container, int mangaId) async {
             .addChaptersBatchToDownloadQueue(ids);
         // Recorded only on success: a failed enqueue produces no queue
         // activity, so no drain edge would ever retry the waiting entry.
-        _awaitingServerDownloads.add(mangaId);
+        awaitingServerDownloads.add(mangaId);
       } catch (_) {
         enqueueFailed = true;
         rethrow;
@@ -397,6 +388,6 @@ Future<bool> _reconcileTracked(ProviderContainer container, int mangaId) async {
       await ctrl.recordChapterDeleted(id, gen);
     },
   );
-  await _persistAwaiting(container);
+  await persistAwaitingServerDownloads(container.read);
   return !enqueueFailed;
 }

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -40,6 +40,13 @@ const _maxCatchUpPages = 3;
 
 bool _running = false;
 
+/// Set by the [downloadsMapProvider] drain listener when a drain event fires
+/// while a catch-up pass holds [_running]. Rather than dropping the event, we
+/// record it here and replay [_pullAwaiting] at the tail of the current pass so
+/// chapters that became serverIsDownloaded during the pass are not stranded
+/// until the next update cycle.
+bool _drainMissedDuringPass = false;
+
 /// Manga whose reconcile had to ask the SERVER to download chapters first.
 /// Their device pull can only happen after those finish — see
 /// [pullAfterServerDownloads].
@@ -74,7 +81,13 @@ void initChapterCatchUp(ProviderContainer container) {
   // catch-up reconcile become pullable to the device.
   container.listen(downloadsMapProvider, (previous, next) {
     if ((previous?.isNotEmpty ?? false) && next.isEmpty) {
-      unawaited(pullAfterServerDownloads(container));
+      if (_running) {
+        // A catch-up pass is in flight — defer rather than drop. The pass's
+        // own tail will call _pullAwaiting again with fresh server state.
+        _drainMissedDuringPass = true;
+      } else {
+        unawaited(pullAfterServerDownloads(container));
+      }
     }
   });
   // Catch anything the server found while the app was closed.
@@ -120,9 +133,10 @@ Future<void> _adoptWorkerObligations(ProviderContainer container) async {
   }
 }
 
-/// Single-flight: a trigger landing mid-pass is dropped, since its chapters
-/// are newer than the watermark and the next pass (launch or update-finish)
-/// will pick them up.
+/// Single-flight: an update trigger landing mid-pass is dropped, since its
+/// chapters are newer than the watermark and will be picked up by the next
+/// pass. A server-download drain event landing mid-pass is instead deferred
+/// via [_drainMissedDuringPass] and replayed at the tail of the current pass.
 Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
   if (_running) return;
   if (!container.read(offlineActiveProvider)) return;
@@ -155,7 +169,15 @@ Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
     );
     // Didn't reach the watermark (or this is the first pass, with none yet)?
     // Fall back to every keep-rule manga instead of skipping the tail.
-    final touched = scan.sawWatermark ? scan.touched : keepRuleManga;
+    final feedTouched = scan.sawWatermark ? scan.touched : keepRuleManga;
+    // Also include manga still awaiting a server-side download. Their
+    // serverIsDownloaded flag can flip without generating a new feed entry
+    // (e.g. a manual re-download via the WebUI), so the watermark scan would
+    // miss them — always give them a fresh sync attempt.
+    final touched = {
+      ...feedTouched,
+      ..._awaitingServerDownloads.where(keepRuleManga.contains),
+    };
     final allSynced = await _syncAndReconcile(container, touched);
 
     // Only a fully-processed pass may advance the watermark — a skipped manga
@@ -174,6 +196,14 @@ Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
     // queue-drain edge alone can be missed when downloads finish faster than
     // the subscription reports them.
     await _pullAwaiting(container);
+    // If a drain event arrived while this pass was in flight, the listener
+    // deferred it instead of dropping it. Re-run the pull now so chapters that
+    // became serverIsDownloaded during the pass are not stranded until the next
+    // update cycle.
+    if (_drainMissedDuringPass) {
+      _drainMissedDuringPass = false;
+      await _pullAwaiting(container);
+    }
     // Freshest device-state snapshot for the background worker.
     await writeCatchupWorkSpec(container.read);
   } catch (e) {
@@ -185,8 +215,9 @@ Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
 
 /// Second hop: chapters the server had to download from the source first.
 /// Once its queue drains, re-run the chain for the manga that were waiting so
-/// the device copies get pulled. Single-flight with the catch-up pass, whose
-/// own tail retry covers a drain edge that lands mid-pass.
+/// the device copies get pulled. Single-flight with the catch-up pass; a drain
+/// event landing mid-pass sets [_drainMissedDuringPass] instead of being
+/// dropped, and is replayed at the pass's tail.
 Future<void> pullAfterServerDownloads(ProviderContainer container) async {
   if (_running) return;
   _running = true;

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -52,6 +52,35 @@ bool _drainMissedDuringPass = false;
 /// [pullAfterServerDownloads].
 final Set<int> _awaitingServerDownloads = {};
 
+/// Resets all module-private state. The three globals above persist across
+/// `test()` cases in the same file (one isolate per file), so every test
+/// exercising this module must call this in `setUp`.
+@visibleForTesting
+void resetChapterCatchUpStateForTest() {
+  _running = false;
+  _drainMissedDuringPass = false;
+  _awaitingServerDownloads.clear();
+}
+
+@visibleForTesting
+void seedAwaitingServerDownloadsForTest(Iterable<int> mangaIds) {
+  _awaitingServerDownloads
+    ..clear()
+    ..addAll(mangaIds);
+}
+
+/// Test-only mirror of the [downloadsMapProvider] drain listener installed by
+/// [initChapterCatchUp]. Lets a test simulate a queue-drain event landing at
+/// an arbitrary point in time without wiring up the full listener chain.
+@visibleForTesting
+void simulateQueueDrainForTest(ProviderContainer container) {
+  if (_running) {
+    _drainMissedDuringPass = true;
+  } else {
+    unawaited(pullAfterServerDownloads(container));
+  }
+}
+
 /// Called once from app bootstrap, after the offline engine is up.
 void initChapterCatchUp(ProviderContainer container) {
   // Restore the second-hop obligations — the watermark has already moved past

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -147,7 +147,13 @@ Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
           in await container.read(offlineDatabaseProvider).libraryManga())
         if (m.keepRule != OfflineKeepRule.off) m.id,
     };
-    if (keepRuleManga.isEmpty) return;
+    if (keepRuleManga.isEmpty) {
+      if (_drainMissedDuringPass) {
+        _drainMissedDuringPass = false;
+        await _pullAwaiting(container);
+      }
+      return;
+    }
 
     final prefs = container.read(sharedPreferencesProvider);
     final watermark = prefs.getInt(DBKeys.offlineCatchUpWatermark.name) ?? 0;
@@ -223,6 +229,10 @@ Future<void> pullAfterServerDownloads(ProviderContainer container) async {
   _running = true;
   try {
     await _pullAwaiting(container);
+    if (_drainMissedDuringPass) {
+      _drainMissedDuringPass = false;
+      await _pullAwaiting(container);
+    }
   } finally {
     _running = false;
   }

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -41,6 +41,7 @@ import 'background/catchup_spec_writer.dart';
 import 'background/catchup_work_spec.dart';
 import 'chapter_commit.dart';
 import 'chapter_download_engine.dart';
+import 'offline_awaiting_server_downloads.dart';
 import 'offline_background_downloads.dart';
 import 'offline_database.dart';
 import 'offline_download_coordinator.dart';
@@ -1363,9 +1364,20 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
     deleteWhileReadingSlots: ref
         .read(localDeleteSettingsProvider)
         .deleteWhileReading,
-    enqueueServerDownload: (ids) => ref
-        .read(downloadsRepositoryProvider)
-        .addChaptersBatchToDownloadQueue(ids),
+    // Registers this manga as owed a device pull once the server's queue
+    // drains (only on success — a failed enqueue produced no queue activity,
+    // so no drain edge would ever retry it). Without this, a manga-details-
+    // triggered download that needed a server fetch first would silently miss
+    // the progressive pull-as-soon-as-the-server-finishes mechanism
+    // (offline_chapter_catchup.dart's downloadsMapProvider listener) and sit
+    // waiting for the next full-library sync instead.
+    enqueueServerDownload: (ids) async {
+      await ref
+          .read(downloadsRepositoryProvider)
+          .addChaptersBatchToDownloadQueue(ids);
+      awaitingServerDownloads.add(mangaId);
+      await persistAwaitingServerDownloads(ref.read);
+    },
     removeFromWorker: (id, gen) async {
       final ctrl = ref.read(backgroundDownloadControllerProvider);
       await ctrl.onRemoved(id);
@@ -1393,9 +1405,16 @@ Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
     deleteWhileReadingSlots: ref
         .read(localDeleteSettingsProvider)
         .deleteWhileReading,
-    enqueueServerDownload: (ids) => ref
-        .read(downloadsRepositoryProvider)
-        .addChaptersBatchToDownloadQueue(ids),
+    // See reconcileManga's matching comment: registers the second-hop pull
+    // obligation so this manga isn't stranded until the next full-library
+    // sync once the server finishes.
+    enqueueServerDownload: (ids) async {
+      await ref
+          .read(downloadsRepositoryProvider)
+          .addChaptersBatchToDownloadQueue(ids);
+      awaitingServerDownloads.add(mangaId);
+      await persistAwaitingServerDownloads(ref.read);
+    },
     removeFromWorker: (id, gen) async {
       final ctrl = ref.read(backgroundDownloadControllerProvider);
       await ctrl.onRemoved(id);
@@ -1429,9 +1448,16 @@ Future<void> reconcileMangaContainer(
     deleteWhileReadingSlots: container
         .read(localDeleteSettingsProvider)
         .deleteWhileReading,
-    enqueueServerDownload: (ids) => container
-        .read(downloadsRepositoryProvider)
-        .addChaptersBatchToDownloadQueue(ids),
+    // See reconcileManga's matching comment: registers the second-hop pull
+    // obligation so this manga isn't stranded until the next full-library
+    // sync once the server finishes.
+    enqueueServerDownload: (ids) async {
+      await container
+          .read(downloadsRepositoryProvider)
+          .addChaptersBatchToDownloadQueue(ids);
+      awaitingServerDownloads.add(mangaId);
+      await persistAwaitingServerDownloads(container.read);
+    },
     removeFromWorker: (id, gen) async {
       final ctrl = container.read(backgroundDownloadControllerProvider);
       await ctrl.onRemoved(id);

--- a/test/src/features/offline/data/offline_chapter_catchup_drain_race_test.dart
+++ b/test/src/features/offline/data/offline_chapter_catchup_drain_race_test.dart
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_chapter_catchup.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+/// Reports "no stored chapters" for every manga, which makes `_syncAndReconcile`
+/// mark the manga unsynced (so `_pullAwaiting` re-queues it) without touching
+/// any of the reconcile machinery (db/manager/coordinator providers). The
+/// first call pauses on [gate] so a test can land a concurrent drain event
+/// while the pass is mid-flight; later calls return immediately.
+class _PausingMangaBookRepository extends MangaBookRepository {
+  _PausingMangaBookRepository() : super(_dummyClient());
+
+  final Completer<void> gate = Completer<void>();
+  int callCount = 0;
+
+  @override
+  Future<List<ChapterDto>?> getStoredChapterList(int mangaId) async {
+    callCount++;
+    if (callCount == 1) await gate.future;
+    return null;
+  }
+}
+
+/// Same contract as above, but never pauses — used where the pause needs to
+/// happen earlier in the call chain (the database read).
+class _CountingMangaBookRepository extends MangaBookRepository {
+  _CountingMangaBookRepository() : super(_dummyClient());
+
+  int callCount = 0;
+
+  @override
+  Future<List<ChapterDto>?> getStoredChapterList(int mangaId) async {
+    callCount++;
+    return null;
+  }
+}
+
+/// An empty in-memory [OfflineDatabase] whose `libraryManga()` pauses on
+/// [gate] before delegating to the real (empty) query — lets a test land a
+/// concurrent drain event while `runKeepRuleCatchUp` is between setting
+/// `_running = true` and reaching the `keepRuleManga.isEmpty` check.
+class _PausingEmptyOfflineDatabase extends OfflineDatabase {
+  _PausingEmptyOfflineDatabase() : super(NativeDatabase.memory());
+
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<List<OfflineManga>> libraryManga() async {
+    await gate.future;
+    return super.libraryManga();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUp(resetChapterCatchUpStateForTest);
+  tearDown(resetChapterCatchUpStateForTest);
+
+  group('pullAfterServerDownloads', () {
+    test(
+        'a drain event landing mid-pass is replayed, not stranded '
+        '(regression: bug 1)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final repo = _PausingMangaBookRepository();
+      var startCalls = 0;
+
+      seedAwaitingServerDownloadsForTest({1});
+
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        mangaBookRepositoryProvider.overrideWithValue(repo),
+        downloadStarterProvider.overrideWithValue(({bool userInitiated = false}) async {
+          startCalls++;
+        }),
+      ]);
+      addTearDown(container.dispose);
+
+      // Runs synchronously up to the paused await inside getStoredChapterList.
+      final passFuture = pullAfterServerDownloads(container);
+
+      // A queue-drain event lands while the pass is still in flight.
+      simulateQueueDrainForTest(container);
+
+      repo.gate.complete();
+      await passFuture;
+
+      expect(repo.callCount, 2,
+          reason: 'the deferred drain must trigger a second _pullAwaiting '
+              'pass so manga 1 (re-queued by the first, failed attempt) '
+              'gets retried instead of stranded');
+      expect(startCalls, 2,
+          reason: 'each _pullAwaiting pass that processes an obligation '
+              'kicks the download starter');
+    });
+
+    test('no concurrent drain event → only a single pass runs', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final repo = _CountingMangaBookRepository();
+      var startCalls = 0;
+
+      seedAwaitingServerDownloadsForTest({1});
+
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        mangaBookRepositoryProvider.overrideWithValue(repo),
+        downloadStarterProvider.overrideWithValue(({bool userInitiated = false}) async {
+          startCalls++;
+        }),
+      ]);
+      addTearDown(container.dispose);
+
+      await pullAfterServerDownloads(container);
+
+      expect(repo.callCount, 1,
+          reason: 'without a concurrent drain event there is nothing to '
+              'replay');
+      expect(startCalls, 1);
+    });
+  });
+
+  group('runKeepRuleCatchUp — empty keep-rule set', () {
+    test(
+        'a drain event landing while the keep-rule set is empty is still '
+        'replayed (regression: bug 2)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final db = _PausingEmptyOfflineDatabase();
+      addTearDown(db.close);
+      final repo = _CountingMangaBookRepository();
+      var startCalls = 0;
+
+      seedAwaitingServerDownloadsForTest({1});
+
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        offlineDatabaseProvider.overrideWithValue(db),
+        mangaBookRepositoryProvider.overrideWithValue(repo),
+        downloadStarterProvider.overrideWithValue(({bool userInitiated = false}) async {
+          startCalls++;
+        }),
+      ]);
+      addTearDown(container.dispose);
+
+      // Runs synchronously up to the paused await inside libraryManga(). At
+      // this point `_running` is already true but the pass has not yet
+      // reached the `keepRuleManga.isEmpty` early return.
+      final passFuture = runKeepRuleCatchUp(container);
+
+      simulateQueueDrainForTest(container);
+
+      db.gate.complete();
+      await passFuture;
+
+      expect(repo.callCount, 1,
+          reason: 'the empty-keep-rule early return must still drain the '
+              'deferred pull instead of leaving it stranded until the next '
+              'pass');
+      expect(startCalls, 1);
+    });
+
+    test('no concurrent drain event → empty keep-rule set is a pure no-op',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final db = _PausingEmptyOfflineDatabase();
+      addTearDown(db.close);
+      db.gate.complete(); // don't pause — nothing to race against here
+      final repo = _CountingMangaBookRepository();
+      var startCalls = 0;
+
+      seedAwaitingServerDownloadsForTest({1});
+
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        offlineDatabaseProvider.overrideWithValue(db),
+        mangaBookRepositoryProvider.overrideWithValue(repo),
+        downloadStarterProvider.overrideWithValue(({bool userInitiated = false}) async {
+          startCalls++;
+        }),
+      ]);
+      addTearDown(container.dispose);
+
+      await runKeepRuleCatchUp(container);
+
+      expect(repo.callCount, 0,
+          reason: 'without a drain event, the empty-keep-rule path must not '
+              'touch _awaitingServerDownloads at all');
+      expect(startCalls, 0);
+    });
+  });
+}

--- a/test/src/features/offline/data/reconcile_manga_awaiting_server_download_test.dart
+++ b/test/src/features/offline/data/reconcile_manga_awaiting_server_download_test.dart
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Regression guard: a manga-details-triggered reconcile (reconcileManga /
+// reconcileMangaWidget / reconcileMangaContainer) that has to ask the server
+// to download a chapter first must register the manga in
+// awaitingServerDownloads, exactly like the automatic keep-rule catch-up
+// pass already did. Without this, the progressive
+// pull-as-soon-as-the-server-queue-drains mechanism
+// (offline_chapter_catchup.dart's downloadsMapProvider listener) never fires
+// for a manga-details-triggered download, which instead sits waiting for the
+// next full-library sync.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/data/downloads/downloads_repository.dart';
+import 'package:tsumiru/src/features/offline/data/chapter_download_engine.dart';
+import 'package:tsumiru/src/features/offline/data/offline_awaiting_server_downloads.dart';
+import 'package:tsumiru/src/features/offline/data/offline_background_downloads.dart';
+import 'package:tsumiru/src/features/offline/data/offline_chapter_catchup.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_coordinator.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_manager.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+import '../../../../helpers/fake_page_store.dart';
+import '../../../../helpers/offline_test_db.dart';
+
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+/// Records every enqueue call; throws instead when [shouldFail] is set, to
+/// exercise the "only register on success" branch.
+class _SpyDownloadsRepository extends DownloadsRepository {
+  _SpyDownloadsRepository() : super(_dummyClient(), _dummyClient());
+
+  final List<int> enqueued = [];
+  bool shouldFail = false;
+
+  @override
+  Future<void> addChaptersBatchToDownloadQueue(List<int> chapterIds) async {
+    if (shouldFail) throw Exception('enqueue failed');
+    enqueued.addAll(chapterIds);
+  }
+}
+
+void main() {
+  late OfflineDatabase db;
+  final store = FakePageStore();
+  late _SpyDownloadsRepository downloadsRepo;
+
+  setUp(() {
+    OfflineDownloadCoordinator.resetSharedStateForTest();
+    resetChapterCatchUpStateForTest();
+    db = testOfflineDatabase();
+    downloadsRepo = _SpyDownloadsRepository();
+  });
+  tearDown(() {
+    resetChapterCatchUpStateForTest();
+    db.close();
+  });
+
+  Future<void> seedMangaNeedingServerDownload(int mangaId) async {
+    await db.upsertMangaMetadata(
+      id: mangaId,
+      title: 'M$mangaId',
+      updatedAt: DateTime(2026),
+    );
+    await db.setKeepRule(mangaId, OfflineKeepRule.all, 3);
+    // Wanted by the rule, but the server hasn't fetched it from the source yet
+    // -- exactly the condition that makes the reconciler call
+    // enqueueServerDownload instead of queueing a device download directly.
+    await db.upsertChapterMetadata(
+      id: mangaId * 100 + 1,
+      mangaId: mangaId,
+      name: 'c1',
+      chapterIndex: 1,
+      isRead: false,
+      lastPageRead: 0,
+      isBookmarked: false,
+      serverIsDownloaded: false,
+      pageCount: 1,
+      updatedAt: DateTime(2026),
+    );
+  }
+
+  Future<WidgetRef> harness(WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    late WidgetRef captured;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          offlineEnabledProvider.overrideWithValue(true),
+          offlineActiveProvider.overrideWithValue(true),
+          offlineDatabaseProvider.overrideWithValue(db),
+          offlinePathsProvider.overrideWithValue(const OfflinePaths('/tmp/x')),
+          offlinePageStoreProvider.overrideWithValue(store),
+          downloadsRepositoryProvider.overrideWithValue(downloadsRepo),
+          offlineDownloadCoordinatorProvider.overrideWithValue(
+            OfflineDownloadCoordinator(
+              db: db,
+              engine: ChapterDownloadEngine(
+                fetchPage: (_) async => throw UnimplementedError(),
+                writePage: store,
+                refreshAuth: () async => false,
+              ),
+              store: store,
+              resolvePages: (_) async => const [],
+            ),
+          ),
+          offlineDownloadManagerProvider.overrideWithValue(
+            OfflineDownloadManager(
+              db: db,
+              store: store,
+              fetchPageUrls: (_) async => const [],
+              fetchBytes: (_) async => throw UnimplementedError(),
+            ),
+          ),
+          downloadStarterProvider.overrideWithValue(
+            ({bool userInitiated = false}) async {},
+          ),
+        ],
+        child: Consumer(
+          builder: (_, ref, __) {
+            captured = ref;
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+    return captured;
+  }
+
+  testWidgets(
+    'reconcileMangaWidget registers the manga in awaitingServerDownloads '
+    'on a successful server-download enqueue',
+    (tester) async {
+      await seedMangaNeedingServerDownload(1);
+      final ref = await harness(tester);
+
+      await reconcileMangaWidget(ref, 1);
+
+      expect(downloadsRepo.enqueued, [101]);
+      expect(awaitingServerDownloads, contains(1),
+          reason: 'without this, the progressive pull-on-server-drain '
+              'mechanism never learns manga 1 owes a device pull, and it '
+              'would sit waiting for the next full-library sync instead');
+    },
+  );
+
+  testWidgets(
+    'reconcileMangaWidget does NOT register the manga when the enqueue fails',
+    (tester) async {
+      await seedMangaNeedingServerDownload(2);
+      downloadsRepo.shouldFail = true;
+      final ref = await harness(tester);
+
+      await reconcileMangaWidget(ref, 2);
+
+      expect(awaitingServerDownloads, isNot(contains(2)),
+          reason: 'a failed enqueue produced no server queue activity, so '
+              'no drain edge would ever retry it -- registering it anyway '
+              'would leave a phantom obligation nothing can complete');
+    },
+  );
+
+  test(
+    'reconcileManga (Ref entry point) registers on success, same as the '
+    'WidgetRef variant',
+    () async {
+      await seedMangaNeedingServerDownload(3);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        offlineDatabaseProvider.overrideWithValue(db),
+        offlinePathsProvider.overrideWithValue(const OfflinePaths('/tmp/x')),
+        downloadsRepositoryProvider.overrideWithValue(downloadsRepo),
+        offlineDownloadCoordinatorProvider.overrideWithValue(
+          OfflineDownloadCoordinator(
+            db: db,
+            engine: ChapterDownloadEngine(
+              fetchPage: (_) async => throw UnimplementedError(),
+              writePage: store,
+              refreshAuth: () async => false,
+            ),
+            store: store,
+            resolvePages: (_) async => const [],
+          ),
+        ),
+        offlineDownloadManagerProvider.overrideWithValue(
+          OfflineDownloadManager(
+            db: db,
+            store: store,
+            fetchPageUrls: (_) async => const [],
+            fetchBytes: (_) async => throw UnimplementedError(),
+          ),
+        ),
+      ]);
+      addTearDown(container.dispose);
+      // reconcileManga takes a plain Ref (a NotifierProvider/Provider
+      // callback's ref), not a WidgetRef -- capture one via a throwaway
+      // provider instead of trying to cast a WidgetRef to it.
+      final ref = container.read(Provider<Ref>((ref) => ref));
+
+      await reconcileManga(ref, 3);
+
+      expect(awaitingServerDownloads, contains(3));
+    },
+  );
+
+  test(
+    'reconcileMangaContainer (ProviderContainer entry point) registers on '
+    'success, same as the WidgetRef variant',
+    () async {
+      await seedMangaNeedingServerDownload(4);
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        offlineDatabaseProvider.overrideWithValue(db),
+        offlinePathsProvider.overrideWithValue(const OfflinePaths('/tmp/x')),
+        downloadsRepositoryProvider.overrideWithValue(downloadsRepo),
+        offlineDownloadCoordinatorProvider.overrideWithValue(
+          OfflineDownloadCoordinator(
+            db: db,
+            engine: ChapterDownloadEngine(
+              fetchPage: (_) async => throw UnimplementedError(),
+              writePage: store,
+              refreshAuth: () async => false,
+            ),
+            store: store,
+            resolvePages: (_) async => const [],
+          ),
+        ),
+        offlineDownloadManagerProvider.overrideWithValue(
+          OfflineDownloadManager(
+            db: db,
+            store: store,
+            fetchPageUrls: (_) async => const [],
+            fetchBytes: (_) async => throw UnimplementedError(),
+          ),
+        ),
+      ]);
+      addTearDown(container.dispose);
+
+      await reconcileMangaContainer(container, 4);
+
+      expect(awaitingServerDownloads, contains(4));
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #371 — chapters that should be downloaded to the device after a library sync were sometimes not downloaded at all, only triggering when the user navigated directly to the manga's detail page (which re-runs a per-manga sync and bypasses the global catch-up machinery entirely).

Two independent gaps in `offline_chapter_catchup.dart` combined to produce this symptom.

---

## Root cause 1 — Drain event silently dropped during a catch-up pass

The `downloadsMapProvider` listener fires when the server's download queue transitions from non-empty to empty — the signal that chapters queued for a server-side download are now ready to be pulled to the device. The listener called `pullAfterServerDownloads`, which is single-flight with `runKeepRuleCatchUp` via the shared `_running` flag.

The race:

1. `runKeepRuleCatchUp` starts (`_running = true`).
2. `_pullAwaiting` queries the server — the chapter is still downloading (`serverIsDownloaded = false`) — re-enqueues the server download, keeps the manga in `_awaitingServerDownloads`.
3. The server **finishes** downloading. `downloadsMapProvider` goes empty. The drain listener fires.
4. `pullAfterServerDownloads` sees `_running = true` → **returns immediately, event is gone**.
5. `runKeepRuleCatchUp` completes. `_running = false`.
6. The server's queue is now empty — no further drain event will fire. `_awaitingServerDownloads` still contains the manga, but the only automatic retry paths are the next library update or the next app launch.

**Fix:** the listener now sets a boolean flag `_drainMissedDuringPass` instead of calling `pullAfterServerDownloads` when a pass is in flight. At the tail of `runKeepRuleCatchUp`, after the regular `_pullAwaiting`, the flag is checked and a second `_pullAwaiting` is run with fresh server state. This closes the race without needing a separate coordination mechanism.

```dart
// listener — before
unawaited(pullAfterServerDownloads(container));

// listener — after
if (_running) {
  _drainMissedDuringPass = true;
} else {
  unawaited(pullAfterServerDownloads(container));
}

// tail of runKeepRuleCatchUp — added
if (_drainMissedDuringPass) {
  _drainMissedDuringPass = false;
  await _pullAwaiting(container);
}
```

---

## Root cause 2 — Watermark scan invisible to `serverIsDownloaded` state changes

`runKeepRuleCatchUp` builds the set of manga to process (`touched`) by scanning the updates feed for entries newer than the stored watermark. This works well for newly discovered chapters, but the `fetchedAt` timestamp on a chapter reflects when the server **first fetched it from the source** — it does not change when the server re-downloads an already-known chapter (e.g. a manual re-download triggered from the WebUI, or a chapter downloaded after being deleted server-side).

As a result, a manga whose chapters became `serverIsDownloaded = true` without producing a new feed entry was invisible to the watermark scan. It was only retried via `_pullAwaiting` if it happened to still be in `_awaitingServerDownloads` — which itself could be empty if an earlier pass had already consumed and removed it (after seeing `serverIsDownloaded = false` and successfully re-enqueueing, which counted as `ok = true`).

**Fix:** manga still present in `_awaitingServerDownloads` are now always merged into `touched` (filtered to the current `keepRuleManga` set so disabled manga are not spammed), guaranteeing a fresh server sync on every pass regardless of feed position.

```dart
// before
final touched = scan.sawWatermark ? scan.touched : keepRuleManga;

// after
final feedTouched = scan.sawWatermark ? scan.touched : keepRuleManga;
final touched = {
  ...feedTouched,
  ..._awaitingServerDownloads.where(keepRuleManga.contains),
};
```

---

## Why navigating to the manga page worked as a workaround

`reconcileManga` (called from `MangaChapterList.build`) always fetches a fresh chapter list directly from the server, updates drift with the current `serverIsDownloaded` state, and calls `downloadStarterProvider()` — completely bypassing the feed watermark and `_awaitingServerDownloads` set. It consistently succeeded because it never depended on either of the mechanisms that were broken.

---

## Testing

- Library update where the server finishes downloading a chapter while `runKeepRuleCatchUp` is mid-pass: device download should now start without requiring a page visit or an additional update.
- Manual re-download of a chapter via the WebUI (or deletion + re-download): device copy should be pulled on the next catch-up pass, not only on a manga-page visit.
- No regression on the standard path (update → server fetch → device pull) — `_pullAwaiting` is idempotent and `_awaitingServerDownloads` is only extended, never incorrectly cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)