### PR TITLE
Rebuild the Server downloads tab as a list matching On device

### DIFF
--- a/lib/src/features/manga_book/domain/downloads/graphql/fragment.graphql
+++ b/lib/src/features/manga_book/domain/downloads/graphql/fragment.graphql
@@ -4,6 +4,7 @@ fragment DownloadDto on DownloadType {
         name
         sourceOrder
         isDownloaded
+        pageCount
     }
 
     manga {

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -6,7 +6,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../../utils/extensions/custom_extensions.dart';
@@ -137,9 +136,40 @@ class _ServerDownloads extends ConsumerWidget {
                 (downloadsChapterIds.length).getValueOnNullOrNegative();
             return RefreshIndicator(
               onRefresh: () => ref.refresh(downloadStatusProvider.future),
-              child: ListView.builder(
+              child: ReorderableListView.builder(
+                buildDefaultDragHandles: false,
+                padding: const EdgeInsets.only(bottom: 88),
+                header: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    ListTile(
+                      dense: true,
+                      leading: const Icon(Icons.download_rounded),
+                      title: Text(context.l10n.downloadsServerTab),
+                      trailing: Text("$downloadsCount"),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                      child: Text(
+                        context.l10n.downloadsServerHint,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: context.theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    const Divider(height: 1),
+                  ],
+                ),
+                onReorder: (oldIndex, newIndex) {
+                  final adjustedNewIndex =
+                      newIndex > oldIndex ? newIndex - 1 : newIndex;
+                  final chapterId = downloadsChapterIds[oldIndex];
+                  ref
+                      .read(downloadsMapProvider.notifier)
+                      .reorder(chapterId, adjustedNewIndex);
+                },
                 itemBuilder: (context, index) {
-                  if (index == downloadsCount) return const Gap(104);
                   final chapterId = downloadsChapterIds[index];
                   return DownloadProgressListTile(
                     key: ValueKey("$chapterId"),
@@ -149,7 +179,7 @@ class _ServerDownloads extends ConsumerWidget {
                     toast: toast,
                   );
                 },
-                itemCount: downloadsCount + 1,
+                itemCount: downloadsCount,
               ),
             );
           }

--- a/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
+++ b/lib/src/features/manga_book/presentation/downloads/downloads_screen.dart
@@ -145,7 +145,7 @@ class _ServerDownloads extends ConsumerWidget {
                     ListTile(
                       dense: true,
                       leading: const Icon(Icons.download_rounded),
-                      title: Text(context.l10n.downloadsServerTab),
+                      title: Text(context.l10n.downloadsQueue),
                       trailing: Text("$downloadsCount"),
                     ),
                     Padding(
@@ -161,14 +161,9 @@ class _ServerDownloads extends ConsumerWidget {
                     const Divider(height: 1),
                   ],
                 ),
-                onReorder: (oldIndex, newIndex) {
-                  final adjustedNewIndex =
-                      newIndex > oldIndex ? newIndex - 1 : newIndex;
-                  final chapterId = downloadsChapterIds[oldIndex];
-                  ref
-                      .read(downloadsMapProvider.notifier)
-                      .reorder(chapterId, adjustedNewIndex);
-                },
+                onReorderItem: (oldIndex, newIndex) => ref
+                    .read(downloadsMapProvider.notifier)
+                    .reorder(downloadsChapterIds[oldIndex], newIndex),
                 itemBuilder: (context, index) {
                   final chapterId = downloadsChapterIds[index];
                   return DownloadProgressListTile(

--- a/lib/src/features/manga_book/presentation/downloads/widgets/download_progress_list_tile.dart
+++ b/lib/src/features/manga_book/presentation/downloads/widgets/download_progress_list_tile.dart
@@ -49,124 +49,133 @@ class DownloadProgressListTile extends HookConsumerWidget {
     }
   }
 
+  String _downloadingText(BuildContext context, DownloadDto downloadUpdate) {
+    final total = downloadUpdate.chapter.pageCount;
+    if (total > 0) {
+      final done = (downloadUpdate.progress * total).round();
+      return '${context.l10n.downloading} · '
+          '${context.l10n.downloadPagesProgress(done, total)}';
+    }
+    return '${context.l10n.downloading} · '
+        '${(downloadUpdate.progress * 100).toInt()}%';
+  }
+
+  String _stateText(BuildContext context, DownloadDto downloadUpdate) =>
+      switch (downloadUpdate.state) {
+        DownloadState.QUEUED => context.l10n.queued,
+        DownloadState.DOWNLOADING => _downloadingText(context, downloadUpdate),
+        DownloadState.ERROR ||
+        DownloadState.FINISHED =>
+          downloadUpdate.toDisplayName(context),
+        DownloadState.$unknown => throw UnimplementedError(),
+      };
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final downloadUpdate = ref.watch(downloadsFromIdProvider(chapterId));
     if (downloadUpdate == null) return const SizedBox.shrink();
-    return Card(
-      margin: KEdgeInsets.h16v4.size,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8.0),
-        child: Row(
-          children: [
-            if ((downloadUpdate.manga.thumbnailUrl).isNotBlank)
-              Padding(
-                padding: KEdgeInsets.a8.size,
-                child: InkWell(
-                  onTap: () => MangaRoute(mangaId: downloadUpdate.manga.id)
-                      .push(context),
-                  child: ClipRRect(
-                    borderRadius: KBorderRadius.r8.radius,
-                    child: ServerImage(
-                      imageUrl: downloadUpdate.manga.thumbnailUrl!,
-                      size: const Size.square(56),
-                    ),
-                  ),
-                ),
-              ),
-            Expanded(
-              child: Padding(
-                padding: KEdgeInsets.a4.size,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    ListTile(
-                      contentPadding: EdgeInsets.zero,
-                      dense: true,
-                      title: Text(
-                        downloadUpdate.manga.title,
-                        style: context.textTheme.labelLarge,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                      subtitle: Text(
-                        downloadUpdate.chapter.name,
-                        overflow: TextOverflow.ellipsis,
-                        style: context.textTheme.labelSmall,
-                      ),
-                      trailing: Text(
-                        downloadUpdate.toDisplayName(context),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    LinearProgressIndicator(
-                      value: downloadUpdate.progress,
-                      semanticsValue:
-                          "${(downloadUpdate.progress * 100).toInt()}%",
-                    ),
-                    Row(
-                      children: [
-                        IconButton(
-                          visualDensity: VisualDensity.compact,
-                          onPressed: index.isZero
-                              ? null
-                              : () => ref
-                                  .read(downloadsMapProvider.notifier)
-                                  .reorder(
-                                      downloadUpdate.chapter.id, index - 1),
-                          icon: const Icon(Icons.arrow_drop_up_rounded),
-                          color: Colors.grey,
-                        ),
-                        IconButton(
-                          visualDensity: VisualDensity.compact,
-                          onPressed: index >= downloadsCount - 1
-                              ? null
-                              : () => ref
-                                  .read(downloadsMapProvider.notifier)
-                                  .reorder(
-                                      downloadUpdate.chapter.id, index + 1),
-                          icon: const Icon(Icons.arrow_drop_down_rounded),
-                          color: Colors.grey,
-                        ),
-                      ],
-                    ),
-                  ],
+    final colorScheme = context.theme.colorScheme;
+    final isError = downloadUpdate.state == DownloadState.ERROR;
+    final isDownloading = downloadUpdate.state == DownloadState.DOWNLOADING;
+    return ReorderableDelayedDragStartListener(
+      index: index,
+      child: Column(
+        children: [
+          ListTile(
+            isThreeLine: true,
+            leading: SizedBox(
+              width: 40,
+              height: 56,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: ServerImage(
+                  imageUrl: downloadUpdate.manga.thumbnailUrl ?? '',
+                  fit: BoxFit.cover,
                 ),
               ),
             ),
-            PopupMenuButton(
-              shape: RoundedRectangleBorder(
-                borderRadius: KBorderRadius.r16.radius,
-              ),
-              itemBuilder: (context) => [
-                if (downloadUpdate.state == DownloadState.ERROR)
-                  PopupMenuItem(
-                    child: Text(context.l10n.retry),
-                    onTap: () => toggleChapterToQueue(
-                        toast, ref, true, downloadUpdate.chapter.id),
-                  ),
-                PopupMenuItem(
-                  child: Text(context.l10n.delete),
-                  onTap: () => toggleChapterToQueue(
-                      toast, ref, false, downloadUpdate.chapter.id),
+            title: Text(
+              downloadUpdate.manga.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  downloadUpdate.chapter.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                if (!index.isZero)
-                  PopupMenuItem(
-                    child: Text(context.l10n.moveToTop),
-                    onTap: () => ref
-                        .read(downloadsMapProvider.notifier)
-                        .reorder(downloadUpdate.chapter.id, 0),
+                Text(
+                  _stateText(context, downloadUpdate),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: isError
+                        ? colorScheme.error
+                        : colorScheme.onSurfaceVariant,
                   ),
-                if (index < downloadsCount - 1)
-                  PopupMenuItem(
-                    child: Text(context.l10n.moveToBottom),
-                    onTap: () => ref
-                        .read(downloadsMapProvider.notifier)
-                        .reorder(downloadUpdate.chapter.id, downloadsCount - 1),
-                  ),
+                ),
               ],
             ),
-          ],
-        ),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                PopupMenuButton(
+                  shape: RoundedRectangleBorder(
+                    borderRadius: KBorderRadius.r16.radius,
+                  ),
+                  itemBuilder: (context) => [
+                    if (isError)
+                      PopupMenuItem(
+                        child: Text(context.l10n.retry),
+                        onTap: () => toggleChapterToQueue(
+                            toast, ref, true, downloadUpdate.chapter.id),
+                      ),
+                    PopupMenuItem(
+                      child: Text(context.l10n.cancel),
+                      onTap: () => toggleChapterToQueue(
+                          toast, ref, false, downloadUpdate.chapter.id),
+                    ),
+                    if (!index.isZero)
+                      PopupMenuItem(
+                        child: Text(context.l10n.moveToTop),
+                        onTap: () => ref
+                            .read(downloadsMapProvider.notifier)
+                            .reorder(downloadUpdate.chapter.id, 0),
+                      ),
+                    if (index < downloadsCount - 1)
+                      PopupMenuItem(
+                        child: Text(context.l10n.moveToBottom),
+                        onTap: () => ref
+                            .read(downloadsMapProvider.notifier)
+                            .reorder(
+                                downloadUpdate.chapter.id, downloadsCount - 1),
+                      ),
+                  ],
+                ),
+                ReorderableDragStartListener(
+                  index: index,
+                  child: Icon(
+                    Icons.drag_handle_rounded,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+            onTap: () =>
+                MangaRoute(mangaId: downloadUpdate.manga.id).push(context),
+          ),
+          if (isDownloading)
+            Padding(
+              padding: const EdgeInsets.only(left: 72, right: 16),
+              child: LinearProgressIndicator(
+                minHeight: 2,
+                value: downloadUpdate.progress,
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -3051,6 +3051,22 @@
   "@downloadsOnDeviceTab": {
     "description": "Downloads tab: files downloaded on this device"
   },
+  "downloadsServerHint": "Chapters the server is fetching. Long-press a row to reorder.",
+  "@downloadsServerHint": {
+    "description": "Hint shown above the server download queue"
+  },
+  "downloadPagesProgress": "{done}/{total} pages",
+  "@downloadPagesProgress": {
+    "description": "Progress text for a downloading chapter, e.g. 24/25 pages",
+    "placeholders": {
+      "done": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "offlineNoFiles": "Nothing downloaded on this device yet",
   "@offlineNoFiles": {
     "description": "Empty state for the on-device downloads tab"

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -3051,6 +3051,10 @@
   "@downloadsOnDeviceTab": {
     "description": "Downloads tab: files downloaded on this device"
   },
+  "downloadsQueue": "Queue",
+  "@downloadsQueue": {
+    "description": "Header title above the server download queue"
+  },
   "downloadsServerHint": "Chapters the server is fetching. Long-press a row to reorder.",
   "@downloadsServerHint": {
     "description": "Hint shown above the server download queue"

--- a/test/src/features/manga_book/download_status_icon_queued_test.dart
+++ b/test/src/features/manga_book/download_status_icon_queued_test.dart
@@ -28,6 +28,7 @@ DownloadDto _download(DownloadState state, double progress) =>
         name: 'c1',
         sourceOrder: 1,
         isDownloaded: false,
+        pageCount: 20,
       ),
       manga: Fragment$DownloadDto$manga(id: 1, title: 'M', downloadCount: 0),
       progress: progress,

--- a/test/src/features/manga_book/presentation/downloads/download_progress_list_tile_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/download_progress_list_tile_test.dart
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tsumiru/src/features/manga_book/domain/downloads/downloads_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/downloads/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/downloads/controller/downloads_controller.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/downloads/widgets/download_progress_list_tile.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+DownloadDto _download({
+  required DownloadState state,
+  double progress = 0,
+  int pageCount = 20,
+  int tries = 0,
+}) =>
+    Fragment$DownloadDto(
+      chapter: Fragment$DownloadDto$chapter(
+        id: 1,
+        name: 'Chapter 1',
+        sourceOrder: 1,
+        isDownloaded: false,
+        pageCount: pageCount,
+      ),
+      manga: Fragment$DownloadDto$manga(
+        id: 1,
+        title: 'Test Manga',
+        downloadCount: 0,
+      ),
+      progress: progress,
+      state: state,
+      tries: tries,
+      position: 0,
+    );
+
+Future<void> _pump(WidgetTester tester, DownloadDto download) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        downloadsFromIdProvider(1).overrideWithValue(download),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: DownloadProgressListTile(
+            chapterId: 1,
+            toast: null,
+            index: 0,
+            downloadsCount: 1,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('queued row shows the queued label, no progress bar, no retry',
+      (tester) async {
+    await _pump(tester, _download(state: DownloadState.QUEUED));
+
+    final l10n = AppLocalizations.of(
+        tester.element(find.byType(DownloadProgressListTile)))!;
+    expect(find.text(l10n.queued), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+
+    await tester.tap(find.byType(PopupMenuButton));
+    await tester.pumpAndSettle();
+    expect(find.text(l10n.retry), findsNothing);
+    expect(find.text(l10n.cancel), findsOneWidget);
+  });
+
+  testWidgets('downloading row shows page progress and a progress bar',
+      (tester) async {
+    await _pump(
+      tester,
+      _download(state: DownloadState.DOWNLOADING, progress: 0.96, pageCount: 25),
+    );
+
+    final l10n = AppLocalizations.of(
+        tester.element(find.byType(DownloadProgressListTile)))!;
+    expect(find.textContaining('24/25'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+    await tester.tap(find.byType(PopupMenuButton));
+    await tester.pumpAndSettle();
+    expect(find.text(l10n.retry), findsNothing);
+  });
+
+  testWidgets('error row shows the error label, no progress bar, and retry',
+      (tester) async {
+    await _pump(
+      tester,
+      _download(state: DownloadState.ERROR, tries: 3),
+    );
+
+    final l10n = AppLocalizations.of(
+        tester.element(find.byType(DownloadProgressListTile)))!;
+    expect(find.textContaining('Error'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+
+    await tester.tap(find.byType(PopupMenuButton));
+    await tester.pumpAndSettle();
+    expect(find.text(l10n.retry), findsOneWidget);
+  });
+}

--- a/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
+++ b/test/src/features/manga_book/presentation/downloads/downloads_controller_test.dart
@@ -75,6 +75,7 @@ Map<String, dynamic> _queueItem({
         'name': 'Ch. $chapterId',
         'sourceOrder': position,
         'isDownloaded': false,
+        'pageCount': 0,
         '__typename': 'ChapterType',
       },
       'manga': {


### PR DESCRIPTION
The Server tab used tall cards with a large cover, a progress bar on every row, up and down arrows, and a menu. It is now the same three-line list as the On device tab: small cover, series, chapter, and a state line. Only the active download shows a progress line, with a page count. Reorder by long-press or the drag handle. The row menu holds Retry, Cancel, Move to top, and Move to bottom. Tapping a row opens the series. Adds the chapter page count to the download query.

Design: vault plans/2026-09-05-server-downloads-tab-redesign-design.md. Verified on device.