### PR TITLE
Stop the handoff tests asserting a restart before it lands

### DIFF
--- a/test/offline/background/background_download_controller_test.dart
+++ b/test/offline/background/background_download_controller_test.dart
@@ -197,6 +197,17 @@ void main() {
     );
   }
 
+  /// Pumps until [ready] holds. A bare `pumpEventQueue()` gives a fixed number
+  /// of turns, so on a loaded machine an in-flight restart is asserted before
+  /// it lands.
+  Future<void> pumpUntil(bool Function() ready) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    while (!ready() && DateTime.now().isBefore(deadline)) {
+      await pumpEventQueue(times: 1);
+    }
+    await pumpEventQueue();
+  }
+
   List<_ManualTimer> useManualTimers() {
     final timers = <_ManualTimer>[];
     makeTimer = (duration, callback) {
@@ -534,7 +545,7 @@ void main() {
 
       service.running = false;
       timers.singleWhere((timer) => timer.isActive).fire();
-      await pumpEventQueue();
+      await pumpUntil(() => service.starts >= 1);
 
       expect(service.starts, 1);
       expect(service.running, isTrue);
@@ -583,7 +594,7 @@ void main() {
         const Duration(milliseconds: 500),
       );
       timers.singleWhere((timer) => timer.isActive).fire();
-      await pumpEventQueue();
+      await pumpUntil(() => service.starts >= 1);
 
       expect(service.starts, 1);
       expect(service.running, isTrue);
@@ -604,7 +615,7 @@ void main() {
     await controller.pause();
 
     timers.singleWhere((timer) => timer.isActive).fire();
-    await pumpEventQueue();
+    await pumpUntil(() => service.starts >= 1);
     expect(service.starts, 1);
     expect(service.messages, [
       {'op': 'pause'},
@@ -619,7 +630,7 @@ void main() {
     service.onStart = null;
     service.running = false;
     timers.singleWhere((timer) => timer.isActive).fire();
-    await pumpEventQueue();
+    await pumpUntil(() => service.starts >= 2);
 
     expect(service.starts, 2);
     expect(service.running, isTrue);
@@ -678,7 +689,7 @@ void main() {
               timer.duration == const Duration(milliseconds: 500),
         )
         .fire();
-    await pumpEventQueue();
+    await pumpUntil(() => service.starts >= 1);
 
     expect(service.starts, 1);
     expect(parkTimer.isActive, isFalse);

--- a/test/offline/background/background_download_controller_test.dart
+++ b/test/offline/background/background_download_controller_test.dart
@@ -481,10 +481,12 @@ void main() {
       expect(service.running, isFalse);
       final startsBeforeChange = service.starts;
 
+      final expectedStarts =
+          startsBeforeChange + (state == 'queued' ? 1 : 0);
       container.read(offlineWifiOnlyProvider.notifier).update(false);
-      await pumpEventQueue();
+      await pumpUntil(() => service.starts >= expectedStarts);
 
-      expect(service.starts, startsBeforeChange + (state == 'queued' ? 1 : 0));
+      expect(service.starts, expectedStarts);
       expect(service.running, state == 'queued');
       if (state == 'refused') {
         expect(container.read(offlineDownloadsStalledProvider), 'background');


### PR DESCRIPTION
Three tests in `background_download_controller_test.dart` failed at random on three separate branches tonight, and passed 33/33 when the file ran on its own. They arrived with #431, so this only started today.

They fire a manual timer, call `pumpEventQueue()`, then assert the service restarted. `pumpEventQueue()` runs a fixed number of event-loop turns, so under CPU contention the restart is still in flight when the assertion reads `service.starts`, giving "expected 2, got 1". Loading all cores on a clean checkout of main reproduces it; the app code is not involved.

This adds a `pumpUntil` helper that pumps until the expected state arrives or ten seconds pass, and uses it for the five assertions that wait on a restart. Assertions that check nothing happened keep the plain pump, since there is no state to wait for.

Tests only, no production code touched.

## Verification

Two consecutive full-suite runs pass, 1,960 tests each. Before this, the same file reddened on the #422 merge branch, the macOS keychain branch, and the catch-up branch.