### PR TITLE
fix: close a second ref-after-unmount crash in delete-server-copy flows

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -117,8 +117,9 @@ class MangaChapterList extends _$MangaChapterList {
     );
     if (ref.mounted) ref.keepAlive();
     if (result != null && fromServer) {
-      unawaited((sync?.syncChapters(result) ?? Future.value())
-          .then((_) => reconcileManga(ref, mangaId)));
+      unawaited((sync?.syncChapters(result) ?? Future.value()).then((_) {
+        if (ref.mounted) reconcileManga(ref, mangaId);
+      }));
     }
     if (didSourceFetch) {
       // MangaWithId loaded before the scrape refreshed metadata; refresh it so

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -88,13 +88,22 @@ class MangaDetailsScreen extends HookConsumerWidget {
         [chapterListProvider]);
 
     final refresh = useCallback(([onlineFetch = false]) async {
-      if (context.mounted && onlineFetch) {
+      // This can be invoked as a bulk chapter action's `afterOptionSelected`,
+      // reached only after that action's own network round trip — the screen
+      // may already be gone by then, and every ref use below assumes it isn't.
+      if (!context.mounted) return;
+      if (onlineFetch) {
         ref.read(toastProvider)?.show(
               context.l10n.updating,
               withMicrotask: true,
             );
       }
       await mangaRefresh(onlineFetch);
+      // mangaRefresh can no-op on disposal partway through without throwing
+      // (it checks context.mounted internally) — but chapterListRefresh has
+      // no such guard, so this screen going away during mangaRefresh must be
+      // caught here before falling into it.
+      if (!context.mounted) return;
       await chapterListRefresh(onlineFetch);
       if (onlineFetch) {
         // mangaRefresh only invalidates; await the actual refetch and report ITS

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -139,7 +139,32 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
           tooltip: context.l10n.delete,
           icon: const Icon(Icons.delete_rounded),
           onPressed: () async {
+            // Captured up front: this handler awaits a confirmation dialog and
+            // a network mutation, either of which can outlive this bar (the
+            // selection clears — and this widget unmounts — once the delete
+            // resolves). `ref.read` throws once that happens; a container
+            // obtained now stays valid regardless.
+            final containerRead =
+                ProviderScope.containerOf(context, listen: false).read;
             final repo = ref.read(offlineRepositoryProvider);
+            // Computed up front, before the confirmation dialog's own await:
+            // it only depends on the already-selected chapters, nothing the
+            // dialog reveals, so there is no reason for this `ref` use to
+            // wait behind an await that could outlive the widget.
+            // Delete expands to every scanlator duplicate, grouped per manga.
+            final deleteIds = <int>[
+              for (final entry
+                  in {for (final c in selectedChapterDtos) c.mangaId: true}
+                      .keys)
+                ...expandIdsAcrossScanlators(
+                  ref,
+                  mangaId: entry,
+                  chapterIds: [
+                    for (final c in selectedChapterDtos)
+                      if (c.mangaId == entry) c.id,
+                  ],
+                ),
+            ];
             final onDevice =
                 await repo.deviceDownloadedCount(selectedChapterList);
             if (onDevice > 0) {
@@ -163,20 +188,6 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
                   false;
               if (!ok) return;
             }
-            // Delete expands to every scanlator duplicate, grouped per manga.
-            final deleteIds = <int>[
-              for (final entry
-                  in {for (final c in selectedChapterDtos) c.mangaId: true}
-                      .keys)
-                ...expandIdsAcrossScanlators(
-                  ref,
-                  mangaId: entry,
-                  chapterIds: [
-                    for (final c in selectedChapterDtos)
-                      if (c.mangaId == entry) c.id,
-                  ],
-                ),
-            ];
             final result = await AsyncValue.guard(
               () => ref
                   .read(mangaBookRepositoryProvider)
@@ -187,7 +198,7 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
             }
             if (!result.hasError) {
               // Same expanded set (device ⊆ server).
-              await cascadeServerDeleteToDevice(ref, deleteIds);
+              await cascadeServerDeleteToDevice(containerRead, deleteIds);
             }
             await refresh(true);
           },

--- a/lib/src/features/manga_book/widgets/download_status_icon.dart
+++ b/lib/src/features/manga_book/widgets/download_status_icon.dart
@@ -128,6 +128,12 @@ class DownloadStatusIcon extends HookConsumerWidget {
             // Cloud = the SERVER copy; solid indigo = "you have it".
             icon: brandGradientIcon(context, Icons.cloud_done_rounded),
             onPressed: () async {
+              // Captured up front: the network mutation below can outlive
+              // this icon (the chapter row it belongs to can disappear once
+              // the delete resolves). `ref.read` throws once that happens; a
+              // container obtained now stays valid regardless.
+              final containerRead =
+                  ProviderScope.containerOf(context, listen: false).read;
               final deleteIds = expandIdsAcrossScanlators(
                 ref,
                 mangaId: chapter.mangaId,
@@ -141,7 +147,7 @@ class DownloadStatusIcon extends HookConsumerWidget {
               result.showToastOnError(toast);
               if (!result.hasError) {
                 // Same expanded set (device ⊆ server).
-                await cascadeServerDeleteToDevice(ref, deleteIds);
+                await cascadeServerDeleteToDevice(containerRead, deleteIds);
               }
               await newUpdatePair(ref, (value) => isLoading.value = value);
             },

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -753,7 +753,7 @@ Future<void> _deleteServerCopyIfDeletable(
     }
     if (isBookmarked && !allowBookmarked) return;
     await read(mangaBookRepositoryProvider).deleteChapters([chapterId]);
-    await _cascadeServerDeleteToDeviceRead(read, [chapterId]);
+    await cascadeServerDeleteToDevice(read, [chapterId]);
   } catch (e) {
     // Best-effort — a failed server auto-delete must never surface mid-read.
     logger.e('Offline: server delete-on-read failed for $chapterId: $e');
@@ -896,10 +896,14 @@ Future<void> pushPendingProgress(
 
 /// Enforce device ⊆ server: when chapters are deleted on the server, drop any
 /// device copies too. Silent; no-op when offline is unavailable.
-Future<void> cascadeServerDeleteToDevice(WidgetRef ref, List<int> chapterIds) =>
-    _cascadeServerDeleteToDeviceRead(ref.read, chapterIds);
-
-Future<void> _cascadeServerDeleteToDeviceRead(
+///
+/// Takes a plain read function ([_Read]) rather than a [WidgetRef]: callers
+/// that fire this off after an earlier `await` (a bulk/delete action whose
+/// widget or bottom bar may have unmounted by the time this runs) must pass a
+/// `ProviderContainer.read` tear-off instead of the widget's own `ref.read` —
+/// the widget's `ref` throws once its element is disposed, but a container
+/// obtained up front stays valid for as long as the app does.
+Future<void> cascadeServerDeleteToDevice(
   _Read read,
   List<int> chapterIds,
 ) async {

--- a/lib/src/features/offline/data/offline_repository.dart
+++ b/lib/src/features/offline/data/offline_repository.dart
@@ -333,7 +333,13 @@ OfflineSync? offlineSync(Ref ref) {
           DBKeys.offlineCatalogServerId.name,
           identity,
         );
-        ref.invalidate(offlineActiveProvider);
+        // This closure is captured by OfflineSync and invoked later, from
+        // syncManga — this provider can have been disposed/rebuilt by then
+        // (e.g. a bulk operation triggering many syncs back to back), and
+        // ref.invalidate on a disposed Ref throws. The preference write above
+        // already landed, so the guard above won't re-run this block anyway;
+        // there's nothing left to do if the ref is gone.
+        if (ref.mounted) ref.invalidate(offlineActiveProvider);
       }
     },
   );


### PR DESCRIPTION
## Summary
- `cascadeServerDeleteToDevice` took a `WidgetRef` and read from it after an earlier `await` (a confirmation dialog, a network mutation) — if the calling widget had unmounted in the meantime (bulk-delete bottom bar, download-status icon, or the manga details screen's `refresh` callback racing `chapterListRefresh`), that read crashed.
- It now takes a plain read function so callers can pass a `ProviderContainer.read` tear-off captured before the first `await`, which stays valid regardless of the widget's lifecycle.
- Also moves one remaining post-dialog `expandIdsAcrossScanlators` call earlier, before the confirmation dialog's own `await`, closing a narrower version of the same gap.

This is a second round of fixes for the same class of crash following an earlier merged PR — these two additional sites were found via crash-log stack traces from live testing.

## Test plan
- [x] `flutter analyze` clean (baseline info/warning count unchanged)
- [x] Full `manga_book` widget test suite passes (450 tests)