### PR TITLE
Stop following the Simple Login redirect so the session cookie is seen

### DIFF
--- a/lib/src/features/auth/data/simple_login_client.dart
+++ b/lib/src/features/auth/data/simple_login_client.dart
@@ -42,15 +42,12 @@ class SimpleLoginClient {
     required String username,
     required String password,
   }) async {
-    final uri = Uri.parse('$serverBaseUrl/login.html');
-    final response = await _http.post(
-      uri,
-      headers: {
-        'Content-Type':
-            'application/x-www-form-urlencoded; charset=utf-8',
-      },
-      body: {'user': username, 'pass': password},
-    );
+    final request = http.Request('POST', Uri.parse('$serverBaseUrl/login.html'))
+      ..bodyFields = {'user': username, 'pass': password}
+      ..headers['Content-Type'] =
+          'application/x-www-form-urlencoded; charset=utf-8'
+      ..followRedirects = false;
+    final response = await http.Response.fromStream(await _http.send(request));
 
     if (response.statusCode == 200) {
       // Server re-rendered the login page → bad credentials.

--- a/test/src/features/auth/data/simple_login_client_test.dart
+++ b/test/src/features/auth/data/simple_login_client_test.dart
@@ -33,6 +33,24 @@ void main() {
       expect(cookie, 'JSESSIONID=abc.123');
     });
 
+    test('login does not follow the 303 so the cookie is observed', () async {
+      bool? followRedirects;
+      final mock = MockClient((request) async {
+        followRedirects = request.followRedirects;
+        return http.Response('', 303, headers: {
+          'set-cookie': 'JSESSIONID=abc; Path=/; HttpOnly',
+          'location': '/',
+        });
+      });
+      final cookie = await SimpleLoginClient(httpClient: mock).login(
+        serverBaseUrl: 'http://s',
+        username: 'u',
+        password: 'p',
+      );
+      expect(followRedirects, isFalse);
+      expect(cookie, 'JSESSIONID=abc');
+    });
+
     test('login throws SimpleLoginAuthFailure on 200 (re-rendered form)',
         () async {
       final mock = MockClient((request) async => http.Response(


### PR DESCRIPTION
With valid credentials the server answers the login post with a 303 carrying the session cookie. The default client re-issued the redirect as a GET without the cookie, landed on the login page with a 200, and the app reported bad credentials for every Simple Login attempt on native builds.

The login request now leaves redirects unfollowed and reads the cookie from the 303 directly. A test pins the redirect setting. Verified against a Suwayomi container in SIMPLE_LOGIN mode: valid credentials return a session cookie, invalid ones report the failure.

Closes #408