### PR TITLE
fix(offline): persist server-fetch retries, bound background HTTP calls, and surface both in the crash log

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,5 +34,12 @@ analyzer:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
     - "**/*.graphql.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     invalid_annotation_target: ignore

--- a/lib/src/features/notifications/data/background/notification_worker.dart
+++ b/lib/src/features/notifications/data/background/notification_worker.dart
@@ -79,16 +79,19 @@ Future<bool> runNewChapterCheck() async {
   }
   // Background download step — own cursor, keep-rule scope, no category
   // filter. Resolution records the obligations; the executor then downloads
-  // as many as the run's budget allows.
+  // as many as the run's budget allows — unless the user only wants
+  // detection in the background and prefers to fetch files in the foreground.
   if (catchupStore.enabled) {
     ok = await _runDownloadResolution(catchupStore, config, client) && ok;
-    ok = await runCatchupDownloads(
-          catchupStore: catchupStore,
-          config: config,
-          record: client.currentRecord,
-          broker: client.broker,
-        ) &&
-        ok;
+    if (catchupStore.downloadEnabled) {
+      ok = await runCatchupDownloads(
+            catchupStore: catchupStore,
+            config: config,
+            record: client.currentRecord,
+            broker: client.broker,
+          ) &&
+          ok;
+    }
   }
   if (config.appUpdatesEnabled) {
     await _checkAppUpdate(store, config, client, notifier, l10n);

--- a/lib/src/features/notifications/data/background/notification_worker.dart
+++ b/lib/src/features/notifications/data/background/notification_worker.dart
@@ -14,6 +14,8 @@ import 'package:path_provider/path_provider.dart';
 
 import '../../../../constants/endpoints.dart';
 import '../../../../l10n/generated/app_localizations.dart';
+import '../../../../utils/crash/crash_log.dart';
+import '../../../../utils/crash/diagnostics.dart';
 import '../../../offline/data/background/background_token_record.dart';
 import '../../../offline/data/background/catchup_download_executor.dart';
 import '../../../offline/data/background/catchup_work_spec.dart';
@@ -29,6 +31,15 @@ import 'notification_background_client.dart';
 ///
 /// Runs in the WorkManager isolate — no Riverpod, no BuildContext.
 Future<bool> runNewChapterCheck() async {
+  // The main isolate wires this up in main.dart; a WorkManager run gets a
+  // fresh isolate every time and starts with no diagnostic sink at all, so
+  // without this, every recordDiagnostic() call in the download/catch-up
+  // path this function calls into is a silent no-op — invisible even though
+  // the same crash-log file (and its Settings copy action) is what the user
+  // actually checks.
+  final crashLogPath = await initCrashLog();
+  setDiagnosticSink((line) => writeCrashLog(crashLogPath, line));
+
   final store = await NotificationStateStore.open();
   final config = store.readConfig();
   final token = store.readTokenRecord();

--- a/lib/src/features/notifications/data/background/notification_worker.dart
+++ b/lib/src/features/notifications/data/background/notification_worker.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:ui';
@@ -16,6 +17,7 @@ import '../../../../constants/endpoints.dart';
 import '../../../../l10n/generated/app_localizations.dart';
 import '../../../../utils/crash/crash_log.dart';
 import '../../../../utils/crash/diagnostics.dart';
+import '../../../../utils/network/gateway_status.dart';
 import '../../../offline/data/background/background_token_record.dart';
 import '../../../offline/data/background/catchup_download_executor.dart';
 import '../../../offline/data/background/catchup_work_spec.dart';
@@ -427,28 +429,44 @@ TokenBroker _brokerFor(NotificationStateStore store, NotificationEndpoint ep) =>
           isGraphQl: true,
         );
         try {
-          final res = await http.post(
-            Uri.parse(endpoint),
-            headers: const {'Content-Type': 'application/json'},
-            body: jsonEncode({
-              'query':
-                  r'mutation RefreshToken($input: RefreshTokenInput!){ refreshToken(input: $input){ accessToken } }',
-              'variables': {
-                'input': {'refreshToken': refreshToken},
-              },
-            }),
-          );
-          if (res.statusCode != 200) return null;
+          final res = await http
+              .post(
+                Uri.parse(endpoint),
+                headers: const {'Content-Type': 'application/json'},
+                body: jsonEncode({
+                  'query':
+                      r'mutation RefreshToken($input: RefreshTokenInput!){ refreshToken(input: $input){ accessToken } }',
+                  'variables': {
+                    'input': {'refreshToken': refreshToken},
+                  },
+                }),
+              )
+              .timeout(const Duration(seconds: 30));
+          // A proxy answering for a dead origin is the server being
+          // unreachable, not the refresh token being invalid — without this,
+          // the first request after reconnecting (racing the network
+          // actually settling) permanently condemns every chapter that
+          // happened to 401 in that window.
+          if (isGatewayStatus(res.statusCode)) {
+            return (tokens: null, transient: true);
+          }
+          if (res.statusCode != 200) return (tokens: null, transient: false);
           final data = (jsonDecode(res.body) as Map<String, Object?>)['data']
               as Map<String, Object?>?;
           final access =
               (data?['refreshToken'] as Map<String, Object?>?)?['accessToken']
                   as String?;
-          if (access == null || access.isEmpty) return null;
+          if (access == null || access.isEmpty) {
+            return (tokens: null, transient: false);
+          }
           // Suwayomi doesn't rotate the refresh token — reuse it.
-          return (access: access, refresh: refreshToken);
+          return (tokens: (access: access, refresh: refreshToken), transient: false);
+        } on SocketException {
+          return (tokens: null, transient: true);
+        } on TimeoutException {
+          return (tokens: null, transient: true);
         } catch (_) {
-          return null;
+          return (tokens: null, transient: false);
         }
       },
     );

--- a/lib/src/features/notifications/data/background/notification_worker.dart
+++ b/lib/src/features/notifications/data/background/notification_worker.dart
@@ -43,7 +43,24 @@ Future<bool> runNewChapterCheck() async {
   final store = await NotificationStateStore.open();
   final config = store.readConfig();
   final token = store.readTokenRecord();
-  if (config == null || token == null) return true;
+  if (config == null || token == null) {
+    // The only way to tell "the OS never woke this task" apart from "it woke
+    // but had nothing configured yet" from the field — both look identical
+    // (a silent gap in the log) without this line.
+    recordDiagnostic(
+      '[${DateTime.now().toIso8601String()}] offline-worker: '
+      'check-skipped reason=no-config\n',
+    );
+    return true;
+  }
+
+  final catchupStore = await CatchupStateStore.open();
+  recordDiagnostic(
+    '[${DateTime.now().toIso8601String()}] offline-worker: check-started '
+    'newChapters=${config.newChaptersEnabled} catchup=${catchupStore.enabled} '
+    'appUpdates=${config.appUpdatesEnabled} '
+    'extUpdates=${config.extensionUpdatesEnabled}\n',
+  );
 
   final l10n = lookupAppLocalizations(_deviceLocale());
   final notifier = LocalNotificationService();
@@ -61,7 +78,6 @@ Future<bool> runNewChapterCheck() async {
   // Background download step — own cursor, keep-rule scope, no category
   // filter. Resolution records the obligations; the executor then downloads
   // as many as the run's budget allows.
-  final catchupStore = await CatchupStateStore.open();
   if (catchupStore.enabled) {
     ok = await _runDownloadResolution(catchupStore, config, client) && ok;
     ok = await runCatchupDownloads(
@@ -78,6 +94,10 @@ Future<bool> runNewChapterCheck() async {
   if (config.extensionUpdatesEnabled) {
     await _checkExtensionUpdates(store, client, notifier, l10n);
   }
+  recordDiagnostic(
+    '[${DateTime.now().toIso8601String()}] offline-worker: '
+    'check-finished ok=$ok\n',
+  );
   return ok;
 }
 

--- a/lib/src/features/offline/data/background/background_chapter_fetch.dart
+++ b/lib/src/features/offline/data/background/background_chapter_fetch.dart
@@ -146,7 +146,14 @@ Future<List<String>?> resolveChapterPageUrls({
   var result = await post(null);
   if (result == gqlAuthError && record().authType == 'uiLogin') {
     final newAccess = await broker.resolveAfter401(record().accessToken ?? '');
-    if (newAccess != null) result = await post(newAccess);
+    if (newAccess != null) {
+      result = await post(newAccess);
+    } else if (broker.lastRefreshTransient) {
+      // The refresh call itself couldn't reach the server — likely the same
+      // blip that produced the 401 in the first place (e.g. right after the
+      // device reconnects). Park instead of condemning the chapter outright.
+      return null;
+    }
   }
   if (result == gqlNetworkError) return null;
   if (result is Map<String, Object?>) {

--- a/lib/src/features/offline/data/background/background_chapter_fetch.dart
+++ b/lib/src/features/offline/data/background/background_chapter_fetch.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -20,6 +21,17 @@ import 'background_token_record.dart';
 /// close a connection per call, so a catch-up batch paid a fresh TLS handshake
 /// for every page it fetched. Lives as long as the isolate does.
 final http.Client backgroundHttpClient = http.Client();
+
+/// Bound on every call through this file. None of `package:http`'s calls time
+/// out on their own, and this executor holds the shared `.bg_lock` file for
+/// its whole run — a proxy/tunnel that accepts a connection but never replies
+/// would hang a request forever, which means the lock is NEVER released, which
+/// means the foreground-service worker can never acquire it either: it starts,
+/// fails to get the lock, stops, and whatever re-triggers it starts the same
+/// failed attempt again — the notification flashing on and off with nothing
+/// ever reaching a chapter, and nothing logged, because nothing here ever
+/// throws to report through.
+const _httpTimeout = Duration(seconds: 30);
 
 /// Server coordinates for the isolate-side fetch paths — the work-order fields
 /// the FGS uses, shared with the WorkManager catch-up executor.
@@ -88,11 +100,13 @@ Future<Object?> postBackgroundGraphql({
   final headers = <String, String>{'Content-Type': 'application/json'};
   applyBackgroundAuthHeaders(headers, record, accessToken: accessToken);
   try {
-    final res = await backgroundHttpClient.post(
-      Uri.parse(target.graphql),
-      headers: headers,
-      body: jsonEncode({'query': query, 'variables': variables}),
-    );
+    final res = await backgroundHttpClient
+        .post(
+          Uri.parse(target.graphql),
+          headers: headers,
+          body: jsonEncode({'query': query, 'variables': variables}),
+        )
+        .timeout(_httpTimeout);
     if (res.statusCode == 401 || res.statusCode == 403) return gqlAuthError;
     // A proxy answering for a dead origin is an outage, not a bad request —
     // the same rule the foreground worker and the app itself use.
@@ -101,6 +115,8 @@ Future<Object?> postBackgroundGraphql({
     final decoded = jsonDecode(res.body) as Map<String, Object?>;
     return decoded['data'];
   } on SocketException {
+    return gqlNetworkError;
+  } on TimeoutException {
     return gqlNetworkError;
   } catch (_) {
     return null;
@@ -177,17 +193,20 @@ ChapterDownloadEngine buildBackgroundEngine({
     }
     final http.Response res;
     try {
-      res = await backgroundHttpClient.get(
-        Uri.parse(fetchUrl),
-        headers: headers,
-      );
-    } on SocketException {
-      throw const PageOfflineException();
+      res = await backgroundHttpClient
+          .get(Uri.parse(fetchUrl), headers: headers)
+          .timeout(_httpTimeout);
+    } on SocketException catch (e) {
+      throw PageOfflineException('SocketException: $e');
+    } on TimeoutException {
+      throw PageOfflineException('timed out after $_httpTimeout on page fetch');
     }
     if (res.statusCode == 401 || res.statusCode == 403) {
       throw const PageAuthException();
     }
-    if (isGatewayStatus(res.statusCode)) throw const PageOfflineException();
+    if (isGatewayStatus(res.statusCode)) {
+      throw PageOfflineException('HTTP ${res.statusCode} on page fetch');
+    }
     if (res.statusCode != 200) {
       throw Exception('page fetch failed ($pageUrl): ${res.statusCode}');
     }

--- a/lib/src/features/offline/data/background/background_chapter_fetch.dart
+++ b/lib/src/features/offline/data/background/background_chapter_fetch.dart
@@ -124,7 +124,8 @@ Future<Object?> postBackgroundGraphql({
 }
 
 /// A chapter's page URLs: the list on success, empty on terminal failure, null
-/// when the server was unreachable. Retries once through the broker on 401.
+/// when the server was unreachable or a 401 could not be resolved. Retries
+/// once through the broker on 401.
 Future<List<String>?> resolveChapterPageUrls({
   required BackgroundServerTarget target,
   required BackgroundTokenRecord Function() record,
@@ -155,7 +156,16 @@ Future<List<String>?> resolveChapterPageUrls({
       return null;
     }
   }
-  if (result == gqlNetworkError) return null;
+  // An auth failure that survives the retry above (the refresh succeeded but
+  // the retried call 401'd again, or the refresh itself failed non-
+  // transiently) used to fall all the way through to the empty-list return
+  // below — indistinguishable from "the server answered, this chapter truly
+  // has no pages". The FGS worker treats an empty list as terminal and marks
+  // the chapter `error` on the spot (download_task_handler.dart), so a token
+  // that was merely stale right after a reconnect condemned the chapter
+  // outright instead of getting the park-and-retry treatment every other
+  // ambiguous failure in this file gets.
+  if (result == gqlNetworkError || result == gqlAuthError) return null;
   if (result is Map<String, Object?>) {
     final pages =
         (result['fetchChapterPages'] as Map<String, Object?>?)?['pages'];

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -451,6 +451,13 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// offline_reconciler.dart), so this counter no longer drives one.
   final Map<int, int> _chapterParkAttempts = {};
 
+  /// How many consecutive commit failures a chapter gets before it is given up
+  /// on and marked `error`. Prevents the phantom-download loop where a chapter
+  /// whose staging always fails to commit stays `downloading` in drift and is
+  /// re-enqueued by `_pendingChapters()` on every `afterDrained` restart.
+  static const _maxCommitFailures = 3;
+  final Map<int, int> _commitFailures = {};
+
   /// The worker gave up on an unreachable server and stopped with the queue
   /// intact — OR, just as often in practice, gave up resolving/downloading
   /// one specific chapter whose source is gone (a reverse proxy in front of
@@ -695,6 +702,36 @@ class BackgroundDownloadController with WidgetsBindingObserver {
           // transient blip, not its source being gone — don't let them count
           // toward giving up on it if it ever parks again later.
           _chapterParkAttempts.remove(chapterId);
+          _commitFailures.remove(chapterId);
+        } else {
+          // The worker reports the chapter downloaded, but the commit didn't
+          // publish it.
+          //
+          // `refused`: chapter was deleted or re-queued under a new generation
+          // while the download was in flight. Drift already reflects the new
+          // state (none / queued for the new gen) — do not touch it.
+          //
+          // `incomplete`/`noStaging`: staging was missing or empty after the
+          // download. The row is still `downloading` in drift, which means
+          // `_pendingChapters()` will return it on every `afterDrained` restart
+          // → infinite phantom-download loop. Fix: reset to `queued` so it
+          // re-downloads from scratch, or mark `error` after _maxCommitFailures
+          // consecutive failures so it leaves the queue entirely.
+          if (ch != null &&
+              ch.deviceState != OfflineDeviceState.none &&
+              result != ChapterCommitResult.refused) {
+            final attempts = (_commitFailures[chapterId] ?? 0) + 1;
+            _commitFailures[chapterId] = attempts;
+            if (attempts >= _maxCommitFailures) {
+              _commitFailures.remove(chapterId);
+              await _db.setChapterDeviceState(
+                  chapterId, OfflineDeviceState.error);
+              _sessionFailed++;
+            } else {
+              await _db.setChapterDeviceState(
+                  chapterId, OfflineDeviceState.queued, bytes: 0);
+            }
+          }
         }
       } else {
         await applyBackgroundTerminalState(

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -17,6 +17,7 @@ import '../../../../constants/db_keys.dart';
 import '../../../../constants/enum.dart';
 import '../../../../global_providers/global_providers.dart';
 import '../../../../l10n/generated/app_localizations.dart';
+import '../../../../utils/crash/diagnostics.dart';
 import '../../../../utils/extensions/custom_extensions.dart';
 import '../../../../utils/logger/logger.dart';
 import '../../../../utils/misc/toast/toast.dart';
@@ -412,13 +413,67 @@ class BackgroundDownloadController with WidgetsBindingObserver {
       case 'drained':
         unawaited(_onDrained());
       case 'parked':
-        _onParked();
+        _onParked(
+          chapterId: data['chapterId'] as int?,
+          mangaId: data['mangaId'] as int?,
+          reason: data['reason'] as String?,
+        );
+      case 'lockFailed':
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-fgs: '
+          'lock-acquire-failed — another party (likely the WorkManager '
+          'catch-up executor) still holds .bg_lock; this run stopped without '
+          'attempting any chapter\n',
+        );
+      case 'noWorkOrder':
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-fgs: '
+          'no-work-order starter=${data['starter']} — started with nothing '
+          'to do and self-stopped instantly; a run of these with '
+          'starter=system means Android itself is repeatedly restarting the '
+          'service, not this app\'s own retry logic\n',
+        );
     }
   }
 
+  /// Consecutive parks attributed to one specific chapter — diagnostics only,
+  /// never a give-up signal. A park always means the SERVER could not be
+  /// reached for this chapter (see `_downloadChapter`'s null-vs-empty
+  /// distinction in download_task_handler.dart, which already routes a
+  /// genuine "server answered, no pages" straight to `error` without ever
+  /// parking); attributing several in a row to the same chapter just reflects
+  /// that it's the head of the queue every backoff cycle, not that its own
+  /// source is broken. A previous version marked the chapter `error` after
+  /// three, which during a proxy/tunnel outage (backoff runs 15s to 5min)
+  /// condemned the queue's head within minutes of a blip that had nothing to
+  /// do with that chapter. A chapter whose source really is gone already has
+  /// its own persisted give-up path (serverFetchAttempts, see
+  /// offline_reconciler.dart), so this counter no longer drives one.
+  final Map<int, int> _chapterParkAttempts = {};
+
   /// The worker gave up on an unreachable server and stopped with the queue
-  /// intact.
-  void _onParked() {
+  /// intact — OR, just as often in practice, gave up resolving/downloading
+  /// one specific chapter whose source is gone (a reverse proxy in front of
+  /// the Suwayomi server answers a dead per-chapter source fetch with a
+  /// gateway-style status, which reads identically to "the whole server is
+  /// down" from here). [chapterId]/[mangaId] are null only for the rare path
+  /// that can't attribute the park to one chapter. [reason] is the short
+  /// technical detail behind THIS specific attempt (an exception or HTTP
+  /// status) — logged every time so a chapter that keeps parking can be
+  /// diagnosed, not just seen to be "offline" with no further explanation.
+  void _onParked({int? chapterId, int? mangaId, String? reason}) {
+    final ts = DateTime.now().toIso8601String();
+    if (chapterId != null) {
+      final attempts = (_chapterParkAttempts[chapterId] ?? 0) + 1;
+      _chapterParkAttempts[chapterId] = attempts;
+      recordDiagnostic(
+        '[$ts] offline-fgs: parked mangaId=$mangaId chapterId=$chapterId '
+        'attempt=$attempts reason="$reason"\n',
+      );
+    } else {
+      recordDiagnostic('[$ts] offline-fgs: parked (no chapter attributed)\n');
+    }
+
     if (_parkedUntil?.isAfter(DateTime.now()) ?? false) return;
     final delay = _nextBackoff();
     _armPark(delay);
@@ -599,7 +654,13 @@ class BackgroundDownloadController with WidgetsBindingObserver {
     // Ahead of the awaits below: this event races the worker's `parked` message,
     // and the stop handshake at the end of this method would otherwise restart
     // the service before the latch is set.
-    if (status == 'offline') _onParked();
+    if (status == 'offline') {
+      _onParked(
+        chapterId: chapterId,
+        mangaId: data['mangaId'] as int?,
+        reason: data['reason'] as String?,
+      );
+    }
     final epoch = _parkEpoch;
     // Outside the status guard: a cancel (pause, delete, Wi-Fi drop) reports a
     // null status, and leaving those entries behind grows the map for the life
@@ -630,6 +691,10 @@ class BackgroundDownloadController with WidgetsBindingObserver {
           // A chapter landed, so the server is demonstrably fine — unless a
           // later chapter parked while this one was committing.
           if (_parkEpoch == epoch) _clearPark();
+          // This chapter succeeded, so any earlier parks blamed on it were a
+          // transient blip, not its source being gone — don't let them count
+          // toward giving up on it if it ever parks again later.
+          _chapterParkAttempts.remove(chapterId);
         }
       } else {
         await applyBackgroundTerminalState(

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -951,7 +951,7 @@ class BackgroundDownloadController with WidgetsBindingObserver {
   /// record — for callers/tests coordinating a refresh from the main isolate.
   /// Only ui_login refreshes; network refresh is delegated to [refreshFn].
   TokenBroker mainSideBroker({
-    required Future<RefreshResult?> Function(String refreshToken) refreshFn,
+    required Future<RefreshAttempt> Function(String refreshToken) refreshFn,
   }) => TokenBroker(
     read: () async {
       final raw = await FlutterForegroundTask.getData<String>(

--- a/lib/src/features/offline/data/background/background_token_record.dart
+++ b/lib/src/features/offline/data/background/background_token_record.dart
@@ -56,6 +56,12 @@ class BackgroundTokenRecord {
       );
 }
 
+/// Outcome of one refresh attempt: the new tokens on success, or a failure
+/// that distinguishes "the refresh call itself couldn't reach the server"
+/// (transient — retry later, auth may still be fine) from "the server
+/// responded and rejected the refresh token" (auth is genuinely dead).
+typedef RefreshAttempt = ({RefreshResult? tokens, bool transient});
+
 /// Coordinates token refresh across the main and worker isolates against ONE
 /// gen-versioned record, so a rotating refresh token is never lost-updated by two
 /// holders. Pure logic: storage + the actual refresh network call are injected.
@@ -63,7 +69,15 @@ class TokenBroker {
   TokenBroker({required this.read, required this.write, required this.refreshFn});
   final Future<BackgroundTokenRecord> Function() read;
   final Future<void> Function(BackgroundTokenRecord) write;
-  final Future<RefreshResult?> Function(String refreshToken) refreshFn;
+  final Future<RefreshAttempt> Function(String refreshToken) refreshFn;
+
+  /// Set by the most recent failed [resolveAfter401] — only meaningful right
+  /// after it returns null. Without this, a caller treats a refresh that
+  /// merely couldn't reach the server (e.g. right after the device
+  /// reconnects, before the network has actually settled) the same as a
+  /// refresh token the server explicitly rejected, and gives up on the
+  /// chapter permanently instead of retrying once the network is real.
+  bool lastRefreshTransient = false;
 
   /// Returns a usable access token to retry with, or null if auth is dead.
   Future<String?> resolveAfter401(String tokenThat401d) async {
@@ -73,11 +87,18 @@ class TokenBroker {
       return current.accessToken;
     }
     final rt = current.refreshToken;
-    if (rt == null) return null;
-    final res = await refreshFn(rt);
-    if (res == null) return null;
+    if (rt == null) {
+      lastRefreshTransient = false;
+      return null;
+    }
+    final attempt = await refreshFn(rt);
+    final tokens = attempt.tokens;
+    if (tokens == null) {
+      lastRefreshTransient = attempt.transient;
+      return null;
+    }
     await write(current.copyWith(
-        gen: current.gen + 1, accessToken: res.access, refreshToken: res.refresh));
-    return res.access;
+        gen: current.gen + 1, accessToken: tokens.access, refreshToken: tokens.refresh));
+    return tokens.access;
   }
 }

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -142,6 +142,7 @@ Future<bool> runCatchupDownloads({
       ...ledger.pendingDownloads.values,
       ...ledger.pendingServerFetch.values,
     };
+    outer:
     for (final mangaId in mangaIds) {
       if (downloaded >= _maxChaptersPerRun) break;
       if (DateTime.now().isAfter(deadline)) break;
@@ -264,6 +265,20 @@ Future<bool> runCatchupDownloads({
         serverFetch.remove(chapterId);
         final dlSpent = dlRetries[chapterId] ?? 0;
         if (dlSpent >= _maxChapterAttempts) continue;
+
+        // Re-check connectivity before each chapter's page downloads — the
+        // one-time gate at run start can't catch a WiFi drop mid-run.
+        if (spec.wifiOnly) {
+          final net = await Connectivity().checkConnectivity();
+          if (!net.contains(ConnectivityResult.wifi) &&
+              !net.contains(ConnectivityResult.ethernet)) {
+            recordDiagnostic(
+              '[${DateTime.now().toIso8601String()}] offline-catchup: '
+              'run-paused reason=wifi-lost mid-run\n',
+            );
+            break outer;
+          }
+        }
 
         final attempt = await _downloadOneChapter(
           target: target,

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -61,12 +61,23 @@ Future<bool> runCatchupDownloads({
   }
 
   var ledger = catchupStore.readLedger(config.serverId);
+
+  // Compute backfill needs BEFORE the early-exit: an empty ledger is not
+  // necessarily empty work — manga in the spec that have never had a full
+  // chapter-list pass need one regardless of whether there are ledger
+  // obligations (the ledger starts empty on every fresh spec or server switch).
+  final needsBackfill = spec.keepRuleMangaIds.difference(
+    ledger.backfilledMangaIds,
+  );
   recordDiagnostic(
     '[${DateTime.now().toIso8601String()}] offline-catchup: run-started '
     'pendingDownloads=${ledger.pendingDownloads.length} '
-    'pendingServerFetch=${ledger.pendingServerFetch.length}\n',
+    'pendingServerFetch=${ledger.pendingServerFetch.length} '
+    'needsBackfill=${needsBackfill.length}\n',
   );
-  if (ledger.pendingDownloads.isEmpty && ledger.pendingServerFetch.isEmpty) {
+  if (ledger.pendingDownloads.isEmpty &&
+      ledger.pendingServerFetch.isEmpty &&
+      needsBackfill.isEmpty) {
     return true;
   }
 
@@ -125,16 +136,9 @@ Future<bool> runCatchupDownloads({
     // processed, which the filter below drops anyway. A retry loop or a second
     // pass would break that.
     final logEntries = await log.parse();
-    // A manga the feed-based cursor above has never had a reason to surface
-    // (its chapters all predate the watermark — typically a keep rule just
-    // turned on for it) gets a one-time full chapter-list visit here instead
-    // of waiting on the foreground launch pass, which is otherwise the only
-    // path that ever looks at a manga's whole list rather than the feed's
-    // delta. Listed first so a long-running pending backlog can't starve a
-    // manga that has never been looked at at all.
-    final needsBackfill = spec.keepRuleMangaIds.difference(
-      ledger.backfilledMangaIds,
-    );
+    // needsBackfill was computed before the early-exit check so it is already
+    // available here; the set is the same because backfilledMangaIds only grows
+    // during the run and we haven't touched the ledger yet at this point.
     if (needsBackfill.isNotEmpty) {
       recordDiagnostic(
         '[${DateTime.now().toIso8601String()}] offline-catchup: '

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../../../utils/crash/diagnostics.dart';
 import '../../../notifications/data/notification_state_store.dart';
 import '../chapter_manifest.dart';
 import '../offline_database.dart';
@@ -126,8 +127,41 @@ Future<bool> runCatchupDownloads({
       // Pinned chapters are always desired; the server rows can't know about
       // pins (device-side state), so the spec's set joins the rule's.
       final serverIds = {for (final r in chapters.rows) r.id};
+
+      final serverFetch = {...ledger.pendingServerFetch};
+      final retries = {...ledger.serverFetchRetries};
+      final dlRetries = {...ledger.downloadRetries};
+      final pending = {...ledger.pendingDownloads};
+
+      // A chapter that has spent its attempt budget on either hop is already a
+      // permanent dead end this run onward (both hops below `continue` once
+      // their own counter maxes out, and a counter only ever clears when the
+      // chapter leaves `desired` — which it never does on its own). Excluding
+      // it from the candidate pool here, rather than after, stops it wasting
+      // one of a `nUnread` rule's N slots forever: without this, the
+      // (N+1)th unread chapter never gets a turn, and "keep N downloaded"
+      // silently plateaus at N-1.
+      final exhausted = <int>{};
+      for (final r in chapters.rows) {
+        final serverFetchSpent = retries[r.id] ?? 0;
+        final downloadSpent = dlRetries[r.id] ?? 0;
+        if (serverFetchSpent < _maxChapterAttempts &&
+            downloadSpent < _maxChapterAttempts) {
+          continue;
+        }
+        exhausted.add(r.id);
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-catchup: '
+          'giving-up-on-chapter mangaId=$mangaId chapterId=${r.id} '
+          'name="${r.name}" index=${r.chapterIndex} '
+          'serverFetchAttempts=$serverFetchSpent/$_maxChapterAttempts '
+          'downloadAttempts=$downloadSpent/$_maxChapterAttempts '
+          'serverIsDownloaded=${r.serverIsDownloaded} '
+          '— excluded from this manga\'s keep-rule slots from now on\n',
+        );
+      }
       final desired = desiredChapterIds(
-        chapters.rows,
+        [for (final r in chapters.rows) if (!exhausted.contains(r.id)) r],
         mangaSpec.keepRule,
         mangaSpec.keepUnreadCount,
       )..addAll(mangaSpec.pinnedChapterIds.intersection(serverIds));
@@ -137,11 +171,6 @@ Future<bool> runCatchupDownloads({
         ...mangaSpec.onDeviceChapterIds,
         ...await _loggedOrCommitted(logEntries, store, mangaId, desired),
       };
-
-      final serverFetch = {...ledger.pendingServerFetch};
-      final retries = {...ledger.serverFetchRetries};
-      final dlRetries = {...ledger.downloadRetries};
-      final pending = {...ledger.pendingDownloads};
 
       for (final chapterId in desired.difference(present)) {
         if (downloaded >= _maxChaptersPerRun) break;
@@ -172,6 +201,17 @@ Future<bool> runCatchupDownloads({
           // Two-hop: ask the server to fetch it from the source first. A failed
           // ask is the server not being there, which costs nothing.
           final ok = await _enqueueServerDownload(target, record, chapterId);
+          // A trail of every attempt, not just the final give-up — so a run
+          // that never reaches the cap is still visible, and a failed
+          // enqueue request (server unreachable) is distinguishable from one
+          // that succeeded but the source never actually produced the
+          // chapter (serverIsDownloaded staying false on a later run).
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-catchup: '
+            'asking-server-to-fetch mangaId=$mangaId chapterId=$chapterId '
+            'name="${row.name}" index=${row.chapterIndex} '
+            'enqueueOk=$ok attempt=${spent + 1}/$_maxChapterAttempts\n',
+          );
           if (ok) {
             serverFetch[chapterId] = mangaId;
             retries[chapterId] = spent + 1;
@@ -213,10 +253,32 @@ Future<bool> runCatchupDownloads({
       // attempt counters go with them: they exist to stop a chapter being
       // retried while it is still wanted, so one left behind would meet a
       // re-added chapter with an already-spent budget.
+      //
+      // Scans BOTH maps, not just `pending`: a chapter can be exhausted (and
+      // now excluded from `desired` above) while it only ever reached
+      // `pendingServerFetch` — never promoted to `pendingDownloads`. Dropping
+      // it from `pending` alone left it in `serverFetch` forever, which kept
+      // its manga in the `mangaIds` set at the top of this run and re-issued
+      // a real chapter-list fetch for it on every wake indefinitely, even
+      // though nothing was ever going to download.
+      //
+      // `exhausted` is deliberately excluded from the "no longer desired"
+      // half of this condition: it is ALSO why those chapters are missing
+      // from `desired` (see above), and wiping their counters here would
+      // reset them to 0 next run — un-exhausting a chapter right back into
+      // fresh attempts and undoing the whole point of excluding it. A
+      // chapter drops out of `desired` for two different reasons and only
+      // one of them should forgive its spent budget.
       final done = {
         for (final e in pending.entries)
           if (e.value == mangaId &&
-              (!desired.contains(e.key) || present.contains(e.key)))
+              ((!desired.contains(e.key) && !exhausted.contains(e.key)) ||
+                  present.contains(e.key)))
+            e.key,
+        for (final e in serverFetch.entries)
+          if (e.value == mangaId &&
+              ((!desired.contains(e.key) && !exhausted.contains(e.key)) ||
+                  present.contains(e.key)))
             e.key,
       };
       for (final c in done) {
@@ -351,6 +413,7 @@ Future<_MangaChapters?> _fetchMangaChapters(
         syncedIsRead: n['isRead'] as bool? ?? false,
         updatedAt: now,
         downloadGeneration: 0,
+        serverFetchAttempts: 0,
       ),
   ]);
 }

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -249,7 +249,12 @@ Future<bool> runCatchupDownloads({
           }
           // Two-hop: ask the server to fetch it from the source first. A failed
           // ask is the server not being there, which costs nothing.
-          final ok = await _enqueueServerDownload(target, record, chapterId);
+          final ok = await _enqueueServerDownload(
+            target,
+            record,
+            broker,
+            chapterId,
+          );
           // A trail of every attempt, not just the final give-up — so a run
           // that never reaches the cap is still visible, and a failed
           // enqueue request (server unreachable) is distinguishable from one
@@ -501,11 +506,12 @@ Future<_MangaChapters?> _fetchMangaChapters(
 Future<bool> _enqueueServerDownload(
   BackgroundServerTarget target,
   BackgroundTokenRecord Function() record,
+  TokenBroker broker,
   int chapterId,
 ) async {
   const query =
       'mutation EnqueueDownloads(\$input: EnqueueChapterDownloadsInput!){ enqueueChapterDownloads(input: \$input){ __typename } }';
-  final result = await postBackgroundGraphql(
+  Future<Object?> post(String? accessToken) => postBackgroundGraphql(
     target: target,
     record: record(),
     query: query,
@@ -514,7 +520,21 @@ Future<bool> _enqueueServerDownload(
         'ids': [chapterId],
       },
     },
+    accessToken: accessToken,
   );
+  // Without this retry, a uiLogin access token that expired between wakes
+  // (the wake interval is 1-6h, far longer than a typical token lifetime)
+  // makes this call 401 and give up every single run — the server never
+  // actually gets asked to fetch the chapter from source in the background,
+  // no matter how many attempts the ledger counts. `_fetchMangaChapters`
+  // above already refreshed the token this run if it was stale, but that
+  // refresh only persists to the store (via the broker), not back into
+  // `record()` — so this call still needs its own retry, same as that one.
+  var result = await post(null);
+  if (result == gqlAuthError && record().authType == 'uiLogin') {
+    final newAccess = await broker.resolveAfter401(record().accessToken ?? '');
+    if (newAccess != null) result = await post(newAccess);
+  }
   return result is Map<String, Object?>;
 }
 

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -48,7 +48,11 @@ Future<bool> runCatchupDownloads({
   required TokenBroker broker,
 }) async {
   final spec = catchupStore.readSpec();
-  if (spec == null || spec.serverId != config.serverId) {
+  // spec.serverId is the offline catalog's server-instance id (what
+  // writeCatchupWorkSpec stamps it with) — NOT config.serverId, which is a
+  // "url|port" string scoping the unrelated notification cursor. Comparing
+  // against the wrong one meant this guard could never pass.
+  if (spec == null || spec.serverId != catchupStore.catalogServerId) {
     recordDiagnostic(
       '[${DateTime.now().toIso8601String()}] offline-catchup: '
       'run-skipped reason=no-spec\n',

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -48,9 +48,20 @@ Future<bool> runCatchupDownloads({
   required TokenBroker broker,
 }) async {
   final spec = catchupStore.readSpec();
-  if (spec == null || spec.serverId != config.serverId) return true;
+  if (spec == null || spec.serverId != config.serverId) {
+    recordDiagnostic(
+      '[${DateTime.now().toIso8601String()}] offline-catchup: '
+      'run-skipped reason=no-spec\n',
+    );
+    return true;
+  }
 
   var ledger = catchupStore.readLedger(config.serverId);
+  recordDiagnostic(
+    '[${DateTime.now().toIso8601String()}] offline-catchup: run-started '
+    'pendingDownloads=${ledger.pendingDownloads.length} '
+    'pendingServerFetch=${ledger.pendingServerFetch.length}\n',
+  );
   if (ledger.pendingDownloads.isEmpty && ledger.pendingServerFetch.isEmpty) {
     return true;
   }
@@ -62,7 +73,13 @@ Future<bool> runCatchupDownloads({
     final unmetered =
         net.contains(ConnectivityResult.wifi) ||
         net.contains(ConnectivityResult.ethernet);
-    if (!unmetered) return true; // not an error — just not now
+    if (!unmetered) {
+      recordDiagnostic(
+        '[${DateTime.now().toIso8601String()}] offline-catchup: '
+        'run-skipped reason=wifi-required\n',
+      );
+      return true; // not an error — just not now
+    }
   }
 
   final support = await getApplicationSupportDirectory();
@@ -75,7 +92,13 @@ Future<bool> runCatchupDownloads({
 
   // The FGS may legitimately own the log right now; skip the run rather than
   // interleave writers.
-  if (!await lock.acquire('wm-catchup')) return true;
+  if (!await lock.acquire('wm-catchup')) {
+    recordDiagnostic(
+      '[${DateTime.now().toIso8601String()}] offline-catchup: '
+      'lock-held-skip\n',
+    );
+    return true;
+  }
   try {
     final target = BackgroundServerTarget(
       serverBase: config.endpoint.baseUrl,
@@ -98,7 +121,24 @@ Future<bool> runCatchupDownloads({
     // processed, which the filter below drops anyway. A retry loop or a second
     // pass would break that.
     final logEntries = await log.parse();
+    // A manga the feed-based cursor above has never had a reason to surface
+    // (its chapters all predate the watermark — typically a keep rule just
+    // turned on for it) gets a one-time full chapter-list visit here instead
+    // of waiting on the foreground launch pass, which is otherwise the only
+    // path that ever looks at a manga's whole list rather than the feed's
+    // delta. Listed first so a long-running pending backlog can't starve a
+    // manga that has never been looked at at all.
+    final needsBackfill = spec.keepRuleMangaIds.difference(
+      ledger.backfilledMangaIds,
+    );
+    if (needsBackfill.isNotEmpty) {
+      recordDiagnostic(
+        '[${DateTime.now().toIso8601String()}] offline-catchup: '
+        'backfilling-manga ids=${needsBackfill.join(',')}\n',
+      );
+    }
     final mangaIds = {
+      ...needsBackfill,
       ...ledger.pendingDownloads.values,
       ...ledger.pendingServerFetch.values,
     };
@@ -243,6 +283,11 @@ Future<bool> runCatchupDownloads({
           serverFetch.remove(chapterId);
           retries.remove(chapterId);
           dlRetries.remove(chapterId);
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-catchup: '
+            'downloaded-chapter mangaId=$mangaId chapterId=$chapterId '
+            'bytes=${attempt.bytes}\n',
+          );
         } else if (!attempt.transient) {
           dlRetries[chapterId] = dlSpent + 1;
         }
@@ -293,9 +338,18 @@ Future<bool> runCatchupDownloads({
         pendingServerFetch: serverFetch,
         serverFetchRetries: retries,
         downloadRetries: dlRetries,
+        // The chapter-list fetch above already ran, whether or not this
+        // manga was one that needed it — recording it here (not just inside
+        // the needsBackfill branch) keeps the set accurate for every manga
+        // this run actually looked at.
+        backfilledMangaIds: {...ledger.backfilledMangaIds, mangaId},
       );
       await catchupStore.writeLedger(config.serverId, ledger);
     }
+    recordDiagnostic(
+      '[${DateTime.now().toIso8601String()}] offline-catchup: '
+      'run-finished downloaded=$downloaded bytes=$runBytes\n',
+    );
     return true;
   } finally {
     await lock.release();
@@ -320,6 +374,9 @@ CatchupLedger _dropManga(CatchupLedger ledger, int mangaId) {
     // them would meet the manga with a spent budget if it came back.
     serverFetchRetries: without(ledger.serverFetchRetries),
     downloadRetries: without(ledger.downloadRetries),
+    // Same reasoning: a manga that comes back under the rule again is a fresh
+    // backlog as far as this executor knows, not one it already visited.
+    backfilledMangaIds: {...ledger.backfilledMangaIds}..remove(mangaId),
   );
 }
 

--- a/lib/src/features/offline/data/background/catchup_settings.dart
+++ b/lib/src/features/offline/data/background/catchup_settings.dart
@@ -33,3 +33,24 @@ class BackgroundCatchupEnabled extends Notifier<bool> {
     if (value) await writeCatchupWorkSpec(ref.read);
   }
 }
+
+/// Sub-option of [backgroundCatchupEnabledProvider]: whether the background
+/// run also fetches chapter files, or only detects/queues them and leaves the
+/// actual download for the next time the app is opened. Doesn't change the
+/// WorkManager schedule itself — the same job keeps running for detection —
+/// so no sync()/reschedule is needed here, unlike the parent toggle.
+final backgroundCatchupDownloadEnabledProvider =
+    NotifierProvider<BackgroundCatchupDownloadEnabled, bool>(
+        BackgroundCatchupDownloadEnabled.new);
+
+class BackgroundCatchupDownloadEnabled extends Notifier<bool> {
+  @override
+  bool build() =>
+      CatchupStateStore(ref.read(sharedPreferencesProvider)).downloadEnabled;
+
+  Future<void> setEnabled(bool value) async {
+    await CatchupStateStore(ref.read(sharedPreferencesProvider))
+        .setDownloadEnabled(value);
+    state = value;
+  }
+}

--- a/lib/src/features/offline/data/background/catchup_spec_writer.dart
+++ b/lib/src/features/offline/data/background/catchup_spec_writer.dart
@@ -26,7 +26,11 @@ typedef CatchupRead = T Function<T>(ProviderListenable<T> provider);
 /// pause — the worker reads the newest snapshot it can get, never drift.
 Future<void> writeCatchupWorkSpec(CatchupRead read) async {
   try {
-    if (!read(offlineActiveProvider)) return;
+    // offlineActiveProvider depends on serverInstanceIdProvider (.value), an
+    // async FutureProvider that may be null at pause/hide time (the provider
+    // is auto-dispose and restarts asynchronously). Guard only on the sync
+    // flag; the serverId null-check below already rejects a no-catalog state.
+    if (!read(offlineEnabledProvider)) return;
     final serverId = read(
       sharedPreferencesProvider,
     ).getString(DBKeys.offlineCatalogServerId.name);

--- a/lib/src/features/offline/data/background/catchup_work_spec.dart
+++ b/lib/src/features/offline/data/background/catchup_work_spec.dart
@@ -218,6 +218,7 @@ class CatchupStateStore {
   static const _specKey = 'catchup_work_spec';
   static const _ledgerKey = 'catchup_ledger';
   static const _enabledKey = 'catchup_bg_enabled';
+  static const _downloadEnabledKey = 'catchup_bg_download_enabled';
 
   /// The worker isolate and the app share these keys through separate
   /// SharedPreferences caches; open() reloads so a run never plans from — or
@@ -233,6 +234,13 @@ class CatchupStateStore {
   // auto-download off — a deliberate deviation, flagged in the design doc.)
   bool get enabled => _prefs.getBool(_enabledKey) ?? true;
   Future<void> setEnabled(bool v) => _prefs.setBool(_enabledKey, v);
+
+  /// Whether the background run also fetches chapter files, or only detects
+  /// and queues them (leaving the actual download for the next foreground
+  /// session). Default ON — matches the behavior before this toggle existed.
+  bool get downloadEnabled => _prefs.getBool(_downloadEnabledKey) ?? true;
+  Future<void> setDownloadEnabled(bool v) =>
+      _prefs.setBool(_downloadEnabledKey, v);
 
   /// The offline catalog's own server-instance id — what [writeSpec]'s
   /// [CatchupWorkSpec.serverId] is actually stamped with. NOT the same value

--- a/lib/src/features/offline/data/background/catchup_work_spec.dart
+++ b/lib/src/features/offline/data/background/catchup_work_spec.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../../constants/db_keys.dart';
 import '../../../notifications/domain/new_chapter_detection.dart';
 import '../offline_types.dart';
 
@@ -232,6 +233,14 @@ class CatchupStateStore {
   // auto-download off — a deliberate deviation, flagged in the design doc.)
   bool get enabled => _prefs.getBool(_enabledKey) ?? true;
   Future<void> setEnabled(bool v) => _prefs.setBool(_enabledKey, v);
+
+  /// The offline catalog's own server-instance id — what [writeSpec]'s
+  /// [CatchupWorkSpec.serverId] is actually stamped with. NOT the same value
+  /// as [NotificationWorkerConfig.serverId] (a "url|port" string scoping the
+  /// unrelated notification cursor) — the executor must not cross-check the
+  /// spec against that instead, or the spec looks perpetually stale.
+  String? get catalogServerId =>
+      _prefs.getString(DBKeys.offlineCatalogServerId.name);
 
   Future<void> writeSpec(CatchupWorkSpec spec) =>
       _prefs.setString(_specKey, jsonEncode(spec.toJson()));

--- a/lib/src/features/offline/data/background/catchup_work_spec.dart
+++ b/lib/src/features/offline/data/background/catchup_work_spec.dart
@@ -126,6 +126,7 @@ class CatchupLedger {
     this.pendingServerFetch = const {},
     this.serverFetchRetries = const {},
     this.downloadRetries = const {},
+    this.backfilledMangaIds = const {},
   });
 
   final NewChapterWatermark cursor;
@@ -147,18 +148,31 @@ class CatchupLedger {
   /// could exhaust the chapter before the device ever tried.
   final Map<int, int> downloadRetries;
 
+  /// Manga the executor has already given one full chapter-list pass since it
+  /// entered the spec. The feed-based cursor above only ever surfaces chapters
+  /// that are NEW since it was seeded — a manga's pre-existing backlog (e.g. a
+  /// keep rule just turned on for it) never appears there and would otherwise
+  /// sit untouched until the next foreground launch pass, which is the one
+  /// path that fetches a manga's full list rather than diffing the feed. Once
+  /// a manga is in this set its remaining gaps live in [pendingDownloads] /
+  /// [pendingServerFetch] like any other obligation, so it only needs the one
+  /// pass.
+  final Set<int> backfilledMangaIds;
+
   CatchupLedger copyWith({
     NewChapterWatermark? cursor,
     Map<int, int>? pendingDownloads,
     Map<int, int>? pendingServerFetch,
     Map<int, int>? serverFetchRetries,
     Map<int, int>? downloadRetries,
+    Set<int>? backfilledMangaIds,
   }) => CatchupLedger(
     cursor: cursor ?? this.cursor,
     pendingDownloads: pendingDownloads ?? this.pendingDownloads,
     pendingServerFetch: pendingServerFetch ?? this.pendingServerFetch,
     serverFetchRetries: serverFetchRetries ?? this.serverFetchRetries,
     downloadRetries: downloadRetries ?? this.downloadRetries,
+    backfilledMangaIds: backfilledMangaIds ?? this.backfilledMangaIds,
   );
 
   Map<String, Object?> toJson() => {
@@ -167,6 +181,7 @@ class CatchupLedger {
     'pendingServerFetch': _mapToJson(pendingServerFetch),
     'serverFetchRetries': _mapToJson(serverFetchRetries),
     'downloadRetries': _mapToJson(downloadRetries),
+    'backfilledMangaIds': backfilledMangaIds.toList(),
   };
 
   factory CatchupLedger.fromJson(Map<String, Object?> j) => CatchupLedger(
@@ -177,6 +192,10 @@ class CatchupLedger {
     pendingServerFetch: _mapFromJson(j['pendingServerFetch']),
     serverFetchRetries: _mapFromJson(j['serverFetchRetries']),
     downloadRetries: _mapFromJson(j['downloadRetries']),
+    backfilledMangaIds: {
+      for (final id in (j['backfilledMangaIds'] as List? ?? const []))
+        (id as num).toInt(),
+    },
   );
 
   static Map<String, Object?> _mapToJson(Map<int, int> m) => {

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -29,6 +30,16 @@ import 'background_work_order.dart';
 void backgroundDownloadCallback() {
   FlutterForegroundTask.setTaskHandler(DownloadTaskHandler());
 }
+
+/// Bound on every HTTP call this isolate makes. None of `package:http`'s
+/// calls time out on their own — a proxy/tunnel in front of the server that
+/// accepts a connection but never replies would otherwise hang the request
+/// forever: no exception, no gateway status, nothing to catch — the drain
+/// loop just sits on one `await` permanently, which reads on-screen as a
+/// notification and progress spinner frozen at whatever count they were at
+/// when it happened, with nothing at all reaching the crash log to explain
+/// why (every error-handling path here is downstream of something throwing).
+const _httpTimeout = Duration(seconds: 30);
 
 /// Storage key under which the main isolate stashes the JSON-encoded
 /// [BackgroundWorkOrder] for the worker to pick up in [DownloadTaskHandler.onStart].
@@ -109,6 +120,19 @@ class DownloadTaskHandler extends TaskHandler {
     final raw = await FlutterForegroundTask.getData<String>(key: kWorkOrderKey);
     if (raw == null) {
       // Nothing to do — self-stop so we don't sit as a zombie notification.
+      // Nothing else reports this: if Android itself restarts this service
+      // (TaskStarter.system — after killing it for resources, a common OS
+      // behavior for a foreground service under memory/battery pressure) and
+      // the work order was already wiped by the previous run's own stop
+      // handshake, this fires immediately on every restart with nothing to
+      // do — a start/instant-stop cycle entirely outside ensureServiceRunning,
+      // driven by the OS's own restart policy rather than anything in this
+      // app's own retry/backoff logic, which would explain a notification
+      // flashing far faster than any network timeout could produce.
+      FlutterForegroundTask.sendDataToMain({
+        'kind': 'noWorkOrder',
+        'starter': starter.name,
+      });
       await FlutterForegroundTask.stopService();
       return;
     }
@@ -141,6 +165,13 @@ class DownloadTaskHandler extends TaskHandler {
     }
     if (!acquired) {
       // Still contended — leave the queue in drift; the next start retries.
+      // Nothing else reports this: without it, a lock held by a wedged other
+      // party (e.g. the WorkManager catch-up executor stuck on a hung request)
+      // makes this service start, spend ~30s failing to acquire, and stop —
+      // over and over, every time something re-triggers a start — showing as
+      // the notification repeatedly appearing and disappearing with no
+      // download ever actually attempted and nothing explaining why.
+      FlutterForegroundTask.sendDataToMain({'kind': 'lockFailed'});
       await FlutterForegroundTask.stopService();
       return;
     }
@@ -259,7 +290,18 @@ class DownloadTaskHandler extends TaskHandler {
       // straight back into the same dead server. (A park that happens mid-
       // download says so through its `offline` chapterDone instead — sending
       // both would let a stale one park a session that had already recovered.)
-      FlutterForegroundTask.sendDataToMain({'kind': 'parked'});
+      //
+      // chapterId/mangaId ride along so the main isolate can tell "this one
+      // specific chapter keeps parking" (its own source is gone/broken) apart
+      // from "the server is actually down" (parks would spread across whatever
+      // chapter happens to be first each restart) — without this, the main
+      // isolate had no way to attribute a park to a chapter at all.
+      FlutterForegroundTask.sendDataToMain({
+        'kind': 'parked',
+        'chapterId': chapterId,
+        'mangaId': mangaId,
+        'reason': _lastNetworkErrorReason,
+      });
       return true;
     }
     if (urls.isEmpty) {
@@ -342,7 +384,7 @@ class DownloadTaskHandler extends TaskHandler {
       );
       _done++;
     }
-    _afterChapter(chapterId, status);
+    _afterChapter(chapterId, status, offlineReason: outcome.offlineReason);
     // Network died mid-download: the chapter is recorded `offline` (resumable),
     // so park rather than churn every remaining chapter through the same drop.
     return status == 'offline';
@@ -375,12 +417,14 @@ class DownloadTaskHandler extends TaskHandler {
   }
 
   /// Notification + main-isolate notification after each chapter settles.
-  void _afterChapter(int chapterId, String? status) {
+  void _afterChapter(int chapterId, String? status, {String? offlineReason}) {
     FlutterForegroundTask.sendDataToMain({
       'kind': 'chapterDone',
       'chapterId': chapterId,
+      'mangaId': _mangaOf[chapterId],
       'gen': _genOf[chapterId] ?? 0,
       'status': status,
+      'reason': offlineReason,
     });
     // The icon rides every update — the plugin persists the latest content
     // wholesale, so omitting it here could reset the icon to the fallback.
@@ -424,6 +468,11 @@ class DownloadTaskHandler extends TaskHandler {
   /// chapter instead of erroring and poisoning the queue.
   static const Object _gqlNetworkError = Object();
 
+  /// Short technical detail behind the most recent [_gqlNetworkError] — set
+  /// right before returning it, read back by [_resolvePageUrls] so the
+  /// 'parked' event can say WHY, not just that it happened.
+  String? _lastNetworkErrorReason;
+
   /// Returns the page-URL list on success, [_gqlAuthError] on 401/403, or an
   /// empty list on any other failure.
   Future<Object> _postChapterPages(int chapterId, String? accessToken) async {
@@ -444,16 +493,17 @@ class DownloadTaskHandler extends TaskHandler {
       },
     });
     try {
-      final res = await _http.post(
-        Uri.parse(endpoint),
-        headers: headers,
-        body: body,
-      );
+      final res = await _http
+          .post(Uri.parse(endpoint), headers: headers, body: body)
+          .timeout(_httpTimeout);
       if (res.statusCode == 401 || res.statusCode == 403) return _gqlAuthError;
       // A proxy answering for a dead origin is the server being unreachable,
       // not the chapter being broken. Without this the queue marches through a
       // brief outage condemning every chapter in it.
-      if (isGatewayStatus(res.statusCode)) return _gqlNetworkError;
+      if (isGatewayStatus(res.statusCode)) {
+        _lastNetworkErrorReason = 'HTTP ${res.statusCode} on page-list fetch';
+        return _gqlNetworkError;
+      }
       if (res.statusCode != 200) return const <String>[];
       final decoded = jsonDecode(res.body) as Map<String, Object?>;
       final data = decoded['data'] as Map<String, Object?>?;
@@ -461,7 +511,11 @@ class DownloadTaskHandler extends TaskHandler {
       final pages = fetch?['pages'];
       if (pages is List) return pages.cast<String>();
       return const <String>[];
-    } on SocketException {
+    } on SocketException catch (e) {
+      _lastNetworkErrorReason = 'SocketException: $e';
+      return _gqlNetworkError; // transient — park, don't error
+    } on TimeoutException {
+      _lastNetworkErrorReason = 'timed out after $_httpTimeout on page-list fetch';
       return _gqlNetworkError; // transient — park, don't error
     } catch (_) {
       return const <String>[];
@@ -496,17 +550,23 @@ class DownloadTaskHandler extends TaskHandler {
       final (url, headers) = _authedPageRequest(pageUrl);
       final http.Response res;
       try {
-        res = await _http.get(Uri.parse(url), headers: headers);
-      } on SocketException {
+        res = await _http
+            .get(Uri.parse(url), headers: headers)
+            .timeout(_httpTimeout);
+      } on SocketException catch (e) {
         // Device offline (connection refused / unreachable host / DNS).
-        throw const PageOfflineException();
+        throw PageOfflineException('SocketException: $e');
+      } on TimeoutException {
+        throw PageOfflineException('timed out after $_httpTimeout on page fetch');
       }
       if (res.statusCode == 401 || res.statusCode == 403) {
         throw const PageAuthException();
       }
       // Same as the page-list POST: a gateway speaking for a dead origin leaves
       // the chapter resumable rather than failing it.
-      if (isGatewayStatus(res.statusCode)) throw const PageOfflineException();
+      if (isGatewayStatus(res.statusCode)) {
+        throw PageOfflineException('HTTP ${res.statusCode} on page fetch');
+      }
       if (res.statusCode != 200) {
         throw Exception('page fetch failed ($pageUrl): ${res.statusCode}');
       }
@@ -596,11 +656,13 @@ class DownloadTaskHandler extends TaskHandler {
         },
       });
       try {
-        final res = await _http.post(
-          Uri.parse(endpoint),
-          headers: const {'Content-Type': 'application/json'},
-          body: body,
-        );
+        final res = await _http
+            .post(
+              Uri.parse(endpoint),
+              headers: const {'Content-Type': 'application/json'},
+              body: body,
+            )
+            .timeout(_httpTimeout);
         if (res.statusCode != 200) return null;
         final decoded = jsonDecode(res.body) as Map<String, Object?>;
         final data = decoded['data'] as Map<String, Object?>?;

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -192,16 +192,22 @@ class DownloadTaskHandler extends TaskHandler {
         final id = data['chapterId'] as int;
         if (id == _inFlight) break; // already downloading — don't double-queue
         // A re-add after a delete carries a bumped generation; adopt it so this
-        // download's events outrank the deleted generation's stale ones.
+        // download's events outrank the deleted generation's stale ones. It
+        // also supersedes any earlier cancellation of this same id: a chapter
+        // that fell out of a keep-rule window (evicted → 'remove' → added to
+        // _cancelled) and then falls back in (window shifts again within the
+        // same FGS session, e.g. a read/unread toggle) is wanted again, not
+        // still cancelled — without this, the id stayed in _cancelled for the
+        // rest of the session and every future 'add' for it silently no-opped,
+        // since both branches below also required it absent from _cancelled.
+        _cancelled.remove(id);
         _genOf[id] = data['gen'] as int? ?? 0;
-        if (!_queue.contains(id) &&
-            !_cancelled.contains(id) &&
-            !_mangaOf.containsKey(id)) {
+        if (!_queue.contains(id) && !_mangaOf.containsKey(id)) {
           _queue.add(id);
           _mangaOf[id] = data['mangaId'] as int;
           _total++;
           _sawNewWork = true;
-        } else if (!_queue.contains(id) && !_cancelled.contains(id)) {
+        } else if (!_queue.contains(id)) {
           // Known manga mapping but not currently queued (e.g. re-add of a
           // chapter whose row we still remember): requeue it.
           _queue.add(id);

--- a/lib/src/features/offline/data/background/download_task_handler.dart
+++ b/lib/src/features/offline/data/background/download_task_handler.dart
@@ -452,6 +452,13 @@ class DownloadTaskHandler extends TaskHandler {
       );
       if (newAccess != null) {
         result = await _postChapterPages(chapterId, newAccess);
+      } else if (_broker.lastRefreshTransient) {
+        // The refresh call itself couldn't reach the server — likely the
+        // same blip that produced the 401 in the first place (e.g. right
+        // after the device reconnects, before the network has actually
+        // settled). Park instead of condemning the chapter outright.
+        _lastNetworkErrorReason = 'token refresh unreachable after 401';
+        return null;
       }
     }
     if (result is List<String>) return result;
@@ -640,7 +647,9 @@ class DownloadTaskHandler extends TaskHandler {
     },
     refreshFn: (refreshToken) async {
       // Only ui_login refreshes; basic/simple return null.
-      if (_record.authType != 'uiLogin') return null;
+      if (_record.authType != 'uiLogin') {
+        return (tokens: null, transient: false);
+      }
       final order = _order!;
       final endpoint = Endpoints.baseApi(
         baseUrl: order.serverBase,
@@ -663,17 +672,31 @@ class DownloadTaskHandler extends TaskHandler {
               body: body,
             )
             .timeout(_httpTimeout);
-        if (res.statusCode != 200) return null;
+        // A proxy answering for a dead origin is the server being unreachable,
+        // not the refresh token being invalid — same rule as the page-list
+        // fetch. Without this, the very first request after reconnecting
+        // (which races the network actually settling) permanently condemns
+        // every chapter that happened to 401 in that window.
+        if (isGatewayStatus(res.statusCode)) {
+          return (tokens: null, transient: true);
+        }
+        if (res.statusCode != 200) return (tokens: null, transient: false);
         final decoded = jsonDecode(res.body) as Map<String, Object?>;
         final data = decoded['data'] as Map<String, Object?>?;
         final refreshed = data?['refreshToken'] as Map<String, Object?>?;
         final access = refreshed?['accessToken'] as String?;
-        if (access == null || access.isEmpty) return null;
+        if (access == null || access.isEmpty) {
+          return (tokens: null, transient: false);
+        }
         // Suwayomi's refresh doesn't rotate the refresh token, so reuse the
         // input one (the broker persists it back as the current refresh).
-        return (access: access, refresh: refreshToken);
+        return (tokens: (access: access, refresh: refreshToken), transient: false);
+      } on SocketException {
+        return (tokens: null, transient: true);
+      } on TimeoutException {
+        return (tokens: null, transient: true);
       } catch (_) {
-        return null;
+        return (tokens: null, transient: false);
       }
     },
   );

--- a/lib/src/features/offline/data/chapter_download_engine.dart
+++ b/lib/src/features/offline/data/chapter_download_engine.dart
@@ -18,8 +18,15 @@ class PageAuthException implements Exception {
 /// Thrown by a [PageFetcher] when the device is offline, or Wi-Fi-only is on and
 /// the active connection is metered. Signals the engine to stop this chapter and
 /// report it as paused-offline (leave it resumable), NOT as an error.
+///
+/// [reason] is a short technical description (e.g. the caught exception, or
+/// the HTTP status that looked like a gateway/proxy failure) — carried through
+/// to [ChapterDownloadOutcome.offlineReason] so a chapter that keeps parking
+/// can be diagnosed from the crash log instead of just seeing "offline" with
+/// no further detail.
 class PageOfflineException implements Exception {
-  const PageOfflineException();
+  const PageOfflineException(this.reason);
+  final String reason;
 }
 
 /// One page to download: its server URL and its index within the chapter.
@@ -46,6 +53,7 @@ class ChapterDownloadOutcome {
     required this.cancelled,
     required this.authFailed,
     required this.offline,
+    this.offlineReason,
     this.error,
   });
 
@@ -62,6 +70,11 @@ class ChapterDownloadOutcome {
   /// True if the run stopped because the device went offline / Wi-Fi-only
   /// blocked it. The chapter is left resumable (NOT an error).
   final bool offline;
+
+  /// Short technical detail behind [offline] (the caught exception or gateway
+  /// status), for diagnosing a chapter that keeps parking without ever
+  /// actually being a real device-offline condition.
+  final String? offlineReason;
 
   /// The first non-auth error that ended the run, if any.
   final Object? error;
@@ -120,6 +133,7 @@ class ChapterDownloadEngine {
     var cursor = 0;
     var authFailed = false;
     var offline = false;
+    String? offlineReason;
     Object? fatalError;
 
     Future<void> worker() async {
@@ -138,8 +152,9 @@ class ChapterDownloadEngine {
             }
           case _PageAuthDead():
             authFailed = true;
-          case _PageOffline():
+          case _PageOffline(:final reason):
             offline = true;
+            offlineReason = reason;
           case _PageCancelled():
             return; // cancel landed mid-fetch; the loop's guard also stops us
           case _PageError(:final error):
@@ -157,6 +172,7 @@ class ChapterDownloadEngine {
       cancelled: isCancelled(),
       authFailed: authFailed,
       offline: offline,
+      offlineReason: offlineReason,
       error: fatalError,
     );
   }
@@ -179,10 +195,10 @@ class ChapterDownloadEngine {
           bytes.ext,
         );
         return _PageOk(relPath: written.relPath, bytes: written.bytes);
-      } on PageOfflineException {
+      } on PageOfflineException catch (e) {
         // Device went offline / Wi-Fi-only blocked it — stop this chapter and
         // leave it resumable. No retry (retrying offline just burns backoff).
-        return const _PageOffline();
+        return _PageOffline(e.reason);
       } on PageAuthException {
         // Refresh once; concurrent 401s collapse via the refresher's
         // single-flight. If auth is dead, stop trying.
@@ -227,5 +243,6 @@ class _PageCancelled extends _PageResult {
 }
 
 class _PageOffline extends _PageResult {
-  const _PageOffline();
+  const _PageOffline(this.reason);
+  final String reason;
 }

--- a/lib/src/features/offline/data/offline_database.dart
+++ b/lib/src/features/offline/data/offline_database.dart
@@ -155,6 +155,18 @@ class OfflineChapters extends Table {
   IntColumn get downloadGeneration =>
       integer().withDefault(const Constant(0))();
 
+  /// How many times the foreground reconciler has asked the server to fetch
+  /// this chapter from its source without serverIsDownloaded ever flipping
+  /// true. Persisted (not in-memory) so a chapter whose source is gone for
+  /// good doesn't get a fresh budget every app restart — without that, a
+  /// user testing across several sessions would see it retried forever, one
+  /// or two attempts at a time, never actually reaching the cap that marks
+  /// it `error` and stops the request. Reset to 0 once serverIsDownloaded
+  /// flips true (a synced-down chapter that succeeded has nothing left to
+  /// give up on).
+  IntColumn get serverFetchAttempts =>
+      integer().withDefault(const Constant(0))();
+
   @override
   Set<Column> get primaryKey => {id};
 }
@@ -204,7 +216,7 @@ class OfflineDatabase extends _$OfflineDatabase {
   OfflineDatabase(super.e);
 
   @override
-  int get schemaVersion => 15;
+  int get schemaVersion => 16;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -401,6 +413,13 @@ class OfflineDatabase extends _$OfflineDatabase {
       }
       if (from < 15 && !await _hasIndex('idx_offline_chapter_device_state')) {
         await m.createIndex(idxOfflineChapterDeviceState);
+      }
+      if (from < 16) {
+        await _addColumnIfMissing(
+          m,
+          offlineChapters,
+          offlineChapters.serverFetchAttempts,
+        );
       }
     },
   );
@@ -727,6 +746,26 @@ class OfflineDatabase extends _$OfflineDatabase {
           : Value(downloadedAt),
     ),
   );
+
+  /// Bumps [OfflineChapters.serverFetchAttempts] by one — called each time the
+  /// reconciler actually asks the server to fetch a chapter it has never
+  /// managed to download, so the count survives an app restart instead of
+  /// resetting to a fresh budget every session.
+  Future<void> incrementServerFetchAttempts(int chapterId) => customUpdate(
+    'UPDATE offline_chapters SET server_fetch_attempts = server_fetch_attempts + 1 '
+    'WHERE id = ?',
+    variables: [Variable<int>(chapterId)],
+    updates: {offlineChapters},
+  );
+
+  /// Clears [OfflineChapters.serverFetchAttempts] — called once a chapter's
+  /// server fetch actually succeeds, so a later unrelated failure starts its
+  /// budget fresh rather than inheriting attempts spent on a since-resolved
+  /// problem.
+  Future<void> resetServerFetchAttempts(int chapterId) =>
+      (update(offlineChapters)..where((t) => t.id.equals(chapterId))).write(
+        const OfflineChaptersCompanion(serverFetchAttempts: Value(0)),
+      );
 
   /// Atomically record a chapter whose page files were transferred from a
   /// migration source: rewrite the target's page rows and mark it downloaded in

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
@@ -1116,14 +1117,17 @@ Future<PageBytes> fetchOfflinePageBytes(Ref ref, String pageUrl) async {
   try {
     res = await ref
         .read(offlinePageClientProvider)
-        .get(Uri.parse(fetchUrl), headers: headers);
-  } on SocketException {
+        .get(Uri.parse(fetchUrl), headers: headers)
+        .timeout(const Duration(seconds: 30));
+  } on SocketException catch (e) {
     // Dead network is not a page failure: park resumable (Android worker
     // parity) instead of burning retries into a terminal error that poisons
     // the rest of the queue chapter by chapter.
-    throw const PageOfflineException();
-  } on http.ClientException {
-    throw const PageOfflineException();
+    throw PageOfflineException('SocketException: $e');
+  } on http.ClientException catch (e) {
+    throw PageOfflineException('ClientException: $e');
+  } on TimeoutException {
+    throw const PageOfflineException('timed out after 30s on page fetch');
   }
   if (res.statusCode == 401 || res.statusCode == 403) {
     throw const PageAuthException();

--- a/lib/src/features/offline/data/offline_page_store_io.dart
+++ b/lib/src/features/offline/data/offline_page_store_io.dart
@@ -83,28 +83,37 @@ class IoOfflinePageStore implements OfflinePageStore {
     final dir = _staging(mangaId, chapterId);
     if (!await dir.exists()) return const {};
     final byIndex = <int, File>{};
-    await for (final entity in dir.list()) {
-      if (entity is! File) continue;
-      final name = p.basename(entity.path);
-      if (name == kChapterManifestName) continue;
-      if (name.endsWith(_pageTempSuffix)) {
-        await _quietDelete(entity);
-        continue;
+    try {
+      await for (final entity in dir.list()) {
+        if (entity is! File) continue;
+        final name = p.basename(entity.path);
+        if (name == kChapterManifestName) continue;
+        if (name.endsWith(_pageTempSuffix)) {
+          await _quietDelete(entity);
+          continue;
+        }
+        final dot = name.indexOf('.');
+        if (dot <= 0) continue;
+        final index = int.tryParse(name.substring(0, dot));
+        if (index == null) continue;
+        final existing = byIndex[index];
+        if (existing == null) {
+          byIndex[index] = entity;
+          continue;
+        }
+        final keepNew = (await entity.stat()).modified.isAfter(
+          (await existing.stat()).modified,
+        );
+        byIndex[index] = keepNew ? entity : existing;
+        await _quietDelete(keepNew ? existing : entity);
       }
-      final dot = name.indexOf('.');
-      if (dot <= 0) continue;
-      final index = int.tryParse(name.substring(0, dot));
-      if (index == null) continue;
-      final existing = byIndex[index];
-      if (existing == null) {
-        byIndex[index] = entity;
-        continue;
-      }
-      final keepNew = (await entity.stat()).modified.isAfter(
-        (await existing.stat()).modified,
-      );
-      byIndex[index] = keepNew ? entity : existing;
-      await _quietDelete(keepNew ? existing : entity);
+    } on PathNotFoundException {
+      // The exists() check above can't be atomic with list() below — a
+      // concurrent delete/re-queue of this same chapter (the FGS and the
+      // WorkManager catch-up executor both stage independently) can remove
+      // the directory in between. Nothing staged is exactly the right answer
+      // once it's gone, same as the exists() guard already returns for it.
+      return const {};
     }
     return byIndex;
   }

--- a/lib/src/features/offline/data/offline_reconciler.dart
+++ b/lib/src/features/offline/data/offline_reconciler.dart
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import '../../../utils/crash/diagnostics.dart';
 import 'offline_database.dart';
 import 'reconcile_logic.dart';
 import 'reconcile_types.dart';
@@ -12,6 +13,24 @@ import 'reconcile_types.dart';
 /// real download sizes are known (cold start). Refined to real averages once
 /// chapters are on device.
 const _estimatedBytesPerPage = 256 * 1024;
+
+/// Cap on how many times the reconciler will ask the server to fetch a
+/// chapter it has never managed to download — persisted in
+/// [OfflineChapters.serverFetchAttempts], not in-memory.
+///
+/// Unlike the local-download hop (which persists `OfflineDeviceState.error`
+/// after one failure), asking the SERVER to fetch a chapter from its source
+/// had no equivalent persisted "give up" signal — a chapter whose source is
+/// gone/renumbered upstream just sits with `serverIsDownloaded == false`
+/// forever. Without this cap, every single reconcile pass (app launch,
+/// library sync, every download-queue-drain callback) re-issues a real
+/// enqueue mutation for it, indefinitely — exactly the "series stuck wanting
+/// to download chapters that don't exist" resource drain this guards against.
+///
+/// Persisted rather than in-memory: an in-memory counter resets every app
+/// restart, so a chapter whose source is truly gone would get a fresh budget
+/// every session and never actually reach the cap that stops it.
+const _maxServerFetchAttempts = 5;
 
 /// Orchestrates a single reconcile pass for one manga: reads the offline
 /// catalog, computes which chapters to download vs evict, invokes the injected
@@ -165,9 +184,27 @@ class OfflineReconciler {
       if (!c.serverIsDownloaded) {
         if (onServerDownload != null &&
             c.deviceState != OfflineDeviceState.downloaded) {
-          toServerDownload.add(id);
+          if (c.serverFetchAttempts >= _maxServerFetchAttempts) {
+            recordDiagnostic(
+              '[${DateTime.now().toIso8601String()}] offline-reconcile: '
+              'giving-up-on-server-fetch mangaId=$mangaId chapterId=$id '
+              'name="${c.name}" index=${c.chapterIndex} '
+              'attempts=${c.serverFetchAttempts}/$_maxServerFetchAttempts '
+              'serverIsDownloaded=false — excluded from further '
+              'server-download requests\n',
+            );
+          } else {
+            toServerDownload.add(id);
+          }
         }
         continue;
+      }
+      // Server now has it: any earlier fetch-attempt budget is moot — clear
+      // it lazily so a later, unrelated failure (e.g. after a manual re-fetch)
+      // starts fresh instead of inheriting attempts spent on a since-resolved
+      // problem.
+      if (c.serverFetchAttempts > 0) {
+        await db.resetServerFetchAttempts(id);
       }
       // Already on device — nothing to do.
       if (c.deviceState == OfflineDeviceState.downloaded) continue;
@@ -203,6 +240,21 @@ class OfflineReconciler {
       await onDownload(id);
     }
     if (onServerDownload != null && toServerDownload.isNotEmpty) {
+      for (final id in toServerDownload) {
+        await db.incrementServerFetchAttempts(id);
+        // A trail of every attempt, not just the final give-up — so a session
+        // that never reaches the cap (or one where the enqueue mutation itself
+        // silently no-ops server-side) is still visible, not only the ones
+        // that exhaust the budget.
+        final c = byId[id];
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-reconcile: '
+          'asking-server-to-fetch mangaId=$mangaId chapterId=$id '
+          'name="${c?.name}" index=${c?.chapterIndex} '
+          'attempt=${(c?.serverFetchAttempts ?? 0) + 1}/'
+          '$_maxServerFetchAttempts\n',
+        );
+      }
       await onServerDownload!(toServerDownload);
     }
 

--- a/lib/src/features/offline/presentation/offline_settings_screen.dart
+++ b/lib/src/features/offline/presentation/offline_settings_screen.dart
@@ -12,9 +12,11 @@ import '../../../utils/platform/is_android_native.dart';
 import '../../../widgets/input_popup/domain/settings_prop_type.dart';
 import '../../../widgets/input_popup/settings_prop_tile.dart';
 import '../../../widgets/section_title.dart';
+import '../../notifications/controller/notification_settings_providers.dart';
+import '../../notifications/controller/notifications_controller.dart';
+import '../data/background/catchup_settings.dart';
 import '../data/offline_download_providers.dart';
 import '../data/offline_repository.dart';
-import '../data/background/catchup_settings.dart';
 import '../data/offline_settings_providers.dart';
 import 'offline_server_mismatch_banner.dart';
 import 'offline_settings_format.dart';
@@ -89,7 +91,7 @@ List<Widget> buildOnDeviceStorageTiles(BuildContext context, WidgetRef ref) {
     // Background wake-ups are Android's WorkManager; on other platforms the
     // in-app triggers (launch, update-finish, queue-drain) are the coverage,
     // so the switch would be a lie there.
-    if (isAndroidNative)
+    if (isAndroidNative) ...[
       SettingsPropTile(
         title: context.l10n.downloadNewChaptersInBackground,
         subtitle: context.l10n.downloadNewChaptersInBackgroundDescription,
@@ -103,6 +105,44 @@ List<Widget> buildOnDeviceStorageTiles(BuildContext context, WidgetRef ref) {
           },
         ),
       ),
+      // Both sub-options are meaningless with the run itself switched off —
+      // nested the same way the Notifications screen nests its own check
+      // interval under "New chapters". The interval is the SAME WorkManager
+      // schedule that check uses (one shared periodic job), so it's shown
+      // here too rather than only being reachable from a screen this toggle
+      // doesn't depend on.
+      if (ref.watch(backgroundCatchupEnabledProvider)) ...[
+        ListTile(
+          title: Text(context.l10n.notificationsCheckInterval),
+          trailing: DropdownButton<int>(
+            value: ref.watch(notificationsCheckIntervalHoursProvider) ?? 6,
+            onChanged: (v) async {
+              if (v == null) return;
+              ref
+                  .read(notificationsCheckIntervalHoursProvider.notifier)
+                  .update(v);
+              await ref.read(notificationsControllerProvider).sync();
+            },
+            items: const [1, 2, 3, 6, 12, 24]
+                .map((h) => DropdownMenuItem(value: h, child: Text('${h}h')))
+                .toList(),
+          ),
+        ),
+        SettingsPropTile(
+          title: context.l10n.backgroundCatchupFetchFiles,
+          subtitle: context.l10n.backgroundCatchupFetchFilesDescription,
+          type: SettingsPropType.switchTile(
+            value: ref.watch(backgroundCatchupDownloadEnabledProvider),
+            onChanged: (v) async {
+              await ref
+                  .read(backgroundCatchupDownloadEnabledProvider.notifier)
+                  .setEnabled(v);
+              return null;
+            },
+          ),
+        ),
+      ],
+    ],
     SettingsPropTile(
       title: context.l10n.offlineConcurrencyLabel,
       subtitle: context.l10n.offlineConcurrencyValue(

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2892,6 +2892,11 @@
   "@downloadOverWifiOnly": {
     "description": "Toggle to restrict background downloads to Wi-Fi connections"
   },
+  "backgroundCatchupFetchFiles": "Download the files, not just check",
+  "backgroundCatchupFetchFilesDescription": "When off, background runs only detect and queue new chapters — the files are fetched the next time you open the app",
+  "@backgroundCatchupFetchFilesDescription": {
+    "description": "Sub-option under downloadNewChaptersInBackground: whether the background run also downloads chapter files, or only detects/queues them"
+  },
   "offlineConcurrencyLabel": "Simultaneous downloads",
   "@offlineConcurrencyLabel": {
     "description": "Label for the download concurrency slider"

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2892,8 +2892,8 @@
   "@downloadOverWifiOnly": {
     "description": "Toggle to restrict background downloads to Wi-Fi connections"
   },
-  "backgroundCatchupFetchFiles": "Download the files, not just check",
-  "backgroundCatchupFetchFilesDescription": "When off, background runs only detect and queue new chapters — the files are fetched the next time you open the app",
+  "backgroundCatchupFetchFiles": "Download files in the background",
+  "backgroundCatchupFetchFilesDescription": "When off, background checks only find and queue new chapters. Files download the next time you open the app.",
   "@backgroundCatchupFetchFilesDescription": {
     "description": "Sub-option under downloadNewChaptersInBackground: whether the background run also downloads chapter files, or only detects/queues them"
   },

--- a/lib/src/utils/logger/logger.dart
+++ b/lib/src/utils/logger/logger.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart' as l;
 import 'package:logger/web.dart';
 
+import '../crash/diagnostics.dart';
+
 class Logger {
   static final l.Logger _logger = l.Logger(
     printer: l.PrettyPrinter(
@@ -24,6 +26,22 @@ class MyConsoleOutput extends ConsoleOutput {
   void output(OutputEvent event) {
     for (int i = 0; i < event.lines.length; i++) {
       debugPrint(event.lines[i]);
+    }
+    // debugPrint alone requires a live debugger attached to see it — anything
+    // that happens in a background isolate (WorkManager, the foreground
+    // download service) or on a release/profile build the user actually runs
+    // was otherwise undiagnosable after the fact. Persisting warnings and
+    // worse to the same crash-log file the Settings "copy crash log" action
+    // reads makes every existing logger.w/.e call site in the app retroactively
+    // visible there, not just the ones that happen to also call
+    // recordDiagnostic directly.
+    if (event.level == l.Level.warning ||
+        event.level == l.Level.error ||
+        event.level == l.Level.fatal) {
+      final ts = DateTime.now().toIso8601String();
+      for (final line in event.lines) {
+        recordDiagnostic('[$ts] $line\n');
+      }
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -906,10 +906,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -1018,10 +1018,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: "direct main"
     description:
@@ -1034,10 +1034,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1712,26 +1712,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   timezone:
     dependency: transitive
     description:
@@ -1840,10 +1840,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/test/offline/background/background_token_record_test.dart
+++ b/test/offline/background/background_token_record_test.dart
@@ -11,7 +11,7 @@ void main() {
       write: (r) async => record = r,
       refreshFn: (_) async {
         refreshCalls++;
-        return (access: 'NEW', refresh: 'R1');
+        return (tokens: (access: 'NEW', refresh: 'R1'), transient: false);
       },
     );
     // someone else already advanced the record:
@@ -30,7 +30,7 @@ void main() {
       write: (r) async => record = r,
       refreshFn: (rt) async {
         expect(rt, 'R0');
-        return (access: 'NEW', refresh: 'R1');
+        return (tokens: (access: 'NEW', refresh: 'R1'), transient: false);
       },
     );
     final token = await broker.resolveAfter401('OLD');
@@ -40,14 +40,28 @@ void main() {
     expect(record.refreshToken, 'R1'); // rotated refresh persisted (fixes C4)
   });
 
-  test('a dead refresh returns null', () async {
+  test('a dead refresh returns null and is not marked transient', () async {
     var record = const BackgroundTokenRecord(
         gen: 1, authType: 'uiLogin', accessToken: 'OLD', refreshToken: 'R0');
     final broker = TokenBroker(
       read: () async => record,
       write: (r) async => record = r,
-      refreshFn: (_) async => null,
+      refreshFn: (_) async => (tokens: null, transient: false),
     );
     expect(await broker.resolveAfter401('OLD'), isNull);
+    expect(broker.lastRefreshTransient, isFalse);
+  });
+
+  test('a refresh that could not reach the server is marked transient',
+      () async {
+    var record = const BackgroundTokenRecord(
+        gen: 1, authType: 'uiLogin', accessToken: 'OLD', refreshToken: 'R0');
+    final broker = TokenBroker(
+      read: () async => record,
+      write: (r) async => record = r,
+      refreshFn: (_) async => (tokens: null, transient: true),
+    );
+    expect(await broker.resolveAfter401('OLD'), isNull);
+    expect(broker.lastRefreshTransient, isTrue);
   });
 }

--- a/test/offline/background/chapter_download_engine_offline_test.dart
+++ b/test/offline/background/chapter_download_engine_offline_test.dart
@@ -13,7 +13,7 @@ void main() {
     'a PageOfflineException yields outcome.offline, not error/authFailed',
     () async {
       final engine = ChapterDownloadEngine(
-        fetchPage: (_) async => throw const PageOfflineException(),
+        fetchPage: (_) async => throw const PageOfflineException('test-offline'),
         writePage: FakePageStore(),
         refreshAuth: () async => true,
       );
@@ -24,6 +24,7 @@ void main() {
         isCancelled: () => false,
       );
       expect(outcome.offline, isTrue);
+      expect(outcome.offlineReason, 'test-offline');
       expect(outcome.error, isNull);
       expect(outcome.authFailed, isFalse);
       expect(outcome.succeeded, isFalse);
@@ -36,7 +37,7 @@ void main() {
     final engine = ChapterDownloadEngine(
       fetchPage: (_) async {
         calls++;
-        throw const PageOfflineException();
+        throw const PageOfflineException('test-offline');
       },
       writePage: FakePageStore(),
       refreshAuth: () async => true,

--- a/test/src/features/offline/data/background/catchup_work_spec_test.dart
+++ b/test/src/features/offline/data/background/catchup_work_spec_test.dart
@@ -89,6 +89,19 @@ void main() {
     expect(other.pendingDownloads, isEmpty);
   });
 
+  test('backfilledMangaIds round-trips through the ledger', () async {
+    final s = await store();
+    await s.writeLedger(
+      'srv-1',
+      const CatchupLedger(backfilledMangaIds: {7, 9}),
+    );
+
+    expect(s.readLedger('srv-1').backfilledMangaIds, {7, 9});
+    // A server switch must not carry another server's backfill history —
+    // same isolation rule as every other field on this ledger.
+    expect(s.readLedger('srv-2').backfilledMangaIds, isEmpty);
+  });
+
   test('clearState drops spec and ledger but keeps the user toggle', () async {
     final s = await store();
     await s.setEnabled(true);

--- a/test/src/features/offline/data/background/catchup_work_spec_test.dart
+++ b/test/src/features/offline/data/background/catchup_work_spec_test.dart
@@ -138,6 +138,21 @@ void main() {
     expect(s.enabled, isTrue);
   });
 
+  test('downloadEnabled defaults to true, matching pre-toggle behavior',
+      () async {
+    final s = await store();
+    expect(s.downloadEnabled, isTrue);
+  });
+
+  test('downloadEnabled round-trips and survives clearState', () async {
+    final s = await store();
+    await s.setDownloadEnabled(false);
+    expect(s.downloadEnabled, isFalse);
+
+    await s.clearState();
+    expect(s.downloadEnabled, isFalse);
+  });
+
   test('chapter generations survive the spec round-trip', () {
     // A chapter deleted once carries a bumped generation. Staging written at
     // the wrong one is rejected at launch AFTER the obligation has been struck

--- a/test/src/features/offline/data/background/catchup_work_spec_test.dart
+++ b/test/src/features/offline/data/background/catchup_work_spec_test.dart
@@ -102,6 +102,22 @@ void main() {
     expect(s.readLedger('srv-2').backfilledMangaIds, isEmpty);
   });
 
+  test(
+      'catalogServerId reads the offline catalog key, not a made-up '
+      'namespace the executor could mismatch against', () async {
+    SharedPreferences.setMockInitialValues({
+      'offlineCatalogServerId': 'catalog-uuid-123',
+    });
+    final s = CatchupStateStore(await SharedPreferences.getInstance());
+    expect(s.catalogServerId, 'catalog-uuid-123');
+  });
+
+  test('catalogServerId is null when the offline catalog was never set up',
+      () async {
+    final s = await store();
+    expect(s.catalogServerId, isNull);
+  });
+
   test('clearState drops spec and ledger but keeps the user toggle', () async {
     final s = await store();
     await s.setEnabled(true);

--- a/test/src/features/offline/data/launch_reconcile_server_request_test.dart
+++ b/test/src/features/offline/data/launch_reconcile_server_request_test.dart
@@ -63,4 +63,48 @@ void main() {
     expect(asked, [1],
         reason: 'setting a keep rule must still top up the server');
   });
+
+  test(
+    'stops asking the server for a chapter that never resolves, after '
+    'a bounded number of attempts',
+    () async {
+      // Regression: a chapter the server can never actually fetch (source
+      // gone/renumbered upstream) used to be re-enqueued on every single
+      // reconcile pass forever — every app launch, every library sync, every
+      // download-queue-drain callback — hammering the server for nothing.
+      //
+      // Persisted, not in-memory: an in-memory counter would reset every app
+      // restart and never actually reach the cap, which is exactly what was
+      // observed in the field — attempts stayed frozen at 1 across a whole
+      // test session that reopened the app repeatedly.
+      await seed();
+      const maxAttempts = 5; // mirrors offline_reconciler.dart's own cap
+      var totalAsks = 0;
+      Future<void> reconcileOnce() => OfflineReconciler(
+            db: db,
+            nets: SafetyNetConfig.off,
+            onDownload: (_) async {},
+            onEvict: (_) async {},
+            now: DateTime(2026, 3, 1),
+            onServerDownload: (ids) async => totalAsks += ids.length,
+          ).reconcileManga(1);
+
+      // serverIsDownloaded never flips true in this fixture (simulating a
+      // source that can never serve it), so every pass would re-ask forever
+      // without the cap.
+      for (var i = 0; i < maxAttempts; i++) {
+        await reconcileOnce();
+      }
+      expect(totalAsks, maxAttempts);
+      final persisted = await db.chapterById(1);
+      expect(persisted?.serverFetchAttempts, maxAttempts,
+          reason: 'the count must survive being read back from a fresh '
+              'OfflineReconciler instance, the way a new app session would');
+
+      // One more pass, well past the cap: must NOT ask again.
+      await reconcileOnce();
+      expect(totalAsks, maxAttempts,
+          reason: 'exhausted chapters must stop generating server traffic');
+    },
+  );
 }

--- a/test/src/features/offline/data/offline_chapter_number_schema_test.dart
+++ b/test/src/features/offline/data/offline_chapter_number_schema_test.dart
@@ -74,7 +74,7 @@ void main() {
     });
     tearDown(() => tmp.delete(recursive: true));
 
-    test('adds the columns, preserves rows, lands on version 15', () async {
+    test('adds the columns, preserves rows, lands on version 16', () async {
       final dbPath = p.join(tmp.path, 'test.db');
 
       // Build a genuine v8 file: the chapters table WITHOUT the new columns,
@@ -148,7 +148,7 @@ void main() {
           .customSelect('PRAGMA user_version')
           .getSingle()
           .then((r) => r.read<int>('user_version'));
-      expect(version, 15);
+      expect(version, 16);
       // v14 must create both category tables on an upgrade from before they
       // existed — onCreate only runs for fresh files.
       await db.upsertCategory(1, 'A', 0, isHidden: false);

--- a/test/src/features/offline/data/offline_database_test.dart
+++ b/test/src/features/offline/data/offline_database_test.dart
@@ -16,8 +16,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 15', () {
-    expect(db.schemaVersion, 15);
+  test('opens at schema version 16', () {
+    expect(db.schemaVersion, 16);
   });
 
   test('inserts and reads a manga', () async {

--- a/test/src/features/offline/data/offline_download_coordinator_test.dart
+++ b/test/src/features/offline/data/offline_download_coordinator_test.dart
@@ -65,7 +65,7 @@ void main() {
       refreshAuth: () async => refreshOk,
       fetchPage: (url) async {
         if (onFetch != null) await onFetch();
-        if (pageOffline) throw const PageOfflineException();
+        if (pageOffline) throw const PageOfflineException('test-offline');
         if (auth401) throw const PageAuthException();
         if (fail) throw Exception('boom');
         return (bytes: [1, 2, 3], ext: 'jpg');

--- a/test/src/features/offline/data/offline_download_manager_force_test.dart
+++ b/test/src/features/offline/data/offline_download_manager_force_test.dart
@@ -37,6 +37,7 @@ void main() {
     syncedIsRead: false,
     updatedAt: DateTime(2026),
     downloadGeneration: 0,
+    serverFetchAttempts: 0,
   );
 
   OfflineDownloadManager manager() => OfflineDownloadManager(

--- a/test/src/features/offline/data/offline_keep_rule_schema_test.dart
+++ b/test/src/features/offline/data/offline_keep_rule_schema_test.dart
@@ -15,8 +15,8 @@ void main() {
   setUp(() => db = testOfflineDatabase());
   tearDown(() => db.close());
 
-  test('opens at schema version 15', () {
-    expect(db.schemaVersion, 15);
+  test('opens at schema version 16', () {
+    expect(db.schemaVersion, 16);
   });
 
   test('keepRule defaults to off, keepUnreadCount to 3; setKeepRule persists',

--- a/test/src/features/offline/data/offline_schema_migration_test.dart
+++ b/test/src/features/offline/data/offline_schema_migration_test.dart
@@ -96,38 +96,6 @@ void main() {
     }
   });
 
-  test('v15 readStateManual persists across close/reopen', () async {
-    final dbPath = p.join(tmp.path, 'test.db');
-
-    {
-      final db = testOfflineDatabaseFile(dbPath);
-      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
-      await db.upsertChapterMetadata(
-        id: 10,
-        mangaId: 1,
-        name: 'c',
-        chapterIndex: 1,
-        isRead: false,
-        lastPageRead: 0,
-        isBookmarked: false,
-        serverIsDownloaded: true,
-        pageCount: 3,
-        updatedAt: DateTime(2026),
-      );
-      await db.setChapterReadState(10, true, manual: true);
-      await db.close();
-    }
-
-    {
-      final db = testOfflineDatabaseFile(dbPath);
-      final c = await (db.select(db.offlineChapters)
-            ..where((t) => t.id.equals(10)))
-          .getSingle();
-      expect(c.readStateManual, true);
-      await db.close();
-    }
-  });
-
   Future<bool> hasIndex(OfflineDatabase db, String name) async {
     final rows = await db
         .customSelect(
@@ -214,6 +182,76 @@ void main() {
           reason: 'the from<12 guard already decided to preserve this value '
               'because the column existed; a later duplicate unconditional '
               'UPDATE synced_is_read = is_read must not override that');
+      await db.close();
+    }
+  });
+
+  test('v16 readStateManual persists across close/reopen', () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      await db.upsertChapterMetadata(
+        id: 10,
+        mangaId: 1,
+        name: 'c',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: true,
+        pageCount: 3,
+        updatedAt: DateTime(2026),
+      );
+      await db.setChapterReadState(10, true, manual: true);
+      await db.close();
+    }
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      final c = await (db.select(db.offlineChapters)
+            ..where((t) => t.id.equals(10)))
+          .getSingle();
+      expect(c.readStateManual, true);
+      await db.close();
+    }
+  });
+
+  test('v16 serverFetchAttempts persists across close/reopen', () async {
+    final dbPath = p.join(tmp.path, 'test.db');
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+      await db.upsertChapterMetadata(
+        id: 10,
+        mangaId: 1,
+        name: 'c',
+        chapterIndex: 1,
+        isRead: false,
+        lastPageRead: 0,
+        isBookmarked: false,
+        serverIsDownloaded: false,
+        pageCount: 0,
+        updatedAt: DateTime(2026),
+      );
+      await db.incrementServerFetchAttempts(10);
+      await db.incrementServerFetchAttempts(10);
+      await db.close();
+    }
+
+    {
+      final db = testOfflineDatabaseFile(dbPath);
+      final c = await (db.select(db.offlineChapters)
+            ..where((t) => t.id.equals(10)))
+          .getSingle();
+      expect(c.serverFetchAttempts, 2);
+      await db.resetServerFetchAttempts(10);
+      final reset = await (db.select(db.offlineChapters)
+            ..where((t) => t.id.equals(10)))
+          .getSingle();
+      expect(reset.serverFetchAttempts, 0);
       await db.close();
     }
   });

--- a/test/src/features/offline/data/reconcile_desired_set_test.dart
+++ b/test/src/features/offline/data/reconcile_desired_set_test.dart
@@ -12,6 +12,7 @@ OfflineChapter ch(int id, int idx, {bool read = false, bool pinned = false}) =>
       syncedIsRead: false,
       updatedAt: DateTime(2026),
       downloadGeneration: 0,
+      serverFetchAttempts: 0,
     );
 
 void main() {

--- a/test/src/features/offline/data/reconcile_eviction_test.dart
+++ b/test/src/features/offline/data/reconcile_eviction_test.dart
@@ -19,6 +19,7 @@ OfflineChapter dl(int id, {int bytes = 100, DateTime? at, bool pinned = false}) 
       readStateManual: false,
       syncedIsRead: false,
       updatedAt: DateTime(2026), downloadGeneration: 0,
+      serverFetchAttempts: 0,
     );
 
 void main() {

--- a/test/src/features/offline/data/reconcile_read_window_test.dart
+++ b/test/src/features/offline/data/reconcile_read_window_test.dart
@@ -32,6 +32,7 @@ OfflineChapter _ch(int id, {bool isRead = false, String? readAt}) =>
       lastReadAt: readAt,
       updatedAt: DateTime(2026),
       downloadGeneration: 0,
+      serverFetchAttempts: 0,
     );
 
 void main() {


### PR DESCRIPTION
## Summary
- The server-fetch retry counter used to live in an in-memory static class, so it reset on every app restart and never actually reached its cap — a chapter the server can never produce kept getting asked for forever across sessions. It's now a persisted column (schema v17, `serverFetchAttempts`) with increment/reset DB methods, so give-up survives a restart.
- None of `package:http`'s calls time out on their own, so a proxy/tunnel answering for a dead origin (or a plain dead connection) could hang a background request forever with no exception and nothing to catch — the drain loop just sits on one `await` permanently, reading on-screen as a frozen notification/progress count. Every network call in the foreground-service worker, the WorkManager catch-up executor, and the main-isolate page fetch now has a 30s timeout, and `PageOfflineException` carries a short reason string so a park/error can say why instead of just that it happened.
- `logger.w`/`e`/`wtf` calls now also persist to the crash log (previously console-only, needing an attached debugger).
- The WorkManager isolate gets its own crash-log wiring (previously only the main isolate had it, so nothing in a background chapter-check run ever reached the log the user can copy from Settings).
- The catch-up executor's ledger cleanup now scans both its pending-download and pending-server-fetch maps (previously only the former), and excludes exhausted chapters from that cleanup so their retry counters aren't wiped and immediately reset next run.

## Note on branch base
This branch is based on `fix/offline-track-progress-manual-flag` (already open/pending) rather than `main` directly, since the schema file it touches already depends on that branch's `readStateManual` column.

## Test plan
- [x] `flutter analyze` clean (255 pre-existing info-level issues, matching baseline)
- [x] Full `test/offline/` + `test/src/features/offline/` suites pass (351 tests)