### PR TITLE
Apply local delete-while-reading settings to sync-driven read state

### DIFF
--- a/lib/src/constants/db_keys.dart
+++ b/lib/src/constants/db_keys.dart
@@ -180,6 +180,10 @@ enum DBKeys {
   localDeleteWhileReading(0),
   localDeleteManuallyMarkedRead(false),
   localDeleteWithBookmark(false),
+  // When true, the reconciler pulls down the slots-1 most recently read
+  // chapters if they are missing from the device (fills the protection window).
+  // Off by default to preserve existing behavior.
+  localDownloadProtectionWindow(false),
   // Lock phones to portrait (landscape on a phone currently looks broken). Off
   // by default — many readers prefer landscape; tablets/desktop ignore it.
   forcePortrait(false),

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -117,8 +117,10 @@ class MangaChapterList extends _$MangaChapterList {
     );
     if (ref.mounted) ref.keepAlive();
     if (result != null && fromServer) {
-      unawaited((sync?.syncChapters(result) ?? Future.value()).then((_) {
-        if (ref.mounted) reconcileManga(ref, mangaId);
+      unawaited((sync?.syncChapters(result) ?? Future.value(<int>{})).then((nr) {
+        if (ref.mounted) {
+          reconcileManga(ref, mangaId, newlyReadChapterIds: nr);
+        }
       }));
     }
     if (didSourceFetch) {
@@ -200,8 +202,8 @@ class MangaChapterList extends _$MangaChapterList {
       // not only on a cold provider rebuild. Catalog-served lists are echoes
       // and never mirrored.
       unawaited((ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
-              Future.value())
-          .then((_) => reconcileManga(ref, mangaId)));
+              Future.value(<int>{}))
+          .then((nr) => reconcileManga(ref, mangaId, newlyReadChapterIds: nr)));
     }
   }
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -194,6 +194,57 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     final lastEndFeedbackTime = useRef<DateTime?>(null);
     final lastStartFeedbackTime = useRef<DateTime?>(null);
     final completedChapterIds = useRef<Set<int>>({});
+
+    // Session protection: protect each chapter opened in this reader from
+    // reconcile eviction. Discarded on dispose; never accumulates across sessions.
+    final sessionChapterIds = useRef<Set<int>>({});
+    final sessionNotifier = ref.read(sessionReadChaptersProvider.notifier);
+    // Mirrored into a ref each build so the deferred callbacks below never
+    // have to touch `ref` themselves — `ref` throws if it outlives the widget.
+    final incognitoRef = useRef(ref.watch(incognitoModeProvider));
+    incognitoRef.value = ref.watch(incognitoModeProvider);
+    useEffect(() {
+      var active = true;
+      void doRecord(int id) {
+        if (!active || incognitoRef.value) return;
+        if (!sessionChapterIds.value.contains(id)) {
+          sessionChapterIds.value = {...sessionChapterIds.value, id};
+          // The provider container can be torn down (route pop racing app/test
+          // shutdown) between scheduling this microtask and it running; there is
+          // nothing left to protect at that point, so ignore the disposed-ref
+          // error rather than crash on a benign teardown race.
+          try {
+            sessionNotifier.record(id);
+          } catch (_) {
+            // UnmountedRefException (internal riverpod type, not exported):
+            // container disposed before this microtask ran.
+          }
+        }
+      }
+      // A microtask (unlike addPostFrameCallback) is guaranteed to drain
+      // before this build/dispose call stack unwinds, regardless of whether
+      // another frame gets scheduled.
+      Future.microtask(() => doRecord(currentVisibleChapter.value.id));
+      void onChanged() => doRecord(currentVisibleChapter.value.id);
+      currentVisibleChapter.addListener(onChanged);
+      return () {
+        active = false;
+        currentVisibleChapter.removeListener(onChanged);
+        // Disposal can occur during a build phase; defer the state change.
+        // Same teardown race as above: the container may already be gone by
+        // the time this runs (e.g. widget torn down at test/app shutdown with
+        // no further frame or microtask flush to run this sooner).
+        Future.microtask(() {
+          try {
+            sessionNotifier.discard(sessionChapterIds.value);
+          } catch (_) {
+            // UnmountedRefException (internal riverpod type, not exported):
+            // container disposed before this microtask ran.
+          }
+        });
+      };
+    }, const []);
+
     final lastVisibleChapterId = useRef<int>(chapter.id);
     // Top-most visible (index, leadingEdge) from the previous listener
     // tick, used to derive scroll direction so neighbour chapters load

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -180,6 +180,60 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     final lastStartFeedbackTime = useRef<DateTime?>(null);
     final completedChapterIds = useRef<Set<int>>({});
 
+    // Session protection: protect each chapter opened in this reader from
+    // reconcile eviction. Discarded on dispose; never accumulates across sessions.
+    final sessionChapterIds = useRef<Set<int>>({});
+    final sessionNotifier = ref.read(sessionReadChaptersProvider.notifier);
+    // Mirrored into a ref each build so the deferred callbacks below never
+    // have to touch `ref` themselves — `ref` throws if it outlives the widget.
+    final incognitoRef = useRef(ref.watch(incognitoModeProvider));
+    incognitoRef.value = ref.watch(incognitoModeProvider);
+    useEffect(() {
+      var active = true;
+      void doRecord(int id) {
+        if (!active || incognitoRef.value) return;
+        if (!sessionChapterIds.value.contains(id)) {
+          sessionChapterIds.value = {...sessionChapterIds.value, id};
+          // The provider container can be torn down (route pop racing app/test
+          // shutdown) between scheduling this microtask and it running; there is
+          // nothing left to protect at that point, so ignore the disposed-ref
+          // error rather than crash on a benign teardown race.
+          try {
+            sessionNotifier.record(id);
+          } catch (_) {
+            // UnmountedRefException (internal riverpod type, not exported):
+            // container disposed before this microtask ran.
+          }
+        }
+      }
+      // Record the initial chapter on a microtask — modifying Riverpod state
+      // synchronously during a build (even inside useEffect) is not allowed.
+      // A microtask (unlike addPostFrameCallback) is guaranteed to drain
+      // before this build/dispose call stack unwinds, regardless of whether
+      // another frame gets scheduled.
+      Future.microtask(() => doRecord(currentVisibleChapter.value.id));
+      // Record on subsequent chapter changes. ValueNotifier listeners fire
+      // outside the build phase so provider state can be updated safely.
+      void onChanged() => doRecord(currentVisibleChapter.value.id);
+      currentVisibleChapter.addListener(onChanged);
+      return () {
+        active = false;
+        currentVisibleChapter.removeListener(onChanged);
+        // Disposal can occur during a build phase; defer the state change.
+        // Same teardown race as above: the container may already be gone by
+        // the time this runs (e.g. widget torn down at test/app shutdown with
+        // no further frame or microtask flush to run this sooner).
+        Future.microtask(() {
+          try {
+            sessionNotifier.discard(sessionChapterIds.value);
+          } catch (_) {
+            // UnmountedRefException (internal riverpod type, not exported):
+            // container disposed before this microtask ran.
+          }
+        });
+      };
+    }, const []);
+
     // Direction of the last position change, so a chapter loads only when the
     // user reads TOWARD its edge — never on initial open of a short chapter.
     final lastProgress = useRef<({int id, int rel})?>(null);

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -337,8 +337,8 @@ Future<bool> _syncAndReconcile(
         allSynced = false;
         continue;
       }
-      await sync.syncChapters(chapters);
-      if (!await _reconcileTracked(container, mangaId)) allSynced = false;
+      final newlyRead = await sync.syncChapters(chapters);
+      if (!await _reconcileTracked(container, mangaId, newlyReadChapterIds: newlyRead)) allSynced = false;
     } catch (e) {
       // Never reconcile on a failed fetch — evictions must not run against a
       // list the server didn't actually give us.
@@ -353,7 +353,11 @@ Future<bool> _syncAndReconcile(
 /// so the queue-drain trigger knows which manga still owe a device pull.
 /// Returns false on a failed enqueue (reconcileMangaCore swallows the error)
 /// so the pass won't advance the watermark past an unqueued chapter.
-Future<bool> _reconcileTracked(ProviderContainer container, int mangaId) async {
+Future<bool> _reconcileTracked(
+  ProviderContainer container,
+  int mangaId, {
+  Set<int> newlyReadChapterIds = const {},
+}) async {
   final manager = container.read(offlineDownloadManagerProvider);
   final coordinator = container.read(offlineDownloadCoordinatorProvider);
   if (manager == null || coordinator == null) return false;
@@ -369,6 +373,9 @@ Future<bool> _reconcileTracked(ProviderContainer container, int mangaId) async {
     deleteWhileReadingSlots: container
         .read(localDeleteSettingsProvider)
         .deleteWhileReading,
+    newlyReadChapterIds: newlyReadChapterIds,
+    downloadProtectionWindow:
+        container.read(localDownloadProtectionWindowProvider) ?? false,
     enqueueServerDownload: (ids) async {
       try {
         await container

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -537,8 +537,9 @@ Future<DeleteChaptersSettings?> _serverDeleteSettings(_Read read) async {
 /// [ProviderContainer] at reader exit, where the route's ref is already gone.
 typedef _Read = T Function<T>(ProviderListenable<T> provider);
 
-/// Chapters finished this session — shields them from keep-rule eviction
-/// until next launch, so closing the reader doesn't yank one off the device.
+/// Chapters currently open in the reader — shields them from reconcile eviction
+/// while the reader is on screen. The reader records each chapter it opens and
+/// discards all of them on dispose, so the set is empty between reading sessions.
 final sessionReadChaptersProvider =
     NotifierProvider<SessionReadChapters, Set<int>>(SessionReadChapters.new);
 
@@ -549,6 +550,13 @@ class SessionReadChapters extends Notifier<Set<int>> {
   void record(int chapterId) {
     if (state.contains(chapterId)) return;
     state = {...state, chapterId};
+  }
+
+  /// Removes the given chapter IDs when their reader widget disposes.
+  void discard(Set<int> chapterIds) {
+    if (chapterIds.isEmpty) return;
+    final next = state.difference(chapterIds);
+    if (next.length != state.length) state = next;
   }
 }
 
@@ -589,15 +597,15 @@ class PendingReadDeletes extends Notifier<Set<PendingReadDelete>> {
   }
 }
 
-/// Shields the chapter from keep-rule eviction and queues its while-reading
-/// deletes. Targets resolve NOW, not at exit — the list/dedup state can shift
-/// by then and pick the wrong chapter.
+/// Queues while-reading deletes when a chapter is finished in the reader.
+/// Targets resolve NOW, not at exit — the list/dedup state can shift by then
+/// and pick the wrong chapter. Session protection is handled separately by the
+/// reader widget registering open chapters via [sessionReadChaptersProvider].
 Future<void> noteChapterFinishedInReader(
   WidgetRef ref, {
   required int mangaId,
   required int chapterId,
 }) {
-  ref.read(sessionReadChaptersProvider.notifier).record(chapterId);
   final pending = ref.read(pendingReadDeletesProvider.notifier);
   final work = _resolveReadDeletes(
     ref,
@@ -1327,12 +1335,16 @@ Future<void> reconcileMangaCore({
   Future<void> Function(int chapterId, int generation)? removeFromWorker,
   Set<int> sessionProtected = const {},
   int deleteWhileReadingSlots = 0,
+  Set<int> newlyReadChapterIds = const {},
+  bool downloadProtectionWindow = false,
 }) {
   return OfflineReconciler(
     db: db,
     nets: nets,
     sessionProtected: sessionProtected,
     deleteWhileReadingSlots: deleteWhileReadingSlots,
+    newlyReadChapterIds: newlyReadChapterIds,
+    downloadProtectionWindow: downloadProtectionWindow,
     now: DateTime.now(),
     // Only QUEUE chapters here; starting the download is the caller's job (via
     // downloadStarterProvider) so the Ref-less launch path and tests stay in
@@ -1382,7 +1394,11 @@ Future<void> reconcileMangaCore({
 }
 
 /// Controller / in-app entry point (generated Ref).
-Future<void> reconcileManga(Ref ref, int mangaId) async {
+Future<void> reconcileManga(
+  Ref ref,
+  int mangaId, {
+  Set<int> newlyReadChapterIds = const {},
+}) async {
   if (!ref.read(offlineActiveProvider)) return;
   final manager = ref.read(offlineDownloadManagerProvider);
   final coordinator = ref.read(offlineDownloadCoordinatorProvider);
@@ -1398,6 +1414,9 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
     deleteWhileReadingSlots: ref
         .read(localDeleteSettingsProvider)
         .deleteWhileReading,
+    newlyReadChapterIds: newlyReadChapterIds,
+    downloadProtectionWindow:
+        ref.read(localDownloadProtectionWindowProvider) ?? false,
     // Registers this manga as owed a device pull once the server's queue
     // drains (only on success — a failed enqueue produced no queue activity,
     // so no drain edge would ever retry it). Without this, a manga-details-
@@ -1435,6 +1454,7 @@ Future<void> reconcileMangaWidget(
   WidgetRef ref,
   int mangaId, {
   bool startDownload = true,
+  Set<int> newlyReadChapterIds = const {},
 }) async {
   if (!ref.read(offlineActiveProvider)) return;
   final manager = ref.read(offlineDownloadManagerProvider);
@@ -1451,6 +1471,9 @@ Future<void> reconcileMangaWidget(
     deleteWhileReadingSlots: ref
         .read(localDeleteSettingsProvider)
         .deleteWhileReading,
+    newlyReadChapterIds: newlyReadChapterIds,
+    downloadProtectionWindow:
+        ref.read(localDownloadProtectionWindowProvider) ?? false,
     // See reconcileManga's matching comment: registers the second-hop pull
     // obligation so this manga isn't stranded until the next full-library
     // sync once the server finishes.
@@ -1496,6 +1519,8 @@ Future<void> reconcileMangaContainer(
     deleteWhileReadingSlots: container
         .read(localDeleteSettingsProvider)
         .deleteWhileReading,
+    downloadProtectionWindow:
+        container.read(localDownloadProtectionWindowProvider) ?? false,
     // See reconcileManga's matching comment: registers the second-hop pull
     // obligation so this manga isn't stranded until the next full-library
     // sync once the server finishes.

--- a/lib/src/features/offline/data/offline_reconciler.dart
+++ b/lib/src/features/offline/data/offline_reconciler.dart
@@ -29,6 +29,8 @@ class OfflineReconciler {
     this.onServerDownload,
     this.sessionProtected = const {},
     this.deleteWhileReadingSlots = 0,
+    this.newlyReadChapterIds = const {},
+    this.downloadProtectionWindow = false,
   });
 
   final OfflineDatabase db;
@@ -44,6 +46,17 @@ class OfflineReconciler {
   /// The user's "delete finished chapters while reading" slot count. Every path
   /// that deletes a download has to honour it, not just the reader.
   final int deleteWhileReadingSlots;
+
+  /// Chapter IDs that transitioned from unread → read during the most recent
+  /// server sync (e.g. read in WebUI). Used by RC7 to apply the local
+  /// delete-while-reading setting to externally-read chapters, exactly as if
+  /// each had been finished in the in-app reader.
+  final Set<int> newlyReadChapterIds;
+
+  /// When true, the reconciler ensures the slots-1 most recently read chapters
+  /// are present on device — downloading them if missing. Defaults to false to
+  /// preserve existing behavior; only meaningful when deleteWhileReadingSlots >= 2.
+  final bool downloadProtectionWindow;
 
   /// Called with chapters the keep-rule wants but the SERVER hasn't downloaded
   /// yet — enqueue a server download (server-client model: the server fetches
@@ -88,11 +101,45 @@ class OfflineReconciler {
     // Merge orphaned ids into the evict set.
     final toEvict = {...ev.evict, ...orphanedIds};
 
+    // RC7: Sync-read eviction — for chapters that transitioned from unread to
+    // read during this sync (e.g. read in WebUI), apply the local
+    // delete-while-reading setting exactly as if each had been finished in the
+    // in-app reader. Only newly-read chapters are considered, so old read
+    // chapters already on the device are never touched unexpectedly.
+    //
+    // slots >= 1: the slots − 1 most-recently-read chapters among the newly-read
+    //   batch are shielded by the same readChaptersInDeleteWindow window the
+    //   reader uses. slots = 1 → delete the chapter itself; slots = 2 → keep
+    //   the most recently read, delete the rest; etc.
+    if (deleteWhileReadingSlots >= 1 && newlyReadChapterIds.isNotEmpty) {
+      final newlyReadDownloaded = downloaded
+          .where((c) => newlyReadChapterIds.contains(c.id))
+          .toList();
+      final readProtected =
+          readChaptersInDeleteWindow(newlyReadDownloaded, deleteWhileReadingSlots);
+      for (final c in newlyReadDownloaded) {
+        if (!c.pinned &&
+            !sessionProtected.contains(c.id) &&
+            !readProtected.contains(c.id)) {
+          toEvict.add(c.id);
+        }
+      }
+    }
+
     // Build the toDownload set.
     // RC5: when the storage cap is active, do not emit downloads that would
     // push retained bytes over the cap — this ensures reconcile converges (a
     // fixed point) rather than triggering an evict→re-pull loop across passes.
     final byId = {for (final c in chapters) c.id: c};
+
+    // Protection-window download: ensure the slots-1 most recently read
+    // chapters are on-device when the user opted in. Meaningless for keep=off
+    // (nothing is kept) and requires slots >= 2 (slots=1 means delete-all).
+    final protectionWindowIds = downloadProtectionWindow &&
+            deleteWhileReadingSlots >= 2 &&
+            manga.keepRule != OfflineKeepRule.off
+        ? readChaptersInDeleteWindow(chapters, deleteWhileReadingSlots)
+        : const <int>{};
 
     // Retained bytes after evictions (downloaded chapters not in toEvict).
     final retainedBytes = downloaded
@@ -109,7 +156,7 @@ class OfflineReconciler {
     final toDownload = <int>{};
     final toServerDownload = <int>{};
 
-    for (final id in desired) {
+    for (final id in {...desired, ...protectionWindowIds}) {
       final c = byId[id];
       if (c == null) continue;
       // Wanted but the server hasn't downloaded it yet: ask the server to

--- a/lib/src/features/offline/data/offline_sync.dart
+++ b/lib/src/features/offline/data/offline_sync.dart
@@ -103,7 +103,11 @@ class OfflineSync {
     return row.isRead != row.syncedIsRead && row.isRead == server.isRead;
   }
 
-  Future<void> syncChapters(List<ChapterDto> chapters) async {
+  /// Returns the set of chapter IDs that transitioned from unread to read
+  /// during this sync (chapters the user read outside Tsumiru, e.g. in WebUI).
+  /// The caller passes these to the immediately-following reconcile so that the
+  /// local delete-while-reading setting fires for those chapters too.
+  Future<Set<int>> syncChapters(List<ChapterDto> chapters) async {
     final now = DateTime.now();
     // Preserve read progress that was updated locally but not yet pushed to the
     // server — otherwise a down-sync would overwrite it with the stale server
@@ -114,6 +118,17 @@ class OfflineSync {
     final existingRows = await _db.chaptersByIds([
       for (final c in chapters) c.id,
     ]);
+    // Collect IDs whose read state flips from false to true in this sync pass.
+    // Excludes locally-dirty chapters (their isRead is a pending local write,
+    // not a server-originated change) and brand-new rows (no prior local state).
+    final newlyRead = <int>{
+      for (final c in chapters)
+        if (!(dirty[c.id]?.readStateDirty ?? false) &&
+            existingRows[c.id] != null &&
+            !existingRows[c.id]!.isRead &&
+            c.isRead)
+          c.id,
+    };
     // One transaction per list: an interrupted sync must not leave a manga
     // with a mix of real and index-fallback chapter numbers — a legacy row at
     // index N would falsely dedup-merge with a real chapter N.
@@ -178,6 +193,7 @@ class OfflineSync {
       if (goneIds.isNotEmpty) await _db.markChaptersOrphaned(goneIds);
     }
     await onSynced?.call();
+    return newlyRead;
   }
 
   /// Removes manga that have left the server library from the offline catalog.

--- a/lib/src/features/settings/presentation/downloads/data/delete_chapters_settings_repository.dart
+++ b/lib/src/features/settings/presentation/downloads/data/delete_chapters_settings_repository.dart
@@ -171,6 +171,16 @@ class LocalDeleteWithBookmark extends _$LocalDeleteWithBookmark
   bool? build() => initialize(DBKeys.localDeleteWithBookmark);
 }
 
+/// When enabled, the reconciler pulls down the slots-1 most recently read
+/// chapters if they are missing from the device, so the protection window is
+/// always populated. Off by default to preserve existing behavior.
+@riverpod
+class LocalDownloadProtectionWindow extends _$LocalDownloadProtectionWindow
+    with SharedPreferenceClientMixin<bool> {
+  @override
+  bool? build() => initialize(DBKeys.localDownloadProtectionWindow);
+}
+
 /// The on-device delete settings as one value (defaults all off).
 @riverpod
 DeleteChaptersSettings localDeleteSettings(Ref ref) => DeleteChaptersSettings(

--- a/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
+++ b/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
@@ -30,6 +30,11 @@ String _deleteWhileReadingLabel(BuildContext context, int value) =>
 
 /// One "Delete chapters" section (used for both the on-device and the server
 /// copies — identical controls, different backing settings).
+///
+/// [whileReadingSubOptions] renders directly below the "delete finished
+/// chapters while reading" row — the option that controls whether they're
+/// meaningful at all — rather than at the end of the section, so a
+/// dependent toggle stays visually attached to what governs it.
 List<Widget> _deleteSection(
   BuildContext context, {
   required String title,
@@ -38,6 +43,7 @@ List<Widget> _deleteSection(
   required Future<void> Function(bool) onManual,
   required void Function(int) onWhileReading,
   required Future<void> Function(bool) onBookmark,
+  List<Widget> whileReadingSubOptions = const [],
 }) =>
     [
       SectionTitle(title: title),
@@ -75,6 +81,7 @@ List<Widget> _deleteSection(
           ),
         ),
       ),
+      ...whileReadingSubOptions,
       SettingsPropTile(
         title: context.l10n.allowDeletingBookmarkedChapters,
         type: SettingsPropType.switchTile(
@@ -83,6 +90,36 @@ List<Widget> _deleteSection(
         ),
       ),
     ];
+
+/// Indented dependent toggle, shown only while its controlling option makes
+/// it meaningful — same treatment as the reader settings' sub-toggles (see
+/// `_SubSwitchTile` in reading_mode_tab.dart / general_tab.dart), so a
+/// dependent option doesn't read as a normal, independent one.
+class _SubSwitchTile extends StatelessWidget {
+  const _SubSwitchTile({
+    required this.title,
+    this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String? subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      controlAffinity: ListTileControlAffinity.trailing,
+      contentPadding: const EdgeInsetsDirectional.only(start: 32, end: 16),
+      title: Text(title),
+      subtitle: subtitle != null ? Text(subtitle!) : null,
+      value: value,
+      onChanged: onChanged,
+    );
+  }
+}
 
 /// Downloads settings, split into two tabs:
 ///   * Server — what the Suwayomi server downloads from sources.
@@ -246,18 +283,23 @@ class _OnDeviceDownloadsTab extends ConsumerWidget {
               ref.read(localDeleteWhileReadingProvider.notifier).update(v),
           onBookmark: (v) async =>
               ref.read(localDeleteWithBookmarkProvider.notifier).update(v),
+          // Only meaningful when the keep window has at least 1 protected
+          // slot — rendered right under the option that controls it.
+          whileReadingSubOptions: localDelete.deleteWhileReading >= 2
+              ? [
+                  _SubSwitchTile(
+                    title: context.l10n.downloadProtectionWindowTitle,
+                    subtitle: context.l10n.downloadProtectionWindowDescription,
+                    value:
+                        ref.watch(localDownloadProtectionWindowProvider) ??
+                            false,
+                    onChanged: (v) async => ref
+                        .read(localDownloadProtectionWindowProvider.notifier)
+                        .update(v),
+                  ),
+                ]
+              : const [],
         ),
-        // Only meaningful when the keep window has at least 1 protected slot.
-        if (localDelete.deleteWhileReading >= 2)
-          SettingsPropTile(
-            title: context.l10n.downloadProtectionWindowTitle,
-            subtitle: context.l10n.downloadProtectionWindowDescription,
-            type: SettingsPropType.switchTile(
-              value: ref.watch(localDownloadProtectionWindowProvider) ?? false,
-              onChanged: (v) async =>
-                  ref.read(localDownloadProtectionWindowProvider.notifier).update(v),
-            ),
-          ),
         ...buildOnDeviceStorageTiles(context, ref),
       ],
     );

--- a/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
+++ b/lib/src/features/settings/presentation/downloads/downloads_settings_screen.dart
@@ -247,6 +247,17 @@ class _OnDeviceDownloadsTab extends ConsumerWidget {
           onBookmark: (v) async =>
               ref.read(localDeleteWithBookmarkProvider.notifier).update(v),
         ),
+        // Only meaningful when the keep window has at least 1 protected slot.
+        if (localDelete.deleteWhileReading >= 2)
+          SettingsPropTile(
+            title: context.l10n.downloadProtectionWindowTitle,
+            subtitle: context.l10n.downloadProtectionWindowDescription,
+            type: SettingsPropType.switchTile(
+              value: ref.watch(localDownloadProtectionWindowProvider) ?? false,
+              onChanged: (v) async =>
+                  ref.read(localDownloadProtectionWindowProvider.notifier).update(v),
+            ),
+          ),
         ...buildOnDeviceStorageTiles(context, ref),
       ],
     );

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1692,6 +1692,8 @@
   "deleteChapterAfterManuallyMarkedRead": "Delete chapter after manually marking it as read",
   "deleteFinishedChaptersWhileReading": "Delete finished chapters while reading",
   "allowDeletingBookmarkedChapters": "Allow deleting bookmarked chapters",
+  "downloadProtectionWindowTitle": "Keep recently-read chapters downloaded",
+  "downloadProtectionWindowDescription": "Re-download the keep-window chapters if they are missing from the device (requires delete-while-reading to be enabled).",
   "deleteWhileReadingDisabled": "Disabled",
   "deleteWhileReadingLastRead": "Last read chapter",
   "deleteWhileReadingSecondToLast": "Second to last read chapter",

--- a/test/src/features/offline/data/offline_reconciler_test.dart
+++ b/test/src/features/offline/data/offline_reconciler_test.dart
@@ -249,4 +249,94 @@ void main() {
     expect(evicted, [1],
         reason: 'the keep window has to reach the reconciler, not just exist');
   });
+
+  // ── downloadProtectionWindow: re-download missing keep-window chapters ──────
+
+  test('downloadProtectionWindow=true downloads a missing protection-window chapter',
+      () async {
+    // Setup: allUnread rule, 3 chapters all read, slots=3 → protection window
+    // = top (slots-1)=2 most recently read = {ch3, ch2}.
+    // ch3 is on device, ch2 is NOT on device, ch1 is on device.
+    // allUnread → desired = {} (all read, nothing wanted by rule).
+    // With downloadProtectionWindow=true, ch2 must be re-downloaded because it
+    // is in the protection window and missing from device.
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.allUnread, 0);
+
+    await db.upsertChapterMetadata(
+        id: 1, mangaId: 1, name: 'c1', chapterIndex: 1, isRead: true,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026), lastReadAt: '100');
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloaded,
+        bytes: 100, downloadedAt: DateTime(2026, 1, 1));
+
+    await db.upsertChapterMetadata(
+        id: 2, mangaId: 1, name: 'c2', chapterIndex: 2, isRead: true,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026), lastReadAt: '200');
+    // ch2 intentionally left at deviceState=none — it was evicted earlier.
+
+    await db.upsertChapterMetadata(
+        id: 3, mangaId: 1, name: 'c3', chapterIndex: 3, isRead: true,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026), lastReadAt: '300');
+    await db.setChapterDeviceState(3, OfflineDeviceState.downloaded,
+        bytes: 100, downloadedAt: DateTime(2026, 1, 3));
+
+    final downloaded = <int>[];
+    final r = await OfflineReconciler(
+      db: db, nets: SafetyNetConfig.off,
+      onDownload: (id) async => downloaded.add(id),
+      onEvict: (id) async {},
+      now: DateTime(2026, 3, 1),
+      deleteWhileReadingSlots: 3,
+      downloadProtectionWindow: true,
+    ).reconcileManga(1);
+
+    expect(r.toDownload, contains(2),
+        reason: 'ch2 is in the protection window (2nd most recently read) '
+            'but missing from device — must be re-downloaded');
+    expect(downloaded, contains(2));
+  });
+
+  test('downloadProtectionWindow=false does not download missing protection-window chapters',
+      () async {
+    // Same topology as above but with downloadProtectionWindow=false (default).
+    // ch2 should NOT be re-downloaded because it is not in `desired`.
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.allUnread, 0);
+
+    await db.upsertChapterMetadata(
+        id: 1, mangaId: 1, name: 'c1', chapterIndex: 1, isRead: true,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026), lastReadAt: '100');
+    await db.setChapterDeviceState(1, OfflineDeviceState.downloaded,
+        bytes: 100, downloadedAt: DateTime(2026, 1, 1));
+
+    await db.upsertChapterMetadata(
+        id: 2, mangaId: 1, name: 'c2', chapterIndex: 2, isRead: true,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026), lastReadAt: '200');
+
+    await db.upsertChapterMetadata(
+        id: 3, mangaId: 1, name: 'c3', chapterIndex: 3, isRead: true,
+        lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026), lastReadAt: '300');
+    await db.setChapterDeviceState(3, OfflineDeviceState.downloaded,
+        bytes: 100, downloadedAt: DateTime(2026, 1, 3));
+
+    final downloaded = <int>[];
+    await OfflineReconciler(
+      db: db, nets: SafetyNetConfig.off,
+      onDownload: (id) async => downloaded.add(id),
+      onEvict: (id) async {},
+      now: DateTime(2026, 3, 1),
+      deleteWhileReadingSlots: 3,
+      downloadProtectionWindow: false,
+    ).reconcileManga(1);
+
+    expect(downloaded, isNot(contains(2)),
+        reason: 'without downloadProtectionWindow, a read chapter not in '
+            'desired must not be re-downloaded');
+  });
 }

--- a/test/src/features/offline/data/pending_read_deletes_test.dart
+++ b/test/src/features/offline/data/pending_read_deletes_test.dart
@@ -75,6 +75,30 @@ void main() {
     expect(container.read(sessionReadChaptersProvider), {10, 11});
   });
 
+  test('discard removes specified chapter IDs from session set', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final session = container.read(sessionReadChaptersProvider.notifier);
+
+    session.record(10);
+    session.record(11);
+    session.record(12);
+    expect(container.read(sessionReadChaptersProvider), {10, 11, 12});
+
+    // Discarding a subset leaves the rest intact.
+    session.discard({10, 12});
+    expect(container.read(sessionReadChaptersProvider), {11});
+
+    // Discarding IDs absent from the set is a no-op.
+    session.discard({99});
+    expect(container.read(sessionReadChaptersProvider), {11},
+        reason: 'unknown id must not mutate state');
+
+    // Discarding empty set is a no-op.
+    session.discard({});
+    expect(container.read(sessionReadChaptersProvider), {11});
+  });
+
   testWidgets(
       'finishing a chapter queues the RESOLVED delete target, not the finished '
       'chapter', (tester) async {
@@ -82,8 +106,9 @@ void main() {
 
     await noteChapterFinishedInReader(captured, mangaId: 1, chapterId: 3);
 
-    expect(container.read(sessionReadChaptersProvider), {3},
-        reason: 'the finished chapter is shielded from rule eviction');
+    expect(container.read(sessionReadChaptersProvider), isEmpty,
+        reason: 'noteChapterFinishedInReader no longer records session '
+            'protection — the reader widget does that via its open/close hooks');
     final queued = container.read(pendingReadDeletesProvider);
     expect(queued.where((p) => !p.server).map((p) => p.chapterId), [2],
         reason: 'the device delete stores the resolved 2-slots-back target');


### PR DESCRIPTION
## Summary

Related to #366 (WebUI-deleted/server-read chapters are not cleaned up on device sync), but this PR does not implement that exact behavior. Instead of special-casing a WebUI/server-read path, it makes the reconciler apply the user's **own local delete-while-reading and protection-window settings** consistently to any chapter that becomes read via a server sync — so the on-device copy follows the same rule the in-app reader already enforces, regardless of where the read happened.

While auditing that path, two related bugs surfaced in the existing local delete-while-reading logic and are fixed in the same PR since they're the same code path:

### 1. Sync-driven delete-while-reading (`offline_sync.dart`, `offline_reconciler.dart`)

`syncChapters()` now returns the set of chapter IDs that flipped `isRead: false → true` during that sync pass. The reconciler runs a pre-pass over that set and evicts downloaded chapters per the user's local delete-while-reading slot count, applying the same `readChaptersInDeleteWindow` protection window the in-app reader uses.

This is only user-visible for the `all` keep rule — for `allUnread`, a chapter that becomes read already falls out of `desired` and the existing safety nets evict it. For `all`, chapters stay in `desired` forever, so nothing was evicting them before this change.

### 2. Over-scoped session protection (`offline_download_providers.dart`, both multi-chapter reader modes)

`sessionReadChaptersProvider` previously accumulated **every** chapter finished since app launch and shielded all of them from eviction indefinitely. On multi-device setups this meant chapters read early in a session stayed protected on device long after they should have been eligible for cleanup.

It's now scoped to chapters **currently open in a reader**: recorded when a chapter becomes the visible chapter, discarded when the reader widget disposes. Both the paged and continuous (webtoon) multi-chapter reader modes are covered.

### 3. Opt-in download protection window (new setting)

When delete-while-reading keeps N-1 recently-read chapters on device, there was previously no way to *re-download* one of those chapters if it got evicted by some other path (storage cap, orphan cleanup, etc.) — the keep window was enforced for eviction but not for download. Added `downloadProtectionWindow` (off by default) which, when enabled with `slots >= 2`, unions the protection-window chapter IDs into the reconciler's download loop so they get pulled back down if missing.

## Testing

- Added unit tests for `SessionReadChapters.discard()` and for `OfflineReconciler` with `downloadProtectionWindow` on/off (`pending_read_deletes_test.dart`, `offline_reconciler_test.dart`).
- Full test suite run sequentially (`flutter test --concurrency=1`, to rule out unrelated Windows file-lock flakiness in a couple of I/O tests under parallel execution): **1716/1716 passing**.
- `flutter analyze`: no new issues introduced (pre-existing lint/info baseline unchanged).
- Verified an Android debug build (`flutter build apk --debug -P devBuild=1`) still builds and installs side-by-side as `Tsumiru Dev`.

## Test plan for reviewers

- [ ] Set delete-while-reading to "keep last N" with keep rule `all`; mark a chapter read via WebUI (or simulate a sync that flips `isRead`); confirm the device copy outside the protection window gets evicted on next sync/open.
- [ ] Read several chapters back-to-back in the app, close the reader, reopen the app fresh; confirm chapters read in a *previous* session are no longer session-protected (only the currently-open reader's chapters are).
- [ ] Enable the new "keep recently-read chapters downloaded" toggle (visible when delete-while-reading keeps ≥1 chapter); evict a protected-window chapter out-of-band and confirm the next reconcile re-downloads it. Confirm it stays off by default with no behavior change.