### PR TITLE
Submit the login and basic-auth dialogs on Enter

### DIFF
--- a/lib/src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart
+++ b/lib/src/features/settings/presentation/server/widget/credential_popup/credentials_popup.dart
@@ -65,6 +65,17 @@ class CredentialsPopup extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final username = useTextEditingController();
     final password = useTextEditingController();
+    void doSave() {
+      if ((formKey.currentState?.validate()).ifNull()) {
+        ref.read(credentialsProvider.notifier).set(
+              _basicAuth(userName: username.text, password: password.text),
+              forEpoch:
+                  ref.read(authCredentialsStoreProvider.notifier).serverEpoch,
+            );
+        Navigator.pop(context);
+      }
+    }
+
     return AlertDialog(
       title: Text(context.l10n.credentials),
       content: Form(
@@ -76,6 +87,7 @@ class CredentialsPopup extends HookConsumerWidget {
               controller: username,
               validator: (value) =>
                   value.isBlank ? (context.l10n.errorUserName) : null,
+              textInputAction: TextInputAction.next,
               decoration: InputDecoration(
                 hintText: context.l10n.userName,
                 border: const OutlineInputBorder(),
@@ -87,6 +99,8 @@ class CredentialsPopup extends HookConsumerWidget {
               validator: (value) =>
                   value.isBlank ? (context.l10n.errorPassword) : null,
               obscureText: true,
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) => doSave(),
               decoration: InputDecoration(
                 hintText: context.l10n.password,
                 border: const OutlineInputBorder(),
@@ -98,19 +112,7 @@ class CredentialsPopup extends HookConsumerWidget {
       actions: [
         const PopButton(),
         ElevatedButton(
-          onPressed: () async {
-            if ((formKey.currentState?.validate()).ifNull()) {
-              ref.read(credentialsProvider.notifier).set(
-                    _basicAuth(
-                      userName: username.text,
-                      password: password.text,
-                    ),
-                    forEpoch:
-                        ref.read(authCredentialsStoreProvider.notifier).serverEpoch,
-                  );
-              Navigator.pop(context);
-            }
-          },
+          onPressed: doSave,
           child: Text(context.l10n.save),
         ),
       ],

--- a/lib/src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart
+++ b/lib/src/features/settings/presentation/server/widget/credential_popup/login_credentials_popup.dart
@@ -170,6 +170,7 @@ class LoginCredentialsPopup extends HookConsumerWidget {
             TextFormField(
               controller: username,
               validator: (v) => v.isBlank ? context.l10n.errorUserName : null,
+              textInputAction: TextInputAction.next,
               decoration: InputDecoration(
                 hintText: context.l10n.userName,
                 border: const OutlineInputBorder(),
@@ -180,6 +181,10 @@ class LoginCredentialsPopup extends HookConsumerWidget {
               controller: password,
               validator: (v) => v.isBlank ? context.l10n.errorPassword : null,
               obscureText: true,
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) {
+                if (!testing.value) doSave();
+              },
               decoration: InputDecoration(
                 hintText: context.l10n.password,
                 border: const OutlineInputBorder(),


### PR DESCRIPTION
The WebUI login and basic-auth dialogs in server settings only submitted from the Save button. Enter in the password field now saves, and Enter in the username field moves to the password, matching the onboarding screen.