### PR TITLE
fix(offline): mark a chapter error instead of leaving it stuck downloading forever

### DIFF
--- a/lib/src/features/offline/data/offline_download_manager.dart
+++ b/lib/src/features/offline/data/offline_download_manager.dart
@@ -86,12 +86,24 @@ class OfflineDownloadManager {
           page.ext,
         );
       }
-      await commitStagedChapter(
+      final result = await commitStagedChapter(
         db: db,
         store: store,
         mangaId: chapter.mangaId,
         chapterId: chapter.id,
       );
+      // The source answered with zero pages (chapter removed/renamed upstream,
+      // for instance). commitStagedChapter refuses to publish that as
+      // `downloaded`, but left unchecked the row stays `downloading` forever —
+      // not `error`, so the reconciler's error-skip guard never engages and
+      // this chapter is re-selected for download on every pass, looking like
+      // it is stuck trying to fetch a chapter that does not exist.
+      if (result == ChapterCommitResult.incomplete) {
+        throw StateError(
+          'Chapter ${chapter.id} produced no pages to commit '
+          '(pageCount=$pageCount)',
+        );
+      }
     } catch (e, st) {
       logger.e(
         'Offline: download FAILED for chapter ${chapter.id} '

--- a/test/src/features/offline/data/offline_download_manager_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_test.dart
@@ -110,6 +110,30 @@ void main() {
     );
   });
 
+  test(
+    'a chapter the source now serves with zero pages is marked error, '
+    'not left stuck downloading forever',
+    () async {
+      // Regression: a chapter removed/renamed upstream (e.g. after a source
+      // renumbers decimal-numbered chapters) answers with an empty page list.
+      // commitStagedChapter correctly refuses to publish that as `downloaded`,
+      // but the manager used to ignore its result entirely, leaving the row
+      // parked in `downloading` — not `error` — so the reconciler kept
+      // re-selecting it for download on every pass forever.
+      final chapter = await seedChapter();
+      final mgr = managerWith(urls: (_) async => const []);
+
+      await expectLater(mgr.downloadChapter(chapter), throwsStateError);
+
+      final c = (await db.chaptersForManga(552)).single;
+      expect(c.deviceState, OfflineDeviceState.error);
+      final pages = await (db.select(
+        db.offlinePages,
+      )..where((t) => t.chapterId.equals(2000))).get();
+      expect(pages, isEmpty);
+    },
+  );
+
   test('deleteChapter removes files, page rows, and resets state', () async {
     final chapter = await seedChapter();
     await managerWith().downloadChapter(chapter);


### PR DESCRIPTION
## Summary
- `OfflineDownloadManager.downloadChapter` ignored the result of `commitStagedChapter`. When the source answers with zero pages for a chapter (removed/renamed upstream — e.g. a decimal-numbered chapter that got renumbered, or any stale catalog row the source no longer serves), the commit correctly refuses to publish it as `downloaded`, but the chapter's device state was left parked in `downloading` forever — never `error`.
- The reconciler already has a guard to skip re-planning chapters in `error` state (to avoid hammering an unfetchable chapter every pass), but that guard never engaged here since the state never reached `error`. The chapter kept getting re-selected for download on every reconcile pass indefinitely, with no visible progress — looking exactly like the app "stuck trying to download a chapter that doesn't exist."
- Fix: treat an empty commit result as a failure, routing through the existing catch block that purges staging and marks the chapter `error`, same as any other download failure.

## Test plan
- [x] `flutter analyze` clean on the changed files
- [x] New regression test: a chapter whose source returns zero pages now lands in `error` state (not stuck in `downloading`)
- [x] Full `offline_download_manager_test.dart` suite passes (12/12)