### PR TITLE
fix(offline): batch the FGS download start across a bulk keep-rule apply

### DIFF
--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -226,8 +226,15 @@ class CategoryMangaList extends HookConsumerWidget {
                     final db = ref.read(offlineDatabaseProvider);
                     for (final id in ids) {
                       await db.setKeepRule(id, picked.rule, picked.count);
-                      await reconcileMangaWidget(ref, id);
+                      // Queue only — starting per manga let the FGS drain and
+                      // stop between each one, so its "X/Y" notification never
+                      // showed the whole selection's real total. One start
+                      // below, after every manga in the selection is queued.
+                      await reconcileMangaWidget(ref, id, startDownload: false);
                     }
+                    await ref.read(downloadStarterProvider)(
+                      userInitiated: true,
+                    );
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -1377,7 +1377,19 @@ Future<void> reconcileManga(Ref ref, int mangaId) async {
 }
 
 /// Widget entry point — same as [reconcileManga] but accepts a [WidgetRef].
-Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
+///
+/// [startDownload] defaults to true for the single-manga case (see the
+/// comment below). A caller reconciling many manga in a row should pass
+/// false and start once after the whole batch is queued instead — awaiting
+/// this per manga with the FGS start included lets the service drain and
+/// stop between each one (a manga with just one chapter often finishes before
+/// the next manga's reconcile even returns), so every "X/Y" the notification
+/// shows is that one manga's tiny snapshot, never the batch's real total.
+Future<void> reconcileMangaWidget(
+  WidgetRef ref,
+  int mangaId, {
+  bool startDownload = true,
+}) async {
   if (!ref.read(offlineActiveProvider)) return;
   final manager = ref.read(offlineDownloadManagerProvider);
   final coordinator = ref.read(offlineDownloadCoordinatorProvider);
@@ -1404,7 +1416,9 @@ Future<void> reconcileMangaWidget(WidgetRef ref, int mangaId) async {
   );
   // Start downloading the freshly-queued chapters. THIS was the missing wire
   // that made "Download all / unread" silently do nothing on Android.
-  await ref.read(downloadStarterProvider)(userInitiated: true);
+  if (startDownload) {
+    await ref.read(downloadStarterProvider)(userInitiated: true);
+  }
 }
 
 /// Container entry — same as [reconcileMangaWidget] but survives the caller's

--- a/test/src/features/offline/data/offline_download_triggers_test.dart
+++ b/test/src/features/offline/data/offline_download_triggers_test.dart
@@ -107,6 +107,24 @@ void main() {
     );
   });
 
+  testWidgets(
+    'reconcileMangaWidget(startDownload: false) queues without starting',
+    (tester) async {
+      final h = await harness(tester);
+      await reconcileMangaWidget(h.ref, 1, startDownload: false);
+      expect(
+        h.starts(),
+        0,
+        reason:
+            'a caller batching several manga in a row (e.g. a bulk keep-rule '
+            'apply) must be able to queue each one without the FGS starting '
+            'and draining between them — otherwise its notification never '
+            'reflects the batch\'s real total, only whatever tiny snapshot '
+            'happened to be queued at each individual restart',
+      );
+    },
+  );
+
   testWidgets('saveChapterToDevice (single chapter) starts downloads', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- The library screen's "apply keep rule to N selected series" action looped over each selected manga and called `reconcileMangaWidget`, which queues that manga's chapters and immediately starts the foreground download service.
- Awaited sequentially per manga, this let the service drain and stop between manga (a series with just one chapter to fetch often finishes before the next manga's reconcile even returns) — so the download notification's `X/Y` counter kept resetting to whatever tiny batch was queued at each individual restart, never reflecting the whole selection's real total.
- This is also a likely contributor to an earlier-reported symptom: some series' keep rule "wasn't picked up" until visited individually — the bulk path's per-manga restarts made batches easy to miss/interrupt.

## Fix

`reconcileMangaWidget` gains a `startDownload` parameter (default `true`, so every existing caller is unaffected). The bulk-apply loop now queues each manga with `startDownload: false` and starts the download service exactly once, after the entire selection has been queued.

## Test plan

- [x] `flutter analyze` clean (no new issues beyond the pre-existing baseline)
- [x] `flutter test test/src/features/offline/data/offline_download_triggers_test.dart` — added a regression test asserting `startDownload: false` queues without starting the service
- [x] Full offline test suite green after merging into the local integration branch