### PR TITLE
chore(deps): bump 7 native plugins ahead of the AGP 9 migration

### DIFF
--- a/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
+++ b/lib/src/features/browse_center/presentation/extension/widgets/install_extension_file.dart
@@ -5,7 +5,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 

--- a/lib/src/utils/misc/file_picker_utils.dart
+++ b/lib/src/utils/misc/file_picker_utils.dart
@@ -17,9 +17,12 @@ abstract class FilePickerUtils {
       allowedExtensions: extensions,
     );
     if (context != null && context.mounted) {
+      // Web has no file paths, so the bytes have to come back with the pick.
+      final bytes = kIsWeb && file != null ? await file.readAsBytes() : null;
+      if (!context.mounted) return file;
       if (file == null ||
           file.name.isBlank ||
-          (!kIsWeb && (file.path).isBlank)) {
+          (kIsWeb && bytes.isBlank || (!kIsWeb && (file.path).isBlank))) {
         throw context.l10n.errorFilePick;
       }
       if (extensions.isNotBlank &&

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -491,10 +491,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_foreground_task
-      sha256: "0dad7e6a4ac57aeb0e680e35ec7ae997f1a2b8579fdb85b16dd16e299b634f4f"
+      sha256: "076fef2bec81319485312fb873e92a54a722f815afe9f631a724ae9fbab71a31"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "11.0.2"
   flutter_hooks:
     dependency: "direct main"
     description:
@@ -1976,18 +1976,18 @@ packages:
     dependency: "direct main"
     description:
       name: workmanager
-      sha256: "06fc5bdd83e2da35f33b682e25167245d0ccb8b56e9a9ada5bfa079fa3af4b9c"
+      sha256: c2c7a3eb984cfcf5623308042fc8270e7e02f5021b34f491ffc0a1ec8e281d5c
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.7"
+    version: "0.10.9"
   workmanager_android:
     dependency: transitive
     description:
       name: workmanager_android
-      sha256: f89029cbcf0695c772287aa8fbbd7af776f1ea63bc95b60a00617f69468ddaa0
+      sha256: "187d1d34864f57f9e388b33b88c001c494093c53679831a3dec2e8176e8829d1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.6"
+    version: "0.10.8"
   workmanager_apple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,14 +17,14 @@ dependencies:
   cached_network_image: ^3.2.2
   cached_network_image_platform_interface: ^4.0.0
   connectivity_plus: ^7.0.0
-  wakelock_plus: ^1.3.3
+  wakelock_plus: ^1.7.0
   cupertino_icons: ^1.0.5
   # Accent folding for library title sort — Dart and intl ship no collator.
   diacritic: ^0.1.6
   drift: ^2.32.0
   extension_type_unions: ^1.0.10
   file: ^7.0.0
-  file_picker: ^12.0.0
+  file_picker: ^12.1.1
   flex_color_picker: 3.8.0
   flutter:
     sdk: flutter
@@ -33,7 +33,7 @@ dependencies:
       url: https://github.com/DattatreyaReddy/flutter_android_volume_keydown
       ref: "9db2306fd2b4f804f5b9fbf69b97b211f47f527c"
   flutter_cache_manager: ^3.3.0
-  flutter_foreground_task: ^10.0.0
+  flutter_foreground_task: ^11.0.1
   flutter_hooks: ^0.21.0
   flutter_localizations:
     sdk: flutter
@@ -62,8 +62,8 @@ dependencies:
   # HCT (perceived-lightness) color space for the light-mode genre chips. Ships
   # with Flutter itself; declared here because we import it directly.
   material_color_utilities: ^0.13.0
-  network_info_plus: ^8.0.0
-  package_info_plus: ^10.0.0
+  network_info_plus: ^8.2.1
+  package_info_plus: ^10.2.1
   path: ^1.8.3
   path_provider: ^2.0.11
   pub_semver: ^2.1.2
@@ -85,12 +85,12 @@ dependencies:
   url_launcher: ^6.1.6
   web_socket_channel: ^3.0.0
   screen_brightness: ^2.1.11
-  share_plus: ^13.0.0
+  share_plus: ^13.3.0
   gal: ^2.3.2
   image: ^4.8.0
   window_manager: ^0.5.2
   flutter_local_notifications: ^22.1.0
-  workmanager: ^0.10.0
+  workmanager: ^0.10.9
 
 dev_dependencies:
   cross_file: ^0.3.5+4


### PR DESCRIPTION
## Summary

Prerequisite dependency-bump pass for an upcoming AGP 9 / built-in-Kotlin migration (two follow-up PRs are stacked on top of this one and will link back here once opened). Every native plugin in this set still applies the legacy `kotlin-android` Gradle plugin internally at its currently-pinned version, which AGP 9's built-in-Kotlin support rejects outright. This PR only bumps plugin versions and adjusts the few affected call sites — no Gradle/AGP/Kotlin config changes at all, so it's independently safe to merge on the current toolchain.

## What's in this PR

- `wakelock_plus` `^1.3.3` -> `^1.7.0`
- `flutter_foreground_task` `^10.0.0` -> `^11.0.1`
- `file_picker`, `share_plus`, `package_info_plus`, `network_info_plus`, `workmanager` nudged up to the specific versions verified against each package's raw changelog for this migration (`^12.1.1`, `^13.3.0`, `^10.2.1`, `^8.2.1`, `^0.10.9` respectively). Most of these were already partially bumped independently by other already-merged PRs; this just finishes them to the audited target version.
- `FilePickerUtils.pickFile` (`lib/src/utils/misc/file_picker_utils.dart`): the web pick path could return blank bytes and still be treated as a successful pick (web has no `file.path` to fall back on checking). Now explicitly validates the read bytes on web before accepting the pick.
- Removed an import left unused by an earlier, independent file_picker migration in `install_extension_file.dart`.

Note: file_picker's own breaking API change in this range (`FilePickerResult` removed, `pickFiles()` now returns the file list directly) was already migrated by an earlier, separately-merged PR — nothing left to do on that front here.

## Test plan

- [x] `flutter analyze --no-fatal-warnings --no-fatal-infos`: 0 new issues.
- [x] `flutter test`: full suite green.
- [x] A full profile, `--split-per-abi` APK build succeeded against the current toolchain, confirming this dependency bump is safe independent of the AGP 9 step that follows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)