### PR TITLE
Make continuousHorizontalLTR/RTL a real continuous scroll mode

### DIFF
--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -366,8 +366,7 @@ class ReaderScreen extends HookConsumerWidget {
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
                           ),
-                        ReaderMode.singleHorizontalRTL ||
-                        ReaderMode.continuousHorizontalRTL =>
+                        ReaderMode.singleHorizontalRTL =>
                           MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
@@ -378,12 +377,38 @@ class ReaderScreen extends HookConsumerWidget {
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
                           ),
-                        ReaderMode.singleHorizontalLTR ||
-                        ReaderMode.continuousHorizontalLTR =>
+                        ReaderMode.singleHorizontalLTR =>
                           MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
+                            chapterPages: chapterPagesData,
+                            openAtEnd: openAtEnd,
+                          ),
+                        ReaderMode.continuousHorizontalRTL =>
+                          MultiChapterContinuousReaderMode(
+                            chapter: chapterData,
+                            manga: data,
+                            onPageChanged: onPageChanged,
+                            scrollDirection: Axis.horizontal,
+                            reverse: true,
+                            effectiveReaderMode:
+                                ReaderMode.continuousHorizontalRTL,
+                            showReaderLayoutAnimation:
+                                showReaderLayoutAnimation,
+                            chapterPages: chapterPagesData,
+                            openAtEnd: openAtEnd,
+                          ),
+                        ReaderMode.continuousHorizontalLTR =>
+                          MultiChapterContinuousReaderMode(
+                            chapter: chapterData,
+                            manga: data,
+                            onPageChanged: onPageChanged,
+                            scrollDirection: Axis.horizontal,
+                            effectiveReaderMode:
+                                ReaderMode.continuousHorizontalLTR,
+                            showReaderLayoutAnimation:
+                                showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
                           ),
@@ -408,8 +433,7 @@ class ReaderScreen extends HookConsumerWidget {
                           ),
                         ReaderMode.defaultReader || null => switch (
                               defaultReaderMode ?? ReaderMode.singleHorizontalRTL) {
-                            ReaderMode.singleHorizontalLTR ||
-                            ReaderMode.continuousHorizontalLTR =>
+                            ReaderMode.singleHorizontalLTR =>
                               MultiChapterPagedReaderMode(
                                 chapter: chapterData,
                                 manga: data,
@@ -417,13 +441,39 @@ class ReaderScreen extends HookConsumerWidget {
                                 chapterPages: chapterPagesData,
                                 openAtEnd: openAtEnd,
                               ),
-                            ReaderMode.singleHorizontalRTL ||
-                            ReaderMode.continuousHorizontalRTL =>
+                            ReaderMode.singleHorizontalRTL =>
                               MultiChapterPagedReaderMode(
                                 chapter: chapterData,
                                 manga: data,
                                 onPageChanged: onPageChanged,
                                 reverse: true,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                              ),
+                            ReaderMode.continuousHorizontalLTR =>
+                              MultiChapterContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.horizontal,
+                                effectiveReaderMode:
+                                    ReaderMode.continuousHorizontalLTR,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                              ),
+                            ReaderMode.continuousHorizontalRTL =>
+                              MultiChapterContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.horizontal,
+                                reverse: true,
+                                effectiveReaderMode:
+                                    ReaderMode.continuousHorizontalRTL,
                                 showReaderLayoutAnimation:
                                     showReaderLayoutAnimation,
                                 chapterPages: chapterPagesData,

--- a/lib/src/features/manga_book/presentation/reader/utils/reader_mode_kind.dart
+++ b/lib/src/features/manga_book/presentation/reader/utils/reader_mode_kind.dart
@@ -16,13 +16,13 @@ import '../../../../settings/presentation/reader/widgets/reader_tap_invert/reade
 bool isPagedReaderMode(ReaderMode mode) => switch (mode) {
       ReaderMode.singleHorizontalLTR ||
       ReaderMode.singleHorizontalRTL ||
-      ReaderMode.singleVertical ||
-      ReaderMode.continuousHorizontalLTR ||
-      ReaderMode.continuousHorizontalRTL =>
+      ReaderMode.singleVertical =>
         true,
       ReaderMode.defaultReader ||
       ReaderMode.continuousVertical ||
-      ReaderMode.webtoon =>
+      ReaderMode.webtoon ||
+      ReaderMode.continuousHorizontalLTR ||
+      ReaderMode.continuousHorizontalRTL =>
         false,
     };
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -1138,7 +1138,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           dtMs: dtMs,
         );
         final target = pos.pixels + (reverse ? -delta : delta);
-        if (target >= pos.maxScrollExtent && hasReachedEnd.value) {
+        final atEnd = reverse
+            ? target <= pos.minScrollExtent
+            : target >= pos.maxScrollExtent;
+        if (atEnd && hasReachedEnd.value) {
           ref.read(autoScrollActiveProvider.notifier).stop();
           return;
         }

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -498,14 +498,24 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       scaleType.maxContentWidth(context.width, context.height),
       widthLimit,
     );
+    final bool isHorizontal = scrollDirection == Axis.horizontal;
+    // The dimension along the scroll axis (height for a vertical strip,
+    // width for a horizontal one) — this is what a page reserves/grows along.
+    final double mainAxisExtent = isHorizontal ? context.width : context.height;
+    // The dimension a page is capped to across the scroll axis. The
+    // width-limit settings above are vertical-strip-specific (no per-mode
+    // settings surface exists for continuousHorizontalLTR/RTL, which are
+    // legacy-orphan modes), so a horizontal strip simply fills the full
+    // viewport height instead.
+    final double crossAxisExtent = isHorizontal ? context.height : maxContentWidth;
     // Read via ref (like loadedRef) so a once-bound closure — e.g. the
     // positions listener's loadNext/PreviousChapter — can't re-seed heights
     // at a width superseded by a later scale/limit change.
     final layoutParams =
         useRef<({bool naturalSize, double columnWidth})>(
-            (naturalSize: pagesAtNaturalSize, columnWidth: maxContentWidth));
+            (naturalSize: pagesAtNaturalSize, columnWidth: crossAxisExtent));
     layoutParams.value =
-        (naturalSize: pagesAtNaturalSize, columnWidth: maxContentWidth);
+        (naturalSize: pagesAtNaturalSize, columnWidth: crossAxisExtent);
     final ReaderScrollAmount scrollAmount =
         ref.watch(readerScrollAmountKeyProvider) ??
         DBKeys.readerScrollAmount.initial as ReaderScrollAmount;
@@ -562,10 +572,17 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // Read via layoutParams, not closure capture, so a sweep started by
         // an old build still reserves at the current width.
         final layout = layoutParams.value;
-        final renderedWidth = layout.naturalSize
-            ? math.min(w.toDouble(), MediaQuery.sizeOf(context).width)
+        final crossAxisSize = isHorizontal
+            ? MediaQuery.sizeOf(context).height
+            : MediaQuery.sizeOf(context).width;
+        final renderedCrossAxis = layout.naturalSize
+            ? math.min(isHorizontal ? h.toDouble() : w.toDouble(), crossAxisSize)
             : layout.columnWidth;
-        pageHeights.value[url] = renderedWidth * h / w;
+        // Vertical: cross-axis is width(w), main-axis is height(h). Horizontal
+        // is the mirror image — cross-axis is height(h), main-axis is width(w).
+        pageHeights.value[url] = isHorizontal
+            ? renderedCrossAxis * w / h
+            : renderedCrossAxis * h / w;
       }
       info.dispose();
     }
@@ -641,7 +658,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // First build is the initial sweep's job, not this effect's.
     final lastLayoutKey = useRef<(WebtoonScaleType, double)?>(null);
     useEffect(() {
-      final key = (scaleType, maxContentWidth);
+      final key = (scaleType, crossAxisExtent);
       final previous = lastLayoutKey.value;
       lastLayoutKey.value = key;
       if (previous == null || previous == key) return null;
@@ -662,7 +679,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         }
       });
       return null;
-    }, [scaleType, maxContentWidth]);
+    }, [scaleType, crossAxisExtent]);
 
     // --- chapter loading -------------------------------------------------
 
@@ -1209,50 +1226,67 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
 
     final total = InfinityContinuousUtils.getTotalPages(loadedChapters.value);
 
-    // Smart scale centres a narrower strip on wide screens.
-    Widget capWidth(Widget page) => maxContentWidth >= context.width
-        ? page
-        : Center(child: SizedBox(width: maxContentWidth, child: page));
+    // Smart scale centres a narrower strip on wide screens (cross-axis: width
+    // for a vertical strip, height for a horizontal one).
+    Widget capWidth(Widget page) {
+      final containerExtent = isHorizontal ? context.height : context.width;
+      if (crossAxisExtent >= containerExtent) return page;
+      return Center(
+        child: isHorizontal
+            ? SizedBox(height: crossAxisExtent, child: page)
+            : SizedBox(width: crossAxisExtent, child: page),
+      );
+    }
 
     Widget buildItem(BuildContext context, int index) {
       final loc = _locate(index, loadedChapters.value);
+      final fallbackMainAxisExtent = isHorizontal
+          ? mainAxisExtent * InfinityContinuousConfig.horizontalPageWidthRatio
+          : mainAxisExtent * InfinityContinuousConfig.verticalPageHeightRatio;
       if (loc == null) {
-        return SizedBox(
-          height:
-              context.height * InfinityContinuousConfig.verticalPageHeightRatio,
-        );
+        return isHorizontal
+            ? SizedBox(width: fallbackMainAxisExtent)
+            : SizedBox(height: fallbackMainAxisExtent);
       }
-      // Reserve the page's true height so a strip never grows on decode and
-      // shoves the scroll backward. Priority:
-      //   1. this exact page's measured height (re-entry), else
+      // Reserve the page's true main-axis extent so a strip never grows on
+      // decode and shoves the scroll backward. Priority:
+      //   1. this exact page's measured extent (re-entry), else
       //   2. the AVERAGE of pages already measured in this session — manhwa
       //      strips in a chapter are near-uniform, so this places an unloaded
-      //      page within a few px of its real height (the key fix: a page that
+      //      page within a few px of its real extent (the key fix: a page that
       //      loads while ABOVE the viewport barely changes size, so it doesn't
       //      push the reader back — the failure mode the 0.7-screen guess caused
       //      when real strips are 2-4 screens tall), else
       //   3. a one-screen fallback for the very first page (the anchor, which
-      //      grows downward and never jumps the reader).
+      //      grows forward and never jumps the reader).
       final measured = pageHeights.value;
-      final double? avgHeight = measured.isEmpty
+      final double? avgExtent = measured.isEmpty
           ? null
           : measured.values.reduce((a, b) => a + b) / measured.length;
-      final placeholderHeight =
-          measured[loc.imageUrl] ??
-          avgHeight ??
-          context.height * InfinityContinuousConfig.verticalPageHeightRatio;
+      final placeholderExtent =
+          measured[loc.imageUrl] ?? avgExtent ?? fallbackMainAxisExtent;
+      final fit = isHorizontal ? BoxFit.fitHeight : BoxFit.fitWidth;
+      Widget placeholderBox({Widget? child}) => isHorizontal
+          ? SizedBox(width: placeholderExtent, height: double.infinity, child: child)
+          : SizedBox(height: placeholderExtent, width: double.infinity, child: child);
       return ServerImage(
         showReloadButton: true,
-        fit: BoxFit.fitWidth,
+        fit: fit,
         appendApiToUrl: false,
         cropBorders: cropBorders,
-        // Decode at on-screen width, not the ~800×15000 source (#196 GPU cost).
-        memCacheWidth: (maxContentWidth * MediaQuery.devicePixelRatioOf(context))
-            .round()
-            .clamp(1, 1 << 20),
+        // Decode at on-screen size, not the ~800×15000 source (#196 GPU cost).
+        memCacheWidth: isHorizontal
+            ? null
+            : (crossAxisExtent * MediaQuery.devicePixelRatioOf(context))
+                .round()
+                .clamp(1, 1 << 20),
+        memCacheHeight: isHorizontal
+            ? (crossAxisExtent * MediaQuery.devicePixelRatioOf(context))
+                .round()
+                .clamp(1, 1 << 20)
+            : null,
         imageUrl: loc.imageUrl,
-        progressIndicatorBuilder: (_, __, progress) => SizedBox(
-          height: placeholderHeight,
+        progressIndicatorBuilder: (_, __, progress) => placeholderBox(
           child: Center(
             child: CircularProgressIndicator(value: progress.progress),
           ),
@@ -1261,46 +1295,47 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           final image = Image(
             image: imageProvider,
             // scaleDown = lay out at native size, shrink to fit, never enlarge.
-            fit: pagesAtNaturalSize ? BoxFit.scaleDown : BoxFit.fitWidth,
-            width: pagesAtNaturalSize ? null : double.infinity,
+            fit: pagesAtNaturalSize ? BoxFit.scaleDown : fit,
+            width: pagesAtNaturalSize
+                ? null
+                : (isHorizontal ? null : double.infinity),
+            height: pagesAtNaturalSize
+                ? null
+                : (isHorizontal ? double.infinity : null),
             // A page file deleted while still loaded (e.g. delete-on-read, then
             // scrolling back to it offline) would otherwise throw and paint
-            // Flutter's red error widget for every page. Show a stable-height
+            // Flutter's red error widget for every page. Show a stable-extent
             // broken-image placeholder instead.
-            errorBuilder: (context, error, stackTrace) => SizedBox(
-              height: placeholderHeight,
-              width: double.infinity,
+            errorBuilder: (context, error, stackTrace) => placeholderBox(
               child: const Center(
                 child: Icon(Icons.broken_image_rounded, color: Colors.grey),
               ),
             ),
-            // Reserve the page's height UNTIL the bitmap decodes. The network path
+            // Reserve the page's extent UNTIL the bitmap decodes. The network path
             // gets this for free via progressIndicatorBuilder, but the offline
             // (file://) ServerImage branch skips that and renders the bare Image —
-            // which is 0px tall until the local file decodes, then pops to full
-            // height. A wall of pages popping 0->real around a seek lands the jump
-            // on the wrong page (offline-only seek bug). Reserving placeholderHeight
+            // which is 0px until the local file decodes, then pops to full
+            // extent. A wall of pages popping 0->real around a seek lands the jump
+            // on the wrong page (offline-only seek bug). Reserving placeholderExtent
             // keeps every page size-stable, so jumpTo(index) lands true.
             frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
               if (frame == null && !wasSynchronouslyLoaded) {
-                return SizedBox(
-                  height: placeholderHeight,
-                  width: double.infinity,
-                );
+                return placeholderBox();
               }
               // Only measure the REAL decoded image — never the placeholder — so a
-              // strip re-entering the viewport reserves its true height.
+              // strip re-entering the viewport reserves its true extent.
               return MeasureSize(
                 onChange: (size) {
-                  if (size.height <= 0) return;
-                  pageHeights.value[loc.imageUrl] = size.height;
+                  final extent = isHorizontal ? size.width : size.height;
+                  if (extent <= 0) return;
+                  pageHeights.value[loc.imageUrl] = extent;
                 },
                 child: child,
               );
             },
           );
-          // Load-bearing: without Center, the list's tight cross-axis width
-          // pins scaleDown's layout box at full width (letterboxed) instead
+          // Load-bearing: without Center, the list's tight cross-axis extent
+          // pins scaleDown's layout box at full size (letterboxed) instead
           // of letting it shrink to native.
           return pagesAtNaturalSize ? Center(child: image) : image;
         },
@@ -1308,6 +1343,9 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     }
 
     // continuousVertical is the "Long strip with gaps" mode in settings.
+    // continuousHorizontalLTR/RTL have no equivalent gaps setting (they're
+    // legacy-orphan modes with no dedicated settings surface), so they follow
+    // webtoon's no-gap default.
     final pageGap = effectiveReaderMode == ReaderMode.continuousVertical
         ? const Gap(kLongStripPageGap)
         : const SizedBox.shrink();
@@ -1340,8 +1378,9 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       scrollDirection: scrollDirection,
       reverse: reverse,
       itemCount: total,
-      minCacheExtent:
-          context.height * InfinityContinuousConfig.verticalCacheMultiplier,
+      minCacheExtent: isHorizontal
+          ? context.width * InfinityContinuousConfig.horizontalCacheMultiplier
+          : context.height * InfinityContinuousConfig.verticalCacheMultiplier,
       itemBuilder: (context, index) => capWidth(buildItem(context, index)),
       // Transition cards follow the strip's column width — a full-width card
       // interrupting a 30% strip reads as a glitch.

--- a/test/src/features/manga_book/reader/infinity_continuous_horizontal_test.dart
+++ b/test/src/features/manga_book/reader/infinity_continuous_horizontal_test.dart
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// continuousHorizontalLTR/RTL used to be aliases of the paged pager; they now
+// route to MultiChapterContinuousReaderMode with scrollDirection:
+// Axis.horizontal, reusing the same next/previous-chapter boundary triggers
+// as the vertical/webtoon continuous mode (see
+// infinity_scrollback_regression_test.dart, which this file mirrors on the
+// horizontal axis). This locks down that the axis generalisation actually
+// works end-to-end — not just that it compiles — for the direction-gated
+// edge-drag trigger that loads a neighbour chapter.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_batch/chapter_batch_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_page/chapter_page_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/reader_screen.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart';
+import 'package:tsumiru/src/features/tracking/data/tracker_repository.dart';
+import 'package:tsumiru/src/features/tracking/domain/tracking_settings_providers.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+const _png1x1 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+class _FakeMangaWithId extends MangaWithId {
+  _FakeMangaWithId(this.manga);
+  final MangaDto? manga;
+  @override
+  Future<MangaDto?> build({required int mangaId}) async => manga;
+}
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+class _FakeTrackerRepository extends TrackerRepository {
+  _FakeTrackerRepository() : super(_dummyClient());
+  @override
+  Future<void> trackProgress(int mangaId) async {}
+}
+
+class _QuietRepo extends Fake implements MangaBookRepository {
+  @override
+  Future<void> putChapter({
+    required int chapterId,
+    required ChapterChange patch,
+  }) async {}
+}
+
+List<String> _localPages(int count, String tag) {
+  final dir =
+      Directory.systemTemp.createTempSync('tsumiru-scrollback-horiz-$tag-');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final bytes = base64Decode(_png1x1);
+  return [
+    for (var i = 0; i < count; i++)
+      (File('${dir.path}/$i.png')..writeAsBytesSync(bytes)).uri.toString(),
+  ];
+}
+
+MangaDto _horizontalContinuousManga(ReaderMode mode) => Fragment$MangaDto(
+      id: 1,
+      title: 'Test Horizontal Continuous',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 2),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: mode.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 2,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
+
+ChapterDto _chapter({required int id, required int sourceOrder}) =>
+    Fragment$ChapterDto(
+      chapterNumber: sourceOrder.toDouble(),
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: 'Chapter $id',
+      pageCount: 3,
+      sourceOrder: sourceOrder,
+      uploadDate: '0',
+      url: '/chapter/$id',
+      meta: const [],
+    );
+
+ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
+      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+      pages: _localPages(count, 'c$id'),
+    );
+
+/// Pumps the reader open on chapter 2 page 0 (chapter 1 is its previous), in
+/// [mode] (continuousHorizontalLTR/RTL).
+Future<void> _pumpReaderOnChapter2(
+  WidgetTester tester, {
+  required ReaderMode mode,
+  required FutureOr<ChapterPagesDto?> Function() prevPages,
+}) async {
+  tester.view.physicalSize = const Size(800, 1600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  SharedPreferences.setMockInitialValues(const {});
+  final prefs = await SharedPreferences.getInstance();
+
+  final ch1 = _chapter(id: 1, sourceOrder: 1);
+  final ch2 = _chapter(id: 2, sourceOrder: 2);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        mangaBookRepositoryProvider.overrideWithValue(_QuietRepo()),
+        mangaWithIdProvider(mangaId: 1).overrideWith(
+            () => _FakeMangaWithId(_horizontalContinuousManga(mode))),
+        chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
+        chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
+        chapterPagesProvider(chapterId: 1).overrideWith((ref) => prevPages()),
+        chapterPagesProvider(chapterId: 2).overrideWith((ref) => _pages(2, 3)),
+        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
+            .overrideWithValue((first: null, second: ch1)),
+        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+            .overrideWithValue((first: ch2, second: null)),
+        trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const ReaderScreen(mangaId: 1, chapterId: 2),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// A drag gesture toward the start of the horizontal strip: content moves
+/// right (mirrors _dragUp's "content moves down" in the vertical regression
+/// test). For LTR this pulls toward page 0 / the previous chapter; the sign
+/// only matters in that both directions of the axis are exercised across the
+/// two tests below (LTR pulls positive, RTL pulls negative).
+Future<void> _dragTowardPreviousChapter(
+  WidgetTester tester, {
+  required bool reverse,
+}) async {
+  await tester.timedDrag(
+    find.byType(Scrollable).first,
+    Offset(reverse ? -300 : 300, 0),
+    const Duration(milliseconds: 120),
+  );
+  await tester.pumpAndSettle();
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() {
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown = Duration.zero;
+  });
+  tearDown(() {
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown =
+        const Duration(seconds: 4);
+  });
+
+  for (final mode in [
+    ReaderMode.continuousHorizontalLTR,
+    ReaderMode.continuousHorizontalRTL,
+  ]) {
+    testWidgets(
+        '$mode: mounts as a real horizontal continuous strip (never the '
+        'paged pager)', (tester) async {
+      await _pumpReaderOnChapter2(
+        tester,
+        mode: mode,
+        prevPages: () async => _pages(1, 3),
+      );
+
+      final widget = tester.widget<MultiChapterContinuousReaderMode>(
+        find.byType(MultiChapterContinuousReaderMode),
+      );
+      expect(widget.scrollDirection, Axis.horizontal);
+      expect(widget.reverse, mode == ReaderMode.continuousHorizontalRTL);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        '$mode: resume at page 0, a drag at the clamp loads the previous '
+        'chapter', (tester) async {
+      var prevFetches = 0;
+      await _pumpReaderOnChapter2(
+        tester,
+        mode: mode,
+        prevPages: () async {
+          prevFetches++;
+          // Real delay: an unheld autoDispose fetch would get disposed
+          // mid-flight and never complete.
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return _pages(1, 3);
+        },
+      );
+
+      await _dragTowardPreviousChapter(
+        tester,
+        reverse: mode == ReaderMode.continuousHorizontalRTL,
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+
+      expect(prevFetches, greaterThanOrEqualTo(1),
+          reason: 'edge drag on the horizontal strip never asked for the '
+              'previous chapter — the boundary trigger only works on the '
+              'vertical axis');
+      expect(tester.takeException(), isNull);
+    });
+  }
+}

--- a/test/src/features/manga_book/reader/reader_mode_kind_test.dart
+++ b/test/src/features/manga_book/reader/reader_mode_kind_test.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// continuousHorizontalLTR/RTL used to be pure paged-mode aliases (routed to
+// MultiChapterPagedReaderMode) — isPagedReaderMode said `true` for them to
+// match. Now that reader_screen.dart routes them to the real continuous
+// scroll widget (MultiChapterContinuousReaderMode, scrollDirection:
+// Axis.horizontal), isPagedReaderMode must say `false`, so gesture routing
+// and the bottom controls agree with what's actually on screen.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/constants/enum.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/utils/reader_mode_kind.dart';
+
+void main() {
+  group('isPagedReaderMode', () {
+    test('paged modes', () {
+      expect(isPagedReaderMode(ReaderMode.singleHorizontalLTR), isTrue);
+      expect(isPagedReaderMode(ReaderMode.singleHorizontalRTL), isTrue);
+      expect(isPagedReaderMode(ReaderMode.singleVertical), isTrue);
+    });
+
+    test('continuous/webtoon modes, including the horizontal orphans', () {
+      expect(isPagedReaderMode(ReaderMode.defaultReader), isFalse);
+      expect(isPagedReaderMode(ReaderMode.continuousVertical), isFalse);
+      expect(isPagedReaderMode(ReaderMode.webtoon), isFalse);
+      expect(isPagedReaderMode(ReaderMode.continuousHorizontalLTR), isFalse);
+      expect(isPagedReaderMode(ReaderMode.continuousHorizontalRTL), isFalse);
+    });
+  });
+
+  group('isRTLReaderMode', () {
+    test('RTL modes', () {
+      expect(isRTLReaderMode(ReaderMode.singleHorizontalRTL), isTrue);
+      expect(isRTLReaderMode(ReaderMode.continuousHorizontalRTL), isTrue);
+    });
+
+    test('everything else reads LTR/non-directional', () {
+      expect(isRTLReaderMode(ReaderMode.singleHorizontalLTR), isFalse);
+      expect(isRTLReaderMode(ReaderMode.continuousHorizontalLTR), isFalse);
+      expect(isRTLReaderMode(ReaderMode.singleVertical), isFalse);
+      expect(isRTLReaderMode(ReaderMode.continuousVertical), isFalse);
+      expect(isRTLReaderMode(ReaderMode.webtoon), isFalse);
+      expect(isRTLReaderMode(ReaderMode.defaultReader), isFalse);
+    });
+  });
+
+  group('defaultNavigationFor', () {
+    test('horizontal modes (paged or continuous) get right-and-left zones',
+        () {
+      expect(defaultNavigationFor(ReaderMode.singleHorizontalLTR),
+          ReaderNavigationLayout.rightAndLeft);
+      expect(defaultNavigationFor(ReaderMode.singleHorizontalRTL),
+          ReaderNavigationLayout.rightAndLeft);
+      expect(defaultNavigationFor(ReaderMode.continuousHorizontalLTR),
+          ReaderNavigationLayout.rightAndLeft);
+      expect(defaultNavigationFor(ReaderMode.continuousHorizontalRTL),
+          ReaderNavigationLayout.rightAndLeft);
+    });
+
+    test('vertical/webtoon/default get L-shaped zones', () {
+      expect(defaultNavigationFor(ReaderMode.singleVertical),
+          ReaderNavigationLayout.lShaped);
+      expect(defaultNavigationFor(ReaderMode.continuousVertical),
+          ReaderNavigationLayout.lShaped);
+      expect(defaultNavigationFor(ReaderMode.webtoon),
+          ReaderNavigationLayout.lShaped);
+      expect(defaultNavigationFor(ReaderMode.defaultReader),
+          ReaderNavigationLayout.lShaped);
+    });
+  });
+}

--- a/test/src/features/manga_book/reader/reader_screen_test.dart
+++ b/test/src/features/manga_book/reader/reader_screen_test.dart
@@ -22,6 +22,8 @@ import 'package:tsumiru/src/features/manga_book/domain/manga/manga_model.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/controller/reader_controller.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/reader_screen.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart';
 import 'package:tsumiru/src/features/manga_book/presentation/reader/widgets/reader_mode/paged_reader_viewport.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
 import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
@@ -127,6 +129,32 @@ ChapterDto _partReadChapter() => Fragment$ChapterDto(
 ChapterPagesDto _chapterPages() => ChapterPagesDto(
       chapter: ChapterPagesChapterDto(id: 1, pageCount: 3),
       pages: _localPages(3),
+    );
+
+MangaDto _mangaWithMode(ReaderMode mode) => Fragment$MangaDto(
+      id: 1,
+      title: 'Test Manga',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 0),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: mode.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 0,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
     );
 
 void main() {
@@ -290,5 +318,68 @@ void main() {
     // resume position wiped just by navigating to it.
     expect(find.text('3 / 3'), findsOneWidget);
     expect(repo.putChapterCalls, isEmpty);
+  });
+
+  // continuousHorizontalLTR/RTL used to be pure aliases of
+  // singleHorizontalLTR/RTL, silently routed to the paged pager instead of a
+  // real continuous scroll. They must now reach MultiChapterContinuousReaderMode
+  // with scrollDirection: Axis.horizontal (never the paged widget).
+  group('continuousHorizontalLTR/RTL route to the continuous widget', () {
+    Future<void> pumpWithMode(WidgetTester tester, ReaderMode mode) async {
+      tester.view.physicalSize = const Size(800, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      SharedPreferences.setMockInitialValues(const {});
+      final prefs = await SharedPreferences.getInstance();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
+            mangaBookRepositoryProvider.overrideWithValue(_RecordingRepo()),
+            mangaWithIdProvider(mangaId: 1)
+                .overrideWith(() => _FakeMangaWithId(_mangaWithMode(mode))),
+            chapterProvider(chapterId: 1).overrideWith((ref) => _chapter()),
+            chapterPagesProvider(chapterId: 1)
+                .overrideWith((ref) => _chapterPages()),
+            getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+                .overrideWithValue(null),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: ReaderScreen(mangaId: 1, chapterId: 1),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('continuousHorizontalLTR: horizontal continuous, not reversed',
+        (tester) async {
+      await pumpWithMode(tester, ReaderMode.continuousHorizontalLTR);
+
+      expect(find.byType(MultiChapterPagedReaderMode), findsNothing);
+      final widget = tester.widget<MultiChapterContinuousReaderMode>(
+        find.byType(MultiChapterContinuousReaderMode),
+      );
+      expect(widget.scrollDirection, Axis.horizontal);
+      expect(widget.reverse, isFalse);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('continuousHorizontalRTL: horizontal continuous, reversed',
+        (tester) async {
+      await pumpWithMode(tester, ReaderMode.continuousHorizontalRTL);
+
+      expect(find.byType(MultiChapterPagedReaderMode), findsNothing);
+      final widget = tester.widget<MultiChapterContinuousReaderMode>(
+        find.byType(MultiChapterContinuousReaderMode),
+      );
+      expect(widget.scrollDirection, Axis.horizontal);
+      expect(widget.reverse, isTrue);
+      expect(tester.takeException(), isNull);
+    });
   });
 }


### PR DESCRIPTION
Fixes #382

\`continuousHorizontalLTR/RTL\` were pure aliases of the paged horizontal pager — routed to \`MultiChapterPagedReaderMode\` instead of a real continuous scroll. This routes them to \`MultiChapterContinuousReaderMode\` (\`scrollDirection: Axis.horizontal\`), generalizing the widget's axis-dependent sizing/fit/prefetch logic (cross-axis capping, placeholder extent, \`BoxFit\`, \`MeasureSize\`, \`minCacheExtent\`, off-screen decode) so it works for either scroll direction, while reusing the existing next/previous-chapter boundary triggers unchanged (they already reasoned in viewport-fraction/pixel terms, not hardcoded vertical pixels).

\`isPagedReaderMode\` now reports these two modes as non-paged, so gesture routing and the bottom controls agree with the actual behavior.

## Testing
- Added \`reader_mode_kind_test.dart\` locking \`isPagedReaderMode\`/\`isRTLReaderMode\`/\`defaultNavigationFor\` for all 8 \`ReaderMode\` values.
- Added routing tests in \`reader_screen_test.dart\` confirming these two modes reach \`MultiChapterContinuousReaderMode\` with the right \`scrollDirection\`/\`reverse\`, never the paged widget.
- Added \`infinity_continuous_horizontal_test.dart\`, mirroring the existing vertical scrollback regression test on the horizontal axis (mount + edge-drag loads the previous chapter).
- Manually verified on an Android device (dev build): horizontal scroll, previous/next chapter auto-load at the edges, RTL direction.