### PR TITLE
Stop bulk download to server queueing chapters the server already has

### DIFF
--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -19,6 +19,7 @@ import '../../../../widgets/shell/update_banner_state.dart';
 import '../../../manga_book/data/downloads/downloads_repository.dart';
 import '../../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../../manga_book/data/updates/updates_repository.dart';
+import '../../../manga_book/domain/chapter/chapter_model.dart';
 import '../../../manga_book/domain/manga/manga_model.dart';
 import '../../../manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart';
 import '../../../migration/domain/migration_models.dart';
@@ -32,6 +33,14 @@ import 'controller/library_controller.dart';
 import 'controller/library_manga_list.dart';
 import 'widgets/edit_mangas_category_dialog.dart';
 import 'widgets/library_manga_grid_view.dart';
+
+/// Chapter ids worth sending to the server's download queue: the ones it does
+/// not hold yet. A bulk selection is mostly chapters the server already has,
+/// and queueing those buries the real downloads in thousands of no-ops.
+List<int> serverDownloadIds(List<ChapterDto>? chapters) => [
+  for (final c in chapters ?? const <ChapterDto>[])
+    if (!c.isDownloaded) c.id,
+];
 
 class CategoryMangaList extends HookConsumerWidget {
   const CategoryMangaList({super.key, required this.categoryId});
@@ -263,9 +272,7 @@ class CategoryMangaList extends HookConsumerWidget {
                     final dl = ref.read(downloadsRepositoryProvider);
                     for (final id in ids) {
                       final chapters = await repo.getChapterList(id);
-                      final chapterIds = <int>[
-                        for (final c in chapters ?? const []) c.id,
-                      ];
+                      final chapterIds = serverDownloadIds(chapters);
                       if (chapterIds.isNotEmpty) {
                         await dl.addChaptersBatchToDownloadQueue(chapterIds);
                       }

--- a/test/src/features/library/bulk_download_to_server_test.dart
+++ b/test/src/features/library/bulk_download_to_server_test.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Selecting a library and pressing Download to server used to queue every
+// chapter of every series, so a 85-series selection put over 13,000 entries in
+// the server's queue when only a few hundred were actually missing.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/library/presentation/library/category_manga_list.dart';
+
+import '../manga_book/manga_details/chapter_test_helpers.dart';
+
+void main() {
+  group('serverDownloadIds', () {
+    test('skips chapters the server already holds', () {
+      final ids = serverDownloadIds([
+        ch(id: 1, number: 1, isDownloaded: true),
+        ch(id: 2, number: 2),
+        ch(id: 3, number: 3, isDownloaded: true),
+        ch(id: 4, number: 4),
+      ]);
+      expect(ids, [2, 4]);
+    });
+
+    test('a fully downloaded series queues nothing', () {
+      final ids = serverDownloadIds([
+        ch(id: 1, number: 1, isDownloaded: true),
+        ch(id: 2, number: 2, isDownloaded: true),
+      ]);
+      expect(ids, isEmpty);
+    });
+
+    test('a null chapter list queues nothing', () {
+      expect(serverDownloadIds(null), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Selecting series in the library and pressing **Download to server** queued every chapter of every selected series, with no check for what the server already held.

Found while testing tonight's build against a real server: an 85-series selection put more than 13,000 entries in the download queue when roughly 310 chapters were actually missing. The real downloads were buried in thousands of no-ops and the queue stopped being usable as a progress readout.

The fix queues only chapters the server does not have yet. This matches what the series page's download presets already do, and what the neighbouring **Keep on device** action does through the reconciler. Those two paths were already correct; this was the only gap.

The all-or-nothing scope is deliberate and unchanged. Giving the action the same preset menu the series page has is filed separately as #435.

## Verification

Device-tested against a live server. Repeating the exact action that produced the runaway now queues about 310 chapters across the same selection, none of which the server already holds, and the queue drains normally.

New unit tests cover a mixed list, a fully downloaded series, and a null chapter list. `flutter analyze` clean, full suite passes (1,964 tests).