### PR TITLE
Feat/offline chapter drilldown and progress fix

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>12.0</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,132 +1,28 @@
 PODS:
-  - connectivity_plus (0.0.1):
-    - Flutter
-  - DKImagePickerController/Core (4.3.4):
-    - DKImagePickerController/ImageDataManager
-    - DKImagePickerController/Resource
-  - DKImagePickerController/ImageDataManager (4.3.4)
-  - DKImagePickerController/PhotoGallery (4.3.4):
-    - DKImagePickerController/Core
-    - DKPhotoGallery
-  - DKImagePickerController/Resource (4.3.4)
-  - DKPhotoGallery (0.0.17):
-    - DKPhotoGallery/Core (= 0.0.17)
-    - DKPhotoGallery/Model (= 0.0.17)
-    - DKPhotoGallery/Preview (= 0.0.17)
-    - DKPhotoGallery/Resource (= 0.0.17)
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Core (0.0.17):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Preview
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Model (0.0.17):
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Preview (0.0.17):
-    - DKPhotoGallery/Model
-    - DKPhotoGallery/Resource
-    - SDWebImage
-    - SwiftyGif
-  - DKPhotoGallery/Resource (0.0.17):
-    - SDWebImage
-    - SwiftyGif
-  - file_picker (0.0.1):
-    - DKImagePickerController/PhotoGallery
-    - Flutter
   - Flutter (1.0.0)
-  - flutter_native_splash (2.4.3):
+  - flutter_foreground_task (0.0.1):
     - Flutter
-  - fluttertoast (0.0.2):
-    - Flutter
-  - network_info_plus (0.0.1):
-    - Flutter
-  - package_info_plus (0.4.5):
-    - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - permission_handler_apple (9.3.0):
-    - Flutter
-  - SDWebImage (5.13.5):
-    - SDWebImage/Core (= 5.13.5)
-  - SDWebImage/Core (5.13.5)
-  - shared_preferences_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - sqflite_darwin (0.0.4):
-    - Flutter
-    - FlutterMacOS
-  - SwiftyGif (5.4.3)
-  - url_launcher_ios (0.0.1):
+  - workmanager_apple (0.0.1):
     - Flutter
 
 DEPENDENCIES:
-  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
-  - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
-  - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
-  - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
-  - network_info_plus (from `.symlinks/plugins/network_info_plus/ios`)
-  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
-  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
-  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
-  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
-
-SPEC REPOS:
-  trunk:
-    - DKImagePickerController
-    - DKPhotoGallery
-    - SDWebImage
-    - SwiftyGif
+  - flutter_foreground_task (from `.symlinks/plugins/flutter_foreground_task/ios`)
+  - workmanager_apple (from `.symlinks/plugins/workmanager_apple/ios`)
 
 EXTERNAL SOURCES:
-  connectivity_plus:
-    :path: ".symlinks/plugins/connectivity_plus/ios"
-  file_picker:
-    :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
-  flutter_native_splash:
-    :path: ".symlinks/plugins/flutter_native_splash/ios"
-  fluttertoast:
-    :path: ".symlinks/plugins/fluttertoast/ios"
-  network_info_plus:
-    :path: ".symlinks/plugins/network_info_plus/ios"
-  package_info_plus:
-    :path: ".symlinks/plugins/package_info_plus/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
-  permission_handler_apple:
-    :path: ".symlinks/plugins/permission_handler_apple/ios"
-  shared_preferences_foundation:
-    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
-  sqflite_darwin:
-    :path: ".symlinks/plugins/sqflite_darwin/darwin"
-  url_launcher_ios:
-    :path: ".symlinks/plugins/url_launcher_ios/ios"
+  flutter_foreground_task:
+    :path: ".symlinks/plugins/flutter_foreground_task/ios"
+  workmanager_apple:
+    :path: ".symlinks/plugins/workmanager_apple/ios"
 
 SPEC CHECKSUMS:
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
-  DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
-  DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_native_splash: 6cad9122ea0fad137d23137dd14b937f3e90b145
-  fluttertoast: 2c67e14dce98bbdb200df9e1acf610d7a6264ea1
-  network_info_plus: cf61925ab5205dce05a4f0895989afdb6aade5fc
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  SDWebImage: 23d714cd599354ee7906dbae26dff89b421c4370
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
-  SwiftyGif: 6c3eafd0ce693cad58bb63d2b2fb9bacb8552780
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_foreground_task: a159d2c2173b33699ddb3e6c2a067045d7cebb89
+  workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 
-PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
+PODFILE CHECKSUM: 775997f741c536251164e3eacf6e34abf2eb7a17
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		5A3A6DEA545D05395C03CA7F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C7AF1B5C7210FB4BA2BFBE0 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -37,6 +38,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8E9922996FDE9255F7E55E40 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -54,6 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				5A3A6DEA545D05395C03CA7F /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -75,6 +78,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -140,13 +144,15 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				68B5AFE06ECD16CE97286172 /* [CP] Embed Pods Frameworks */,
-				5D466ADE19ACFDF72454276D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
@@ -175,6 +181,9 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -214,23 +223,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		5D466ADE19ACFDF72454276D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		68B5AFE06ECD16CE97286172 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -568,6 +560,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,59 @@
+{
+  "pins" : [
+    {
+      "identity" : "dkcamera",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKCamera",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5c691d11014b910aff69f960475d70e65d9dcc96"
+      }
+    },
+    {
+      "identity" : "dkimagepickercontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKImagePickerController",
+      "state" : {
+        "branch" : "4.3.9",
+        "revision" : "0bdfeacefa308545adde07bef86e349186335915"
+      }
+    },
+    {
+      "identity" : "dkphotogallery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKPhotoGallery",
+      "state" : {
+        "branch" : "master",
+        "revision" : "311c1bc7a94f1538f82773a79c84374b12a2ef3d"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage",
+      "state" : {
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
+      }
+    },
+    {
+      "identity" : "swiftygif",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kirualex/SwiftyGif.git",
+      "state" : {
+        "revision" : "4430cbc148baa3907651d40562d96325426f409a",
+        "version" : "5.4.5"
+      }
+    },
+    {
+      "identity" : "tocropviewcontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TimOliver/TOCropViewController",
+      "state" : {
+        "revision" : "d4a6d8100f4b886fdbc8ae399bf144ff3e9afb7e",
+        "version" : "2.8.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,59 @@
+{
+  "pins" : [
+    {
+      "identity" : "dkcamera",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKCamera",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5c691d11014b910aff69f960475d70e65d9dcc96"
+      }
+    },
+    {
+      "identity" : "dkimagepickercontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKImagePickerController",
+      "state" : {
+        "branch" : "4.3.9",
+        "revision" : "0bdfeacefa308545adde07bef86e349186335915"
+      }
+    },
+    {
+      "identity" : "dkphotogallery",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zhangao0086/DKPhotoGallery",
+      "state" : {
+        "branch" : "master",
+        "revision" : "311c1bc7a94f1538f82773a79c84374b12a2ef3d"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage",
+      "state" : {
+        "revision" : "2de3a496eaf6df9a1312862adcfd54acd73c39c0",
+        "version" : "5.21.7"
+      }
+    },
+    {
+      "identity" : "swiftygif",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kirualex/SwiftyGif.git",
+      "state" : {
+        "revision" : "4430cbc148baa3907651d40562d96325426f409a",
+        "version" : "5.4.5"
+      }
+    },
+    {
+      "identity" : "tocropviewcontroller",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/TimOliver/TOCropViewController",
+      "state" : {
+        "revision" : "d4a6d8100f4b886fdbc8ae399bf144ff3e9afb7e",
+        "version" : "2.8.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,13 +1,16 @@
-import UIKit
 import Flutter
+import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -1,77 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-	<dict>
-		<key>CFBundleDevelopmentRegion</key>
-		<string>$(DEVELOPMENT_LANGUAGE)</string>
-		<key>CFBundleDisplayName</key>
-		<string>Tsumiru</string>
-		<key>CFBundleExecutable</key>
-		<string>$(EXECUTABLE_NAME)</string>
-		<key>CFBundleIdentifier</key>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-		<key>CFBundleInfoDictionaryVersion</key>
-		<string>6.0</string>
-		<key>CFBundleName</key>
-		<string>Tsumiru</string>
-		<key>CFBundlePackageType</key>
-		<string>APPL</string>
-		<key>CFBundleShortVersionString</key>
-		<string>$(FLUTTER_BUILD_NAME)</string>
-		<key>CFBundleSignature</key>
-		<string>????</string>
-		<key>CFBundleVersion</key>
-		<string>$(FLUTTER_BUILD_NUMBER)</string>
-		<key>LSRequiresIPhoneOS</key>
-		<true/>
-		<key>UILaunchStoryboardName</key>
-		<string>LaunchScreen</string>
-		<key>UIMainStoryboardFile</key>
-		<string>Main</string>
-		<key>UISupportedInterfaceOrientations</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationLandscapeLeft</string>
-			<string>UIInterfaceOrientationLandscapeRight</string>
-		</array>
-		<key>UISupportedInterfaceOrientations~ipad</key>
-		<array>
-			<string>UIInterfaceOrientationPortrait</string>
-			<string>UIInterfaceOrientationPortraitUpsideDown</string>
-			<string>UIInterfaceOrientationLandscapeLeft</string>
-			<string>UIInterfaceOrientationLandscapeRight</string>
-		</array>
-		<key>UIViewControllerBasedStatusBarAppearance</key>
-		<false/>
-		<key>CADisableMinimumFrameDurationOnPhone</key>
-		<true/>
-		<key>UIApplicationSupportsIndirectInputEvents</key>
-		<true/>
-		<key>UIStatusBarHidden</key>
-		<false/>
-		<key>CFBundleLocalizations</key>
-		<array>
-			<string>ar</string>
-			<string>de</string>
-			<string>en</string>
-			<string>es</string>
-			<string>fr</string>
-			<string>pt</string>
-			<string>uk</string>
-			<string>ko</string>
-			<string>pt-pt</string>
-			<string>zh</string>
-			<string>zh-hans</string>
-			<string>id</string>
-			<string>it</string>
-			<string>ja</string>
-			<string>nl</string>
-			<string>ru</string>
-			<string>th</string>
-			<string>tr</string>
-			<string>vi</string>
-			<string>fil</string>
-		</array>
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Tsumiru</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>ar</string>
+		<string>de</string>
+		<string>en</string>
+		<string>es</string>
+		<string>fr</string>
+		<string>pt</string>
+		<string>uk</string>
+		<string>ko</string>
+		<string>pt-pt</string>
+		<string>zh</string>
+		<string>zh-hans</string>
+		<string>id</string>
+		<string>it</string>
+		<string>ja</string>
+		<string>nl</string>
+		<string>ru</string>
+		<string>th</string>
+		<string>tr</string>
+		<string>vi</string>
+		<string>fil</string>
+	</array>
+	<key>CFBundleName</key>
+	<string>Tsumiru</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -83,11 +56,59 @@
 			</array>
 		</dict>
 	</array>
-		<key>FlutterDeepLinkingEnabled</key>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>FlutterDeepLinkingEnabled</key>
 	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Save manga pages to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Save manga pages to your photo library.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIStatusBarHidden</key>
+	<false/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -186,9 +186,15 @@ Stream<bool> offlineHasPending(Ref ref) {
 
 /// Live on-device download state for a chapter (none / queued / downloading /
 /// downloaded / error). Always `none` when offline is unavailable.
+///
+/// Guards on [offlineEnabledProvider] (storage opened) rather than
+/// [offlineActiveProvider] (identity verified): this is a read-only stream of
+/// local DB state and does not require server-identity verification. On iOS
+/// (and other platforms) before the identity handshake completes, downloads
+/// can already be queued/downloading and the UI must reflect them.
 @riverpod
 Stream<OfflineDeviceState> offlineChapterState(Ref ref, int chapterId) {
-  if (!ref.watch(offlineActiveProvider)) {
+  if (!ref.watch(offlineEnabledProvider)) {
     return Stream.value(OfflineDeviceState.none);
   }
   return ref.watch(offlineRepositoryProvider).watchChapterState(chapterId);
@@ -202,7 +208,9 @@ Stream<OfflineDeviceState> offlineChapterState(Ref ref, int chapterId) {
 /// count while the download is in flight.
 @riverpod
 double? offlineChapterProgress(Ref ref, int chapterId) {
-  if (!ref.watch(offlineActiveProvider)) return null;
+  // Same rationale as offlineChapterState: this is a read of in-memory
+  // progress state and does not require server-identity verification.
+  if (!ref.watch(offlineEnabledProvider)) return null;
   // Watch THIS chapter's entry, not the whole map. A chapter list holds a few
   // hundred of these, and reading the map wakes every one of them each time any
   // single chapter advances a page — so one download made the entire visible
@@ -1220,6 +1228,28 @@ Stream<({int downloaded, int inFlight})> mangaOfflineProgress(
     return (downloaded: downloaded, inFlight: inFlight);
   }).distinct(); // only rebuild the button when the counts actually change
 }
+
+/// All chapter rows for [mangaId] that have any on-device footprint (queued,
+/// downloading, downloaded, error) — drives the offline series chapter drill-down
+/// screen. Guards on [offlineEnabledProvider] so it works before identity is
+/// verified (pure local-DB read).
+///
+/// Uses a manual StreamProvider.family because [OfflineChapter] is a
+/// drift-generated type that riverpod_generator cannot resolve at code-gen
+/// time (the drift part hasn't been generated yet in that build phase).
+/// This matches the pattern noted in the offline architecture doc.
+final offlineChaptersForMangaProvider =
+    StreamProvider.family<List<OfflineChapter>, int>((ref, mangaId) {
+  if (!ref.watch(offlineEnabledProvider)) return Stream.value(const []);
+  return ref
+      .watch(offlineDatabaseProvider)
+      .watchChaptersForManga(mangaId)
+      .map(
+        (rows) => rows
+            .where((c) => c.deviceState != OfflineDeviceState.none)
+            .toList(),
+      );
+});
 
 /// Every series with an offline footprint — chapters present OR an active
 /// keep-rule — with per-series counts, bytes, and the manga row. Single source

--- a/lib/src/features/offline/presentation/offline_files_view.dart
+++ b/lib/src/features/offline/presentation/offline_files_view.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../../routes/router_config.dart';
 import '../../../utils/extensions/custom_extensions.dart';
 import '../../../widgets/emoticons.dart';
 import '../../../widgets/selection_action_bar.dart';
@@ -18,6 +17,7 @@ import '../data/offline_download_providers.dart';
 import '../data/offline_repository.dart';
 import '../data/offline_series_entry.dart';
 import 'keep_rule_picker.dart';
+import 'offline_series_chapters_screen.dart';
 import 'offline_settings_format.dart';
 
 typedef _SeriesRow = OfflineSeriesEntry;
@@ -140,7 +140,15 @@ class OfflineFilesView extends HookConsumerWidget {
               ),
               onTap: selecting
                   ? () => toggle(s.manga.id)
-                  : () => MangaRoute(mangaId: s.manga.id).push(context),
+                  : () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => OfflineSeriesChaptersScreen(
+                            mangaId: s.manga.id,
+                            mangaTitle: s.manga.title,
+                            thumbnailUrl: s.manga.thumbnailUrl,
+                          ),
+                        ),
+                      ),
               onLongPress: () => toggle(s.manga.id),
             );
           },

--- a/lib/src/features/offline/presentation/offline_series_chapters_screen.dart
+++ b/lib/src/features/offline/presentation/offline_series_chapters_screen.dart
@@ -65,36 +65,39 @@ class OfflineSeriesChaptersScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        title: Row(
           children: [
-            Text(
-              context.l10n.offlineChaptersScreenTitle,
-              style: context.textTheme.titleMedium,
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: thumbnailUrl != null
+                  ? ServerImage(
+                      imageUrl: thumbnailUrl!,
+                      fit: BoxFit.cover,
+                      size: const Size(32, 42),
+                    )
+                  : const Icon(Icons.book_outlined),
             ),
-            Text(
-              mangaTitle,
-              style: context.textTheme.bodySmall?.copyWith(
-                color: context.theme.colorScheme.onSurfaceVariant,
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    context.l10n.offlineChaptersScreenTitle,
+                    style: context.textTheme.titleMedium,
+                  ),
+                  Text(
+                    mangaTitle,
+                    style: context.textTheme.bodySmall?.copyWith(
+                      color: context.theme.colorScheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
               ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
             ),
           ],
-        ),
-        // Compact cover on the left for quick orientation.
-        leading: Padding(
-          padding: const EdgeInsets.all(10),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: thumbnailUrl != null
-                ? ServerImage(
-                    imageUrl: thumbnailUrl!,
-                    fit: BoxFit.cover,
-                    size: const Size(32, 42),
-                  )
-                : const Icon(Icons.book_outlined),
-          ),
         ),
       ),
       body: !hasAny

--- a/lib/src/features/offline/presentation/offline_series_chapters_screen.dart
+++ b/lib/src/features/offline/presentation/offline_series_chapters_screen.dart
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../routes/router_config.dart';
+import '../../../utils/extensions/custom_extensions.dart';
+import '../../../widgets/emoticons.dart';
+import '../../../widgets/server_image.dart';
+import '../data/offline_database.dart';
+import '../data/offline_download_providers.dart';
+import 'offline_settings_format.dart';
+
+/// Drill-down screen from Downloads → On device.
+///
+/// Shows all chapters with any on-device footprint for a given series, grouped
+/// into three buckets:
+///   1. Active (queued / downloading) — with live progress arcs.
+///   2. Downloaded — tap to read offline.
+///   3. Failed — with a retry button.
+///
+/// This screen reads exclusively from the local SQLite catalog and never makes
+/// a network request, so it works fully offline.
+class OfflineSeriesChaptersScreen extends ConsumerWidget {
+  const OfflineSeriesChaptersScreen({
+    super.key,
+    required this.mangaId,
+    required this.mangaTitle,
+    required this.thumbnailUrl,
+  });
+
+  final int mangaId;
+  final String mangaTitle;
+  final String? thumbnailUrl;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final chaptersAsync =
+        ref.watch(offlineChaptersForMangaProvider(mangaId));
+    final chapters = chaptersAsync.value ?? const [];
+
+    // Partition chapters into three buckets.
+    final active = chapters
+        .where((c) =>
+            c.deviceState == OfflineDeviceState.queued ||
+            c.deviceState == OfflineDeviceState.downloading)
+        .toList()
+      ..sort((a, b) => a.chapterIndex.compareTo(b.chapterIndex));
+
+    final downloaded = chapters
+        .where((c) => c.deviceState == OfflineDeviceState.downloaded)
+        .toList()
+      ..sort((a, b) => b.chapterIndex.compareTo(a.chapterIndex));
+
+    final failed = chapters
+        .where((c) => c.deviceState == OfflineDeviceState.error)
+        .toList()
+      ..sort((a, b) => a.chapterIndex.compareTo(b.chapterIndex));
+
+    final hasAny = active.isNotEmpty || downloaded.isNotEmpty || failed.isNotEmpty;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              context.l10n.offlineChaptersScreenTitle,
+              style: context.textTheme.titleMedium,
+            ),
+            Text(
+              mangaTitle,
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.theme.colorScheme.onSurfaceVariant,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+        // Compact cover on the left for quick orientation.
+        leading: Padding(
+          padding: const EdgeInsets.all(10),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: thumbnailUrl != null
+                ? ServerImage(
+                    imageUrl: thumbnailUrl!,
+                    fit: BoxFit.cover,
+                    size: const Size(32, 42),
+                  )
+                : const Icon(Icons.book_outlined),
+          ),
+        ),
+      ),
+      body: !hasAny
+          ? Emoticons(title: context.l10n.offlineChaptersEmpty)
+          : ListView(
+              padding: const EdgeInsets.only(bottom: 16),
+              children: [
+                // ── Active (queued / downloading) ─────────────────────────
+                if (active.isNotEmpty) ...[
+                  _SectionHeader(context.l10n.offlineChaptersActiveSection),
+                  for (final ch in active)
+                    _ActiveChapterTile(chapter: ch),
+                ],
+
+                // ── Downloaded ────────────────────────────────────────────
+                if (downloaded.isNotEmpty) ...[
+                  _SectionHeader(
+                    context.l10n.offlineChaptersDownloadedSection,
+                  ),
+                  for (final ch in downloaded)
+                    _DownloadedChapterTile(
+                      chapter: ch,
+                      mangaId: mangaId,
+                    ),
+                ],
+
+                // ── Failed ────────────────────────────────────────────────
+                if (failed.isNotEmpty) ...[
+                  _SectionHeader(context.l10n.offlineChaptersErrorSection),
+                  for (final ch in failed)
+                    _FailedChapterTile(chapter: ch),
+                ],
+              ],
+            ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Section header
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        title,
+        style: context.textTheme.labelMedium?.copyWith(
+          color: context.theme.colorScheme.primary,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Active tile (queued or downloading)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Shows a determinate progress arc for downloading chapters and a static clock
+/// icon for queued ones — consistent with [OfflineSaveButton] semantics.
+class _ActiveChapterTile extends ConsumerWidget {
+  const _ActiveChapterTile({required this.chapter});
+
+  final OfflineChapter chapter;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isDownloading = chapter.deviceState == OfflineDeviceState.downloading;
+    // Live progress fraction — null while waiting for first page.
+    final progress =
+        ref.watch(offlineChapterProgressProvider(chapter.id));
+
+    Widget leading;
+    if (isDownloading) {
+      leading = SizedBox(
+        width: 36,
+        height: 36,
+        child: Center(
+          child: SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(
+              strokeWidth: 2.5,
+              // Spin until the first page lands.
+              value: (progress == null || progress <= 0) ? null : progress,
+            ),
+          ),
+        ),
+      );
+    } else {
+      // Queued — static clock.
+      leading = Icon(
+        Icons.schedule_rounded,
+        color: context.theme.colorScheme.onSurfaceVariant,
+      );
+    }
+
+    final subtitle = isDownloading
+        ? progress != null && progress > 0
+            ? '${(progress * 100).round()}%'
+            : context.l10n.offlineDownloadAction
+        : context.l10n.offlineChaptersQueued;
+
+    return ListTile(
+      leading: leading,
+      title: Text(
+        chapter.name,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(subtitle),
+      // No onTap — the chapter isn't readable until it commits.
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Downloaded tile — tap to read offline
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _DownloadedChapterTile extends ConsumerWidget {
+  const _DownloadedChapterTile({
+    required this.chapter,
+    required this.mangaId,
+  });
+
+  final OfflineChapter chapter;
+  final int mangaId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isRead = chapter.isRead;
+
+    return ListTile(
+      leading: Icon(
+        Icons.offline_pin_rounded,
+        color: isRead
+            ? context.theme.colorScheme.onSurfaceVariant
+            : context.theme.colorScheme.primary,
+      ),
+      title: Text(
+        chapter.name,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          color: isRead ? context.theme.colorScheme.onSurfaceVariant : null,
+        ),
+      ),
+      subtitle: chapter.bytes > 0
+          ? Text(
+              formatBytes(chapter.bytes),
+              style: TextStyle(
+                color: context.theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          : null,
+      trailing: IconButton(
+        tooltip: context.l10n.offlineChapterDelete,
+        icon: const Icon(Icons.delete_outline_rounded),
+        onPressed: () => deleteChapterFromDevice(ref, chapter.id),
+      ),
+      onTap: () => ReaderRoute(
+        mangaId: mangaId,
+        chapterId: chapter.id,
+        showReaderLayoutAnimation: false,
+      ).push(context),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Failed tile — retry button
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _FailedChapterTile extends ConsumerWidget {
+  const _FailedChapterTile({required this.chapter});
+
+  final OfflineChapter chapter;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      leading: Icon(
+        Icons.error_outline_rounded,
+        color: context.theme.colorScheme.error,
+      ),
+      title: Text(
+        chapter.name,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: TextButton.icon(
+        icon: const Icon(Icons.replay_rounded, size: 18),
+        label: Text(context.l10n.offlineChapterRetry),
+        onPressed: () => saveChapterToDevice(ref, chapter.id),
+      ),
+    );
+  }
+}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -3539,5 +3539,37 @@
         "type": "int"
       }
     }
+  },
+  "offlineChaptersScreenTitle": "Downloaded chapters",
+  "@offlineChaptersScreenTitle": {
+    "description": "AppBar title for the offline series drill-down chapter list"
+  },
+  "offlineChaptersActiveSection": "Downloading / Queued",
+  "@offlineChaptersActiveSection": {
+    "description": "Section header for chapters currently downloading or queued in the offline chapter list"
+  },
+  "offlineChaptersDownloadedSection": "Downloaded",
+  "@offlineChaptersDownloadedSection": {
+    "description": "Section header for fully downloaded chapters in the offline chapter list"
+  },
+  "offlineChaptersErrorSection": "Failed",
+  "@offlineChaptersErrorSection": {
+    "description": "Section header for chapters that failed to download"
+  },
+  "offlineChaptersEmpty": "No chapters saved on this device yet.",
+  "@offlineChaptersEmpty": {
+    "description": "Empty state for the offline chapter drill-down screen"
+  },
+  "offlineChapterRetry": "Retry",
+  "@offlineChapterRetry": {
+    "description": "Button to retry a failed chapter download"
+  },
+  "offlineChapterDelete": "Remove from device",
+  "@offlineChapterDelete": {
+    "description": "Button / tooltip to remove an on-device chapter"
+  },
+  "offlineChaptersQueued": "Queued",
+  "@offlineChaptersQueued": {
+    "description": "Status label for a chapter waiting in the download queue"
   }
 }


### PR DESCRIPTION
Problem On iOS (and any platform where the server identity handshake hasn't completed yet), offline download indicators were invisible, chapter rows showed the save icon even while actively downloading, because offlineChapterState and offlineChapterProgress were gated on offlineActiveProvider (requires server identity) instead of offlineEnabledProvider (storage open = enough for reads).

Tapping a series in the "On device" tab pushed MangaRoute, which needs a live server connection, unusable when fully offline.

preview:
<img width="590" height="1278" alt="IMG_4703" src="https://github.com/user-attachments/assets/26141611-99b2-4822-8cd0-77942d55f1e3" />


<img width="590" height="1278" alt="IMG_4704" src="https://github.com/user-attachments/assets/a0037846-255e-45ab-9039-c10f097a47af" />
