### PR TITLE
Fix webtoon reader boundary-preload triggers and previous-chapter re-anchor (#370)

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_config.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_config.dart
@@ -53,6 +53,29 @@ class InfinityContinuousConfig {
   static const double verticalCacheMultiplier = 2.0;
   static const double horizontalCacheMultiplier = 2.0;
 
+  /// Minimum net pixel movement of the top-most item's leading edge
+  /// between two position-listener ticks before it counts as a
+  /// deliberate scroll, for the purpose of the next/previous-chapter
+  /// boundary trigger's direction check. Expressed in pixels rather
+  /// than a viewport fraction: the previous fixed fraction (0.0015,
+  /// ~1px on a typical phone) let ordinary sub-pixel layout jitter —
+  /// e.g. a page-height correction landing while that page sits at the
+  /// viewport top, see decodeAndCacheHeight — masquerade as a real
+  /// scroll-up gesture and fire loadPreviousChapter unprompted.
+  static const double boundaryScrollDirectionEpsilonPx = 24.0;
+
+  /// Minimum visible-area fraction (see
+  /// [InfinityContinuousUtils.calculateVisibleArea]) a page must clear
+  /// to count toward the next/previous-chapter boundary trigger.
+  /// Deliberately lower than [minVisibleAreaThreshold] (which decides
+  /// the "current" page for progress tracking): a full 40% floor would
+  /// delay the trigger past the point several short pages share the
+  /// screen (see the #100 note on selectCurrentIndex), but the previous
+  /// 0% floor let a single grazed pixel — routinely produced when a
+  /// fast fling through a long chapter briefly lays out its tail pages —
+  /// fire the load several pages before the reader actually gets there.
+  static const double boundaryVisibleAreaThreshold = 0.12;
+
   /// Page height/width ratio for different orientations
   static const double verticalPageHeightRatio = 0.7;
   static const double horizontalPageWidthRatio = 0.7;

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -693,21 +693,42 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         final newPageCount = pages.pages.length;
 
         // Capture the page currently anchoring the viewport so we can
-        // re-pin it after every index shifts up by ``newPageCount``.
+        // re-pin it after every index shifts up by ``newPageCount``. The
+        // leading edge is kept UNCLAMPED for that purpose: jumpTo's
+        // alignment only supports [0, 1] (it aligns the item's top edge to
+        // a point within the viewport — see ItemScrollController.jumpTo),
+        // so a tall page we're deep inside of — routine on long-strip
+        // webtoon content — has a leading edge far below -1.0. Clamping
+        // that into range used to silently discard how far into the page
+        // we'd scrolled, so the re-anchor landed on the page's TOP instead
+        // of where we actually were. We jump to the top (alignment 0, the
+        // one value the API guarantees) and then nudge down by the exact
+        // pixel depth separately below.
         final positions = positionsListener.itemPositions.value.toList()
           ..sort((a, b) => a.itemLeadingEdge.compareTo(b.itemLeadingEdge));
         int? anchorIndex;
-        double anchorAlignment = 0.0;
+        double anchorLeadingEdge = 0.0;
         for (final p in positions) {
           // First item whose top edge is at/below the viewport top is the
           // natural anchor; fall back to the first reported position.
           if (p.itemTrailingEdge > 0) {
             anchorIndex = p.index;
-            anchorAlignment = p.itemLeadingEdge.clamp(-1.0, 1.0);
+            anchorLeadingEdge = p.itemLeadingEdge;
             break;
           }
         }
         anchorIndex ??= positions.isNotEmpty ? positions.first.index : null;
+        // Pixels already scrolled past the anchor's top edge (0 if its top
+        // is still at/below the viewport top — nothing to restore then).
+        double intoAnchorPixels = 0;
+        try {
+          if (anchorLeadingEdge < 0) {
+            intoAnchorPixels = -anchorLeadingEdge *
+                scrollOffsetController.position.viewportDimension;
+          }
+        } catch (_) {
+          // Not laid out yet — landing on the item's top is the best we can do.
+        }
 
         loadedChapters.value = [
           (pages: pages, chapter: prev, chapterId: prev.id),
@@ -717,15 +738,30 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // direction sample so the next tick re-derives it cleanly.
         lastTop.value = null;
 
-        // Re-anchor on the next frame (the rebuilt SPL must register the
-        // new itemCount first). One frame, no animation, no second defer.
+        // Re-anchor across two frames: the first lands the shifted item's
+        // top edge at the viewport top (the only alignment jumpTo actually
+        // supports); the second — once that layout has settled and pixels
+        // reflects it — nudges down by the exact depth we'd read into it,
+        // so a tall page lands back at precisely the same visual spot
+        // instead of resetting to its top. No animation either frame.
         if (anchorIndex != null) {
           final target = anchorIndex + newPageCount;
           // Guard the re-anchor jump too: its settle motion must not be read
           // as a scroll back to the top that prepends yet another chapter.
           markScrollAdjusting();
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            jumpToIndex(index: target, alignment: anchorAlignment);
+            jumpToIndex(index: target, alignment: 0.0);
+            if (intoAnchorPixels > 0) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                try {
+                  final pos = scrollOffsetController.position;
+                  pos.jumpTo(
+                    (pos.pixels + intoAnchorPixels)
+                        .clamp(pos.minScrollExtent, pos.maxScrollExtent),
+                  );
+                } catch (_) {}
+              });
+            }
           });
         }
 
@@ -816,10 +852,27 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // opening a chapter (at page 0, or a short chapter) never auto-
         // loads a neighbour. A neighbour loads only when the user is
         // actively scrolling toward that edge.
-        final minIdx = positions
+        //
+        // minIdx/maxIdx use a stricter visibility floor than the raw
+        // sliver filter above: a page whose edge has only just grazed the
+        // viewport (as little as one rendered pixel) otherwise counts as
+        // "on screen" here, so a fast fling through a long chapter — more
+        // scrolling per gesture — can transiently report the tail page
+        // while the reader, by the 40%-visible standard selectCurrentIndex
+        // uses for progress, is still several pages behind. Falls back to
+        // the raw list if nothing clears the floor (e.g. several short
+        // pages sharing the screen, none individually over threshold).
+        final strictlyVisible = positions
+            .where((p) =>
+                InfinityContinuousUtils.calculateVisibleArea(p) >=
+                InfinityContinuousConfig.boundaryVisibleAreaThreshold)
+            .toList();
+        final boundaryPositions =
+            strictlyVisible.isNotEmpty ? strictlyVisible : positions;
+        final minIdx = boundaryPositions
             .map((p) => p.index)
             .reduce((a, b) => a < b ? a : b);
-        final maxIdx = positions
+        final maxIdx = boundaryPositions
             .map((p) => p.index)
             .reduce((a, b) => a > b ? a : b);
 
@@ -829,7 +882,23 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         bool scrollingUp = false;
         bool scrollingDown = false;
         if (prevTop != null) {
-          const eps = 0.0015;
+          // A fixed viewport-fraction epsilon (the previous 0.0015, ~1px on
+          // a typical phone) shrinks to nothing on tall viewports, letting
+          // ordinary sub-pixel layout jitter — e.g. a page-height
+          // correction landing while that page sits at the viewport top —
+          // masquerade as a deliberate scroll. Measure in real pixels
+          // instead, converting to the viewport-fraction units itemLeadingEdge
+          // uses.
+          double viewportHeight = 0;
+          try {
+            viewportHeight = scrollOffsetController.position.viewportDimension;
+          } catch (_) {
+            // Not laid out yet — fall back to a small-but-safe fraction.
+          }
+          final double eps = viewportHeight > 0
+              ? InfinityContinuousConfig.boundaryScrollDirectionEpsilonPx /
+                  viewportHeight
+              : 0.03;
           if (top.index < prevTop.index) {
             scrollingUp = true;
           } else if (top.index > prevTop.index) {


### PR DESCRIPTION
## Summary

Fixes #370 — in the webtoon / continuous-vertical reader mode, the previous chapter would sometimes load on the slightest upward scroll (with a jarring visual jump on load), and the next chapter would sometimes preload noticeably early (5-10 pages before the actual end) on long chapters.

Three related bugs, all in the boundary-detection and re-anchor logic of the multi-chapter continuous reader mode, combine to produce these symptoms.

---

## Bug 1 — previous chapter loads on sub-pixel jitter

`MultiChapterContinuousReaderMode`'s position listener infers scroll direction by comparing the top-most visible item's leading edge against the previous tick, using `eps = 0.0015` — a *viewport fraction*, roughly 1px on a typical phone screen.

The trigger itself (`scrollingUp && minIdx <= 0`) stays armed for the entire time the chapter's first page has even a sliver of visibility on screen — which is most of the time the reader is on/near that page. With a ~1px threshold, essentially any jitter flips it: a finger micro-movement, or — as this same file's own comments already document as expected behaviour — a page-height self-correction landing while that page sits at the viewport top (an image finishing decode above the viewport and adjusting its reserved height by a few px). Either one was enough to misfire `loadPreviousChapter` with no scroll-up intent from the user.

**Fix:** measure the direction threshold in real pixels (`boundaryScrollDirectionEpsilonPx = 24.0`) instead of a fixed viewport fraction, converting to `itemLeadingEdge`'s fraction units from the live viewport height each tick.

---

## Bug 2 — next chapter preloads several pages before the end on long chapters

The boundary trigger accepted any page with the barest sliver of visibility (`itemTrailingEdge > 0`, no minimum area) to compute `minIdx`/`maxIdx`. This is inconsistent with `selectCurrentIndex`, which requires 40% visible area (`minVisibleAreaThreshold`) before considering a page "current" for progress tracking.

Combined with a 2-viewport-height cache extent (`verticalCacheMultiplier`), a fast fling — more likely on long chapters (50-180 pages) since there's simply more distance to cover per gesture — could transiently lay out the tail pages' first pixels well before the reader's actual (40%-based) reading position got anywhere near them, firing `loadNextChapter` early.

**Fix:** introduce `boundaryVisibleAreaThreshold = 0.12` and filter positions to that floor before computing `minIdx`/`maxIdx` for the boundary trigger specifically, falling back to the unfiltered list if nothing clears it — preserving the existing behaviour for chapters ending in several short pages that share the screen (see the `selectCurrentIndex` #100 note) instead of ever failing to trigger.

---

## Bug 3 — previous-chapter load doesn't restore the same scroll depth

Independent of the trigger itself, the re-anchor logic after prepending the previous chapter's pages was imprecise. It captured the anchor item's `itemLeadingEdge`, clamped it to `[-1.0, 1.0]`, and passed it as `ItemScrollController.jumpTo`'s `alignment`.

`jumpTo`'s `alignment` is documented as `[0.0, 1.0]` only — it positions the item's *top* edge somewhere within the viewport. For a tall page the reader is scrolled deep into (routine on long-strip webtoon content, which is exactly the content type most affected), the true leading edge can be far below `-1.0`. Clamping it silently discarded how far into the page the reader actually was, so the re-anchor landed at the page's *top* instead of the reader's real position — on top of the one-frame visual flash from the insert itself, this produced a visible "jump to a different spot" every time the previous chapter loaded.

**Fix:** keep the anchor's leading edge unclamped for the pixel computation. Jump to `alignment: 0.0` (the one value the API actually supports) to reliably land on the item's top, then — once that layout has settled a frame later — apply a raw pixel nudge via `ScrollOffsetController` for the exact depth that had been read into the page, computed unclamped from `viewportDimension`. No animation on either step.

---

## Files changed

- `lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/infinity_continuous_config.dart` — new `boundaryScrollDirectionEpsilonPx` and `boundaryVisibleAreaThreshold` constants, with rationale in doc comments.
- `lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart` — the three fixes described above.

## Testing

- Long-strip chapter, slow scroll near the top of the first loaded page: previous chapter should no longer load from incidental jitter alone; it still loads promptly on a deliberate upward scroll.
- Long chapter (50-180 pages), fast fling toward the end: next chapter should preload close to the actual end rather than several pages early.
- Load the previous chapter while resting deep inside a tall page: the reader should land back at the same visual position (not reset to the top of that page), with no more than the expected single-frame settle.
- No regression on short-page chapters where several pages share the screen at a boundary (the area-threshold fallback path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)