### PR TITLE
Update share_plus, package_info_plus, network_info_plus, and file_picker together

### DIFF
--- a/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
+++ b/lib/src/features/browse_center/data/extension_repository/extension_repository.dart
@@ -43,7 +43,8 @@ class ExtensionRepository {
               // Web picks carry bytes and a blob URL rather than a real path,
               // so fromPath can't open them.
               extensionFile: kIsWeb
-                  ? http.MultipartFile.fromBytes("extensionFile", file.bytes!,
+                  ? http.MultipartFile.fromBytes(
+                      "extensionFile", await file.readAsBytes(),
                       filename: file.name)
                   : await http.MultipartFile.fromPath(
                       "extensionFile", file.path!),

--- a/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
+++ b/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
@@ -19,13 +19,11 @@ class InstallExtensionFile extends ConsumerWidget {
 
   void extensionFilePicker(WidgetRef ref, BuildContext context) async {
     final toast = ref.read(toastProvider);
-    final file = await FilePicker.pickFiles(
+    final file = await FilePicker.pickFile(
       type: FileType.custom,
       allowedExtensions: ['apk'],
-      // Web has no file paths, so the bytes have to come back with the pick.
-      withData: kIsWeb,
     );
-    if ((file?.files).isNotBlank) {
+    if (file != null) {
       if (context.mounted) {
         toast?.show(context.l10n.installingExtension);
       }
@@ -34,7 +32,7 @@ class InstallExtensionFile extends ConsumerWidget {
       () async {
         await ref
             .read(extensionActionsProvider)
-            .installFile(context, file: file?.files.single);
+            .installFile(context, file: file);
         if (context.mounted) {
           toast?.show(context.l10n.extensionInstalled, instantShow: true);
         }

--- a/lib/src/utils/misc/file_picker_utils.dart
+++ b/lib/src/utils/misc/file_picker_utils.dart
@@ -12,18 +12,14 @@ abstract class FilePickerUtils {
     BuildContext? context,
     List<String>? extensions,
   }) async {
-    final pickedFiles = await FilePicker.pickFiles(
+    final file = await FilePicker.pickFile(
       type: FileType.custom,
       allowedExtensions: extensions,
-      // Web has no file paths, so the bytes have to come back with the pick.
-      withData: kIsWeb,
     );
-    final file = pickedFiles?.files.first;
     if (context != null && context.mounted) {
       if (file == null ||
           file.name.isBlank ||
-          (kIsWeb && (file.bytes).isBlank ||
-              (!kIsWeb && (file.path).isBlank))) {
+          (!kIsWeb && (file.path).isBlank)) {
         throw context.l10n.errorFilePick;
       }
       if (extensions.isNotBlank &&
@@ -44,7 +40,7 @@ abstract class FilePickerUtils {
     if (kIsWeb) {
       return MultipartFile.fromBytes(
         newFileName,
-        file.bytes!,
+        await file.readAsBytes(),
         filename: newFileNameWithExtension,
       );
     } else {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,7 +7,7 @@ import Foundation
 
 import app_links
 import connectivity_plus
-import file_picker
+import file_picker_darwin
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import gal
@@ -21,6 +21,7 @@ import sqflite_darwin
 import url_launcher_macos
 import wakelock_plus
 import window_manager
+import workmanager_apple
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
@@ -39,4 +40,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
+  WorkmanagerPlugin.register(with: registry.registrar(forPlugin: "WorkmanagerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.3"
+  android_file_picker:
+    dependency: transitive
+    description:
+      name: android_file_picker
+      sha256: "0d84bb91fb78af33756107f00cf71ee084474169d481b882b335c3006077a913"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   animated_vector:
     dependency: "direct main"
     description:
@@ -282,7 +290,7 @@ packages:
     source: hosted
     version: "1.15.1"
   cross_file:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: cross_file
       sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
@@ -377,6 +385,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: "direct main"
     description:
@@ -389,10 +405,42 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
+      sha256: "0631f51bbc2e1184bdc9e79384db158dc7830e15b3001feeca700e86563f4d24"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "12.2.0"
+  file_picker_darwin:
+    dependency: transitive
+    description:
+      name: file_picker_darwin
+      sha256: "5c32c9400f5c8976c9dd7aa34693c7d2f0c853c28704a1c1409029cb760f5251"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_picker_linux:
+    dependency: transitive
+    description:
+      name: file_picker_linux
+      sha256: bd52ff1e0048f29df95f913c55ad2991c72791d93e6c42241912c4bdee946cb9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: file_picker_platform_interface
+      sha256: d35d8cb68446fae921335bb61501d66cb2469d74c8f3103b8c6ccdbe3fe5afd8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  file_picker_web:
+    dependency: transitive
+    description:
+      name: file_picker_web
+      sha256: "935560a9d29fa6f006f2855addebb88e88d438e13627d4cc24187033c106f227"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   fixnum:
     dependency: transitive
     description:
@@ -532,14 +580,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.8"
-  flutter_plugin_android_lifecycle:
-    dependency: transitive
-    description:
-      name: flutter_plugin_android_lifecycle
-      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.35"
   flutter_riverpod:
     dependency: transitive
     description:
@@ -592,10 +632,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.2"
   flutter_staggered_grid_view:
     dependency: "direct main"
     description:
@@ -1066,18 +1106,18 @@ packages:
     dependency: "direct main"
     description:
       name: network_info_plus
-      sha256: f926b2ba86aa0086a0dfbb9e5072089bc213d854135c1712f1d29fc89ba3c877
+      sha256: "096a700e2321507e2e587487a442b9baa7ba6cd4e70e3cc1ebbb8327d2632c2d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "8.2.1"
   network_info_plus_platform_interface:
     dependency: transitive
     description:
       name: network_info_plus_platform_interface
-      sha256: "7e7496a8a9d8136859b8881affc613c4a21304afeb6c324bcefc4bd0aff6b94b"
+      sha256: "210b58064bc08e04b3a2b608f1f999cf768871fbd531961dc33a91720869d182"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "3.1.0"
   nm:
     dependency: transitive
     description:
@@ -1130,18 +1170,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.1"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1435,18 +1475,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.2"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "7.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1856,10 +1896,10 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: "61713aa82b7f85c21c9f4cd0a148abd75f38a74ec645fcb1e446f882c82fd09b"
+      sha256: "7253bca0fcf40d8413ddfcf4d2a1fa0a82475e79be25a4f2c564b695c9351486"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.7.0"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
@@ -1912,10 +1952,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: a0b93865d5644f11cf6a8c3f6db909f1ec168958b5805f6cc684adea957cd63d
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.4.0"
   window_manager:
     dependency: "direct main"
     description:
@@ -1924,6 +1964,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
+  windows_file_picker:
+    dependency: transitive
+    description:
+      name: windows_file_picker
+      sha256: d999c1c085374724668af0b674a9758d96255c50933faa2ac1cc51eff8308caf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   drift: ^2.32.0
   extension_type_unions: ^1.0.10
   file: ^7.0.0
-  file_picker: ^11.0.0
+  file_picker: ^12.0.0
   flex_color_picker: 3.8.0
   flutter:
     sdk: flutter
@@ -62,8 +62,8 @@ dependencies:
   # HCT (perceived-lightness) color space for the light-mode genre chips. Ships
   # with Flutter itself; declared here because we import it directly.
   material_color_utilities: ^0.13.0
-  network_info_plus: ^6.0.0
-  package_info_plus: ^8.0.0
+  network_info_plus: ^8.0.0
+  package_info_plus: ^10.0.0
   path: ^1.8.3
   path_provider: ^2.0.11
   pub_semver: ^2.1.2
@@ -85,7 +85,7 @@ dependencies:
   url_launcher: ^6.1.6
   web_socket_channel: ^3.0.0
   screen_brightness: ^2.1.11
-  share_plus: ^12.0.2
+  share_plus: ^13.0.0
   gal: ^2.3.2
   image: ^4.8.0
   window_manager: ^0.5.2
@@ -93,6 +93,7 @@ dependencies:
   workmanager: ^0.10.0
 
 dev_dependencies:
+  cross_file: ^0.3.5+4
   build_runner: ^2.4.14
   # flutter_flavorizr: ^2.1.5
   drift_dev: ^2.32.0

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,12 @@
       "dependencyDashboardApproval": true
     },
     {
+      "description": "The plus packages and file_picker share a win32 pin and only resolve together",
+      "matchManagers": ["pub"],
+      "matchPackageNames": ["share_plus", "package_info_plus", "network_info_plus", "file_picker"],
+      "groupName": "plus-packages"
+    },
+    {
       "description": "Riverpod moves as one migration",
       "matchManagers": ["pub"],
       "matchPackageNames": ["hooks_riverpod", "riverpod_annotation", "riverpod_generator", "flutter_riverpod", "riverpod"],

--- a/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
+++ b/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
@@ -4,6 +4,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import 'dart:typed_data';
+
+import 'package:cross_file/cross_file.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -174,7 +177,7 @@ void main() {
     // Only a BuildContext to hand to the picker call. The container stays
     // detached from the tree: attaching it makes Riverpod defer refreshes to a
     // frame that a bare `await` never pumps.
-    final apk = PlatformFile(name: 'source.apk', size: 4);
+    final apk = _FakeApk();
     late BuildContext capturedContext;
     await tester.pumpWidget(
       MaterialApp(
@@ -212,4 +215,21 @@ class _ThrowingRepository extends ExtensionRepository {
 
   @override
   Future<List<Extension>?> getExtensionListStream() async => <Extension>[];
+}
+
+base class _FakeApk extends PlatformFile {
+  @override
+  String get name => 'source.apk';
+  @override
+  Uri get uri => Uri.file('/tmp/source.apk');
+  @override
+  XFile get xFile => XFile(uri.toFilePath());
+  @override
+  int? lengthSync() => 4;
+  @override
+  Future<int> length() async => 4;
+  @override
+  Future<Uint8List> readAsBytes() async => Uint8List(4);
+  @override
+  Stream<Uint8List> readAsByteStream() => Stream.value(Uint8List(4));
 }


### PR DESCRIPTION
The three plus packages moved to a newer Windows helper library, and file_picker's older releases pinned the previous one, so none of them can be bumped alone. This moves all four at once and adds a Renovate group so they keep moving together.

file_picker 12 returns picked files directly and reads bytes on demand, so the three pick sites and one test fixture are adapted.

Supersedes #398, #390, #374.