### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 1.1.5+51
+version: 1.2.0+52
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
Version bump for the v1.2.0 release: `1.1.5+51` → `1.2.0+52`.

A minor bump rather than a patch, because this release adds functionality: custom HTTP headers, an optional LAN server address, the downloaded-chapters drill-down, chapter grouping on Updates, background download file fetching, and extension repair.

39 changes since v1.1.5.