### PR TITLE
Ask the server once per catch-up pass, not twice

### DIFF
--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -226,8 +226,10 @@ Future<void> runKeepRuleCatchUp(ProviderContainer container) async {
     }
     // Manga still waiting on server-side downloads get retried here too — the
     // queue-drain edge alone can be missed when downloads finish faster than
-    // the subscription reports them.
-    await _pullAwaiting(container);
+    // the subscription reports them. Skipping the ones this pass just
+    // reconciled: their chapters were enqueued moments ago, so a second
+    // reconcile can only re-ask the server for the same chapters (#413).
+    await _pullAwaiting(container, skip: touched);
     // If a drain event arrived while this pass was in flight, the listener
     // deferred it instead of dropping it. Re-run the pull now so chapters that
     // became serverIsDownloaded during the pass are not stranded until the next
@@ -264,12 +266,21 @@ Future<void> pullAfterServerDownloads(ProviderContainer container) async {
   }
 }
 
-Future<void> _pullAwaiting(ProviderContainer container) async {
+/// [skip] holds manga already reconciled by the caller in this same pass.
+/// They keep their obligation for the next drain edge or pass; what they must
+/// not get is a second reconcile moments after the first.
+Future<void> _pullAwaiting(
+  ProviderContainer container, {
+  Set<int> skip = const {},
+}) async {
   if (awaitingServerDownloads.isEmpty) return;
   if (!container.read(offlineActiveProvider)) return;
+  var pulled = false;
   // One obligation at a time, persisted after each: a crash mid-loop keeps
   // the unprocessed rest, and a batch clear would lose them.
   for (final mangaId in {...awaitingServerDownloads}) {
+    if (skip.contains(mangaId)) continue;
+    pulled = true;
     awaitingServerDownloads.remove(mangaId);
     // The reconcile may re-add this manga (a NEW server enqueue) — that is a
     // fresh obligation, not the one being consumed, so it must survive.
@@ -277,7 +288,7 @@ Future<void> _pullAwaiting(ProviderContainer container) async {
     if (!ok) awaitingServerDownloads.add(mangaId);
     await persistAwaitingServerDownloads(container.read);
   }
-  await container.read(downloadStarterProvider)();
+  if (pulled) await container.read(downloadStarterProvider)();
 }
 
 /// Scans the feed for keep-rule manga touched since [watermark]. Boundary

--- a/test/src/features/offline/data/offline_chapter_catchup_double_ask_test.dart
+++ b/test/src/features/offline/data/offline_chapter_catchup_double_ask_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Regression guard for #413. Asking the server to fetch a chapter sends it out
+// to the source, so a single catch-up pass must ask at most once per manga.
+// The pass reconciled every touched manga and then ran the awaiting-pull over
+// the same set, which asked twice per pass and burned the per-chapter attempt
+// budget at double rate.
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/data/updates/updates_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter_page/chapter_page_model.dart';
+import 'package:tsumiru/src/features/manga_book/domain/updates/updates_filter.dart';
+import 'package:tsumiru/src/features/offline/data/offline_chapter_catchup.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+
+/// Counts how many times the pass pulls a manga's chapter list. Returning null
+/// stops the chain before the reconcile machinery, which needs providers this
+/// test deliberately leaves unwired.
+class _CountingMangaBookRepository extends MangaBookRepository {
+  _CountingMangaBookRepository() : super(_dummyClient());
+
+  final calls = <int>[];
+
+  @override
+  Future<List<ChapterDto>?> getStoredChapterList(int mangaId) async {
+    calls.add(mangaId);
+    return null;
+  }
+}
+
+/// An empty feed, so the watermark scan never sees its boundary and the pass
+/// falls back to every keep-rule manga.
+class _EmptyUpdatesRepository extends UpdatesRepository {
+  _EmptyUpdatesRepository() : super(_dummyClient(), _dummyClient());
+
+  @override
+  Future<ChapterPageWithMangaDto?> getRecentChaptersPage({
+    int pageNo = 0,
+    UpdatesFilter filter = kNoUpdatesFilter,
+  }) async => null;
+}
+
+void main() {
+  setUp(resetChapterCatchUpStateForTest);
+  tearDown(resetChapterCatchUpStateForTest);
+
+  test('one catch-up pass pulls a waiting manga once, not twice', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final db = OfflineDatabase(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.upsertMangaMetadata(id: 1, title: 'M', updatedAt: DateTime(2026));
+    await db.setKeepRule(1, OfflineKeepRule.all, 3);
+
+    final repo = _CountingMangaBookRepository();
+    // Already owed a device pull from an earlier pass, so the manga is both
+    // feed-touched and awaiting — the shape that produced the double ask.
+    seedAwaitingServerDownloadsForTest({1});
+
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        offlineDatabaseProvider.overrideWithValue(db),
+        mangaBookRepositoryProvider.overrideWithValue(repo),
+        updatesRepositoryProvider.overrideWithValue(_EmptyUpdatesRepository()),
+        downloadStarterProvider.overrideWithValue(
+          ({bool userInitiated = false}) async {},
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await runKeepRuleCatchUp(container);
+
+    expect(
+      repo.calls,
+      [1],
+      reason:
+          'the tail pull must not re-reconcile a manga the pass already '
+          'handled — each extra reconcile re-asks the server for every '
+          'chapter it does not hold yet',
+    );
+  });
+}


### PR DESCRIPTION
Follow-up to #413. Asking the server to fetch a chapter sends it out to the source, so a keep-rule catch-up pass should ask at most once per series.

It asked twice. The pass reconciles every touched series, then runs the awaiting-pull over a set that includes those same series, reconciling each a second time seconds later. Every reconcile re-requests each chapter the server does not hold yet, so this doubled source traffic and burned the per-chapter attempt budget at twice the rate.

The tail pull now skips series the pass just handled. They keep their pending obligation for the next queue-drain edge or the next pass, which is when the server may actually have finished; what they no longer get is a second request moments after the first. The drain replay is unchanged, since a drain means server state really did move.

Worth noting for anyone reading #413: its stated cause is out of date. The persisted per-chapter cap it asks for already exists from #393, which is unreleased, so the user who reported the storm is running a build with no cap at all. This closes the remaining half.

## Verification

New regression test drives a full pass over a keep-rule series that is already awaiting a pull, and asserts it is reconciled once. It fails on main with `[1, 1]`. The drain-race guards and the server-request guards still pass, analyzer clean, full suite green apart from the flaky handoff tests fixed in #433.

Closes #413