### PR TITLE
Make the Library screen's on-device download badge/filter update live

### DIFF
--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -1316,6 +1316,25 @@ class OfflineDatabase extends _$OfflineDatabase {
     return {for (final r in rows) r.read(offlineChapters.mangaId)!};
   }
 
+  /// Live version of [mangaIdsWithDeviceDownloads] — the Library screen's
+  /// on-device badge/filter previously only read this once (on provider
+  /// creation), so a chapter finishing its download elsewhere (manga details,
+  /// Downloads screen) never updated it until the next navigation/manual
+  /// refresh. Watching lets it update the moment a chapter's deviceState
+  /// flips to downloaded.
+  Stream<Set<int>> watchMangaIdsWithDeviceDownloads() {
+    final query = selectOnly(offlineChapters, distinct: true)
+      ..addColumns([offlineChapters.mangaId])
+      ..where(
+        offlineChapters.deviceState.equalsValue(
+          OfflineDeviceState.downloaded,
+        ),
+      );
+    return query.watch().map(
+      (rows) => {for (final r in rows) r.read(offlineChapters.mangaId)!},
+    );
+  }
+
   /// Total bytes used by downloaded chapters — for the storage UI, without a
   /// filesystem walk.
   Future<int> totalDownloadedBytes() async {

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -6,6 +6,7 @@
 
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:http/http.dart' as http;
@@ -1113,10 +1114,22 @@ Future<PageBytes> fetchOfflinePageBytes(Ref ref, String pageUrl) async {
 /// this device's disk is a purely local fact, so it must survive an unreachable
 /// server and the cold start before `serverInstanceId` resolves. Empty set on
 /// web / when init failed, so both callers no-op.
+///
+/// A live stream, not a one-shot read: the Library screen's on-device
+/// badge/filter previously only ever saw the snapshot from when this provider
+/// was first built, so a chapter finishing its download from the manga
+/// details page or the Downloads screen never showed up on Library until the
+/// next navigation or manual refresh. `distinct()` (by set content, not
+/// identity) keeps a per-page write during an in-progress download — which
+/// touches the same table but never changes which manga have a `downloaded`
+/// chapter — from re-notifying watchers with an unchanged value.
 @riverpod
-Future<Set<int>> offlineDeviceMangaIds(Ref ref) async {
-  if (!ref.watch(offlineEnabledProvider)) return const {};
-  return ref.watch(offlineRepositoryProvider).deviceDownloadedMangaIds();
+Stream<Set<int>> offlineDeviceMangaIds(Ref ref) {
+  if (!ref.watch(offlineEnabledProvider)) return Stream.value(const {});
+  return ref
+      .watch(offlineRepositoryProvider)
+      .watchDeviceDownloadedMangaIds()
+      .distinct(const SetEquality<int>().equals);
 }
 
 /// The keep-offline rule currently set for a manga — used by the popup button

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -130,6 +130,11 @@ class OfflineRepository {
   Future<Set<int>> deviceDownloadedMangaIds() =>
       db.mangaIdsWithDeviceDownloads();
 
+  /// Live version of [deviceDownloadedMangaIds] — see
+  /// [OfflineDatabase.watchMangaIdsWithDeviceDownloads].
+  Stream<Set<int>> watchDeviceDownloadedMangaIds() =>
+      db.watchMangaIdsWithDeviceDownloads();
+
   /// Total bytes used by all downloaded chapters — for the storage settings UI.
   Future<int> totalDownloadedBytes() => db.totalDownloadedBytes();
 }

--- a/test/src/features/offline/data/offline_device_manga_ids_test.dart
+++ b/test/src/features/offline/data/offline_device_manga_ids_test.dart
@@ -4,9 +4,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import '../../../../helpers/offline_test_db.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_paths.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+
+import '../../../../helpers/offline_test_db.dart';
 
 void main() {
   late OfflineDatabase db;
@@ -22,5 +27,98 @@ void main() {
       pageCount: 1, updatedAt: DateTime(2026));
     await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 5);
     expect(await db.mangaIdsWithDeviceDownloads(), {10});
+  });
+
+  group('watchMangaIdsWithDeviceDownloads', () {
+    test(
+      'emits an updated set live as chapters finish downloading elsewhere, '
+      'instead of only reflecting a one-time snapshot',
+      () async {
+        await db.upsertChapterMetadata(id: 1, mangaId: 10, name: 'a', chapterIndex: 1,
+          isRead: false, lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+          pageCount: 1, updatedAt: DateTime(2026));
+        await db.upsertChapterMetadata(id: 2, mangaId: 20, name: 'b', chapterIndex: 1,
+          isRead: false, lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+          pageCount: 1, updatedAt: DateTime(2026));
+
+        final emissions = <Set<int>>[];
+        final sub = db.watchMangaIdsWithDeviceDownloads().listen(emissions.add);
+        addTearDown(sub.cancel);
+
+        await pumpEventQueue();
+        expect(emissions.last, isEmpty,
+            reason: 'nothing downloaded yet');
+
+        // A chapter finishes downloading -- simulates the moment
+        // commitStagedChapter() flips deviceState, whether that happened from
+        // the manga details page, the Downloads screen, or the background
+        // catch-up pass.
+        await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 5);
+        await pumpEventQueue();
+        expect(emissions.last, {10},
+            reason: 'the stream must notice the finished download without '
+                'anything re-reading it manually');
+
+        await db.setChapterDeviceState(2, OfflineDeviceState.downloaded, bytes: 5);
+        await pumpEventQueue();
+        expect(emissions.last, {10, 20});
+      },
+    );
+
+    test('matches mangaIdsWithDeviceDownloads for the same state', () async {
+      await db.upsertChapterMetadata(id: 1, mangaId: 10, name: 'a', chapterIndex: 1,
+        isRead: false, lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+        pageCount: 1, updatedAt: DateTime(2026));
+      await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 5);
+
+      final oneShot = await db.mangaIdsWithDeviceDownloads();
+      final live = await db.watchMangaIdsWithDeviceDownloads().first;
+      expect(live, oneShot);
+    });
+  });
+
+  group('offlineDeviceMangaIdsProvider (end-to-end through Riverpod)', () {
+    test(
+      'updates live when a chapter finishes downloading, without anything '
+      'invalidating or re-reading the provider',
+      () async {
+        await db.upsertChapterMetadata(id: 1, mangaId: 10, name: 'a', chapterIndex: 1,
+          isRead: false, lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
+          pageCount: 1, updatedAt: DateTime(2026));
+
+        final container = ProviderContainer(overrides: [
+          offlineEnabledProvider.overrideWithValue(true),
+          offlineDatabaseProvider.overrideWithValue(db),
+          offlinePathsProvider.overrideWithValue(const OfflinePaths('/tmp/x')),
+        ]);
+        addTearDown(container.dispose);
+
+        final emissions = <Set<int>>[];
+        container.listen(
+          offlineDeviceMangaIdsProvider,
+          (prev, next) {
+            final value = next.value;
+            if (value != null) emissions.add(value);
+          },
+          fireImmediately: true,
+        );
+
+        await pumpEventQueue();
+        expect(emissions.last, isEmpty);
+
+        // This is the exact user-facing bug: a chapter finishing its download
+        // -- from the manga details page, the Downloads screen, or the
+        // background catch-up pass, it doesn't matter which -- must be
+        // reflected on the Library screen's "on device" badge/filter without
+        // needing a manual refresh or re-navigation.
+        await db.setChapterDeviceState(1, OfflineDeviceState.downloaded, bytes: 5);
+        await pumpEventQueue();
+
+        expect(emissions.last, {10},
+            reason: 'the provider must pick up the change live; before this '
+                'fix it only ever reflected whatever was on device the '
+                'moment it was first built');
+      },
+    );
   });
 }

--- a/test/src/widgets/manga_cover/manga_badges_test.dart
+++ b/test/src/widgets/manga_cover/manga_badges_test.dart
@@ -87,8 +87,9 @@ Future<void> _pumpBadges(
   await tester.pumpWidget(ProviderScope(
     overrides: [
       sharedPreferencesProvider.overrideWithValue(sp),
-      offlineDeviceMangaIdsProvider
-          .overrideWith((ref) async => onDevice ? {_kMangaId} : <int>{}),
+      offlineDeviceMangaIdsProvider.overrideWith(
+        (ref) => Stream.value(onDevice ? {_kMangaId} : <int>{}),
+      ),
     ],
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -298,7 +299,7 @@ void main() {
       await tester.pumpWidget(ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(sp),
-          offlineDeviceMangaIdsProvider.overrideWith((ref) async => {_kMangaId}),
+          offlineDeviceMangaIdsProvider.overrideWith((ref) => Stream.value({_kMangaId})),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -332,7 +333,7 @@ void main() {
       await tester.pumpWidget(ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(sp),
-          offlineDeviceMangaIdsProvider.overrideWith((ref) async => {_kMangaId}),
+          offlineDeviceMangaIdsProvider.overrideWith((ref) => Stream.value({_kMangaId})),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## Summary

The Library screen's "on device" badge and "On device" filter never updated live when a chapter finished downloading from another screen (the manga details page, the Downloads screen, or the background catch-up pass) -- only a manual pull-to-refresh or leaving and re-entering the screen picked it up.

**Root cause:** `offlineDeviceMangaIdsProvider` was a one-shot `Future<Set<int>>` read (`OfflineRepository.deviceDownloadedMangaIds()` -> a single `SELECT`), built once and never invalidated by anything in the download pipeline.

**Fix:**
- Added `OfflineDatabase.watchMangaIdsWithDeviceDownloads()` -- a drift `.watch()` twin of the existing one-shot `mangaIdsWithDeviceDownloads()` query -- and `OfflineRepository.watchDeviceDownloadedMangaIds()`.
- Switched `offlineDeviceMangaIdsProvider` from `Future<Set<int>>` to `Stream<Set<int>>`, with `.distinct()` (by set *content*, via `SetEquality`, not instance identity) so a per-page write during an unrelated in-progress download -- which touches the same table but never changes which manga have a *downloaded* chapter -- doesn't re-notify watchers with an unchanged value.
- All three existing consumers (`manga_badges.dart`, `library_controller.dart` x2) already read this provider as `.value ?? const <int>{}` off the `AsyncValue`, a pattern identical for `Future`- and `Stream`-backed generated providers, so none of them needed to change.

## Test plan

- [x] New tests cover the raw `.watch()` stream emitting live as a chapter's `deviceState` flips to `downloaded`, and equivalence with the one-shot query (`offline_device_manga_ids_test.dart`).
- [x] New end-to-end test drives the actual `offlineDeviceMangaIdsProvider` through a real `ProviderContainer` and confirms it updates the moment the underlying database changes, with no manual invalidation anywhere -- confirmed **red** (compile failure without the new watch method) before the fix, **green** after.
- [x] Updated the 3 existing provider-override call sites in `manga_badges_test.dart` from `(ref) async => ...` to `(ref) => Stream.value(...)` to match the new provider shape.
- [x] `flutter analyze --no-fatal-warnings --no-fatal-infos`: 0 new errors/warnings.
- [x] Full `test/src/features/offline/`, `test/offline/`, `test/library/`, `test/src/features/library/`, and `test/src/widgets/manga_cover/` suites (631 tests) pass.
