### PR TITLE
Make extension failures readable and recoverable

### DIFF
--- a/lib/src/features/browse_center/presentation/extension/controller/extension_actions.dart
+++ b/lib/src/features/browse_center/presentation/extension/controller/extension_actions.dart
@@ -32,9 +32,13 @@ class ExtensionActions {
   /// [languageCode] is enabled in the source language filter, so the sources the
   /// new extension brings aren't filtered straight back out of the Sources tab.
   Future<void> install(String pkgName, {String? languageCode}) =>
+      _refreshAfter(() => _install(pkgName, languageCode));
+
+  /// The server has no reinstall mutation, so this is uninstall then install.
+  Future<void> reinstall(String pkgName, {String? languageCode}) =>
       _refreshAfter(() async {
-        await _repository.installExtension(pkgName);
-        if (languageCode.isNotBlank) _enableSourceLanguage(languageCode!);
+        await _repository.uninstallExtension(pkgName);
+        await _install(pkgName, languageCode);
       });
 
   Future<void> installFile(BuildContext context, {PlatformFile? file}) =>
@@ -47,6 +51,11 @@ class ExtensionActions {
 
   Future<void> uninstall(String pkgName) =>
       _refreshAfter(() => _repository.uninstallExtension(pkgName));
+
+  Future<void> _install(String pkgName, String? languageCode) async {
+    await _repository.installExtension(pkgName);
+    if (languageCode.isNotBlank) _enableSourceLanguage(languageCode!);
+  }
 
   /// A blank filter means the user turned every language off (the key defaults
   /// to a populated list), so installing an extension doesn't switch one back on.

--- a/lib/src/features/browse_center/presentation/extension/widgets/extension_list_tile.dart
+++ b/lib/src/features/browse_center/presentation/extension/widgets/extension_list_tile.dart
@@ -27,7 +27,7 @@ class ExtensionListTile extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isLoading = useState(false);
+    final runningAction = useState<String?>(null);
     return ListTile(
       key: key,
       leading: ClipRRect(
@@ -36,7 +36,7 @@ class ExtensionListTile extends HookConsumerWidget {
           url: extension.iconUrl,
           outerSize: const Size.square(48),
           innerSize: const Size.square(24),
-          isLoading: isLoading.value,
+          isLoading: runningAction.value != null,
         ),
       ),
       title: Text(
@@ -66,7 +66,7 @@ class ExtensionListTile extends HookConsumerWidget {
       ),
       trailing: ExtensionListTileTailing(
         extension: extension,
-        isLoading: isLoading,
+        runningAction: runningAction,
         ref: ref,
       ),
     );
@@ -77,27 +77,30 @@ class ExtensionListTileTailing extends StatelessWidget {
   const ExtensionListTileTailing({
     super.key,
     required this.extension,
-    required this.isLoading,
+    required this.runningAction,
     required this.ref,
   });
 
   final Extension extension;
-  final ValueNotifier<bool> isLoading;
+
+  /// The label of the action in flight, or null when the tile is idle.
+  final ValueNotifier<String?> runningAction;
   final WidgetRef ref;
 
   /// Runs an extension action with the button's spinner and error toast.
   /// [ExtensionActions] refreshes both the extension and the source list, so no
   /// caller needs to pass a refresh callback down.
   Future<void> _run(
+    String label,
     Future<void> Function(ExtensionActions actions) action,
   ) async {
     try {
-      isLoading.value = true;
+      runningAction.value = label;
       await AppUtils.guard(
         () => action(ref.read(extensionActionsProvider)),
         ref.read(toastProvider),
       );
-      isLoading.value = false;
+      runningAction.value = null;
     } catch (_) {
       // The refresh this action triggers can rebuild the list and dispose the
       // tile out from under the spinner.
@@ -106,78 +109,99 @@ class ExtensionListTileTailing extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final running = runningAction.value;
     if (extension.isObsolete.ifNull()) {
       return OutlinedButton(
-        onPressed: extension.isInstalled.ifNull() && !isLoading.value
-            ? () => _run((actions) => actions.uninstall(extension.pkgName))
+        onPressed: extension.isInstalled.ifNull() && running == null
+            ? () => _run(
+                  context.l10n.uninstalling,
+                  (actions) => actions.uninstall(extension.pkgName),
+                )
             : null,
         child: Text(
           context.l10n.obsolete,
           style: const TextStyle(color: Colors.redAccent),
         ),
       );
-    } else {
-      if (extension.isInstalled.ifNull()) {
-        final actionButton = TextButton(
-          onPressed: (!isLoading.value)
-              ? () => _run((actions) async {
-                    if (extension.pkgName.isBlank) {
-                      throw context.l10n.errorExtension;
-                    }
-                    if (extension.hasUpdate.ifNull()) {
-                      await actions.update(extension.pkgName);
-                    } else {
-                      await actions.uninstall(extension.pkgName);
-                    }
-                  })
-              : null,
-          child: Text(
-            extension.hasUpdate.ifNull()
-                ? isLoading.value
-                    ? context.l10n.updating
-                    : context.l10n.update
-                : isLoading.value
-                    ? context.l10n.uninstalling
-                    : context.l10n.uninstall,
-          ),
-        );
-        // When an update is pending the single button reads "Update", which used
-        // to leave no way to uninstall the extension. Keep Update but add a
-        // separate uninstall affordance so a pending update can't trap it (#290).
-        if (!extension.hasUpdate.ifNull()) return actionButton;
-        return Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            actionButton,
-            IconButton(
-              tooltip: context.l10n.uninstall,
-              icon: const Icon(Icons.delete_outline),
-              onPressed: isLoading.value
-                  ? null
-                  : () => _run((actions) => actions.uninstall(
-                        extension.pkgName,
-                      )),
-            ),
-          ],
-        );
-      } else {
-        return TextButton(
-          onPressed: !isLoading.value
-              ? () => _run((actions) async {
-                    if (extension.pkgName.isBlank) {
-                      throw context.l10n.errorExtension;
-                    }
-                    await actions.install(
-                      extension.pkgName,
-                      languageCode: extension.language?.code,
-                    );
-                  })
-              : null,
-          child: Text(
-            isLoading.value ? context.l10n.installing : context.l10n.install,
-          ),
-        );
-      }
     }
+    if (!extension.isInstalled.ifNull()) {
+      return TextButton(
+        onPressed: running == null
+            ? () => _run(context.l10n.installing, (actions) async {
+                  if (extension.pkgName.isBlank) {
+                    throw context.l10n.errorExtension;
+                  }
+                  await actions.install(
+                    extension.pkgName,
+                    languageCode: extension.language?.code,
+                  );
+                })
+            : null,
+        child: Text(running ?? context.l10n.install),
+      );
+    }
+    final hasUpdate = extension.hasUpdate.ifNull();
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextButton(
+          onPressed: running == null
+              ? () => _run(
+                    hasUpdate
+                        ? context.l10n.updating
+                        : context.l10n.uninstalling,
+                    (actions) async {
+                      if (extension.pkgName.isBlank) {
+                        throw context.l10n.errorExtension;
+                      }
+                      if (hasUpdate) {
+                        await actions.update(extension.pkgName);
+                      } else {
+                        await actions.uninstall(extension.pkgName);
+                      }
+                    },
+                  )
+              : null,
+          child: Text(
+            running ??
+                (hasUpdate ? context.l10n.update : context.l10n.uninstall),
+          ),
+        ),
+        // A third control squeezes the extension name off a phone screen.
+        if (hasUpdate)
+          PopupMenuButton<VoidCallback>(
+            enabled: running == null,
+            onSelected: (selected) => selected(),
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: _reinstall(context),
+                child: Text(context.l10n.reinstall),
+              ),
+              PopupMenuItem(
+                value: () => _run(
+                  context.l10n.uninstalling,
+                  (actions) => actions.uninstall(extension.pkgName),
+                ),
+                child: Text(context.l10n.uninstall),
+              ),
+            ],
+          )
+        else
+          IconButton(
+            tooltip: context.l10n.reinstall,
+            icon: const Icon(Icons.restart_alt_rounded),
+            onPressed: running == null ? _reinstall(context) : null,
+          ),
+      ],
+    );
   }
+
+  /// Repairs an extension with no loaded sources or a phantom update (#428).
+  VoidCallback _reinstall(BuildContext context) => () => _run(
+        context.l10n.reinstalling,
+        (actions) => actions.reinstall(
+          extension.pkgName,
+          languageCode: extension.language?.code,
+        ),
+      );
 }

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2781,6 +2781,11 @@
   "unifiedSearchAllSources": "Search all sources for \"{query}\"",
   "uninstall": "Uninstall",
   "uninstalling": "Uninstalling",
+  "reinstall": "Reinstall",
+  "@reinstall": {
+    "description": "Button tooltip on an installed extension: uninstall it and install it again"
+  },
+  "reinstalling": "Reinstalling",
   "unknownAuthor": "Unknown Author",
   "unknownManga": "Unknown Manga",
   "unknownSource": "Unknown Source",

--- a/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions/async_value_extensions.dart
@@ -70,12 +70,13 @@ extension AsyncValueExtensions<T> on AsyncValue<T> {
               ServerUnreachableView(
                   onRetry: refresh, offlineEscape: offlineEscapeHatch));
         }
+        final message = error.toString().trim();
         return AppUtils.wrapOn(
             wrapper,
             Emoticons(
-              title: showGenericError
+              title: showGenericError || message.isBlank
                   ? context.l10n.errorSomethingWentWrong
-                  : error.toString(),
+                  : message,
               // Null when there's nothing to show — an empty Column still
               // costs Emoticons' spacing slot. The pin self-gates on the
               // catalog (no ref here); its shrunk state trails the column,

--- a/lib/src/utils/extensions/custom_extensions/graphql_extensions.dart
+++ b/lib/src/utils/extensions/custom_extensions/graphql_extensions.dart
@@ -29,6 +29,16 @@ extension StreamGraphQlExtensions<T> on Stream<QueryResult<T>> {
       map((res) => res.result.apply(parse));
 }
 
+final _serverErrorWrapper =
+    RegExp(r'^Exception while fetching data \([^)]*\)\s*:\s*');
+
+/// Suwayomi packs a whole Java stack trace into `GraphQLError.message`.
+String _readableGraphQLMessage(String message) {
+  final body = message.replaceFirst(_serverErrorWrapper, '').trim();
+  final firstLine = body.split('\n').first.trim();
+  return firstLine == 'null' ? '' : firstLine;
+}
+
 class OperationMessageException implements Exception {
   final OperationException exception;
 
@@ -39,8 +49,10 @@ class OperationMessageException implements Exception {
     StringBuffer toString = StringBuffer();
     List<GraphQLError> graphqlErrors = exception.graphqlErrors;
     for (GraphQLError error in graphqlErrors) {
+      final message = _readableGraphQLMessage(error.message);
+      if (message.isEmpty) continue;
       if (toString.isNotEmpty) toString.write(', ');
-      toString.write(error.message);
+      toString.write(message);
     }
     LinkException? linkException = exception.linkException;
     if (linkException != null && linkException.originalException != null) {

--- a/lib/src/utils/misc/toast/toast.dart
+++ b/lib/src/utils/misc/toast/toast.dart
@@ -50,11 +50,14 @@ class Toast {
     bool withMicrotask = false,
     bool instantShow = false,
   }) {
+    final text = error.trim().isNotBlank
+        ? error.trim()
+        : _context.l10n.errorSomethingWentWrong;
     toast() {
       if (instantShow) close();
       _fToast.showToast(
         child: ToastWidget(
-          text: error,
+          text: text,
           backgroundColor: Colors.red.shade400,
           textColor: Colors.white,
         ),

--- a/test/helpers/fake_extension_repository.dart
+++ b/test/helpers/fake_extension_repository.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/widgets.dart';
+import 'package:graphql/client.dart';
+import 'package:tsumiru/src/features/browse_center/data/extension_repository/extension_repository.dart';
+import 'package:tsumiru/src/features/browse_center/domain/extension/extension_model.dart';
+
+GraphQLClient dummyGraphQLClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+/// Records every mutation the app sends; [calls] keeps their order.
+class FakeExtensionRepository extends ExtensionRepository {
+  FakeExtensionRepository() : super(dummyGraphQLClient());
+
+  final List<String> installed = <String>[];
+  final List<String> uninstalled = <String>[];
+  final List<String> updated = <String>[];
+  final List<PlatformFile> fileInstalls = <PlatformFile>[];
+  final List<String> calls = <String>[];
+
+  @override
+  Future<void> installExtension(String pkgName) async {
+    installed.add(pkgName);
+    calls.add('install $pkgName');
+  }
+
+  @override
+  Future<void> uninstallExtension(String pkgName) async {
+    uninstalled.add(pkgName);
+    calls.add('uninstall $pkgName');
+  }
+
+  @override
+  Future<void> updateExtension(String pkgName) async {
+    updated.add(pkgName);
+    calls.add('update $pkgName');
+  }
+
+  @override
+  Future<void> installExtensionFile(
+    BuildContext context, {
+    PlatformFile? file,
+  }) async {
+    // The real repository rejects a null pick before it mutates anything, so a
+    // test that passed null would pass even if the file stopped being forwarded.
+    if (file == null) throw Exception('no file picked');
+    fileInstalls.add(file);
+  }
+
+  @override
+  Future<List<Extension>?> getExtensionListStream() async => <Extension>[];
+}

--- a/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
+++ b/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
@@ -10,7 +10,6 @@ import 'package:cross_file/cross_file.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:graphql/client.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tsumiru/src/features/browse_center/data/extension_repository/extension_repository.dart';
@@ -21,44 +20,10 @@ import 'package:tsumiru/src/features/browse_center/presentation/extension/contro
 import 'package:tsumiru/src/features/browse_center/presentation/source/controller/source_controller.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
 
-GraphQLClient _dummyClient() =>
-    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
-
-class _FakeExtensionRepository extends ExtensionRepository {
-  _FakeExtensionRepository() : super(_dummyClient());
-
-  final List<String> installed = <String>[];
-  final List<String> uninstalled = <String>[];
-  final List<String> updated = <String>[];
-  final List<PlatformFile> fileInstalls = <PlatformFile>[];
-
-  @override
-  Future<void> installExtension(String pkgName) async => installed.add(pkgName);
-
-  @override
-  Future<void> uninstallExtension(String pkgName) async =>
-      uninstalled.add(pkgName);
-
-  @override
-  Future<void> updateExtension(String pkgName) async => updated.add(pkgName);
-
-  @override
-  Future<void> installExtensionFile(
-    BuildContext context, {
-    PlatformFile? file,
-  }) async {
-    // The real repository rejects a null pick before it mutates anything, so a
-    // test that passed null would pass even if the file stopped being forwarded.
-    if (file == null) throw Exception('no file picked');
-    fileInstalls.add(file);
-  }
-
-  @override
-  Future<List<Extension>?> getExtensionListStream() async => <Extension>[];
-}
+import '../../../../../helpers/fake_extension_repository.dart';
 
 class _CountingSourceRepository extends SourceRepository {
-  _CountingSourceRepository() : super(_dummyClient());
+  _CountingSourceRepository() : super(dummyGraphQLClient());
 
   int listCalls = 0;
 
@@ -70,12 +35,12 @@ class _CountingSourceRepository extends SourceRepository {
 }
 
 void main() {
-  late _FakeExtensionRepository extensions;
+  late FakeExtensionRepository extensions;
   late _CountingSourceRepository sources;
   late ProviderContainer container;
 
   setUp(() async {
-    extensions = _FakeExtensionRepository();
+    extensions = FakeExtensionRepository();
     sources = _CountingSourceRepository();
     SharedPreferences.setMockInitialValues(<String, Object>{});
     container = ProviderContainer(overrides: [
@@ -154,6 +119,28 @@ void main() {
     expect(container.read(sourceLanguageFilterProvider), isEmpty);
   });
 
+  test('reinstalling removes the extension before putting it back', () async {
+    final actions = container.read(extensionActionsProvider);
+    final refetches =
+        await sourceFetchesAfter(() => actions.reinstall('com.example.ext'));
+
+    expect(extensions.calls,
+        <String>['uninstall com.example.ext', 'install com.example.ext']);
+    expect(refetches, 1,
+        reason: 'the rebuilt extension re-registers its sources server-side');
+  });
+
+  test("reinstalling enables the extension's language in the source filter",
+      () async {
+    expect(container.read(sourceLanguageFilterProvider), isNot(contains('ko')));
+
+    await container
+        .read(extensionActionsProvider)
+        .reinstall('com.example.ext', languageCode: 'ko');
+
+    expect(container.read(sourceLanguageFilterProvider), contains('ko'));
+  });
+
   test('a failed install leaves the source list alone', () async {
     final failing = ProviderContainer(overrides: [
       extensionRepositoryProvider.overrideWithValue(_ThrowingRepository()),
@@ -207,7 +194,7 @@ void main() {
 }
 
 class _ThrowingRepository extends ExtensionRepository {
-  _ThrowingRepository() : super(_dummyClient());
+  _ThrowingRepository() : super(dummyGraphQLClient());
 
   @override
   Future<void> installExtension(String pkgName) async =>

--- a/test/src/features/browse_center/presentation/extension/extension_list_tile_test.dart
+++ b/test/src/features/browse_center/presentation/extension/extension_list_tile_test.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/browse_center/data/extension_repository/extension_repository.dart';
+import 'package:tsumiru/src/features/browse_center/domain/extension/extension_model.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/extension/widgets/extension_list_tile.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+
+import '../../../../../helpers/fake_extension_repository.dart';
+
+const _name = 'A Rather Long Extension Name';
+
+Extension _extension({bool hasUpdate = false}) => Extension(
+      hasUpdate: hasUpdate,
+      iconUrl: '',
+      isInstalled: true,
+      contentWarning: Enum$ContentWarning.SAFE,
+      isObsolete: false,
+      lang: 'en',
+      name: _name,
+      pkgName: 'com.example.ext',
+      // ignore: deprecated_member_use_from_same_package
+      versionCode: 1,
+      versionName: '1.4.2',
+    );
+
+/// The real tile's leading image talks to the server; this is its stand-in.
+Future<void> _pumpTile(
+  WidgetTester tester,
+  ProviderContainer container, {
+  bool hasUpdate = false,
+}) async {
+  final running = ValueNotifier<String?>(null);
+  addTearDown(running.dispose);
+  tester.view.physicalSize = const Size(360, 800);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Consumer(
+          builder: (context, ref, _) => ValueListenableBuilder<String?>(
+            valueListenable: running,
+            builder: (context, _, _) => ListTile(
+              leading: const SizedBox.square(dimension: 48),
+              title: const Text(_name, overflow: TextOverflow.ellipsis),
+              subtitle: const Text('English 1.4.2'),
+              trailing: ExtensionListTileTailing(
+                extension: _extension(hasUpdate: hasUpdate),
+                runningAction: running,
+                ref: ref,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  ));
+}
+
+/// Holds the uninstall open so a test can look at the tile mid-reinstall.
+class _PausedExtensionRepository extends FakeExtensionRepository {
+  final gate = Completer<void>();
+
+  @override
+  Future<void> uninstallExtension(String pkgName) async {
+    await gate.future;
+    return super.uninstallExtension(pkgName);
+  }
+}
+
+const _reinstalled = <String>[
+  'uninstall com.example.ext',
+  'install com.example.ext',
+];
+
+void main() {
+  late FakeExtensionRepository extensions;
+  late ProviderContainer container;
+
+  setUp(() async {
+    extensions = FakeExtensionRepository();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    container = ProviderContainer(overrides: [
+      extensionRepositoryProvider.overrideWithValue(extensions),
+      sharedPreferencesProvider
+          .overrideWithValue(await SharedPreferences.getInstance()),
+    ]);
+  });
+
+  tearDown(() => container.dispose());
+
+  testWidgets('an installed extension can be reinstalled in one tap',
+      (tester) async {
+    await _pumpTile(tester, container);
+
+    await tester.tap(find.byTooltip('Reinstall'));
+    await tester.pump();
+
+    expect(extensions.calls, _reinstalled);
+  });
+
+  testWidgets('the button says what is happening while it runs',
+      (tester) async {
+    final paused = _PausedExtensionRepository();
+    final pausedContainer = ProviderContainer(overrides: [
+      extensionRepositoryProvider.overrideWithValue(paused),
+      sharedPreferencesProvider
+          .overrideWithValue(await SharedPreferences.getInstance()),
+    ]);
+    addTearDown(pausedContainer.dispose);
+    await _pumpTile(tester, pausedContainer);
+    expect(find.text('Uninstall'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Reinstall'));
+    await tester.pump();
+
+    expect(find.text('Reinstalling'), findsOneWidget);
+
+    paused.gate.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('an extension with an update pending can still be reinstalled',
+      (tester) async {
+    await _pumpTile(tester, container, hasUpdate: true);
+    expect(find.text('Update'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reinstall'));
+    await tester.pumpAndSettle();
+
+    expect(extensions.calls, _reinstalled);
+  });
+
+  testWidgets('an update pending never hides uninstall', (tester) async {
+    await _pumpTile(tester, container, hasUpdate: true);
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Uninstall'));
+    await tester.pumpAndSettle();
+
+    expect(extensions.calls, <String>['uninstall com.example.ext']);
+  });
+
+  testWidgets('the actions never crowd the extension name off a phone',
+      (tester) async {
+    for (final hasUpdate in [false, true]) {
+      await _pumpTile(tester, container, hasUpdate: hasUpdate);
+
+      expect(tester.takeException(), isNull, reason: 'hasUpdate: $hasUpdate');
+      // Measured at 360dp: a third control squeezes the name to one letter.
+      final actions = tester.widget<Row>(find
+          .descendant(
+              of: find.byType(ExtensionListTileTailing),
+              matching: find.byType(Row))
+          .first);
+      expect(actions.children.length, lessThanOrEqualTo(2),
+          reason: 'hasUpdate: $hasUpdate');
+    }
+  });
+}

--- a/test/src/utils/extensions/graphql_extensions_test.dart
+++ b/test/src/utils/extensions/graphql_extensions_test.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:http/http.dart' as http;
+import 'package:tsumiru/src/utils/extensions/custom_extensions.dart';
+
+String _shown(String serverMessage) => OperationMessageException(
+      OperationException(
+        graphqlErrors: [GraphQLError(message: serverMessage)],
+      ),
+    ).toString();
+
+void main() {
+  group('what a Suwayomi error says on screen', () {
+    test('a Kotlin stack trace collapses to the sentence that matters', () {
+      expect(
+        _shown(
+          "Exception while fetching data (/updateExtension) : Extension can't "
+          "be updated to the same version. Reinstall the extension instead\n"
+          "\n"
+          "java.lang.IllegalStateException: Extension can't be updated to the "
+          "same version. Reinstall the extension instead\n"
+          "\tat suwayomi.tachidesk.manga.impl.extension.Extension."
+          "installExtension(Extension.kt:451)\n"
+          "\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl."
+          "resumeWith(ContinuationImpl.kt:34)",
+        ),
+        "Extension can't be updated to the same version. "
+        "Reinstall the extension instead",
+      );
+    });
+
+    test('a null message leaves nothing to show, so the UI can fall back', () {
+      expect(
+        _shown(
+          "Exception while fetching data (/updateExtension) : null\n"
+          "\n"
+          "java.lang.NullPointerException\n"
+          "\tat suwayomi.tachidesk.manga.impl.extension.Extension."
+          "installExtension(Extension.kt:451)",
+        ),
+        isEmpty,
+      );
+    });
+
+    test('a plain server error is shown exactly as sent', () {
+      expect(_shown('Unauthorized'), 'Unauthorized');
+    });
+
+    test('two errors still read as one list', () {
+      final e = OperationMessageException(OperationException(graphqlErrors: [
+        const GraphQLError(message: 'Unauthorized'),
+        const GraphQLError(
+            message: 'Exception while fetching data (/x) : Not found\n'
+                '\tat suwayomi.Thing.run(Thing.kt:1)'),
+      ]));
+      expect(e.toString(), 'Unauthorized, Not found');
+    });
+
+    test('a transport failure still reports its own cause', () {
+      final e = OperationMessageException(OperationException(
+          linkException: HttpLinkParserException(
+              originalException: const SocketException('server unreachable'),
+              originalStackTrace: StackTrace.empty,
+              response: http.Response('', 500))));
+      expect(e.toString(), contains('server unreachable'));
+    });
+  });
+}

--- a/test/src/utils/misc/toast_test.dart
+++ b/test/src/utils/misc/toast_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/l10n/generated/app_localizations.dart';
+import 'package:tsumiru/src/utils/misc/toast/toast.dart';
+
+Future<Toast> _pumpToastHost(WidgetTester tester) async {
+  late BuildContext hostContext;
+  await tester.pumpWidget(MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Builder(builder: (context) {
+      hostContext = context;
+      return const SizedBox.shrink();
+    }),
+  ));
+  return Toast(hostContext);
+}
+
+void main() {
+  testWidgets('an error with nothing left to say still tells the user',
+      (tester) async {
+    final toast = await _pumpToastHost(tester);
+
+    toast.showError('   ');
+    await tester.pump();
+
+    expect(find.text('Something went wrong!'), findsOneWidget);
+
+    toast.close();
+    await tester.pump(const Duration(seconds: 5));
+  });
+
+  testWidgets('a real error message is shown as it is', (tester) async {
+    final toast = await _pumpToastHost(tester);
+
+    toast.showError("Extension can't be updated to the same version");
+    await tester.pump();
+
+    expect(find.text("Extension can't be updated to the same version"),
+        findsOneWidget);
+
+    toast.close();
+    await tester.pump(const Duration(seconds: 5));
+  });
+}


### PR DESCRIPTION
Two fixes that came out of a real incident: six extensions on a live server ended up installed with no sources loaded, including the user's primary source. Pressing Update produced a screen of Kotlin frames, and the app offered no way to repair it.

## Errors are readable again (#427)

`OperationMessageException.toString()` concatenated each `GraphQLError.message` verbatim, and Suwayomi Server puts a full Java stack trace in that field. The whole thing went to the toast.

The message is now reduced to its first meaningful line. The report's example becomes "Extension can't be updated to the same version. Reinstall the extension instead", which is both readable and actionable. When nothing useful survives, the display falls back to a localised generic message rather than showing `null` or an empty toast. The fallback lives in `Toast.showError`, which has the context, so `toString()` stays free of English. Full detail still reaches the debug log.

This path carries every error toast in the app, so short plain messages pass through untouched. `isConnectionError` callers unwrap `.exception` rather than the string, so offline detection is unaffected. The full-screen error view is guarded the same way.

## Reinstall (#428)

An extension with no loaded sources, or one stuck on a phantom update, can only be repaired by reinstalling. Nothing in the app could do that, and Update is no substitute since it fails when there is no newer version.

`ExtensionActions.reinstall` is uninstall then install through the existing `_refreshAfter`, so the source list cannot be left stale (#344), and the install step keeps the language-enabling behaviour so the restored sources are not filtered straight back out.

On the tile, three side-by-side controls squeeze the extension name off a phone screen, so the layout stays at two: a normal installed extension gets Uninstall plus a Reinstall icon button, and an extension with a pending update gets Update plus an overflow menu holding Reinstall and Uninstall. Uninstall stays reachable behind a pending update, as #290 requires. Obsolete extensions are unchanged.

## Testing

`flutter analyze` clean, `flutter test` 1832 passing. New coverage for the message cleaning, the toast fallback, reinstall ordering and refresh, and the tile layout in both states.

The tile widths were measured under Flutter's test font, which is wider than the real one, so the two-versus-three comparison holds but the on-screen look still wants a device check.

Closes #427
Closes #428