### PR TITLE
Build on JDK 21 so AGP 9 lint can run

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -17,29 +17,39 @@ A manga and webtoon reader for your [Suwayomi](https://suwayomi.org/) server.
 
 You'll need a running Suwayomi server. See [Getting started](https://tsumiru.app/docs/guides/getting-started).
 
-**Android:** download the universal APK below and open it to install (smaller APKs for specific chip types are also attached).
+### Mobile
 
-**Windows:** download the `…-windows-x64.zip` below, extract it anywhere, and run `tsumiru.exe`.
+**Android:** download the universal APK below and open it to install. Smaller APKs for specific chip types are also attached.
 
-**Linux - Flatpak (recommended, auto-updates):**
+**iOS:** the `…-ios.ipa` below is unsigned and has to be sideloaded. Add `https://tsumiru.app/apps.json` as a source in [SideStore](https://sidestore.io/) or [AltStore](https://altstore.io/) to install it and get later releases as updates.
+
+<details>
+<summary>Which sideloading tool should I use?</summary>
+
+- **[SideStore](https://sidestore.io/)** signs and refreshes the app on the device itself, with no computer needed after setup. Best for most people.
+- **[AltStore](https://altstore.io/)** expires every 7 days and only refreshes while a computer running AltServer is switched on and on the same Wi-Fi as your phone.
+- **[TrollStore](https://ios.cfw.guide/installing-trollstore/)** installs permanently with no expiry, but only works on older iPhones and iOS versions with the required vulnerability.
+
+With SideStore or AltStore the app is re-signed periodically, which those tools automate. There is no App Store build.
+</details>
+
+### Desktop
+
+**Windows:** download `…-windows-x64.zip`, extract it anywhere, and run `tsumiru.exe`.
+
+**macOS:** download `…-macos-x64.zip`, extract it, and move the app to Applications. If macOS blocks the first launch, approve it under System Settings → Privacy & Security.
+
+**Linux:** the Flatpak is recommended and auto-updates.
+
 ```sh
 flatpak remote-add --if-not-exists tsumiru https://suwayomi.github.io/Suwayomi-Tsumiru/index.flatpakrepo
 flatpak install tsumiru io.github.aaronbamblett.tsumiru
 ```
-> Added the `tsumiru` remote before? It may still point at the old `tsumiru-app.github.io` URL. Run `flatpak remote-delete tsumiru` first, then the commands above.
 
-**Linux - AppImage (portable):** download the `…-linux-x86_64.AppImage` below, mark it executable (`chmod +x`), and run it.
+For a portable option, download `…-linux-x86_64.AppImage`, mark it executable with `chmod +x`, and run it.
 
-**iOS (sideload only, advanced):** the `…-ios.ipa` below is **unsigned**, so you can't just download and open it. Apple requires every app to be signed to your own account first, using one of these tools:
+### Web
 
-- **[SideStore](https://sidestore.io/):** signs and refreshes the app *on-device*, no computer needed after setup. For most people this is the best option.
-- **[AltStore](https://altstore.io/):** also signs the app, but it expires every 7 days and only auto-refreshes while a computer running AltServer is powered on and on the same Wi-Fi as your phone.
-- **[TrollStore](https://ios.cfw.guide/installing-trollstore/):** permanent install with no expiry, but only works on older iPhones/iOS versions with the required vulnerability.
+Download `…-web.zip` and serve its contents with any static web server.
 
-With SideStore or AltStore the app must be re-signed periodically (the tools automate this). Only TrollStore avoids that. There is no App Store build.
-
-**macOS:** download the `…-macos-x64.zip` below, extract it, and move the app to Applications. If macOS blocks the first launch, approve the app under System Settings → Privacy & Security (Open Anyway).
-
-**Web:** download the `…-web.zip` below and serve its contents with any static web server.
-
-Full docs at [tsumiru.app](https://tsumiru.app/).
+[Full documentation](https://tsumiru.app/)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,7 +32,9 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: "17"
+          # AGP 9 lint calls Java 21 APIs; on 17 it dies with
+          # NoSuchMethodError while analysing plugin sources.
+          java-version: "21"
       - uses: subosito/flutter-action@v2
         with:
           flutter-version-file: .fvmrc

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,3 +43,10 @@ jobs:
       - run: flutter gen-l10n
       - run: dart run build_runner build --delete-conflicting-outputs
       - run: flutter build apk --debug
+      # Debug builds skip lint, so a release-only lint failure (an AGP
+      # upgrade breaking a plugin's analysis, say) stayed invisible until
+      # release day. This runs the same checks without needing the
+      # signing secrets a full release build would.
+      - name: Lint the release variant
+        run: ./gradlew :app:lintVitalRelease --console=plain
+        working-directory: android

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -94,7 +94,9 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: "17"
+          # AGP 9 lint calls Java 21 APIs; on 17 it dies with
+          # NoSuchMethodError while analysing plugin sources.
+          java-version: "21"
 
       - name: Install Linux build deps
         if: matrix.target == 'linux'


### PR DESCRIPTION
The v1.2.0 release build failed on Android. Five platforms succeeded, so the release correctly stayed a draft.

AGP 9's bundled lint calls `List.removeLast()`, a Java 21 API. Our workflows pin JDK 17, so lint dies with `NoSuchMethodError` while analysing `url_launcher_android`. It is lint crashing, not our code failing.

Nothing caught it earlier because only release builds run `lintVitalAnalyzeRelease`. PR checks build `flutter build apk --debug`, which skips lint entirely, so the AGP 9 migration passed every check we had and failed the first time it met a real release build. The weekly all-platform dry run exists for this, but the migration landed after the last Monday run.

## Verification

Reproduced and fixed locally, same machine, same command, only the JDK changed:

- JDK 17: `flutter build apk --release` fails in `:url_launcher_android:lintVitalAnalyzeRelease` with the identical `NoSuchMethodError` seen in CI.
- JDK 21: lint passes. The build then stops at `validateSigningRelease` ("Keystore file not set"), which is expected off CI since the release keystore is a secret.

## Also here

The release notes template's install section is reorganised by device type, the iOS tool comparison is folded into a details block, and the AltStore source URL is promoted so iOS users get updates automatically. The same restructure has been applied to the v1.2.0 draft and backfilled to v1.1.3, v1.1.4 and v1.1.5, which had lost their install section entirely.