### PR TITLE
fix(offline): stop stranding a chapter in queued when its terminal event races its own chapterStart

### DIFF
--- a/lib/src/features/offline/data/background/background_completion_log.dart
+++ b/lib/src/features/offline/data/background/background_completion_log.dart
@@ -188,7 +188,17 @@ Future<void> applyBackgroundTerminalState({
     final c = await db.chapterById(chapterId);
     if (c == null || c.deviceState == OfflineDeviceState.none) return;
     if (eventGeneration < c.downloadGeneration) return; // stale generation
-    if (c.deviceState == OfflineDeviceState.downloading) {
+    // Accepts `queued` as well as `downloading`: the worker's `chapterStart`
+    // event (which flips queued -> downloading) is dispatched via
+    // `unawaited()` on the main isolate, same as this terminal event — there
+    // is no ordering guarantee between them. A chapter that fails fast enough
+    // (this event's transaction landing before chapterStart's) was previously
+    // silently skipped here because its row still read `queued`, leaving it
+    // stranded there forever: still "pending" to every future restart, with
+    // no error and nothing logged to explain why — the exact mechanism behind
+    // a fast, silent, repeating foreground-service restart loop.
+    if (c.deviceState == OfflineDeviceState.downloading ||
+        c.deviceState == OfflineDeviceState.queued) {
       await db.setChapterDeviceState(chapterId, OfflineDeviceState.error);
     }
   });

--- a/test/offline/background/background_completion_log_replay_test.dart
+++ b/test/offline/background/background_completion_log_replay_test.dart
@@ -411,18 +411,44 @@ void main() {
     });
 
     test(
-      'a stale error event does not error a freshly queued chapter',
+      'an error event still fails a chapter still reading queued (same generation)',
       () async {
+        // The worker's chapterStart event (queued -> downloading) is
+        // dispatched unawaited on the main isolate, same as this terminal
+        // event — there is no ordering guarantee between them. A chapter
+        // that fails fast enough for this event to land first must still be
+        // failed here, or it's stranded in `queued` forever: still "pending"
+        // to every future restart, with nothing to explain why. Staleness is
+        // what the generation check above already exists to catch (see the
+        // dedicated tests below) — device state alone was never a reliable
+        // signal for "this event belongs to an attempt that hasn't happened
+        // yet".
         await db.setChapterDeviceState(5, OfflineDeviceState.queued);
         await applyBackgroundTerminalState(
           db: db,
           chapterId: 5,
           status: 'error',
         );
+        expect((await db.chapterById(5))!.deviceState, OfflineDeviceState.error);
+      },
+    );
+
+    test(
+      'a genuinely stale error event (older generation) does not touch a '
+      'freshly re-queued chapter',
+      () async {
+        await db.setChapterDeviceState(5, OfflineDeviceState.queued);
+        await db.bumpChapterGeneration(5); // now generation 1: re-queued
+        await applyBackgroundTerminalState(
+          db: db,
+          chapterId: 5,
+          status: 'error',
+          eventGeneration: 0, // event from before the re-queue
+        );
         expect(
           (await db.chapterById(5))!.deviceState,
           OfflineDeviceState.queued,
-          reason: 'error applies only to a chapter actually mid-download',
+          reason: 'a deleted/re-queued generation event must not touch the new one',
         );
       },
     );


### PR DESCRIPTION
## Summary
Root cause of #391 (the foreground download service restart-loop / notification-flashing bug).

- `applyBackgroundTerminalState` only flipped a chapter to `error` when its device state read `downloading`.
- The worker's `chapterStart` event (which flips `queued` -> `downloading`) and a terminal `chapterDone` event are both dispatched via `unawaited()` from the same synchronous event switch on the main isolate — there is no ordering guarantee between them.
- A chapter that fails fast enough for its terminal event's transaction to land before its own `chapterStart` write commits would still read `queued` at the point of this check. The guard silently did nothing, leaving the row exactly as it was.
- Since the pending-chapters query treats `queued` and `downloading` identically ("still owed a download attempt"), a chapter stranded this way never left the candidate pool: every subsequent service restart picked it right back up, failed the same way, and raced the same write again — a fast, silent, endlessly-repeating cycle.
- Guard now accepts `queued` too. Genuine staleness (an event from a deleted/re-queued generation) is already independently caught by the generation check above it, which a new dedicated test also covers explicitly (the one existing test that asserted the old, buggy behavior has been corrected).

See #391 for the full investigation and the on-device log that confirms this exact race firing for two previously-stuck chapters, both then correctly transitioning to `error` with the queue draining normally afterward.

## Test plan
- [x] `flutter analyze` clean (255 pre-existing info-level issues, matching baseline)
- [x] `test/offline/` suite passes (76 tests, including the corrected + new test cases)
- [x] Reproduced and confirmed the fix on a physical device (Pixel 9a) via crash-log instrumentation