### PR TITLE
fix(offline): preserve manual-vs-auto provenance for offline-queued read-state changes

### DIFF
--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -347,6 +347,7 @@ Future<_MangaChapters?> _fetchMangaChapters(
         progressDirty: false,
         bookmarkDirty: false,
         readStateDirty: false,
+        readStateManual: false,
         syncedIsRead: n['isRead'] as bool? ?? false,
         updatedAt: now,
         downloadGeneration: 0,

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -103,6 +103,16 @@ class OfflineChapters extends Table {
   BoolColumn get readStateDirty =>
       boolean().withDefault(const Constant(false))();
 
+  /// Whether the pending [readStateDirty] change came from a manual mark-read
+  /// action (library/updates bulk "mark read") rather than ordinary reading.
+  /// Only meaningful while [readStateDirty] is true — read by
+  /// [pushPendingProgress] to pick the right tracker-sync gate
+  /// (updateProgressManualMarkRead vs updateProgressAfterReading) when
+  /// flushing a read-state change that was queued offline; a stale value left
+  /// over from a since-cleared write is never consulted.
+  BoolColumn get readStateManual =>
+      boolean().withDefault(const Constant(false))();
+
   /// The read state already reflected in the manga row's stored [OfflineMangas
   /// .unreadCount] — NOT simply "what the server last said". Invariant the
   /// offline view depends on: shown unread = stored count − Σ(isRead −
@@ -187,7 +197,7 @@ class OfflineDatabase extends _$OfflineDatabase {
   OfflineDatabase(super.e);
 
   @override
-  int get schemaVersion => 14;
+  int get schemaVersion => 15;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -381,6 +391,13 @@ class OfflineDatabase extends _$OfflineDatabase {
         if (!await _hasTable(offlineMangaCategories)) {
           await m.createTable(offlineMangaCategories);
         }
+      }
+      if (from < 15) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.readStateManual,
+        );
       }
     },
   );
@@ -784,10 +801,19 @@ class OfflineDatabase extends _$OfflineDatabase {
 
   /// Record local reading progress (read offline / always). Marks it
   /// `progressDirty` so it's pushed to the server on the next online sync.
+  ///
+  /// [manual] records whether this read-state change came from a manual
+  /// mark-read action (bulk "mark read" with a position reset) rather than
+  /// ordinary reading — [pushPendingProgress] reads it back to pick the right
+  /// tracker-sync gate when flushing offline-queued read-state changes.
+  /// Ignored (never written) when [isRead] is null, matching [readStateDirty]
+  /// itself: a partial position-only write has no read-state provenance to
+  /// record.
   Future<void> setChapterProgress(
     int chapterId, {
     required int lastPageRead,
     bool? isRead,
+    bool manual = false,
   }) => (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
     OfflineChaptersCompanion(
       lastPageRead: Value(lastPageRead),
@@ -800,6 +826,8 @@ class OfflineDatabase extends _$OfflineDatabase {
       // writes can't push a stale isRead (the ch-99 loop).
       isRead: isRead == null ? const Value.absent() : Value(isRead),
       readStateDirty: isRead == null ? const Value.absent() : const Value(true),
+      readStateManual:
+          isRead == null ? const Value.absent() : Value(manual),
     ),
   );
 
@@ -808,11 +836,20 @@ class OfflineDatabase extends _$OfflineDatabase {
 
   /// Record a local read/unread change (list actions, mark-read). Position
   /// untouched; pushed under its own flag on the next online sync.
-  Future<void> setChapterReadState(int chapterId, bool isRead) =>
-      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+  ///
+  /// [manual] is true for every caller of this method today (it's only ever
+  /// invoked from the manual mark-read path — ordinary reading progress goes
+  /// through [setChapterProgress] instead) — see that method's doc comment
+  /// for what it's used for.
+  Future<void> setChapterReadState(
+    int chapterId,
+    bool isRead, {
+    bool manual = true,
+  }) => (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
         OfflineChaptersCompanion(
           isRead: Value(isRead),
           readStateDirty: const Value(true),
+          readStateManual: Value(manual),
           // Marking read counts as reading activity for the Last Read sort;
           // un-reading is bookkeeping and leaves the timestamp alone.
           lastReadAt: isRead ? Value(_nowEpochSeconds()) : const Value.absent(),

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -406,7 +406,12 @@ Future<bool> recordReadStateWithDependencies({
   if (offlineEnabled && db != null) {
     for (final id in chapterIds) {
       if (resetPosition) {
-        await db.setChapterProgress(id, lastPageRead: 0, isRead: isRead);
+        await db.setChapterProgress(
+          id,
+          lastPageRead: 0,
+          isRead: isRead,
+          manual: true,
+        );
       } else {
         await db.setChapterReadState(id, isRead);
       }
@@ -775,6 +780,11 @@ Future<void> pushPendingProgress(
   // Collect manga IDs where progress was pushed successfully AND the chapter
   // is marked read — deduplicated so we call trackProgress once per manga.
   final syncedReadMangaIds = <int>{};
+  // Whether ANY synced chapter for that manga this pass came from a manual
+  // mark-read action rather than ordinary reading — read back from
+  // readStateManual (see OfflineChapters' doc comment) so the tracker-sync
+  // gate below checks the same toggle the action would have used online.
+  final syncedReadIsManual = <int, bool>{};
 
   for (final c in await db.dirtyChapters()) {
     var pushProgress = c.progressDirty;
@@ -848,7 +858,11 @@ Future<void> pushPendingProgress(
           isBookmarked: c.isBookmarked,
         );
       }
-      if (c.readStateDirty && c.isRead) syncedReadMangaIds.add(c.mangaId);
+      if (c.readStateDirty && c.isRead) {
+        syncedReadMangaIds.add(c.mangaId);
+        syncedReadIsManual[c.mangaId] =
+            (syncedReadIsManual[c.mangaId] ?? false) || c.readStateManual;
+      }
     }
   }
 
@@ -862,6 +876,9 @@ Future<void> pushPendingProgress(
   final enabledAfterReading = container
       .read(updateProgressAfterReadingProvider)
       .ifNull();
+  final enabledManualMarkRead = container
+      .read(updateProgressManualMarkReadProvider)
+      .ifNull();
 
   for (final mangaId in syncedReadMangaIds) {
     try {
@@ -871,8 +888,8 @@ Future<void> pushPendingProgress(
       if (!shouldTrackProgress(
         isRead: true,
         enabledAfterReading: enabledAfterReading,
-        enabledManualMarkRead: false,
-        manual: false,
+        enabledManualMarkRead: enabledManualMarkRead,
+        manual: syncedReadIsManual[mangaId] ?? false,
         trackRecordCount: records.length,
       )) {
         continue;

--- a/test/src/features/offline/data/offline_chapter_number_schema_test.dart
+++ b/test/src/features/offline/data/offline_chapter_number_schema_test.dart
@@ -74,7 +74,7 @@ void main() {
     });
     tearDown(() => tmp.delete(recursive: true));
 
-    test('adds the columns, preserves rows, lands on version 14', () async {
+    test('adds the columns, preserves rows, lands on version 15', () async {
       final dbPath = p.join(tmp.path, 'test.db');
 
       // Build a genuine v8 file: the chapters table WITHOUT the new columns,
@@ -148,7 +148,7 @@ void main() {
           .customSelect('PRAGMA user_version')
           .getSingle()
           .then((r) => r.read<int>('user_version'));
-      expect(version, 14);
+      expect(version, 15);
       // v14 must create both category tables on an upgrade from before they
       // existed — onCreate only runs for fresh files.
       await db.upsertCategory(1, 'A', 0, isHidden: false);

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -16,8 +16,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 14', () {
-    expect(db.schemaVersion, 14);
+  test('opens at schema version 15', () {
+    expect(db.schemaVersion, 15);
   });
 
   test('inserts and reads a manga', () async {

--- a/test/src/features/offline/data/offline_download_manager_force_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_force_test.dart
@@ -33,6 +33,7 @@ void main() {
     progressDirty: false,
     bookmarkDirty: false,
     readStateDirty: false,
+    readStateManual: false,
     syncedIsRead: false,
     updatedAt: DateTime(2026),
     downloadGeneration: 0,

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 14', () {
-    expect(db.schemaVersion, 14);
+  test('opens at schema version 15', () {
+    expect(db.schemaVersion, 15);
   });
 
   test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',

--- a/test/src/features/offline/data/offline_schema_migration_test.dart
+++ b/test/src/features/offline/data/offline_schema_migration_test.dart
@@ -95,6 +95,38 @@ void main() {
     }
   });
 
+  test('v15 readStateManual persists across close/reopen', () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      await db.upsertChapterMetadata(
+        id: 10,
+        mangaId: 1,
+        name: 'c',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 3,
+        updatedAt: DateTime(2026),
+      );
+      await db.setChapterReadState(10, true, manual: true);
+      await db.close();
+    }
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      final c = await (db.select(db.offlineChapters)
+            ..where((t) => t.id.equals(10)))
+          .getSingle();
+      expect(c.readStateManual, true);
+      await db.close();
+    }
+  });
+
   test('v4 lastReadAt persists across close/reopen', () async {
     final dbPath = p.join(tmp.path, 'test.db');
 

--- a/test/src/features/offline/data/reconcile_desired_set_test.dart
+++ b/test/src/features/offline/data/reconcile_desired_set_test.dart
@@ -8,7 +8,8 @@ OfflineChapter ch(int id, int idx, {bool read = false, bool pinned = false}) =>
       lastPageRead: 0, isBookmarked: false, serverIsDownloaded: true,
       deviceState: OfflineDeviceState.none, pageCount: 1, bytes: 0,
       pinned: pinned, downloadedAt: null, progressDirty: false,
-      bookmarkDirty: false, readStateDirty: false, syncedIsRead: false,
+      bookmarkDirty: false, readStateDirty: false, readStateManual: false,
+      syncedIsRead: false,
       updatedAt: DateTime(2026),
       downloadGeneration: 0,
     );

--- a/test/src/features/offline/data/reconcile_eviction_test.dart
+++ b/test/src/features/offline/data/reconcile_eviction_test.dart
@@ -16,6 +16,7 @@ OfflineChapter dl(int id, {int bytes = 100, DateTime? at, bool pinned = false}) 
       deviceState: OfflineDeviceState.downloaded, pageCount: 1, bytes: bytes,
       pinned: pinned, downloadedAt: at ?? DateTime(2026, 1, id),
       progressDirty: false, bookmarkDirty: false, readStateDirty: false,
+      readStateManual: false,
       syncedIsRead: false,
       updatedAt: DateTime(2026), downloadGeneration: 0,
     );

--- a/test/src/features/offline/data/reconcile_read_window_test.dart
+++ b/test/src/features/offline/data/reconcile_read_window_test.dart
@@ -27,6 +27,7 @@ OfflineChapter _ch(int id, {bool isRead = false, String? readAt}) =>
       progressDirty: false,
       bookmarkDirty: false,
       readStateDirty: false,
+      readStateManual: false,
       syncedIsRead: false,
       lastReadAt: readAt,
       updatedAt: DateTime(2026),

--- a/test/src/features/offline/push_pending_progress_tracking_test.dart
+++ b/test/src/features/offline/push_pending_progress_tracking_test.dart
@@ -143,6 +143,15 @@ class _FixedToggle extends UpdateProgressAfterReading {
   bool? build() => _value;
 }
 
+/// Same, for the manual-mark-read toggle.
+class _FixedManualToggle extends UpdateProgressManualMarkRead {
+  _FixedManualToggle(this._value);
+  final bool _value;
+
+  @override
+  bool? build() => _value;
+}
+
 // ---------------------------------------------------------------------------
 // Helper: seed a chapter row (optionally dirty)
 // ---------------------------------------------------------------------------
@@ -201,6 +210,7 @@ Future<
   required List<int> mangaIds,
   int trackRecordCount = 1,
   bool toggleOn = true,
+  bool manualToggleOn = false,
   MangaBookRepository? repository,
 }) async {
   SharedPreferences.setMockInitialValues({});
@@ -220,6 +230,8 @@ Future<
     trackerRepositoryProvider.overrideWithValue(fakeTracker),
     updateProgressAfterReadingProvider
         .overrideWith(() => _FixedToggle(toggleOn)),
+    updateProgressManualMarkReadProvider
+        .overrideWith(() => _FixedManualToggle(manualToggleOn)),
     for (final id in mangaIds)
       mangaTrackRecordsProvider(mangaId: id)
           .overrideWith((_) => Future.value(records)),
@@ -364,6 +376,103 @@ void main() {
 
       expect(tracker.trackProgressCalls, isEmpty,
           reason: 'isRead=false chapters must not trigger tracker');
+    });
+  });
+
+  group('pushPendingProgress → manual vs auto tracker gate', () {
+    test(
+        'a manual mark-read queued offline is gated on the MANUAL toggle, '
+        'not the after-reading toggle', () async {
+      // after-reading OFF, manual-mark-read ON: an offline manual mark-read
+      // must still reach the tracker once reconnected.
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 1,
+        toggleOn: false,
+        manualToggleOn: true,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await recordReadStateWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: _FailingMangaBookRepository(),
+        chapterIds: [10],
+        isRead: true,
+        resetPosition: true,
+      );
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls, [1],
+          reason: 'manual-mark-read toggle is ON — the flush must use it, '
+              'not the (OFF) after-reading toggle');
+    });
+
+    test(
+        'a manual mark-read queued offline is suppressed when the MANUAL '
+        'toggle is off, even with after-reading ON', () async {
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 1,
+        toggleOn: true,
+        manualToggleOn: false,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await recordReadStateWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: _FailingMangaBookRepository(),
+        chapterIds: [10],
+        isRead: true,
+        resetPosition: true,
+      );
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls, isEmpty,
+          reason: 'manual-mark-read toggle is OFF — a manual action must not '
+              'borrow the (ON) after-reading toggle');
+    });
+
+    test(
+        'ordinary offline reading progress still uses the after-reading '
+        'toggle, unaffected by the manual toggle', () async {
+      final (:container, :db, :tracker) = await _build(
+        mangaIds: [1],
+        trackRecordCount: 1,
+        toggleOn: true,
+        manualToggleOn: false,
+      );
+      addTearDown(() {
+        container.dispose();
+        db.close();
+      });
+
+      await _seed(db, 10, mangaId: 1);
+      await recordReadingProgressWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: _FailingMangaBookRepository(),
+        chapterId: 10,
+        lastPageRead: 9,
+        isRead: true,
+      );
+
+      await pushPendingProgress(container);
+
+      expect(tracker.trackProgressCalls, [1],
+          reason: 'the auto/reading path is untouched by this fix — still '
+              'gated on after-reading alone');
     });
   });
 


### PR DESCRIPTION
## Summary

`pushPendingProgress` (the reconnect flush for read/progress changes queued while offline) always called `shouldTrackProgress` with `manual: false`, regardless of whether the underlying read-state change actually came from a **manual mark-read action** (library/updates bulk "mark read") or **ordinary reading**. The offline DB had no per-row flag distinguishing the two, so the flush always gated on "update after reading" and never on "update on manual mark-read" — the opposite of the gate the online path uses for the exact same action.

Online, `multi_chapters_action_icon.dart` correctly calls `maybeTrackProgressOnReadFetch(..., manual: true)`, but only `if (ok && change.isRead == true)` — i.e. only when the immediate synchronous server push succeeds. Offline, that push fails, so the manual-gated call never fires, and the chapter is left `readStateDirty` for `pushPendingProgress` to flush later using the wrong gate.

**Concrete impact:**
- With "update after reading" **OFF** and "update on manual mark-read" **ON**: bulk-marking chapters read while offline never nudges the tracker on reconnect, even though the user explicitly enabled that exact path.
- With the toggles flipped: an offline manual mark-read wrongly pushes to the tracker under the "after reading" gate instead of staying silent as configured.

## Fix

- Added `OfflineChapters.readStateManual` (schema v14 → v15): set `true` when a read-state change is recorded through the manual bulk mark-read path (`recordReadStateWithDependencies`, via `setChapterReadState`/`setChapterProgress`'s new `manual` parameter) and `false` through the ordinary reading-progress path (`recordReadingProgressWithDependencies`).
- `pushPendingProgress` now reads this back per chapter, aggregates it per manga (a manga counts as manual if *any* of its synced-read chapters this pass were), and passes that instead of a hardcoded `false`.
- Updated one background-isolate call site (`catchup_download_executor.dart`) and four test fixture builders that construct `OfflineChapter` rows directly to supply the new field; bumped three schema-version sentinel tests 14 → 15.

## Test plan

- [x] New schema-migration test: `readStateManual` persists across close/reopen.
- [x] Three new targeted tests in `push_pending_progress_tracking_test.dart` proving: a manual mark-read queued offline is gated on the manual toggle (not after-reading); it's correctly suppressed when the manual toggle is off even with after-reading on; the ordinary reading path is unaffected and still uses only the after-reading toggle.
- [x] `flutter analyze --no-fatal-warnings --no-fatal-infos`: no new issues.
- [x] Full `test/src/features/offline/` + `test/offline/` suite (339/339) green.