### PR TITLE
Perf/stability audit fixes: reader decode cap, library search debounce, auth token refresh, GraphQL retry safety, offline query/schema cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,8 @@ flatpak/bundle/
 .flatpak-out/
 .flatpak-builder/
 
-# Claude Code local settings (personal hooks/config)
-.claude/settings.local.json
+# Claude Code local settings/scratch (personal hooks/config, nothing tracked here)
+.claude/
 
 # FVM local SDK symlink (version pinned in .fvmrc)
 .fvm/

--- a/lib/src/features/auth/data/auth_coordinator.dart
+++ b/lib/src/features/auth/data/auth_coordinator.dart
@@ -214,7 +214,7 @@ class AuthCoordinator extends _$AuthCoordinator {
             _proactiveRefreshTimer != null) {
           return;
         }
-        _scheduleProactiveRefresh(ref.read(graphQlClientProvider));
+        _scheduleProactiveRefresh();
       },
       fireImmediately: true,
     );
@@ -224,7 +224,11 @@ class AuthCoordinator extends _$AuthCoordinator {
   /// (Re)schedules the proactive refresh Timer from the currently-stored
   /// `uiAccessTokenExpiresAt`. Idempotent — cancels any existing Timer
   /// first. No-op if there is no expiry (logout / non-ui mode).
-  void _scheduleProactiveRefresh(GraphQLClient gqlClient) {
+  ///
+  /// Does NOT capture a [GraphQLClient] — [_firePeriodicRefresh] reads
+  /// `graphQlClientProvider` fresh when the Timer actually fires (see its
+  /// doc comment for why capturing one here was a bug).
+  void _scheduleProactiveRefresh() {
     _proactiveRefreshTimer?.cancel();
     _proactiveRefreshTimer = null;
 
@@ -241,13 +245,13 @@ class AuthCoordinator extends _$AuthCoordinator {
 
     _proactiveRefreshTimer = Timer(delay, () {
       _proactiveRefreshTimer = null;
-      _firePeriodicRefresh(gqlClient);
+      _firePeriodicRefresh();
     });
   }
 
   /// Schedules a transient-failure backoff Timer. Cancels any existing
   /// Timer first so we never have two pending.
-  void _scheduleBackoffRefresh(GraphQLClient gqlClient) {
+  void _scheduleBackoffRefresh() {
     _proactiveRefreshTimer?.cancel();
     final stepIndex =
         _proactiveBackoffStep.clamp(0, _backoffSchedule.length - 1);
@@ -255,20 +259,32 @@ class AuthCoordinator extends _$AuthCoordinator {
     _proactiveBackoffStep++;
     _proactiveRefreshTimer = Timer(delay, () {
       _proactiveRefreshTimer = null;
-      _firePeriodicRefresh(gqlClient);
+      _firePeriodicRefresh();
     });
   }
 
   /// Common Timer body — calls `refreshUiAccessToken` and dispatches
   /// the next schedule based on outcome.
-  Future<void> _firePeriodicRefresh(GraphQLClient gqlClient) async {
+  ///
+  /// Reads `graphQlClientProvider` fresh on every firing instead of taking
+  /// it as a parameter. It used to be threaded through from whichever
+  /// `ref.read(graphQlClientProvider)` happened at the FIRST schedule (in
+  /// `build()`'s credentials listener) and reused for every reschedule
+  /// after that — a transient-failure backoff loop, or a success reschedule
+  /// racing the credentials listener's own reschedule, could keep closing
+  /// over that same original client forever. A server switch (or any other
+  /// change that rebuilds `graphQlClientProvider`) mid-loop then left the
+  /// proactive refresh silently retrying against the OLD server
+  /// indefinitely, since nothing else re-reads the provider on this path.
+  Future<void> _firePeriodicRefresh() async {
     try {
+      final gqlClient = ref.read(graphQlClientProvider);
       final outcome = await refreshUiAccessToken(gqlClient: gqlClient);
       if (outcome is RefreshSuccess) {
         _proactiveBackoffStep = 0;
-        _scheduleProactiveRefresh(gqlClient);
+        _scheduleProactiveRefresh();
       } else if (outcome is RefreshTransientFailure) {
-        _scheduleBackoffRefresh(gqlClient);
+        _scheduleBackoffRefresh();
       }
       // RefreshAuthFailure: tokens are cleared and the credentials
       // listener will fire with uiAccessToken=null, triggering
@@ -276,7 +292,7 @@ class AuthCoordinator extends _$AuthCoordinator {
     } catch (e, st) {
       debugPrint('proactive refresh callback raised: $e\n$st');
       // Treat unexpected throws as transient — keep trying.
-      _scheduleBackoffRefresh(gqlClient);
+      _scheduleBackoffRefresh();
     }
   }
 

--- a/lib/src/features/library/presentation/library/controller/library_controller.dart
+++ b/lib/src/features/library/presentation/library/controller/library_controller.dart
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
+
 import 'package:diacritic/diacritic.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -277,7 +279,7 @@ class CategoryMangaListWithQueryAndFilter
   @override
   AsyncValue<List<MangaDto>?> build({required int categoryId}) {
     final mangaList = ref.watch(categoryMangaListProvider(categoryId));
-    final query = ref.watch(libraryQueryProvider);
+    final query = ref.watch(libraryQueryDebouncedProvider);
     final mangaFilterUnread = ref.watch(libraryMangaFilterUnreadProvider);
     final mangaFilterDownloaded =
         ref.watch(libraryMangaFilterDownloadedProvider);
@@ -355,6 +357,28 @@ class CategoryMangaListWithQueryAndFilter
 class LibraryQuery extends _$LibraryQuery with StateProviderMixin<String?> {
   @override
   String? build() => null;
+}
+
+/// [libraryQueryProvider], but only propagating a change once the query has
+/// held still for 300ms. The search field itself reads/writes the raw
+/// provider directly (so typing feels instant and the clear button reacts
+/// immediately) — this one exists purely so the two expensive
+/// filter/sort/group passes below don't re-run on every keystroke.
+@riverpod
+class LibraryQueryDebounced extends _$LibraryQueryDebounced {
+  Timer? _timer;
+
+  @override
+  String? build() {
+    ref.onDispose(() => _timer?.cancel());
+    ref.listen<String?>(libraryQueryProvider, (previous, next) {
+      _timer?.cancel();
+      _timer = Timer(const Duration(milliseconds: 300), () {
+        if (ref.mounted) state = next;
+      });
+    });
+    return ref.read(libraryQueryProvider);
+  }
 }
 
 @riverpod
@@ -664,7 +688,7 @@ class GroupedMangaListWithQueryAndFilter
       }
     }
     final allAsync = ref.watch(libraryMangaListProvider);
-    final query = ref.watch(libraryQueryProvider);
+    final query = ref.watch(libraryQueryDebouncedProvider);
     final mangaFilterUnread = ref.watch(libraryMangaFilterUnreadProvider);
     final mangaFilterDownloaded =
         ref.watch(libraryMangaFilterDownloadedProvider);

--- a/lib/src/features/manga_book/presentation/reader/crop/crop_isolate.dart
+++ b/lib/src/features/manga_book/presentation/reader/crop/crop_isolate.dart
@@ -25,19 +25,37 @@ class CroppedImageData {
 
 // Sendable argument bundle for [compute].
 class _CropRequest {
-  const _CropRequest(this.encodedBytes, this.threshold);
+  const _CropRequest(
+    this.encodedBytes,
+    this.threshold,
+    this.targetWidth,
+    this.targetHeight,
+  );
   final Uint8List encodedBytes;
   final int threshold;
+  final int? targetWidth;
+  final int? targetHeight;
 }
 
 /// Decodes [encodedBytes], detects borders, and returns the cropped RGBA in a
 /// background isolate. Returns null when the image can't be decoded or no
 /// border was found (caller falls back to the uncropped image).
+///
+/// [targetWidth]/[targetHeight] (display px, one may be null to preserve
+/// aspect) downscale the cropped region in this same isolate call — the decode
+/// cap [ServerImage] applies to the un-cropped path can't reach this one
+/// (these are already-decoded raw pixels, not an encoded buffer the engine's
+/// decode-time resize can act on), so it has to happen here instead.
 Future<CroppedImageData?> cropImageBytes(
   Uint8List encodedBytes, {
   int threshold = 20,
+  int? targetWidth,
+  int? targetHeight,
 }) {
-  return compute(_cropEntry, _CropRequest(encodedBytes, threshold));
+  return compute(
+    _cropEntry,
+    _CropRequest(encodedBytes, threshold, targetWidth, targetHeight),
+  );
 }
 
 CroppedImageData? _cropEntry(_CropRequest req) {
@@ -61,5 +79,29 @@ CroppedImageData? _cropEntry(_CropRequest req) {
     dst += rowEnd - rowStart;
   }
 
-  return CroppedImageData(rgba: out, width: rect.width, height: rect.height);
+  // Only ever downscale — an upscale would blur a crop that's already
+  // smaller than the cap for no benefit.
+  final needsResize =
+      (req.targetWidth != null && req.targetWidth! < rect.width) ||
+      (req.targetHeight != null && req.targetHeight! < rect.height);
+  if (!needsResize) {
+    return CroppedImageData(rgba: out, width: rect.width, height: rect.height);
+  }
+
+  final resized = img.copyResize(
+    img.Image.fromBytes(
+      width: rect.width,
+      height: rect.height,
+      bytes: out.buffer,
+      numChannels: 4,
+      order: img.ChannelOrder.rgba,
+    ),
+    width: req.targetWidth,
+    height: req.targetHeight,
+  );
+  return CroppedImageData(
+    rgba: resized.getBytes(order: img.ChannelOrder.rgba),
+    width: resized.width,
+    height: resized.height,
+  );
 }

--- a/lib/src/features/manga_book/presentation/reader/crop/cropped_image_provider.dart
+++ b/lib/src/features/manga_book/presentation/reader/crop/cropped_image_provider.dart
@@ -32,6 +32,8 @@ class CroppedImageProvider extends ImageProvider<CroppedImageProvider> {
     this.localPath,
     this.threshold = 20,
     this.scale = 1.0,
+    this.targetWidth,
+    this.targetHeight,
   });
 
   /// URL fetched when the bytes aren't already cached (token-appended for
@@ -48,6 +50,15 @@ class CroppedImageProvider extends ImageProvider<CroppedImageProvider> {
   final int threshold;
   final double scale;
 
+  /// Decode-size cap (display px; see [ServerImage.memCacheWidth] /
+  /// [memCacheHeight]), applied internally by this provider on both branches
+  /// of [_load] — wrapping this provider in `ResizeImage` (as the un-cropped
+  /// paths do) would silently do nothing here, because the cropped branch
+  /// never calls the `decode` callback `ResizeImage` relies on (it starts
+  /// from already-decoded raw pixels, not an encoded buffer).
+  final int? targetWidth;
+  final int? targetHeight;
+
   @override
   Future<CroppedImageProvider> obtainKey(ImageConfiguration configuration) =>
       SynchronousFuture<CroppedImageProvider>(this);
@@ -58,18 +69,23 @@ class CroppedImageProvider extends ImageProvider<CroppedImageProvider> {
     ImageDecoderCallback decode,
   ) {
     return OneFrameImageStreamCompleter(
-      key._load(),
+      key._load(decode),
       informationCollector: () =>
           <DiagnosticsNode>[ErrorDescription('Crop source: ${key.cacheKey}')],
     );
   }
 
-  Future<ImageInfo> _load() async {
+  Future<ImageInfo> _load(ImageDecoderCallback decode) async {
     final bytes = await _fetchBytes();
-    final cropped = await cropImageBytes(bytes, threshold: threshold);
+    final cropped = await cropImageBytes(
+      bytes,
+      threshold: threshold,
+      targetWidth: targetWidth,
+      targetHeight: targetHeight,
+    );
     final ui.Image image = cropped != null
         ? await _decodeRgba(cropped)
-        : await _decodeEncoded(bytes);
+        : await _decodeEncoded(bytes, decode);
     return ImageInfo(image: image, scale: scale);
   }
 
@@ -95,8 +111,23 @@ class CroppedImageProvider extends ImageProvider<CroppedImageProvider> {
     return completer.future;
   }
 
-  Future<ui.Image> _decodeEncoded(Uint8List bytes) async {
-    final codec = await ui.instantiateImageCodec(bytes);
+  /// No border was found (or none was needed) — decode via the callback the
+  /// engine handed [loadImage], so [targetWidth]/[targetHeight] still apply
+  /// through the engine's own decode-time downscale (what `ResizeImage`
+  /// itself builds on), instead of decoding at native resolution and never
+  /// shrinking it.
+  Future<ui.Image> _decodeEncoded(
+    Uint8List bytes,
+    ImageDecoderCallback decode,
+  ) async {
+    final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+    final codec = await decode(
+      buffer,
+      getTargetSize: (targetWidth == null && targetHeight == null)
+          ? null
+          : (int intrinsicWidth, int intrinsicHeight) =>
+                ui.TargetImageSize(width: targetWidth, height: targetHeight),
+    );
     final frame = await codec.getNextFrame();
     return frame.image;
   }
@@ -107,10 +138,19 @@ class CroppedImageProvider extends ImageProvider<CroppedImageProvider> {
       other.cacheKey == cacheKey &&
       other.localPath == localPath &&
       other.threshold == threshold &&
-      other.scale == scale;
+      other.scale == scale &&
+      other.targetWidth == targetWidth &&
+      other.targetHeight == targetHeight;
 
   @override
-  int get hashCode => Object.hash(cacheKey, localPath, threshold, scale);
+  int get hashCode => Object.hash(
+        cacheKey,
+        localPath,
+        threshold,
+        scale,
+        targetWidth,
+        targetHeight,
+      );
 
   @override
   String toString() => 'CroppedImageProvider($cacheKey, t:$threshold)';

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -19,6 +19,7 @@ import '../../../../global_providers/global_providers.dart';
 import '../../../../l10n/generated/app_localizations.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/logger/logger.dart';
+import '../../../../utils/misc/toast/toast.dart';
 import '../../../auth/data/auth_credentials_store.dart';
 import '../../../notifications/controller/notification_settings_providers.dart';
 import '../../../notifications/data/local_notification_service.dart';
@@ -184,6 +185,16 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       );
       if (res is ServiceRequestFailure) {
         logger.e('Offline: foreground service failed to start: ${res.error}');
+        // Previously silent: chapters stayed queued in drift with nothing
+        // downloading and no signal at all (e.g. notification permission
+        // denied). A toast is a best-effort surface only — it's a no-op
+        // when there's no active UI (background launch/replay), which still
+        // leaves that path silent; making it durably visible there needs a
+        // persisted banner, not attempted here.
+        _ref.read(toastProvider)?.showError(
+          'Downloads paused: couldn\'t start the download service '
+          '(${res.error})',
+        );
       }
     } finally {
       _ensuring = false;

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -369,20 +369,13 @@ class OfflineDatabase extends _$OfflineDatabase {
           );
         }
       }
-      if (from < 10) {
-        await _addColumnIfMissing(
-          m,
-          offlineChapters,
-          offlineChapters.syncedIsRead,
-        );
-        // Assume existing rows agree with the server: the correction then
-        // starts at zero and behaves exactly as it did before this column,
-        // until the next down-sync records real baselines. Guessing the other
-        // way would invent corrections for chapters nobody has touched.
-        await customStatement(
-          'UPDATE offline_chapters SET synced_is_read = is_read',
-        );
-      }
+      // NOTE: a second `if (from < 10)` step used to duplicate this exact
+      // add-column-then-backfill for synced_is_read. Removed (2026) — the
+      // `if (from < 12)` block above already covers every from<10 upgrade
+      // (12 > 10) with the SAME guarded backfill (only runs when the column
+      // was actually missing), so the second copy only ever re-ran a no-op
+      // unconditional UPDATE. Harmless today, but this invariant has broken
+      // from exactly this shape of duplicate writer before — don't re-add it.
       if (from < 14) {
         // onCreate only runs for brand-new databases, so an upgrade from a
         // version without these tables has to create them itself.

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -634,6 +634,30 @@ class OfflineDatabase extends _$OfflineDatabase {
         .toList();
   }
 
+  /// Batched form of [categoriesForManga]: one join query covering every id
+  /// in [mangaIds] instead of one round-trip per manga. A manga with no
+  /// entry in the result has no categories (same meaning as an empty list
+  /// from the single-id form).
+  Future<Map<int, List<OfflineCategory>>> categoriesForMangas(
+    Set<int> mangaIds,
+  ) async {
+    if (mangaIds.isEmpty) return {};
+    final query = select(offlineMangaCategories).join([
+      innerJoin(
+        offlineCategories,
+        offlineCategories.id.equalsExp(offlineMangaCategories.categoryId),
+      ),
+    ])
+      ..where(offlineMangaCategories.mangaId.isIn(mangaIds))
+      ..orderBy([OrderingTerm(expression: offlineCategories.sortOrder)]);
+    final byManga = <int, List<OfflineCategory>>{};
+    for (final row in await query.get()) {
+      final mangaId = row.readTable(offlineMangaCategories).mangaId;
+      byManga.putIfAbsent(mangaId, () => []).add(row.readTable(offlineCategories));
+    }
+    return byManga;
+  }
+
   /// All persisted categories — for the offline category-list fallback.
   Future<List<OfflineCategory>> allOfflineCategories() => (select(
     offlineCategories,

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -61,6 +61,13 @@ class OfflineMangas extends Table {
 /// server-side is reconciled via [OfflineDeviceState.orphaned] and evicted on
 /// the next reconcile pass, not cascade-deleted.
 @TableIndex(name: 'idx_offline_chapter_manga', columns: {#mangaId})
+// deviceState is filtered on by chaptersInState/nextQueuedChapter/
+// watchOfflineChapters and the watchOfflineSeries join/aggregate — all
+// unindexed full scans without this, and (worse) drift's per-table .watch()
+// reruns watchOfflineSeries' whole join on every OfflineChapters write, so an
+// active download's per-page byte/pageCount updates were driving repeated
+// full-table scans of a table that can hold years of chapter metadata.
+@TableIndex(name: 'idx_offline_chapter_device_state', columns: {#deviceState})
 class OfflineChapters extends Table {
   IntColumn get id => integer()();
   IntColumn get mangaId => integer()();
@@ -399,6 +406,9 @@ class OfflineDatabase extends _$OfflineDatabase {
           offlineChapters.readStateManual,
         );
       }
+      if (from < 15 && !await _hasIndex('idx_offline_chapter_device_state')) {
+        await m.createIndex(idxOfflineChapterDeviceState);
+      }
     },
   );
 
@@ -408,6 +418,18 @@ class OfflineDatabase extends _$OfflineDatabase {
     final rows = await customSelect(
       "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
       variables: [Variable<String>(table.actualTableName)],
+    ).get();
+    return rows.isNotEmpty;
+  }
+
+  /// Same idempotency concern as [_hasTable]/[_addColumnIfMissing]: an
+  /// intermediate/dev build can leave an index present at an older recorded
+  /// schema version, and `CREATE INDEX` (unlike `addColumn`) has no built-in
+  /// "if missing" guard in drift's Migrator.
+  Future<bool> _hasIndex(String name) async {
+    final rows = await customSelect(
+      "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+      variables: [Variable<String>(name)],
     ).get();
     return rows.isNotEmpty;
   }
@@ -577,12 +599,16 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// Downloaded-library manga per category, for the offline tab counts.
   /// Membership rows outside [mangaIds] don't count.
   Future<Map<int, int>> mangaCountByCategory(Set<int> mangaIds) async {
-    final rows = await select(offlineMangaCategories).get();
+    if (mangaIds.isEmpty) return {};
+    final categoryId = offlineMangaCategories.categoryId;
+    final mangaCount = offlineMangaCategories.mangaId.count();
+    final query = selectOnly(offlineMangaCategories)
+      ..addColumns([categoryId, mangaCount])
+      ..where(offlineMangaCategories.mangaId.isIn(mangaIds))
+      ..groupBy([categoryId]);
     final counts = <int, int>{};
-    for (final row in rows) {
-      if (mangaIds.contains(row.mangaId)) {
-        counts[row.categoryId] = (counts[row.categoryId] ?? 0) + 1;
-      }
+    for (final row in await query.get()) {
+      counts[row.read(categoryId)!] = row.read(mangaCount) ?? 0;
     }
     return counts;
   }
@@ -591,12 +617,15 @@ class OfflineDatabase extends _$OfflineDatabase {
   /// render under Default. A row pointing at a pruned/unmirrored category
   /// doesn't count either; the mapper's inner join drops it the same way.
   Future<Set<int>> uncategorizedOf(Set<int> mangaIds) async {
+    if (mangaIds.isEmpty) return {};
     final rows = await (select(offlineMangaCategories).join([
       innerJoin(
         offlineCategories,
         offlineCategories.id.equalsExp(offlineMangaCategories.categoryId),
       ),
-    ])).get();
+    ])
+          ..where(offlineMangaCategories.mangaId.isIn(mangaIds)))
+        .get();
     final categorized = {
       for (final row in rows) row.readTable(offlineMangaCategories).mangaId,
     };

--- a/lib/src/features/offline/data/offline_read_fallback.dart
+++ b/lib/src/features/offline/data/offline_read_fallback.dart
@@ -78,11 +78,10 @@ Future<List<MangaDto>?> libraryWithOfflineFallback({
     final lastReadByManga = await db.lastReadAtByManga();
     final firstUnreadByManga = await db.firstUnreadDownloadedChapterByManga();
     final readDelta = await db.unsyncedReadDeltaByManga();
-    // Load all category memberships in one pass keyed by mangaId
-    final categoryMap = <int, List<OfflineCategory>>{};
-    for (final m in rows) {
-      categoryMap[m.id] = await db.categoriesForManga(m.id);
-    }
+    // Load all category memberships in one query, keyed by mangaId.
+    final categoryMap = await db.categoriesForMangas({
+      for (final m in rows) m.id,
+    });
     // The manga column carries the server's Last-Read snapshot for every
     // library entry; a chapter-row max can be newer when something was read
     // offline since the last sync. Numeric max — both are epoch strings.

--- a/lib/src/features/offline/data/reconcile_logic.dart
+++ b/lib/src/features/offline/data/reconcile_logic.dart
@@ -83,22 +83,29 @@ Set<int> readChaptersInDeleteWindow(List<OfflineChapter> chapters, int slots) {
     }
   }
 
-  // 3) Storage cap: evict oldest non-pinned until under cap.
+  // 3) Storage cap: evict oldest non-pinned until under cap. Tracks the
+  // retained total as a running value instead of re-folding the whole
+  // (already-filtered) list on every iteration — same result, O(n log n)
+  // (the sort) instead of O(n^2) for a manga with many downloaded chapters.
   var overCapWarning = false;
   if (nets.storageCapEnabled) {
-    int total() => downloaded
-        .where((c) => !evict.contains(c.id))
-        .fold(0, (s, c) => s + c.bytes);
     final candidates = downloaded
         .where((c) => !c.pinned && !evict.contains(c.id))
         .toList()
       ..sort((a, b) => (a.downloadedAt ?? DateTime(0))
           .compareTo(b.downloadedAt ?? DateTime(0)));
+    var retainedBytes = downloaded
+        .where((c) => !evict.contains(c.id))
+        .fold(0, (s, c) => s + c.bytes);
     var i = 0;
-    while (total() > nets.storageCapBytes && i < candidates.length) {
-      evict.add(candidates[i++].id);
+    while (retainedBytes > nets.storageCapBytes && i < candidates.length) {
+      retainedBytes -= candidates[i].bytes;
+      evict.add(candidates[i].id);
+      i++;
     }
-    if (total() > nets.storageCapBytes) overCapWarning = true; // only pinned left
+    if (retainedBytes > nets.storageCapBytes) {
+      overCapWarning = true; // only pinned left
+    }
   }
 
   return (evict: evict, overCapWarning: overCapWarning);

--- a/lib/src/utils/network/timeout_http_client.dart
+++ b/lib/src/utils/network/timeout_http_client.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
@@ -32,12 +33,18 @@ class TimeoutHttpClient extends http.BaseClient {
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
     int attempt = 0;
     http.BaseRequest current = request;
+    // A GraphQL mutation isn't idempotent — a timeout doesn't mean the server
+    // didn't already apply it, so retrying can silently double an effect
+    // (re-enqueue a download, re-create a category, ...). This client is only
+    // ever used for the GraphQL HttpLink, so its body is always the standard
+    // `{"query": "...", ...}` shape when it parses as one.
+    final isMutation = _isMutationRequest(request);
 
     while (true) {
       try {
         return await _inner.send(current).timeout(timeout);
       } on TimeoutException {
-        if (attempt >= retries) rethrow;
+        if (isMutation || attempt >= retries) rethrow;
         // Streamed/multipart bodies are single-use and can't be safely retried.
         final retryClone = _cloneRequest(request);
         if (retryClone == null) rethrow;
@@ -45,6 +52,24 @@ class TimeoutHttpClient extends http.BaseClient {
         await Future.delayed(retryDelay);
         current = retryClone;
       }
+    }
+  }
+
+  /// True only when [request] is confidently identified as a GraphQL
+  /// mutation (a parseable `{"query": "mutation ..."}` body). Anything that
+  /// doesn't parse that way — a plain query, an anonymous/shorthand query, a
+  /// non-GraphQL body, no body at all — is treated as safe to retry, same as
+  /// before this check existed.
+  bool _isMutationRequest(http.BaseRequest request) {
+    if (request is! http.Request) return false;
+    try {
+      final decoded = jsonDecode(request.body);
+      if (decoded is! Map) return false;
+      final query = decoded['query'];
+      if (query is! String) return false;
+      return query.trimLeft().startsWith('mutation');
+    } catch (_) {
+      return false;
     }
   }
 

--- a/lib/src/widgets/server_image.dart
+++ b/lib/src/widgets/server_image.dart
@@ -159,8 +159,13 @@ class ServerImage extends HookConsumerWidget {
     // Renders a crop provider through the same imageBuilder/wrapper contract as
     // the normal paths (imageBuilder fires immediately with the provider, like
     // the offline branch; consumers show the frame once it decodes).
-    Widget renderCrop(ImageProvider rawProvider) {
-      final provider = _capDecode(rawProvider, cacheWidth, cacheHeight);
+    //
+    // No `_capDecode`/`ResizeImage` wrap here, unlike the other paths below:
+    // `CroppedImageProvider` takes the decode cap directly (targetWidth/
+    // targetHeight passed in at the call sites) and applies it itself, since
+    // wrapping it in `ResizeImage` would silently do nothing for the cropped
+    // branch (see the provider's own doc comment).
+    Widget renderCrop(ImageProvider provider) {
       if (imageBuilder != null) {
         return AppUtils.wrapOn(wrapper, imageBuilder!(context, provider));
       }
@@ -197,6 +202,8 @@ class ServerImage extends HookConsumerWidget {
           fetchUrl: imageUrl,
           cacheKey: localPath,
           localPath: localPath,
+          targetWidth: cacheWidth,
+          targetHeight: cacheHeight,
         ));
       }
       final ImageProvider provider =
@@ -382,6 +389,8 @@ class ServerImage extends HookConsumerWidget {
         fetchUrl: fetchUrl,
         cacheKey: baseApi,
         headers: httpHeaders,
+        targetWidth: cacheWidth,
+        targetHeight: cacheHeight,
       ));
     }
 

--- a/test/src/features/auth/data/auth_coordinator_proactive_refresh_client_test.dart
+++ b/test/src/features/auth/data/auth_coordinator_proactive_refresh_client_test.dart
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/auth/data/auth_coordinator.dart';
+import 'package:tsumiru/src/features/auth/data/auth_credentials_store.dart';
+import 'package:tsumiru/src/features/auth/data/secure_credentials_provider.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+/// Builds a minimal JWT with the given payload. Signature is a fixed
+/// placeholder; the decoder doesn't verify it. Mirrors the helper in
+/// auth_credentials_store_test.dart.
+String _buildJwt(Map<String, dynamic> payload) {
+  String b64Url(String s) =>
+      base64Url.encode(utf8.encode(s)).replaceAll('=', '');
+  return '${b64Url('{"alg":"HS256"}')}.${b64Url(jsonEncode(payload))}.sig';
+}
+
+class _InMemorySecureStorage implements FlutterSecureStorage {
+  _InMemorySecureStorage(Map<String, String> seed) : _store = {...seed};
+  final Map<String, String> _store;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _store.remove(key);
+    } else {
+      _store[key] = value;
+    }
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async =>
+      _store[key];
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _store.remove(key);
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} not stubbed');
+}
+
+/// Test-only stand-in for "the live GraphQLClient changed" (e.g. a server
+/// switch, an auth-link rebuild): [graphQlClientProvider] is overridden to
+/// rebuild from [port], and each rebuild records the port it used in [built]
+/// — flipping [port] then calling `container.invalidate(graphQlClientProvider)`
+/// simulates the provider's dependencies changing.
+class _FakeClientSource {
+  int port = 1;
+  final built = <int>[];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'a fired proactive refresh reads the CURRENT graphQlClientProvider, '
+    'not the one captured when it was scheduled',
+    () async {
+      debugResetAuthCoordinatorSingleFlight();
+
+      // Already-expired so the computed proactive-refresh delay clamps to
+      // Duration.zero — the Timer fires on the next event-loop turn instead
+      // of needing a real (or faked) wait.
+      final expiredJwt = _buildJwt({
+        'exp': DateTime.now()
+                .toUtc()
+                .subtract(const Duration(minutes: 5))
+                .millisecondsSinceEpoch ~/
+            1000,
+      });
+      final storage = _InMemorySecureStorage({
+        'auth.ui.accessToken': expiredJwt,
+        'auth.ui.refreshToken': 'R',
+      });
+
+      final source = _FakeClientSource();
+      final container = ProviderContainer(overrides: [
+        secureStorageProvider.overrideWithValue(storage),
+        graphQlClientProvider.overrideWith((ref) {
+          source.built.add(source.port);
+          // Loopback + a closed/unused port: the mutation attempt fails fast
+          // with connection-refused; we only care that THIS client (built
+          // from the CURRENT port) is the one the refresh call receives, not
+          // that the mutation itself succeeds.
+          return GraphQLClient(
+            link: HttpLink('http://127.0.0.1:${source.port}'),
+            cache: GraphQLCache(),
+          );
+        }),
+      ]);
+      addTearDown(container.dispose);
+
+      // Hydrate the credentials store BEFORE constructing AuthCoordinator, so
+      // its build()'s `ref.listen(..., fireImmediately: true)` sees an
+      // already-resolved (non-loading) state on the very first call.
+      await container.read(authCredentialsStoreProvider.future);
+
+      // Triggers AuthCoordinator.build(): the listener above fires
+      // immediately, schedules the proactive-refresh Timer at delay zero.
+      container.read(authCoordinatorProvider.notifier);
+
+      // Simulate the client changing AFTER the refresh was scheduled but
+      // BEFORE it fires (a server switch landing in that window).
+      source.port = 2;
+      container.invalidate(graphQlClientProvider);
+
+      // Let the zero-delay Timer fire and the resulting (fast, local,
+      // connection-refused) mutation attempt resolve.
+      await pumpEventQueue();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(
+        source.built.contains(2),
+        isTrue,
+        reason: 'the fired refresh must have read graphQlClientProvider '
+            'again to pick up port 2 — before the fix it kept using '
+            'whatever client was live when the Timer was first scheduled '
+            '(port 1, or no read at all), forever.',
+      );
+      expect(
+        source.built.last,
+        2,
+        reason: 'the LAST client built must be the current one at fire '
+            'time, not a stale one from scheduling time',
+      );
+    },
+  );
+}

--- a/test/src/features/library/library_query_debounced_test.dart
+++ b/test/src/features/library/library_query_debounced_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/library/presentation/library/controller/library_controller.dart';
+
+void main() {
+  group('LibraryQueryDebounced', () {
+    test('mirrors the raw query at build time', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container.listen(libraryQueryDebouncedProvider, (_, __) {});
+
+      expect(container.read(libraryQueryDebouncedProvider), isNull);
+    });
+
+    test(
+      'a burst of keystrokes only propagates the last value, after 300ms quiet',
+      () {
+        fakeAsync((async) {
+          final container = ProviderContainer();
+          container.listen(libraryQueryDebouncedProvider, (_, __) {});
+          final notifier = container.read(libraryQueryProvider.notifier);
+
+          notifier.update('o');
+          async.elapse(const Duration(milliseconds: 100));
+          notifier.update('on');
+          async.elapse(const Duration(milliseconds: 100));
+          notifier.update('one');
+
+          // Each keystroke restarted the window, so 200ms after the last one
+          // (100ms + 100ms of quiet accumulated below) is still under 300ms.
+          async.elapse(const Duration(milliseconds: 200));
+          expect(container.read(libraryQueryDebouncedProvider), isNull);
+
+          // Past 300ms of quiet since 'one': now it propagates.
+          async.elapse(const Duration(milliseconds: 101));
+          expect(container.read(libraryQueryDebouncedProvider), 'one');
+
+          container.dispose();
+        });
+      },
+    );
+
+    test('a later keystroke restarts the debounce window', () {
+      fakeAsync((async) {
+        final container = ProviderContainer();
+        container.listen(libraryQueryDebouncedProvider, (_, __) {});
+        final notifier = container.read(libraryQueryProvider.notifier);
+
+        notifier.update('re');
+        async.elapse(const Duration(milliseconds: 299));
+        expect(container.read(libraryQueryDebouncedProvider), isNull);
+
+        // Just before the window elapses, another keystroke restarts it.
+        notifier.update('rez');
+        async.elapse(const Duration(milliseconds: 299));
+        expect(container.read(libraryQueryDebouncedProvider), isNull);
+
+        async.elapse(const Duration(milliseconds: 2));
+        expect(container.read(libraryQueryDebouncedProvider), 'rez');
+
+        container.dispose();
+      });
+    });
+
+    test('clearing the query (null) still propagates after the delay', () {
+      fakeAsync((async) {
+        final container = ProviderContainer();
+        container.listen(libraryQueryDebouncedProvider, (_, __) {});
+        final notifier = container.read(libraryQueryProvider.notifier);
+
+        notifier.update('abc');
+        async.elapse(const Duration(milliseconds: 300));
+        expect(container.read(libraryQueryDebouncedProvider), 'abc');
+
+        notifier.update(null);
+        async.elapse(const Duration(milliseconds: 300));
+        expect(container.read(libraryQueryDebouncedProvider), isNull);
+
+        container.dispose();
+      });
+    });
+  });
+}

--- a/test/src/features/manga_book/reader/crop_isolate_test.dart
+++ b/test/src/features/manga_book/reader/crop_isolate_test.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:tsumiru/src/features/manga_book/presentation/reader/crop/crop_isolate.dart';
+
+/// PNG-encodes a [width]x[height] image: a solid [border] field with a solid
+/// [fill] rectangle [rect] cut into it — [cropImageBytes] decodes real
+/// encoded bytes (unlike [findContentRect], which takes raw RGBA directly).
+Uint8List _encodedImage(
+  int width,
+  int height,
+  img.Color border,
+  ({int left, int top, int right, int bottom}) rect,
+  img.Color fill,
+) {
+  final image = img.Image(width: width, height: height);
+  img.fill(image, color: border);
+  img.fillRect(
+    image,
+    x1: rect.left,
+    y1: rect.top,
+    x2: rect.right - 1,
+    y2: rect.bottom - 1,
+    color: fill,
+  );
+  return img.encodePng(image);
+}
+
+void main() {
+  group('cropImageBytes', () {
+    // 100x100 white field, red 80x80 content block (6% border each side —
+    // comfortably past findContentRect's area guard).
+    final rect = (left: 10, top: 10, right: 90, bottom: 90);
+    late Uint8List encoded;
+
+    setUp(() {
+      encoded = _encodedImage(
+        100,
+        100,
+        img.ColorRgb8(255, 255, 255),
+        rect,
+        img.ColorRgb8(255, 0, 0),
+      );
+    });
+
+    test('no target size: crops without resizing', () async {
+      final result = await cropImageBytes(encoded);
+      expect(result, isNotNull);
+      expect(result!.width, 80);
+      expect(result.height, 80);
+      // Every pixel of the cropped output is the red fill.
+      for (var p = 0; p < result.rgba.length; p += 4) {
+        expect(result.rgba[p], 255);
+        expect(result.rgba[p + 1], 0);
+        expect(result.rgba[p + 2], 0);
+      }
+    });
+
+    test('targetWidth smaller than the crop downsizes it', () async {
+      final result = await cropImageBytes(
+        encoded,
+        targetWidth: 40,
+      );
+      expect(result, isNotNull);
+      expect(result!.width, 40);
+      // Square content, single dimension given -> aspect preserved.
+      expect(result.height, 40);
+      expect(result.rgba.length, 40 * 40 * 4);
+    });
+
+    test('targetHeight smaller than the crop downsizes it', () async {
+      final result = await cropImageBytes(
+        encoded,
+        targetHeight: 20,
+      );
+      expect(result, isNotNull);
+      expect(result!.height, 20);
+      expect(result.width, 20);
+    });
+
+    test('target size larger than the crop is left untouched (no upscale)',
+        () async {
+      final result = await cropImageBytes(
+        encoded,
+        targetWidth: 500,
+        targetHeight: 500,
+      );
+      expect(result, isNotNull);
+      expect(result!.width, 80);
+      expect(result.height, 80);
+    });
+
+    test('no border found: still returns null with a target size set',
+        () async {
+      final uniform = img.Image(width: 20, height: 20);
+      img.fill(uniform, color: img.ColorRgb8(255, 255, 255));
+      final result = await cropImageBytes(
+        img.encodePng(uniform),
+        targetWidth: 10,
+      );
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -118,4 +118,55 @@ void main() {
     expect(await db.select(db.offlineMangaCategories).get(), isEmpty);
     expect(await db.select(db.offlinePages).get(), isEmpty);
   });
+
+  group('categoriesForMangas', () {
+    Future<void> seedManga(int id) => db.upsertMangaMetadata(
+          id: id,
+          title: 'M$id',
+          updatedAt: DateTime.utc(2026),
+        );
+
+    test('empty input short-circuits to an empty map', () async {
+      expect(await db.categoriesForMangas(const {}), isEmpty);
+    });
+
+    test('batches every id into one query, keyed by mangaId, ordered by '
+        "each category's sortOrder, and omits ids with no categories",
+        () async {
+      await db.upsertCategory(1, 'Reading', 0, isHidden: false);
+      await db.upsertCategory(2, 'Plan to read', 1, isHidden: false);
+      await seedManga(10);
+      await seedManga(20);
+      await seedManga(30); // uncategorized
+      await db.replaceMangaCategories(10, [2, 1]); // inserted out of order
+      await db.replaceMangaCategories(20, [1]);
+
+      final result = await db.categoriesForMangas({10, 20, 30});
+
+      expect(result[10]!.map((c) => c.id).toList(), [1, 2],
+          reason: 'sortOrder governs, not insertion order');
+      expect(result[20]!.map((c) => c.id).toList(), [1]);
+      expect(result.containsKey(30), isFalse,
+          reason: 'no membership rows -> no entry, same as the single-id '
+              'form returning an empty list');
+    });
+
+    test('matches categoriesForManga(id) for each id in the batch', () async {
+      await db.upsertCategory(1, 'Reading', 0, isHidden: false);
+      await db.upsertCategory(2, 'Plan to read', 1, isHidden: false);
+      await seedManga(10);
+      await seedManga(20);
+      await db.replaceMangaCategories(10, [1, 2]);
+      await db.replaceMangaCategories(20, [2]);
+
+      final batched = await db.categoriesForMangas({10, 20});
+      final single10 = await db.categoriesForManga(10);
+      final single20 = await db.categoriesForManga(20);
+
+      expect(batched[10]!.map((c) => c.id).toList(),
+          single10.map((c) => c.id).toList());
+      expect(batched[20]!.map((c) => c.id).toList(),
+          single20.map((c) => c.id).toList());
+    });
+  });
 }

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -169,4 +169,51 @@ void main() {
           single20.map((c) => c.id).toList());
     });
   });
+
+  group('mangaCountByCategory / uncategorizedOf', () {
+    Future<void> seedManga(int id) => db.upsertMangaMetadata(
+          id: id,
+          title: 'M$id',
+          updatedAt: DateTime.utc(2026),
+        );
+
+    test('mangaCountByCategory: empty input short-circuits to an empty map',
+        () async {
+      expect(await db.mangaCountByCategory(const {}), isEmpty);
+    });
+
+    test('mangaCountByCategory: counts only rows whose mangaId is in the '
+        'requested set', () async {
+      await db.upsertCategory(1, 'Reading', 0, isHidden: false);
+      await seedManga(10);
+      await seedManga(20);
+      await seedManga(30);
+      await db.replaceMangaCategories(10, [1]);
+      await db.replaceMangaCategories(20, [1]);
+      // Not in the requested set below -- must not inflate category 1's count.
+      await db.replaceMangaCategories(30, [1]);
+
+      expect(await db.mangaCountByCategory({10, 20}), {1: 2});
+    });
+
+    test('uncategorizedOf: empty input short-circuits to an empty set',
+        () async {
+      expect(await db.uncategorizedOf(const {}), isEmpty);
+    });
+
+    test('uncategorizedOf: only considers requested ids, and a membership '
+        'pointing at a never-mirrored category still counts as '
+        'uncategorized (mirrors the mapper\'s inner join)', () async {
+      await db.upsertCategory(1, 'Reading', 0, isHidden: false);
+      await seedManga(10); // categorized
+      await seedManga(20); // orphan membership -> counts as uncategorized
+      await seedManga(30); // truly uncategorized
+      await seedManga(40); // categorized, but NOT in the requested set
+      await db.replaceMangaCategories(10, [1]);
+      await db.replaceMangaCategories(20, [99]); // 99 was never mirrored
+      await db.replaceMangaCategories(40, [1]);
+
+      expect(await db.uncategorizedOf({10, 20, 30}), {20, 30});
+    });
+  });
 }

--- a/test/src/features/offline/data/offline_read_fallback_test.dart
+++ b/test/src/features/offline/data/offline_read_fallback_test.dart
@@ -49,6 +49,29 @@ void main() {
     expect(r!.map((m) => m.id).toSet(), {1, 2});
   });
 
+  test('library: each manga gets its OWN categories, not another manga\'s '
+      '(one batched query, not per-manga)', () async {
+    await db.upsertCategory(1, 'Reading', 0, isHidden: false);
+    await db.upsertCategory(2, 'Plan to read', 1, isHidden: false);
+    await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));
+    await db.upsertMangaMetadata(id: 2, title: 'B', updatedAt: DateTime(2026));
+    // A third, uncategorized manga: must come back with an empty list, not
+    // crash or silently borrow manga 1's/2's categories.
+    await db.upsertMangaMetadata(id: 3, title: 'C', updatedAt: DateTime(2026));
+    await db.replaceMangaCategories(1, [1, 2]);
+    await db.replaceMangaCategories(2, [1]);
+    await seedDownloadedChapter(1);
+    await seedDownloadedChapter(2);
+    await seedDownloadedChapter(3);
+
+    final r = await libraryWithOfflineFallback(
+        fetch: boom, db: db, offlineEnabled: true);
+    final byId = {for (final m in r!) m.id: m};
+    expect(byId[1]!.categories.nodes.map((n) => n.id).toList(), [1, 2]);
+    expect(byId[2]!.categories.nodes.map((n) => n.id).toList(), [1]);
+    expect(byId[3]!.categories.nodes, isEmpty);
+  });
+
   test('library: offline continue-reading target is the earliest unread '
       'downloaded chapter', () async {
     await db.upsertMangaMetadata(id: 1, title: 'A', updatedAt: DateTime(2026));

--- a/test/src/features/offline/data/offline_schema_migration_test.dart
+++ b/test/src/features/offline/data/offline_schema_migration_test.dart
@@ -170,6 +170,54 @@ void main() {
     }
   });
 
+  test(
+      'an upgrade from < 10 does not clobber a synced_is_read value an '
+      'interim build already set (no more duplicate unconditional backfill)',
+      () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    // Simulates an interim/dev build: the column already physically exists
+    // (created by a prior run at the CURRENT schema) but the recorded version
+    // is forced back below 10 -- the exact inconsistent state the surrounding
+    // migration's own comments call out repeatedly. synced_is_read is set to
+    // something that deliberately does NOT match is_read, standing in for a
+    // real unsettled local correction this device is tracking.
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      await db.upsertChapterMetadata(
+        id: 10,
+        mangaId: 1,
+        name: 'c',
+        chapterIndex: 1,
+        isRead: true,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 1,
+        updatedAt: DateTime(2026),
+      );
+      await db.customStatement(
+        'UPDATE offline_chapters SET synced_is_read = 0 WHERE id = 10',
+      );
+      await db.customStatement('PRAGMA user_version = 9');
+      await db.close();
+    }
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      final c = await (db.select(db.offlineChapters)
+            ..where((t) => t.id.equals(10)))
+          .getSingle();
+      expect(c.isRead, isTrue);
+      expect(c.syncedIsRead, isFalse,
+          reason: 'the from<12 guard already decided to preserve this value '
+              'because the column existed; a later duplicate unconditional '
+              'UPDATE synced_is_read = is_read must not override that');
+      await db.close();
+    }
+  });
+
   test('v4 lastReadAt persists across close/reopen', () async {
     final dbPath = p.join(tmp.path, 'test.db');
 

--- a/test/src/features/offline/data/offline_schema_migration_test.dart
+++ b/test/src/features/offline/data/offline_schema_migration_test.dart
@@ -6,6 +6,7 @@
 
 import 'dart:io';
 
+import 'package:drift/drift.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:tsumiru/src/features/offline/data/offline_database.dart';
@@ -123,6 +124,48 @@ void main() {
             ..where((t) => t.id.equals(10)))
           .getSingle();
       expect(c.readStateManual, true);
+      await db.close();
+    }
+  });
+
+  Future<bool> hasIndex(OfflineDatabase db, String name) async {
+    final rows = await db
+        .customSelect(
+          "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+          variables: [Variable<String>(name)],
+        )
+        .get();
+    return rows.isNotEmpty;
+  }
+
+  test('v15 creates idx_offline_chapter_device_state on a fresh database',
+      () async {
+    final db = testOfflineDatabaseFile(p.join(tmp.path, 'test.db'));
+    expect(await hasIndex(db, 'idx_offline_chapter_device_state'), isTrue);
+    await db.close();
+  });
+
+  test(
+      'v15 creates idx_offline_chapter_device_state when upgrading from an '
+      'older on-disk database', () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    // Open at the current schema (creating the index via onCreate), then
+    // force the recorded version back down — the same inconsistent state an
+    // existing install upgrading from before this index existed would be in.
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      await db.customStatement('DROP INDEX idx_offline_chapter_device_state');
+      await db.customStatement('PRAGMA user_version = 14');
+      await db.close();
+    }
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      // Touch the db to force it open (drift opens lazily).
+      await db.select(db.offlineMangas).get();
+      expect(await hasIndex(db, 'idx_offline_chapter_device_state'), isTrue);
       await db.close();
     }
   });

--- a/test/utils/timeout_http_client_test.dart
+++ b/test/utils/timeout_http_client_test.dart
@@ -1,9 +1,14 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:tsumiru/src/utils/network/timeout_http_client.dart';
+
+http.Request _graphqlRequest(String query) =>
+    http.Request('POST', Uri.parse('http://x/api/graphql'))
+      ..body = jsonEncode({'query': query, 'variables': <String, dynamic>{}});
 
 void main() {
   group('TimeoutHttpClient', () {
@@ -71,6 +76,71 @@ void main() {
 
       await expectLater(client.send(req), throwsA(isA<TimeoutException>()));
       expect(attempts, 1);
+    });
+
+    test('does not retry a GraphQL mutation on timeout (not idempotent)',
+        () async {
+      var attempts = 0;
+      final mock = MockClient.streaming((request, bodyStream) async {
+        attempts++;
+        await bodyStream.drain<void>();
+        throw TimeoutException('slow');
+      });
+      final client = TimeoutHttpClient(
+        const Duration(seconds: 5),
+        retries: 2,
+        retryDelay: Duration.zero,
+        inner: mock,
+      );
+
+      final req = _graphqlRequest('mutation UpdateChapter { id }');
+
+      await expectLater(client.send(req), throwsA(isA<TimeoutException>()));
+      expect(attempts, 1,
+          reason: 'a mutation may already have been applied server-side; '
+              'retrying risks silently doubling its effect');
+    });
+
+    test('still retries a GraphQL query on timeout', () async {
+      var attempts = 0;
+      final mock = MockClient.streaming((request, bodyStream) async {
+        attempts++;
+        if (attempts == 1) throw TimeoutException('slow');
+        return http.StreamedResponse(Stream.value(<int>[]), 200,
+            request: request);
+      });
+      final client = TimeoutHttpClient(
+        const Duration(seconds: 5),
+        retries: 2,
+        retryDelay: Duration.zero,
+        inner: mock,
+      );
+
+      final res =
+          await client.send(_graphqlRequest('query GetLibrary { id }'));
+      expect(res.statusCode, 200);
+      expect(attempts, 2);
+    });
+
+    test('still retries an anonymous/shorthand GraphQL query on timeout',
+        () async {
+      var attempts = 0;
+      final mock = MockClient.streaming((request, bodyStream) async {
+        attempts++;
+        if (attempts == 1) throw TimeoutException('slow');
+        return http.StreamedResponse(Stream.value(<int>[]), 200,
+            request: request);
+      });
+      final client = TimeoutHttpClient(
+        const Duration(seconds: 5),
+        retries: 2,
+        retryDelay: Duration.zero,
+        inner: mock,
+      );
+
+      final res = await client.send(_graphqlRequest('{ library { id } }'));
+      expect(res.statusCode, 200);
+      expect(attempts, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary

A batch of independent, low-risk performance and correctness fixes found during a targeted audit of the app (Riverpod state management, GraphQL/network layer, offline/Drift subsystem). Each item is its own commit, individually tested (unit tests added/updated where feasible, full relevant test suites re-run), and scoped to avoid touching areas with in-flight work on other branches.

No architectural changes, no behavior changes to any documented/intentional design decision — these are bug fixes and targeted optimizations only.

## What's in this PR (commit-by-commit)

1. **`chore: ignore the whole .claude/ directory`** — nothing under `.claude/` is tracked; replaces the narrow `.claude/settings.local.json` ignore entry with the whole directory so local Claude Code artifacts stop showing up in `git status`.

2. **`fix(reader): honor the decode-size cap on the crop-borders path`** — `CroppedImageProvider.loadImage` never called the `decode` callback Flutter hands it, so wrapping it in `ResizeImage` (as `ServerImage` does for every other image path) was a silent no-op. Cropped/auto-crop pages on long-strip webtoon chapters kept decoding at native resolution (up to ~800x15000), reintroducing the "#196 high-GPU-while-scrolling" cost `memCacheWidth`/`memCacheHeight` exist to prevent — but only on this path. Fixed both branches: the uncropped path now decodes via the engine's own decode-time downscale (`ImmutableBuffer` + `getTargetSize`, the same mechanism `ResizeImage` itself builds on); the cropped path downscales the cropped RGBA buffer in the same background isolate that already does the crop (via `image`'s `copyResize`, never upscaling). `CroppedImageProvider` now takes `targetWidth`/`targetHeight` directly instead of relying on the now-redundant outer `ResizeImage` wrap.
   - New unit tests in `crop_isolate_test.dart` cover no-resize, downscale-by-width, downscale-by-height, no-upscale, and the no-border-found case.

3. **`perf(library): debounce the search query feeding filter/sort/group`** — `libraryQueryProvider` fed straight into `CategoryMangaListWithQueryAndFilter`/`GroupedMangaListWithQueryAndFilter`, so every keystroke in the library search box re-ran the full filter+sort pipeline for every open tab, on a library that can hold thousands of entries. Added `libraryQueryDebouncedProvider`, which mirrors the raw provider but only propagates a change after 300ms of quiet (a `Timer` inside the notifier, restarted via `ref.listen`, cancelled on dispose). The search field and the AppBar's clear-button/global-search affordances keep reading the raw provider directly, so typing still feels instant — only the two expensive pipeline providers switch to the debounced one.
   - New `fakeAsync`-based tests cover the initial value, a debounced keystroke burst, window-restart on a late keystroke, and clearing the query.

4. **`fix(auth): stop the proactive-refresh Timer chain from pinning a stale GraphQLClient`** — `AuthCoordinator`'s proactive ui_login token-refresh `Timer` only read `graphQlClientProvider` once (in `build()`'s credentials listener), then threaded that same captured client through every reschedule (`_scheduleProactiveRefresh` / `_scheduleBackoffRefresh` / `_firePeriodicRefresh`) for as long as the loop kept running under its own steam — a transient-failure backoff chain, or a success reschedule racing the credentials listener's own reschedule and overwriting it. If the user switched servers (or anything else rebuilt `graphQlClientProvider`) while that loop was alive, it kept retrying the refresh mutation against the OLD server indefinitely — a silent, hard-to-diagnose auth failure loop. Fixed by not capturing a client at all: `_firePeriodicRefresh` reads `ref.read(graphQlClientProvider)` fresh at the moment it actually fires.
   - New test overrides `graphQlClientProvider` to record which "generation" it built, schedules a refresh with an already-expired token (delay clamps to zero), swaps the client after scheduling but before the Timer fires, and asserts the fired refresh used the new client. Confirmed red against the pre-fix code (temporarily reverted via `git stash` during development) and green after.

5. **`fix(network): stop retrying GraphQL mutations on timeout`** — `TimeoutHttpClient` (the sole `http.Client` behind the GraphQL `HttpLink`, used for every query AND mutation) retried any clonable request on timeout with no distinction between the two. A mutation is not idempotent — a timeout only means we did not see the response in time, not that the server had not already applied it (enqueue a download, create a category, update read state, ...). Retrying it risked silently duplicating that effect. Added a narrow, conservative check: only skip the retry when the request's JSON body confidently parses as `{"query": "mutation ..."}`. Anything else — a named query, an anonymous/shorthand query, a non-GraphQL or unparseable body — keeps retrying exactly as before.
   - New tests confirm a mutation body is never retried while a query (named or anonymous/shorthand) still is; all 3 pre-existing tests pass unchanged.

6. **`perf(offline): batch the offline library's per-manga category lookup`** — `libraryWithOfflineFallback`'s `serveCatalog()` looped over every downloaded series and awaited `db.categoriesForManga(m.id)` one at a time — an N+1 query, run every time the offline library falls back to the on-device catalog, despite a comment claiming it already loaded "all category memberships in one pass". Added `OfflineDatabase.categoriesForMangas(Set<int>)`: one join query over every requested id, grouped by mangaId.
   - New tests cover the empty-input short-circuit, per-manga grouping ordered by sortOrder, omission of uncategorized ids, equivalence with the single-id form, and an end-to-end case through `libraryWithOfflineFallback` confirming each manga gets its own categories rather than mixing them up.

7. **`perf(offline): index deviceState; push mangaCountByCategory/uncategorizedOf into SQL`** — `OfflineChapters` had no index on `deviceState`, despite `chaptersInState`, `nextQueuedChapter`, `mangaIdsWithDeviceDownloads`, and `watchOfflineSeries`'s join/aggregate all filtering on it — full scans on a table that can hold years of chapter metadata. Worse, drift's `.watch()` invalidates per-table, so `watchOfflineSeries` (the Downloads -> On device screen) re-ran its whole join+aggregate on every single per-page byte/pageCount write during an active download. Added `idx_offline_chapter_device_state` (schemaVersion 14 -> 15), guarded the same idempotent way as every other migration step in this file. Also: `mangaCountByCategory` pulled the entire `OfflineMangaCategories` table into Dart and filtered/counted it there; `uncategorizedOf` joined across the whole table with no id filter at all. Both now push the mangaId filter into SQL and let SQLite do the counting/grouping.
   - New tests confirm the index is created both for a fresh database and when upgrading an existing on-disk one from schema 14; direct unit tests for both rewritten methods (including the orphaned-membership-counts-as-uncategorized case the mapper depends on); 3 pre-existing tests that hardcoded `schemaVersion == 14` updated to 15.

8. **`perf+fix(offline): O(n^2) eviction loop, and a duplicate migration step that could clobber synced_is_read`** — `applySafetyNets()`'s storage-cap eviction loop re-folded the whole (already-filtered) downloaded-chapter list on every iteration to recompute the retained total — O(n^2) for a manga with many downloaded chapters. Switched to a running total updated by subtraction as each candidate is evicted — O(n log n) (the sort dominates). Also removed a duplicate `if (from < 10)` migration step for `synced_is_read`: the first occurrence (inside `if (from < 12)`) deliberately guards its backfill on the column having been missing, per its own comment, so an interim/dev build that already has the column with a real value is not stomped — the second, redundant step ran the backfill unconditionally, silently able to overwrite that preserved value for exactly the device class (from<10, column already present) this migration's own comments repeatedly warn about.
   - New migration test builds an on-disk fixture with `synced_is_read` already diverged from `is_read` at a forced pre-v10 recorded version, and asserts the value survives the upgrade — confirmed red against the pre-fix duplicate step and green after.

9. **`fix(offline): surface a failed foreground-service start to the user`** — `ensureServiceRunning()` only logged when the Android foreground download service failed to start (e.g. notification permission denied) — chapters stayed queued in drift with zero user-visible signal. Added a best-effort error toast at the failure point. This covers the common interactive case (user taps "save chapter", the service fails to start right then). It does **not** fix the fully-silent case of a failure during a background/headless launch replay — `toastProvider` degrades to a no-op with no active UI. Making that path durably visible would need a persisted banner surfaced on a real screen — a bigger addition, deliberately left as a follow-up rather than folded into this fix.
   - Not independently unit-tested: `ensureServiceRunning()` (like the rest of this file) returns immediately on `!Platform.isAndroid`, which is always true in the `flutter test` VM host — this branch is unreachable in the current harness regardless of the change, consistent with zero existing direct tests for this file. Verified via `flutter analyze` and the full offline test suites (regression-free).

## What was deliberately left out of scope

A few other findings from the same audit pass were set aside because fixing them would touch files with substantial, actively-evolving work elsewhere (recent reader/offline branches), and folding them in here would risk merge conflicts or rework:

- An unbounded `keepAlive` cache in the manga-details controller (no release path across sessions/server switches).
- The per-manga (rather than device-wide) storage cap accounting in the offline reconciler.
- Trimming the library's whole-library GraphQL query to a lighter fragment (would need new `.graphql` files + codegen regen — a bigger, separate change).
- Adding remote crash/error reporting for field visibility (a product/architecture decision needing its own discussion, not a drop-in fix).

## Test plan

- [x] `dart run build_runner build` regenerated cleanly after every schema/provider-affecting change.
- [x] `flutter analyze --no-fatal-warnings --no-fatal-infos` — 0 new errors/warnings vs. the pre-change baseline (260 vs 255 total issues, entirely new `info`-level lints in the new test files).
- [x] Every commit's touched area re-tested individually, then the broader containing suite re-run for regressions.
- [x] Full repo suite (`flutter test`): **1709/1709 passing**, 0 failures.
- [x] Three fixes (crop decode cap, auth stale client, migration dedup) were verified red-before/green-after by temporarily reverting the source change via `git stash` and re-running the new test.
