### PR TITLE
Keep macOS logins across restarts on ad-hoc signed builds

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -613,12 +613,13 @@ packages:
     source: hosted
     version: "10.3.1"
   flutter_secure_storage_darwin:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_secure_storage_darwin
-      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
-      url: "https://pub.dev"
-    source: hosted
+      path: flutter_secure_storage_darwin
+      ref: "8d1209c9debd56b176a2efe99c308ba47d2b56e8"
+      resolved-ref: "8d1209c9debd56b176a2efe99c308ba47d2b56e8"
+      url: "https://github.com/Suwayomi/flutter_secure_storage.git"
+    source: git
     version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,6 +94,16 @@ dependencies:
   workmanager: ^0.10.9
   battery_plus: ^7.1.1
 
+# Pinned until juliansteenbakker/flutter_secure_storage#1104 lands upstream.
+# Our macOS builds are ad-hoc signed, so the plugin's synchronizable keychain
+# queries fail for want of an entitlement and no login survives a restart.
+dependency_overrides:
+  flutter_secure_storage_darwin:
+    git:
+      url: https://github.com/Suwayomi/flutter_secure_storage.git
+      ref: 8d1209c9debd56b176a2efe99c308ba47d2b56e8
+      path: flutter_secure_storage_darwin
+
 dev_dependencies:
   cross_file: ^0.3.5+4
   build_runner: ^2.4.14


### PR DESCRIPTION
macOS users lose their login on every restart. The app launches (that was #361), but credentials never persist.

The keychain plugin runs every delete and existence check twice: once against the iCloud-synchronizable keychain, once against the local one. Our macOS releases are ad-hoc signed and carry no `keychain-access-groups` entitlement, so the synchronizable query is rejected with `errSecMissingEntitlement` (-34018) and takes the whole operation with it. `write` swallows that error and `delete` does not, which is why storage looks half-working rather than broken. No plugin option avoids the query, and the code is identical in the latest release and on upstream's development branch.

This pins `flutter_secure_storage_darwin` to a patched build of the version already in use (0.3.2, from tag v10.3.1), hosted on a fork under the Suwayomi org. The patch skips the synchronizable query on macOS when the data protection keychain is off, in both `performDelete` and `containsKey`. Without that keychain there is no synchronizable item to find, so the query has nothing to do. Other platforms are untouched, and the resolved version does not change.

Temporary: the same patch is up against juliansteenbakker/flutter_secure_storage#1104, and the override comes out when it merges.

## Verification

`flutter analyze` clean and the full suite passes on Linux. The Swift only compiles on macOS, so the release build is the first compile check, and the reporter on #360 has a Mac and will confirm login persistence against the release.

Closes #360