### PR TITLE
Handle repeated chapters consistently

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -50,8 +50,7 @@ class MangaWithId extends _$MangaWithId {
       },
       db: ref.watch(offlineReadDatabaseProvider),
       offlineEnabled: ref.watch(offlineActiveProvider),
-      offlineFirst:
-          ref.watch(viewOfflineNowProvider) ||
+      offlineFirst: ref.watch(viewOfflineNowProvider) ||
           ref.watch(serverUnreachableProvider),
       mangaId: mangaId,
     );
@@ -60,9 +59,8 @@ class MangaWithId extends _$MangaWithId {
     if (ref.mounted) ref.keepAlive();
     // Don't mirror browsed (non-library) manga into the offline catalog.
     if (manga != null && manga.inLibrary && fromServer) {
-      unawaited(
-        sync?.syncManga(manga, fetchedAtGen: fetchGen) ?? Future.value(),
-      );
+      unawaited(sync?.syncManga(manga, fetchedAtGen: fetchGen) ??
+          Future.value());
     }
     return manga;
   }
@@ -77,9 +75,8 @@ class MangaChapterList extends _$MangaChapterList {
   @override
   Future<List<ChapterDto>?> build({required int mangaId}) async {
     final repo = ref.watch(mangaBookRepositoryProvider);
-    final refreshFromSource = ref
-        .watch(refreshChaptersFromSourceProvider)
-        .ifNull();
+    final refreshFromSource =
+        ref.watch(refreshChaptersFromSourceProvider).ifNull();
     // getMangaAndChapterList also refreshes metadata server-side; track it so
     // we know to refresh MangaWithId too (#363).
     var didSourceFetch = false;
@@ -113,20 +110,17 @@ class MangaChapterList extends _$MangaChapterList {
       },
       db: ref.watch(offlineReadDatabaseProvider),
       offlineEnabled: ref.watch(offlineActiveProvider),
-      offlineFirst:
-          ref.watch(viewOfflineNowProvider) ||
+      offlineFirst: ref.watch(viewOfflineNowProvider) ||
           ref.watch(serverUnreachableProvider),
       mangaId: mangaId,
     );
     if (ref.mounted) ref.keepAlive();
     if (result != null && fromServer) {
-      unawaited(
-        (sync?.syncChapters(result) ?? Future.value(<int>{})).then((nr) {
-          if (ref.mounted) {
-            reconcileManga(ref, mangaId, newlyReadChapterIds: nr);
-          }
-        }),
-      );
+      unawaited((sync?.syncChapters(result) ?? Future.value(<int>{})).then((nr) {
+        if (ref.mounted) {
+          reconcileManga(ref, mangaId, newlyReadChapterIds: nr);
+        }
+      }));
     }
     if (didSourceFetch) {
       // MangaWithId loaded before the scrape refreshed metadata; refresh it so
@@ -153,43 +147,41 @@ class MangaChapterList extends _$MangaChapterList {
     final offlineDb = ref.read(offlineReadDatabaseProvider);
     // An explicit refresh is a deliberate retry — but while the user has the
     // offline view pinned, honor it here too.
-    final viewOffline =
-        ref.read(viewOfflineNowProvider) || ref.read(serverUnreachableProvider);
+    final viewOffline = ref.read(viewOfflineNowProvider) ||
+        ref.read(serverUnreachableProvider);
     var didSourceFetch = false;
     // Wrap in chaptersWithOfflineFallback like build() does, so an explicit
     // refresh while the device is offline serves the on-device catalog instead
     // of erroring/clearing the list.
     // Mirror only genuine server responses (see build()).
     var fromServer = false;
-    final result = await AsyncValue.guard(
-      () => chaptersWithOfflineFallback(
-        fetch: () async {
-          final stored = await repo.getStoredChapterList(mangaId);
-          fromServer = true;
-          if (!refreshFromSource && stored != null && stored.isNotEmpty) {
-            return stored;
-          }
-          try {
-            final fetched = await repo.getMangaAndChapterList(mangaId);
-            if (fetched != null && fetched.isNotEmpty) {
-              didSourceFetch = true;
-              return fetched;
+    final result = await AsyncValue.guard(() => chaptersWithOfflineFallback(
+          fetch: () async {
+            final stored = await repo.getStoredChapterList(mangaId);
+            fromServer = true;
+            if (!refreshFromSource && stored != null && stored.isNotEmpty) {
+              return stored;
             }
-          } catch (_) {
-            // Source down / gone — fall back to stored instead of clearing.
-          }
-          return stored;
-        },
-        db: offlineDb,
-        offlineEnabled: offlineDb != null,
-        offlineFirst: viewOffline,
-        // An explicit refresh can run a full source scrape, which routinely
-        // outlives the offline cap; the user asked and is watching, so give
-        // it a real window instead of silently serving stale catalog rows.
-        fetchTimeout: const Duration(seconds: 60),
-        mangaId: mangaId,
-      ),
-    );
+            try {
+              final fetched = await repo.getMangaAndChapterList(mangaId);
+              if (fetched != null && fetched.isNotEmpty) {
+                didSourceFetch = true;
+                return fetched;
+              }
+            } catch (_) {
+              // Source down / gone — fall back to stored instead of clearing.
+            }
+            return stored;
+          },
+          db: offlineDb,
+          offlineEnabled: offlineDb != null,
+          offlineFirst: viewOffline,
+              // An explicit refresh can run a full source scrape, which routinely
+          // outlives the offline cap; the user asked and is watching, so give
+          // it a real window instead of silently serving stale catalog rows.
+          fetchTimeout: const Duration(seconds: 60),
+          mangaId: mangaId,
+        ));
     if (ref.mounted) ref.keepAlive();
     // The scrape refreshes metadata too; pick it up so pull-to-refresh
     // updates the synopsis, not just the chapter list.
@@ -208,13 +200,9 @@ class MangaChapterList extends _$MangaChapterList {
       // server-side delete discovered via pull-to-refresh is cleaned up too,
       // not only on a cold provider rebuild. Catalog-served lists are echoes
       // and never mirrored.
-      unawaited(
-        (ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
-                Future.value(<int>{}))
-            .then(
-              (nr) => reconcileManga(ref, mangaId, newlyReadChapterIds: nr),
-            ),
-      );
+      unawaited((ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
+              Future.value(<int>{}))
+          .then((nr) => reconcileManga(ref, mangaId, newlyReadChapterIds: nr)));
     }
   }
 
@@ -250,10 +238,8 @@ Set<String> mangaScanlatorList(Ref ref, {required int mangaId}) {
 class MangaPreferredScanlators extends _$MangaPreferredScanlators {
   @override
   List<String> build({required int mangaId}) {
-    final meta = ref
-        .watch(mangaWithIdProvider(mangaId: mangaId))
-        .value
-        ?.metaData;
+    final meta =
+        ref.watch(mangaWithIdProvider(mangaId: mangaId)).value?.metaData;
     final stored = meta?.preferredScanlators;
     if (stored != null) return stored;
     final legacy = meta?.scanlator;
@@ -290,14 +276,10 @@ class MangaPreferredScanlators extends _$MangaPreferredScanlators {
         if (groups.isEmpty) {
           // Stale ON would silently resume show-all on the next preference.
           ref.invalidate(
-            mangaShowAllScanlatorVersionsProvider(mangaId: mangaId),
-          );
+              mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
         } else {
-          unawaited(
-            AsyncValue.guard(
-              () => reconcileReadAcrossScanlators(ref, mangaId: mangaId),
-            ),
-          );
+          unawaited(AsyncValue.guard(
+              () => reconcileReadAcrossScanlators(ref, mangaId: mangaId)));
         }
       }
     } catch (_) {}
@@ -326,9 +308,7 @@ class MangaChapterListMode extends _$MangaChapterListMode {
 
   Future<void> update(ChapterListMode mode) async {
     await AsyncValue.guard(
-      () => ref
-          .read(mangaBookRepositoryProvider)
-          .patchMangaMeta(
+      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
             mangaId: mangaId,
             key: MangaMetaKeys.chapterListMode.key,
             value: mode.name,
@@ -353,9 +333,7 @@ class MangaRating extends _$MangaRating {
   Future<void> update(int rating) async {
     final next = rating.clamp(0, 5);
     await AsyncValue.guard(
-      () => ref
-          .read(mangaBookRepositoryProvider)
-          .patchMangaMeta(
+      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
             mangaId: mangaId,
             key: MangaMetaKeys.rating.key,
             // Meta values are String-typed server-side (MangaMetaTypeInput.value
@@ -384,9 +362,7 @@ class MangaUserTags extends _$MangaUserTags {
 
   Future<void> _persist(List<String> tags) async {
     await AsyncValue.guard(
-      () => ref
-          .read(mangaBookRepositoryProvider)
-          .patchMangaMeta(
+      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
             mangaId: mangaId,
             key: MangaMetaKeys.tags.key,
             value: jsonEncode(tags),
@@ -419,22 +395,18 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
 }) {
   final chapterList = ref.watch(mangaChapterListProvider(mangaId: mangaId));
   final chapterFilterUnread = ref.watch(mangaChapterFilterUnreadProvider);
-  final chapterFilterDownloaded = ref.watch(
-    mangaChapterFilterDownloadedProvider,
-  );
+  final chapterFilterDownloaded =
+      ref.watch(mangaChapterFilterDownloadedProvider);
   final chapterFilterBookmark = ref.watch(mangaChapterFilterBookmarkedProvider);
   final ChapterSort sortedBy =
       ref.watch(mangaChapterSortProvider) ?? DBKeys.chapterSort.initial;
-  final sortedDirection = ref
-      .watch(mangaChapterSortDirectionProvider)
-      .ifNull(true);
+  final sortedDirection =
+      ref.watch(mangaChapterSortDirectionProvider).ifNull(true);
 
-  final preferredScanlators = ref.watch(
-    mangaPreferredScanlatorsProvider(mangaId: mangaId),
-  );
-  final showAllVersions = ref.watch(
-    mangaShowAllScanlatorVersionsProvider(mangaId: mangaId),
-  );
+  final preferredScanlators =
+      ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+  final showAllVersions =
+      ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
   // No offline gate: catalog rows carry real chapter numbers since schema v9,
   // so dedup groups offline exactly as online (pre-v9 rows fall back to the
   // unique index and simply never collapse).
@@ -461,23 +433,16 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
 
   int applyChapterSort(ChapterDto m1, ChapterDto m2) {
     final sortDirToggle = (sortedDirection ? 1 : -1);
-    final result =
-        (switch (sortedBy) {
-          ChapterSort.fetchedDate =>
-            (int.tryParse(m1.fetchedAt) ?? 0).compareTo(
-              int.tryParse(m2.fetchedAt) ?? 0,
-            ),
+    final result = (switch (sortedBy) {
+          ChapterSort.fetchedDate => (int.tryParse(m1.fetchedAt) ?? 0)
+              .compareTo(int.tryParse(m2.fetchedAt) ?? 0),
           ChapterSort.source => (m1.index).compareTo(m2.index),
-          ChapterSort.uploadDate =>
-            (int.tryParse(m1.uploadDate) ?? 0).compareTo(
-              int.tryParse(m2.uploadDate) ?? 0,
-            ),
-          ChapterSort.chapterNumber => m1.chapterNumber.compareTo(
-            m2.chapterNumber,
-          ),
-          ChapterSort.alphabetical => m1.name.toLowerCase().compareTo(
-            m2.name.toLowerCase(),
-          ),
+          ChapterSort.uploadDate => (int.tryParse(m1.uploadDate) ?? 0)
+              .compareTo(int.tryParse(m2.uploadDate) ?? 0),
+          ChapterSort.chapterNumber =>
+            m1.chapterNumber.compareTo(m2.chapterNumber),
+          ChapterSort.alphabetical =>
+            m1.name.toLowerCase().compareTo(m2.name.toLowerCase()),
         }) *
         sortDirToggle;
     // List.sort is unstable; keep ties in source order (matches Komikku,
@@ -496,11 +461,8 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
     } else if (dedupActive) {
       // Dedup BEFORE filters: filters must see aggregate row state, or an
       // unread filter would strip a read copy and silently swap the winner.
-      list = applyPreferredScanlators(
-        list,
-        preferredScanlators,
-        keepChapterId: keepChapterId,
-      );
+      list = applyPreferredScanlators(list, preferredScanlators,
+          keepChapterId: keepChapterId);
     }
     return [...list.where(applyChapterFilter)]..sort(applyChapterSort);
   });
@@ -514,24 +476,23 @@ AsyncValue<List<ChapterDto>?> mangaChapterListForBulkActions(
   required int mangaId,
 }) {
   final chapterList = ref.watch(mangaChapterListProvider(mangaId: mangaId));
-  final preferred = ref.watch(
-    mangaPreferredScanlatorsProvider(mangaId: mangaId),
-  );
-  final showAll = ref.watch(
-    mangaShowAllScanlatorVersionsProvider(mangaId: mangaId),
-  );
+  final preferred =
+      ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
+  final showAll =
+      ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
   // No offline gate — catalog rows carry real chapter numbers (schema v9),
   // so dedup behaves the same offline; see mangaChapterListWithFilter.
   if (preferred.isEmpty || showAll) return chapterList;
   return chapterList.copyWithData(
-    (data) => data == null ? null : applyPreferredScanlators(data, preferred),
-  );
+      (data) => data == null ? null : applyPreferredScanlators(data, preferred));
 }
 
 @riverpod
-ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
-  final isAscSorted =
-      ref.watch(mangaChapterSortDirectionProvider) ??
+ChapterDto? firstUnreadInFilteredChapterList(
+  Ref ref, {
+  required int mangaId,
+}) {
+  final isAscSorted = ref.watch(mangaChapterSortDirectionProvider) ??
       DBKeys.chapterSortDirection.initial;
   final filteredList = ref
       .watch(mangaChapterListWithFilterProvider(mangaId: mangaId))
@@ -540,13 +501,11 @@ ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
     return null;
   } else {
     if (isAscSorted) {
-      return filteredList.firstWhereOrNull(
-        (element) => !element.isRead.ifNull(true),
-      );
+      return filteredList
+          .firstWhereOrNull((element) => !element.isRead.ifNull(true));
     } else {
-      return filteredList.lastWhereOrNull(
-        (element) => !element.isRead.ifNull(true),
-      );
+      return filteredList
+          .lastWhereOrNull((element) => !element.isRead.ifNull(true));
     }
   }
 }
@@ -559,17 +518,14 @@ ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
   bool shouldAscSort = true,
   String? readerScanlatorGroup,
 }) {
-  final isAscSorted =
-      ref.watch(mangaChapterSortDirectionProvider) ??
+  final isAscSorted = ref.watch(mangaChapterSortDirectionProvider) ??
       DBKeys.chapterSortDirection.initial;
   final filteredList = ref
-      .watch(
-        mangaChapterListWithFilterProvider(
+      .watch(mangaChapterListWithFilterProvider(
           mangaId: mangaId,
           keepChapterId: chapterId,
           readerScanlatorGroup: readerScanlatorGroup,
-        ),
-      )
+        ))
       .value;
   if (filteredList == null) {
     return null;
@@ -578,16 +534,16 @@ ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
       filteredList,
       keepChapterId: chapterId,
     );
-    final current = navigationList.indexWhere(
-      (element) => element.id == chapterId,
-    );
+    final current =
+        navigationList.indexWhere((element) => element.id == chapterId);
     // Not in the filtered list (e.g. unread-only filter while re-reading):
     // otherwise current == -1 would resolve nextChapter to filteredList[0].
     if (current == -1) return (first: null, second: null);
     final prevChapter = current > 0 ? navigationList[current - 1] : null;
-    final nextChapter = current < (navigationList.length - 1)
-        ? navigationList[current + 1]
-        : null;
+    final nextChapter =
+        current < (navigationList.length - 1)
+            ? navigationList[current + 1]
+            : null;
     return (
       first: shouldAscSort && isAscSorted ? nextChapter : prevChapter,
       second: shouldAscSort && isAscSorted ? prevChapter : nextChapter,
@@ -599,8 +555,10 @@ ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
 class MangaChapterSort extends _$MangaChapterSort
     with SharedPreferenceEnumClientMixin<ChapterSort> {
   @override
-  ChapterSort? build() =>
-      initialize(DBKeys.chapterSort, enumList: ChapterSort.values);
+  ChapterSort? build() => initialize(
+        DBKeys.chapterSort,
+        enumList: ChapterSort.values,
+      );
 }
 
 @riverpod
@@ -614,8 +572,10 @@ class MangaChapterSortDirection extends _$MangaChapterSortDirection
 class MangaChapterDisplayMode extends _$MangaChapterDisplayMode
     with SharedPreferenceEnumClientMixin<ChapterDisplay> {
   @override
-  ChapterDisplay? build() =>
-      initialize(DBKeys.chapterDisplay, enumList: ChapterDisplay.values);
+  ChapterDisplay? build() => initialize(
+        DBKeys.chapterDisplay,
+        enumList: ChapterDisplay.values,
+      );
 }
 
 @riverpod
@@ -646,17 +606,17 @@ class MangaCategoryList extends _$MangaCategoryList {
     final result = await ref
         .watch(mangaBookRepositoryProvider)
         .getMangaCategoryList(mangaId: mangaId);
-    return {for (CategoryDto i in (result ?? <CategoryDto>[])) "${i.id}": i};
+    return {
+      for (CategoryDto i in (result ?? <CategoryDto>[])) "${i.id}": i,
+    };
   }
 
   Future<void> refresh() async {
-    final result = await AsyncValue.guard(
-      () => ref
-          .read(mangaBookRepositoryProvider)
-          .getMangaCategoryList(mangaId: mangaId),
-    );
-    state = result.copyWithData(
-      (data) => {for (CategoryDto i in (data ?? <CategoryDto>[])) "${i.id}": i},
-    );
+    final result = await AsyncValue.guard(() => ref
+        .read(mangaBookRepositoryProvider)
+        .getMangaCategoryList(mangaId: mangaId));
+    state = result.copyWithData((data) => {
+          for (CategoryDto i in (data ?? <CategoryDto>[])) "${i.id}": i,
+        });
   }
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -24,7 +24,6 @@ import '../../../data/manga_book/manga_book_repository.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/manga/manga_model.dart';
 import 'scanlator_dedup.dart';
-import 'scanlator_propagation.dart';
 
 part 'manga_details_controller.g.dart';
 
@@ -277,9 +276,6 @@ class MangaPreferredScanlators extends _$MangaPreferredScanlators {
           // Stale ON would silently resume show-all on the next preference.
           ref.invalidate(
               mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
-        } else {
-          unawaited(AsyncValue.guard(
-              () => reconcileReadAcrossScanlators(ref, mangaId: mangaId)));
         }
       }
     } catch (_) {}
@@ -407,12 +403,14 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
       ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
   final showAllVersions =
       ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
-  // No offline gate: catalog rows carry real chapter numbers since schema v9,
-  // so dedup groups offline exactly as online (pre-v9 rows fall back to the
-  // unique index and simply never collapse).
-  final dedupActive = preferredScanlators.isNotEmpty && !showAllVersions;
+  final filterScanlators =
+      preferredScanlators.isNotEmpty && !showAllVersions;
+  final offline = ref.watch(viewOfflineNowProvider) ||
+      ref.watch(serverUnreachableProvider);
 
   bool applyChapterFilter(ChapterDto chapter) {
+    if (chapter.id == keepChapterId) return true;
+
     if (chapterFilterUnread != null &&
         (chapterFilterUnread ^ !(chapter.isRead.ifNull()))) {
       return false;
@@ -456,20 +454,19 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
       list = applyReaderSessionScanlator(
         list,
         scanlatorGroup: readerScanlatorGroup,
+        preferred: preferredScanlators,
+        offline: offline,
         keepChapterId: keepChapterId,
       );
-    } else if (dedupActive) {
-      // Dedup BEFORE filters: filters must see aggregate row state, or an
-      // unread filter would strip a read copy and silently swap the winner.
-      list = applyPreferredScanlators(list, preferredScanlators,
+    } else if (filterScanlators) {
+      list = filterPreferredScanlators(list, preferredScanlators,
           keepChapterId: keepChapterId);
     }
     return [...list.where(applyChapterFilter)]..sort(applyChapterSort);
   });
 }
 
-/// Deduped-but-unfiltered list for bulk actions (download presets): presets
-/// must count chapters, not duplicate copies.
+/// Preferred-scanlator-filtered but otherwise unfiltered list for bulk actions.
 @riverpod
 AsyncValue<List<ChapterDto>?> mangaChapterListForBulkActions(
   Ref ref, {
@@ -480,11 +477,9 @@ AsyncValue<List<ChapterDto>?> mangaChapterListForBulkActions(
       ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
   final showAll =
       ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
-  // No offline gate — catalog rows carry real chapter numbers (schema v9),
-  // so dedup behaves the same offline; see mangaChapterListWithFilter.
   if (preferred.isEmpty || showAll) return chapterList;
-  return chapterList.copyWithData(
-      (data) => data == null ? null : applyPreferredScanlators(data, preferred));
+  return chapterList.copyWithData((data) =>
+      data == null ? null : filterPreferredScanlators(data, preferred));
 }
 
 @riverpod
@@ -530,19 +525,15 @@ ChapterDto? firstUnreadInFilteredChapterList(
   if (filteredList == null) {
     return null;
   } else {
-    final navigationList = skipDuplicateChaptersForNavigation(
-      filteredList,
-      keepChapterId: chapterId,
-    );
     final current =
-        navigationList.indexWhere((element) => element.id == chapterId);
+        filteredList.indexWhere((element) => element.id == chapterId);
     // Not in the filtered list (e.g. unread-only filter while re-reading):
     // otherwise current == -1 would resolve nextChapter to filteredList[0].
     if (current == -1) return (first: null, second: null);
-    final prevChapter = current > 0 ? navigationList[current - 1] : null;
+    final prevChapter = current > 0 ? filteredList[current - 1] : null;
     final nextChapter =
-        current < (navigationList.length - 1)
-            ? navigationList[current + 1]
+        current < (filteredList.length - 1)
+            ? filteredList[current + 1]
             : null;
     return (
       first: shouldAscSort && isAscSorted ? nextChapter : prevChapter,

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -415,6 +415,7 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
   Ref ref, {
   required int mangaId,
   int? keepChapterId,
+  String? readerScanlatorGroup,
 }) {
   final chapterList = ref.watch(mangaChapterListProvider(mangaId: mangaId));
   final chapterFilterUnread = ref.watch(mangaChapterFilterUnreadProvider);
@@ -486,7 +487,13 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
 
   return chapterList.copyWithData((data) {
     var list = data ?? const <ChapterDto>[];
-    if (dedupActive) {
+    if (readerScanlatorGroup != null) {
+      list = applyReaderSessionScanlator(
+        list,
+        scanlatorGroup: readerScanlatorGroup,
+        keepChapterId: keepChapterId,
+      );
+    } else if (dedupActive) {
       // Dedup BEFORE filters: filters must see aggregate row state, or an
       // unread filter would strip a read copy and silently swap the winner.
       list = applyPreferredScanlators(
@@ -550,6 +557,7 @@ ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
   required int mangaId,
   required int chapterId,
   bool shouldAscSort = true,
+  String? readerScanlatorGroup,
 }) {
   final isAscSorted =
       ref.watch(mangaChapterSortDirectionProvider) ??
@@ -559,6 +567,7 @@ ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
         mangaChapterListWithFilterProvider(
           mangaId: mangaId,
           keepChapterId: chapterId,
+          readerScanlatorGroup: readerScanlatorGroup,
         ),
       )
       .value;

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -50,7 +50,8 @@ class MangaWithId extends _$MangaWithId {
       },
       db: ref.watch(offlineReadDatabaseProvider),
       offlineEnabled: ref.watch(offlineActiveProvider),
-      offlineFirst: ref.watch(viewOfflineNowProvider) ||
+      offlineFirst:
+          ref.watch(viewOfflineNowProvider) ||
           ref.watch(serverUnreachableProvider),
       mangaId: mangaId,
     );
@@ -59,8 +60,9 @@ class MangaWithId extends _$MangaWithId {
     if (ref.mounted) ref.keepAlive();
     // Don't mirror browsed (non-library) manga into the offline catalog.
     if (manga != null && manga.inLibrary && fromServer) {
-      unawaited(sync?.syncManga(manga, fetchedAtGen: fetchGen) ??
-          Future.value());
+      unawaited(
+        sync?.syncManga(manga, fetchedAtGen: fetchGen) ?? Future.value(),
+      );
     }
     return manga;
   }
@@ -75,8 +77,9 @@ class MangaChapterList extends _$MangaChapterList {
   @override
   Future<List<ChapterDto>?> build({required int mangaId}) async {
     final repo = ref.watch(mangaBookRepositoryProvider);
-    final refreshFromSource =
-        ref.watch(refreshChaptersFromSourceProvider).ifNull();
+    final refreshFromSource = ref
+        .watch(refreshChaptersFromSourceProvider)
+        .ifNull();
     // getMangaAndChapterList also refreshes metadata server-side; track it so
     // we know to refresh MangaWithId too (#363).
     var didSourceFetch = false;
@@ -110,17 +113,20 @@ class MangaChapterList extends _$MangaChapterList {
       },
       db: ref.watch(offlineReadDatabaseProvider),
       offlineEnabled: ref.watch(offlineActiveProvider),
-      offlineFirst: ref.watch(viewOfflineNowProvider) ||
+      offlineFirst:
+          ref.watch(viewOfflineNowProvider) ||
           ref.watch(serverUnreachableProvider),
       mangaId: mangaId,
     );
     if (ref.mounted) ref.keepAlive();
     if (result != null && fromServer) {
-      unawaited((sync?.syncChapters(result) ?? Future.value(<int>{})).then((nr) {
-        if (ref.mounted) {
-          reconcileManga(ref, mangaId, newlyReadChapterIds: nr);
-        }
-      }));
+      unawaited(
+        (sync?.syncChapters(result) ?? Future.value(<int>{})).then((nr) {
+          if (ref.mounted) {
+            reconcileManga(ref, mangaId, newlyReadChapterIds: nr);
+          }
+        }),
+      );
     }
     if (didSourceFetch) {
       // MangaWithId loaded before the scrape refreshed metadata; refresh it so
@@ -147,41 +153,43 @@ class MangaChapterList extends _$MangaChapterList {
     final offlineDb = ref.read(offlineReadDatabaseProvider);
     // An explicit refresh is a deliberate retry — but while the user has the
     // offline view pinned, honor it here too.
-    final viewOffline = ref.read(viewOfflineNowProvider) ||
-        ref.read(serverUnreachableProvider);
+    final viewOffline =
+        ref.read(viewOfflineNowProvider) || ref.read(serverUnreachableProvider);
     var didSourceFetch = false;
     // Wrap in chaptersWithOfflineFallback like build() does, so an explicit
     // refresh while the device is offline serves the on-device catalog instead
     // of erroring/clearing the list.
     // Mirror only genuine server responses (see build()).
     var fromServer = false;
-    final result = await AsyncValue.guard(() => chaptersWithOfflineFallback(
-          fetch: () async {
-            final stored = await repo.getStoredChapterList(mangaId);
-            fromServer = true;
-            if (!refreshFromSource && stored != null && stored.isNotEmpty) {
-              return stored;
-            }
-            try {
-              final fetched = await repo.getMangaAndChapterList(mangaId);
-              if (fetched != null && fetched.isNotEmpty) {
-                didSourceFetch = true;
-                return fetched;
-              }
-            } catch (_) {
-              // Source down / gone — fall back to stored instead of clearing.
-            }
+    final result = await AsyncValue.guard(
+      () => chaptersWithOfflineFallback(
+        fetch: () async {
+          final stored = await repo.getStoredChapterList(mangaId);
+          fromServer = true;
+          if (!refreshFromSource && stored != null && stored.isNotEmpty) {
             return stored;
-          },
-          db: offlineDb,
-          offlineEnabled: offlineDb != null,
-          offlineFirst: viewOffline,
-              // An explicit refresh can run a full source scrape, which routinely
-          // outlives the offline cap; the user asked and is watching, so give
-          // it a real window instead of silently serving stale catalog rows.
-          fetchTimeout: const Duration(seconds: 60),
-          mangaId: mangaId,
-        ));
+          }
+          try {
+            final fetched = await repo.getMangaAndChapterList(mangaId);
+            if (fetched != null && fetched.isNotEmpty) {
+              didSourceFetch = true;
+              return fetched;
+            }
+          } catch (_) {
+            // Source down / gone — fall back to stored instead of clearing.
+          }
+          return stored;
+        },
+        db: offlineDb,
+        offlineEnabled: offlineDb != null,
+        offlineFirst: viewOffline,
+        // An explicit refresh can run a full source scrape, which routinely
+        // outlives the offline cap; the user asked and is watching, so give
+        // it a real window instead of silently serving stale catalog rows.
+        fetchTimeout: const Duration(seconds: 60),
+        mangaId: mangaId,
+      ),
+    );
     if (ref.mounted) ref.keepAlive();
     // The scrape refreshes metadata too; pick it up so pull-to-refresh
     // updates the synopsis, not just the chapter list.
@@ -200,9 +208,13 @@ class MangaChapterList extends _$MangaChapterList {
       // server-side delete discovered via pull-to-refresh is cleaned up too,
       // not only on a cold provider rebuild. Catalog-served lists are echoes
       // and never mirrored.
-      unawaited((ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
-              Future.value(<int>{}))
-          .then((nr) => reconcileManga(ref, mangaId, newlyReadChapterIds: nr)));
+      unawaited(
+        (ref.read(offlineSyncProvider)?.syncChapters(chapters) ??
+                Future.value(<int>{}))
+            .then(
+              (nr) => reconcileManga(ref, mangaId, newlyReadChapterIds: nr),
+            ),
+      );
     }
   }
 
@@ -238,8 +250,10 @@ Set<String> mangaScanlatorList(Ref ref, {required int mangaId}) {
 class MangaPreferredScanlators extends _$MangaPreferredScanlators {
   @override
   List<String> build({required int mangaId}) {
-    final meta =
-        ref.watch(mangaWithIdProvider(mangaId: mangaId)).value?.metaData;
+    final meta = ref
+        .watch(mangaWithIdProvider(mangaId: mangaId))
+        .value
+        ?.metaData;
     final stored = meta?.preferredScanlators;
     if (stored != null) return stored;
     final legacy = meta?.scanlator;
@@ -276,10 +290,14 @@ class MangaPreferredScanlators extends _$MangaPreferredScanlators {
         if (groups.isEmpty) {
           // Stale ON would silently resume show-all on the next preference.
           ref.invalidate(
-              mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+            mangaShowAllScanlatorVersionsProvider(mangaId: mangaId),
+          );
         } else {
-          unawaited(AsyncValue.guard(
-              () => reconcileReadAcrossScanlators(ref, mangaId: mangaId)));
+          unawaited(
+            AsyncValue.guard(
+              () => reconcileReadAcrossScanlators(ref, mangaId: mangaId),
+            ),
+          );
         }
       }
     } catch (_) {}
@@ -308,7 +326,9 @@ class MangaChapterListMode extends _$MangaChapterListMode {
 
   Future<void> update(ChapterListMode mode) async {
     await AsyncValue.guard(
-      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
+      () => ref
+          .read(mangaBookRepositoryProvider)
+          .patchMangaMeta(
             mangaId: mangaId,
             key: MangaMetaKeys.chapterListMode.key,
             value: mode.name,
@@ -333,7 +353,9 @@ class MangaRating extends _$MangaRating {
   Future<void> update(int rating) async {
     final next = rating.clamp(0, 5);
     await AsyncValue.guard(
-      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
+      () => ref
+          .read(mangaBookRepositoryProvider)
+          .patchMangaMeta(
             mangaId: mangaId,
             key: MangaMetaKeys.rating.key,
             // Meta values are String-typed server-side (MangaMetaTypeInput.value
@@ -362,7 +384,9 @@ class MangaUserTags extends _$MangaUserTags {
 
   Future<void> _persist(List<String> tags) async {
     await AsyncValue.guard(
-      () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
+      () => ref
+          .read(mangaBookRepositoryProvider)
+          .patchMangaMeta(
             mangaId: mangaId,
             key: MangaMetaKeys.tags.key,
             value: jsonEncode(tags),
@@ -394,18 +418,22 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
 }) {
   final chapterList = ref.watch(mangaChapterListProvider(mangaId: mangaId));
   final chapterFilterUnread = ref.watch(mangaChapterFilterUnreadProvider);
-  final chapterFilterDownloaded =
-      ref.watch(mangaChapterFilterDownloadedProvider);
+  final chapterFilterDownloaded = ref.watch(
+    mangaChapterFilterDownloadedProvider,
+  );
   final chapterFilterBookmark = ref.watch(mangaChapterFilterBookmarkedProvider);
   final ChapterSort sortedBy =
       ref.watch(mangaChapterSortProvider) ?? DBKeys.chapterSort.initial;
-  final sortedDirection =
-      ref.watch(mangaChapterSortDirectionProvider).ifNull(true);
+  final sortedDirection = ref
+      .watch(mangaChapterSortDirectionProvider)
+      .ifNull(true);
 
-  final preferredScanlators =
-      ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
-  final showAllVersions =
-      ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+  final preferredScanlators = ref.watch(
+    mangaPreferredScanlatorsProvider(mangaId: mangaId),
+  );
+  final showAllVersions = ref.watch(
+    mangaShowAllScanlatorVersionsProvider(mangaId: mangaId),
+  );
   // No offline gate: catalog rows carry real chapter numbers since schema v9,
   // so dedup groups offline exactly as online (pre-v9 rows fall back to the
   // unique index and simply never collapse).
@@ -432,16 +460,23 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
 
   int applyChapterSort(ChapterDto m1, ChapterDto m2) {
     final sortDirToggle = (sortedDirection ? 1 : -1);
-    final result = (switch (sortedBy) {
-          ChapterSort.fetchedDate => (int.tryParse(m1.fetchedAt) ?? 0)
-              .compareTo(int.tryParse(m2.fetchedAt) ?? 0),
+    final result =
+        (switch (sortedBy) {
+          ChapterSort.fetchedDate =>
+            (int.tryParse(m1.fetchedAt) ?? 0).compareTo(
+              int.tryParse(m2.fetchedAt) ?? 0,
+            ),
           ChapterSort.source => (m1.index).compareTo(m2.index),
-          ChapterSort.uploadDate => (int.tryParse(m1.uploadDate) ?? 0)
-              .compareTo(int.tryParse(m2.uploadDate) ?? 0),
-          ChapterSort.chapterNumber =>
-            m1.chapterNumber.compareTo(m2.chapterNumber),
-          ChapterSort.alphabetical =>
-            m1.name.toLowerCase().compareTo(m2.name.toLowerCase()),
+          ChapterSort.uploadDate =>
+            (int.tryParse(m1.uploadDate) ?? 0).compareTo(
+              int.tryParse(m2.uploadDate) ?? 0,
+            ),
+          ChapterSort.chapterNumber => m1.chapterNumber.compareTo(
+            m2.chapterNumber,
+          ),
+          ChapterSort.alphabetical => m1.name.toLowerCase().compareTo(
+            m2.name.toLowerCase(),
+          ),
         }) *
         sortDirToggle;
     // List.sort is unstable; keep ties in source order (matches Komikku,
@@ -454,8 +489,11 @@ AsyncValue<List<ChapterDto>?> mangaChapterListWithFilter(
     if (dedupActive) {
       // Dedup BEFORE filters: filters must see aggregate row state, or an
       // unread filter would strip a read copy and silently swap the winner.
-      list = applyPreferredScanlators(list, preferredScanlators,
-          keepChapterId: keepChapterId);
+      list = applyPreferredScanlators(
+        list,
+        preferredScanlators,
+        keepChapterId: keepChapterId,
+      );
     }
     return [...list.where(applyChapterFilter)]..sort(applyChapterSort);
   });
@@ -469,23 +507,24 @@ AsyncValue<List<ChapterDto>?> mangaChapterListForBulkActions(
   required int mangaId,
 }) {
   final chapterList = ref.watch(mangaChapterListProvider(mangaId: mangaId));
-  final preferred =
-      ref.watch(mangaPreferredScanlatorsProvider(mangaId: mangaId));
-  final showAll =
-      ref.watch(mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+  final preferred = ref.watch(
+    mangaPreferredScanlatorsProvider(mangaId: mangaId),
+  );
+  final showAll = ref.watch(
+    mangaShowAllScanlatorVersionsProvider(mangaId: mangaId),
+  );
   // No offline gate — catalog rows carry real chapter numbers (schema v9),
   // so dedup behaves the same offline; see mangaChapterListWithFilter.
   if (preferred.isEmpty || showAll) return chapterList;
   return chapterList.copyWithData(
-      (data) => data == null ? null : applyPreferredScanlators(data, preferred));
+    (data) => data == null ? null : applyPreferredScanlators(data, preferred),
+  );
 }
 
 @riverpod
-ChapterDto? firstUnreadInFilteredChapterList(
-  Ref ref, {
-  required int mangaId,
-}) {
-  final isAscSorted = ref.watch(mangaChapterSortDirectionProvider) ??
+ChapterDto? firstUnreadInFilteredChapterList(Ref ref, {required int mangaId}) {
+  final isAscSorted =
+      ref.watch(mangaChapterSortDirectionProvider) ??
       DBKeys.chapterSortDirection.initial;
   final filteredList = ref
       .watch(mangaChapterListWithFilterProvider(mangaId: mangaId))
@@ -494,11 +533,13 @@ ChapterDto? firstUnreadInFilteredChapterList(
     return null;
   } else {
     if (isAscSorted) {
-      return filteredList
-          .firstWhereOrNull((element) => !element.isRead.ifNull(true));
+      return filteredList.firstWhereOrNull(
+        (element) => !element.isRead.ifNull(true),
+      );
     } else {
-      return filteredList
-          .lastWhereOrNull((element) => !element.isRead.ifNull(true));
+      return filteredList.lastWhereOrNull(
+        (element) => !element.isRead.ifNull(true),
+      );
     }
   }
 }
@@ -510,23 +551,34 @@ ChapterDto? firstUnreadInFilteredChapterList(
   required int chapterId,
   bool shouldAscSort = true,
 }) {
-  final isAscSorted = ref.watch(mangaChapterSortDirectionProvider) ??
+  final isAscSorted =
+      ref.watch(mangaChapterSortDirectionProvider) ??
       DBKeys.chapterSortDirection.initial;
   final filteredList = ref
-      .watch(mangaChapterListWithFilterProvider(
-          mangaId: mangaId, keepChapterId: chapterId))
+      .watch(
+        mangaChapterListWithFilterProvider(
+          mangaId: mangaId,
+          keepChapterId: chapterId,
+        ),
+      )
       .value;
   if (filteredList == null) {
     return null;
   } else {
-    final current =
-        filteredList.indexWhere((element) => element.id == chapterId);
+    final navigationList = skipDuplicateChaptersForNavigation(
+      filteredList,
+      keepChapterId: chapterId,
+    );
+    final current = navigationList.indexWhere(
+      (element) => element.id == chapterId,
+    );
     // Not in the filtered list (e.g. unread-only filter while re-reading):
     // otherwise current == -1 would resolve nextChapter to filteredList[0].
     if (current == -1) return (first: null, second: null);
-    final prevChapter = current > 0 ? filteredList[current - 1] : null;
-    final nextChapter =
-        current < (filteredList.length - 1) ? filteredList[current + 1] : null;
+    final prevChapter = current > 0 ? navigationList[current - 1] : null;
+    final nextChapter = current < (navigationList.length - 1)
+        ? navigationList[current + 1]
+        : null;
     return (
       first: shouldAscSort && isAscSorted ? nextChapter : prevChapter,
       second: shouldAscSort && isAscSorted ? prevChapter : nextChapter,
@@ -538,10 +590,8 @@ ChapterDto? firstUnreadInFilteredChapterList(
 class MangaChapterSort extends _$MangaChapterSort
     with SharedPreferenceEnumClientMixin<ChapterSort> {
   @override
-  ChapterSort? build() => initialize(
-        DBKeys.chapterSort,
-        enumList: ChapterSort.values,
-      );
+  ChapterSort? build() =>
+      initialize(DBKeys.chapterSort, enumList: ChapterSort.values);
 }
 
 @riverpod
@@ -555,10 +605,8 @@ class MangaChapterSortDirection extends _$MangaChapterSortDirection
 class MangaChapterDisplayMode extends _$MangaChapterDisplayMode
     with SharedPreferenceEnumClientMixin<ChapterDisplay> {
   @override
-  ChapterDisplay? build() => initialize(
-        DBKeys.chapterDisplay,
-        enumList: ChapterDisplay.values,
-      );
+  ChapterDisplay? build() =>
+      initialize(DBKeys.chapterDisplay, enumList: ChapterDisplay.values);
 }
 
 @riverpod
@@ -589,17 +637,17 @@ class MangaCategoryList extends _$MangaCategoryList {
     final result = await ref
         .watch(mangaBookRepositoryProvider)
         .getMangaCategoryList(mangaId: mangaId);
-    return {
-      for (CategoryDto i in (result ?? <CategoryDto>[])) "${i.id}": i,
-    };
+    return {for (CategoryDto i in (result ?? <CategoryDto>[])) "${i.id}": i};
   }
 
   Future<void> refresh() async {
-    final result = await AsyncValue.guard(() => ref
-        .read(mangaBookRepositoryProvider)
-        .getMangaCategoryList(mangaId: mangaId));
-    state = result.copyWithData((data) => {
-          for (CategoryDto i in (data ?? <CategoryDto>[])) "${i.id}": i,
-        });
+    final result = await AsyncValue.guard(
+      () => ref
+          .read(mangaBookRepositoryProvider)
+          .getMangaCategoryList(mangaId: mangaId),
+    );
+    state = result.copyWithData(
+      (data) => {for (CategoryDto i in (data ?? <CategoryDto>[])) "${i.id}": i},
+    );
   }
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart
@@ -24,6 +24,7 @@ import '../../../data/manga_book/manga_book_repository.dart';
 import '../../../domain/chapter/chapter_model.dart';
 import '../../../domain/manga/manga_model.dart';
 import 'scanlator_dedup.dart';
+import 'scanlator_propagation.dart';
 
 part 'manga_details_controller.g.dart';
 
@@ -276,6 +277,9 @@ class MangaPreferredScanlators extends _$MangaPreferredScanlators {
           // Stale ON would silently resume show-all on the next preference.
           ref.invalidate(
               mangaShowAllScanlatorVersionsProvider(mangaId: mangaId));
+        } else {
+          unawaited(AsyncValue.guard(
+              () => reconcileReadAcrossScanlators(ref, mangaId: mangaId)));
         }
       }
     } catch (_) {}

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
@@ -136,6 +136,52 @@ List<ChapterDto> skipDuplicateChaptersForNavigation(
   ];
 }
 
+/// One reader-session row per numbered chapter. The scanlator of the chapter
+/// used to open the reader wins whenever it has that chapter; otherwise the
+/// source's first release is used. This intentionally ignores the manga's
+/// saved scanlator preference.
+List<ChapterDto> applyReaderSessionScanlator(
+  List<ChapterDto> chapters, {
+  required String scanlatorGroup,
+  int? keepChapterId,
+}) {
+  final byNumber = <double, List<ChapterDto>>{};
+  for (final chapter in chapters) {
+    if (chapter.chapterNumber >= 0) {
+      byNumber.putIfAbsent(chapter.chapterNumber, () => []).add(chapter);
+    }
+  }
+  final selected = <double, ChapterDto>{
+    for (final entry in byNumber.entries)
+      entry.key:
+          entry.value.firstWhereOrNull(
+            (chapter) => keepChapterId != null && chapter.id == keepChapterId,
+          ) ??
+          entry.value.firstWhereOrNull(
+            (chapter) => scanlatorGroupOf(chapter) == scanlatorGroup,
+          ) ??
+          entry.value.reduce(
+            (first, next) =>
+                first.sourceOrder <= next.sourceOrder ? first : next,
+          ),
+  };
+  return [
+    for (final chapter in chapters)
+      if (chapter.chapterNumber < 0 || chapter.chapterNumber.isNaN)
+        chapter
+      else if (selected[chapter.chapterNumber]?.id == chapter.id)
+        chapter.copyWith(
+          isRead: byNumber[chapter.chapterNumber]!.any((x) => x.isRead),
+          isDownloaded: byNumber[chapter.chapterNumber]!.any(
+            (x) => x.isDownloaded,
+          ),
+          isBookmarked: byNumber[chapter.chapterNumber]!.any(
+            (x) => x.isBookmarked,
+          ),
+        ),
+  ];
+}
+
 /// Unread copies whose chapter number has at least one read copy — the
 /// one-time catch-up set when a preference is set on a series with history.
 List<int> reconcileIdsForReadNumbers(List<ChapterDto> allChapters) {

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
@@ -8,8 +8,6 @@ import 'package:collection/collection.dart';
 
 import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../domain/chapter/chapter_model.dart';
-// The generated copyWith is an extension; it must be imported directly.
-import '../../../domain/chapter/graphql/__generated__/fragment.graphql.dart';
 
 /// Group key for chapters with no scanlator; displayed via l10n as "Unknown".
 const String kUnknownScanlatorGroup = '';
@@ -17,179 +15,119 @@ const String kUnknownScanlatorGroup = '';
 String scanlatorGroupOf(ChapterDto c) =>
     c.scanlator.isNotBlank ? c.scanlator! : kUnknownScanlatorGroup;
 
-/// One row per chapter number when [preferred] is non-empty.
-///
-/// Winner group per number: the in-flight copy ([keepChapterId], so an open
-/// reader never loses its chapter), else an in-progress copy, else a
-/// downloaded copy, else the highest-ranked group in [preferred] covering the
-/// number, else the copy the source lists first. All of the winning group's
-/// entries at that number survive (split chapters / v2 re-uploads share a
-/// number). Rows carry aggregate read/downloaded/bookmarked state across ALL
-/// copies of the number. Entries with negative or invalid chapter numbers pass
-/// through.
-List<ChapterDto> applyPreferredScanlators(
+/// Filters by scanlator without assuming that equal chapter numbers identify
+/// alternate releases. Every row from a preferred group survives, including
+/// specials and series whose numbering restarts. [keepChapterId] keeps an open
+/// reader chapter visible even when its group is not preferred.
+List<ChapterDto> filterPreferredScanlators(
   List<ChapterDto> chapters,
   List<String> preferred, {
   int? keepChapterId,
 }) {
   if (preferred.isEmpty) return chapters;
-
-  final byNumber = <double, List<ChapterDto>>{};
-  for (final c in chapters) {
-    if (c.chapterNumber >= 0) {
-      byNumber.putIfAbsent(c.chapterNumber, () => []).add(c);
-    }
-  }
-
-  final winnersByNumber = <double, String>{};
-  for (final entry in byNumber.entries) {
-    final copies = entry.value;
-    final kept = keepChapterId == null
-        ? null
-        : copies.firstWhereOrNull((c) => c.id == keepChapterId);
-    final inProgress =
-        copies.firstWhereOrNull((c) => !c.isRead && c.lastPageRead > 0);
-    final downloaded = copies.firstWhereOrNull((c) => c.isDownloaded);
-    String? winner;
-    if (kept != null) {
-      winner = scanlatorGroupOf(kept);
-    } else if (inProgress != null) {
-      winner = scanlatorGroupOf(inProgress);
-    } else if (downloaded != null) {
-      winner = scanlatorGroupOf(downloaded);
-    } else {
-      winner = preferred.firstWhereOrNull(
-          (g) => copies.any((c) => scanlatorGroupOf(c) == g));
-      winner ??= scanlatorGroupOf(
-          copies.reduce((a, b) => a.sourceOrder <= b.sourceOrder ? a : b));
-    }
-    winnersByNumber[entry.key] = winner;
-  }
-
-  return [
-    for (final c in chapters)
-      // Negated: `!(x >= 0)` also catches NaN, unlike `x < 0`.
-      if (!(c.chapterNumber >= 0))
-        c
-      else if (scanlatorGroupOf(c) == winnersByNumber[c.chapterNumber])
-        c.copyWith(
-          isRead: byNumber[c.chapterNumber]!.any((x) => x.isRead),
-          isDownloaded:
-              byNumber[c.chapterNumber]!.any((x) => x.isDownloaded),
-          isBookmarked:
-              byNumber[c.chapterNumber]!.any((x) => x.isBookmarked),
-        ),
-  ];
-}
-
-/// Ids of every copy sharing [chapterId]'s chapter number (self included).
-/// A negative/invalid number or unknown id returns just the id itself.
-List<int> duplicateChapterIds(List<ChapterDto> allChapters, int chapterId) {
-  final chapter = allChapters.firstWhereOrNull((c) => c.id == chapterId);
-  // Same NaN-safe negation as applyPreferredScanlators.
-  if (chapter == null || !(chapter.chapterNumber >= 0)) return [chapterId];
-  return [
-    for (final c in allChapters)
-      if (c.chapterNumber == chapter.chapterNumber) c.id,
-  ];
-}
-
-/// Write-side union of every same-number copy for each id (self included).
-/// Identity when the raw list is unavailable.
-List<int> expandIdsForDuplicates(
-  List<ChapterDto>? allChapters,
-  List<int> chapterIds,
-) {
-  if (allChapters == null) return chapterIds;
-  final out = <int>{};
-  for (final id in chapterIds) {
-    out.addAll(duplicateChapterIds(allChapters, id));
-  }
-  return out.toList();
-}
-
-/// Keeps one entry for each non-negative chapter number while navigating the
-/// reader. If the open chapter is one of several same-number releases, it is
-/// retained so the reader does not swap its in-flight chapter underneath it.
-/// Negative or invalid numbers remain distinct because they are not reliable
-/// chapter numbers.
-List<ChapterDto> skipDuplicateChaptersForNavigation(
-  List<ChapterDto> chapters, {
-  required int keepChapterId,
-}) {
-  final selectedByNumber = <double, ChapterDto>{};
-  for (final chapter in chapters) {
-    if (!(chapter.chapterNumber >= 0)) continue;
-    if (chapter.id == keepChapterId) {
-      selectedByNumber[chapter.chapterNumber] = chapter;
-    } else {
-      selectedByNumber.putIfAbsent(chapter.chapterNumber, () => chapter);
-    }
-  }
-
   return [
     for (final chapter in chapters)
-      if (!(chapter.chapterNumber >= 0) ||
-          selectedByNumber[chapter.chapterNumber]?.id == chapter.id)
+      if (chapter.id == keepChapterId ||
+          preferred.contains(scanlatorGroupOf(chapter)))
         chapter,
   ];
 }
 
-/// One reader-session row per numbered chapter. The scanlator of the chapter
-/// used to open the reader wins whenever it has that chapter; otherwise the
-/// source's first release is used. This intentionally ignores the manga's
-/// saved scanlator preference.
+String _normalizedChapterName(String name) =>
+    name.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');
+
+bool _canConfidentlyMatch(ChapterDto previous, ChapterDto chapter) {
+  if (!(previous.chapterNumber >= 0) || !(chapter.chapterNumber >= 0)) {
+    return false;
+  }
+  return previous.chapterNumber == chapter.chapterNumber &&
+      _normalizedChapterName(previous.name) ==
+          _normalizedChapterName(chapter.name) &&
+      scanlatorGroupOf(previous) != scanlatorGroupOf(chapter);
+}
+
+ChapterDto _pickReaderRelease(
+  List<ChapterDto> releases, {
+  required String scanlatorGroup,
+  required List<String> preferred,
+  required bool offline,
+  int? keepChapterId,
+}) {
+  final kept = releases.firstWhereOrNull((c) => c.id == keepChapterId);
+  if (kept != null) return kept;
+
+  final downloaded = releases.where((c) => c.isDownloaded).toList();
+  final candidates = offline && downloaded.isNotEmpty ? downloaded : releases;
+  return candidates.firstWhereOrNull(
+        (c) => scanlatorGroupOf(c) == scanlatorGroup,
+      ) ??
+      preferred
+          .map((group) => candidates.firstWhereOrNull(
+                (c) => scanlatorGroupOf(c) == group,
+              ))
+          .firstWhereOrNull((c) => c != null) ??
+      candidates.reduce((a, b) =>
+          a.sourceOrder <= b.sourceOrder ? a : b);
+}
+
+/// Builds the reader path without globally grouping equal chapter numbers.
+/// Only adjacent source-order rows with the same normalized name and number,
+/// and with distinct scanlators, are considered alternate releases. Anything
+/// uncertain remains an independent reader entry.
 List<ChapterDto> applyReaderSessionScanlator(
   List<ChapterDto> chapters, {
   required String scanlatorGroup,
+  List<String> preferred = const [],
+  bool offline = false,
   int? keepChapterId,
 }) {
-  final byNumber = <double, List<ChapterDto>>{};
-  for (final chapter in chapters) {
-    if (chapter.chapterNumber >= 0) {
-      byNumber.putIfAbsent(chapter.chapterNumber, () => []).add(chapter);
+  if (chapters.isEmpty) return chapters;
+
+  final sourceOrdered = [...chapters]
+    ..sort((a, b) {
+      final bySourceOrder = a.sourceOrder.compareTo(b.sourceOrder);
+      return bySourceOrder != 0 ? bySourceOrder : a.id.compareTo(b.id);
+    });
+  final releaseGroups = <List<ChapterDto>>[];
+  for (final chapter in sourceOrdered) {
+    if (releaseGroups.isEmpty) {
+      releaseGroups.add([chapter]);
+      continue;
+    }
+    final current = releaseGroups.last;
+    final groupAlreadyPresent = current.any(
+      (candidate) => scanlatorGroupOf(candidate) == scanlatorGroupOf(chapter),
+    );
+    if (!groupAlreadyPresent &&
+        _canConfidentlyMatch(current.last, chapter)) {
+      current.add(chapter);
+    } else {
+      releaseGroups.add([chapter]);
     }
   }
-  final selected = <double, ChapterDto>{
-    for (final entry in byNumber.entries)
-      entry.key:
-          entry.value.firstWhereOrNull(
-            (chapter) => keepChapterId != null && chapter.id == keepChapterId,
-          ) ??
-          entry.value.firstWhereOrNull(
-            (chapter) => scanlatorGroupOf(chapter) == scanlatorGroup,
-          ) ??
-          entry.value.reduce(
-            (first, next) =>
-                first.sourceOrder <= next.sourceOrder ? first : next,
-          ),
+
+  final selectedIds = <int>{
+    for (final releases in releaseGroups)
+      _pickReaderRelease(
+        releases,
+        scanlatorGroup: scanlatorGroup,
+        preferred: preferred,
+        offline: offline,
+        keepChapterId: keepChapterId,
+      ).id,
   };
   return [
     for (final chapter in chapters)
-      if (chapter.chapterNumber < 0 || chapter.chapterNumber.isNaN)
-        chapter
-      else if (selected[chapter.chapterNumber]?.id == chapter.id)
-        chapter.copyWith(
-          isRead: byNumber[chapter.chapterNumber]!.any((x) => x.isRead),
-          isDownloaded: byNumber[chapter.chapterNumber]!.any(
-            (x) => x.isDownloaded,
-          ),
-          isBookmarked: byNumber[chapter.chapterNumber]!.any(
-            (x) => x.isBookmarked,
-          ),
-        ),
+      if (selectedIds.contains(chapter.id)) chapter,
   ];
 }
 
-/// Unread copies whose chapter number has at least one read copy — the
-/// one-time catch-up set when a preference is set on a series with history.
-List<int> reconcileIdsForReadNumbers(List<ChapterDto> allChapters) {
-  final readNumbers = <double>{
-    for (final c in allChapters)
-      if (c.isRead && c.chapterNumber >= 0) c.chapterNumber,
-  };
-  return [
-    for (final c in allChapters)
-      if (!c.isRead && readNumbers.contains(c.chapterNumber)) c.id,
-  ];
-}
+/// The server exposes no stable relation between alternate releases, so a
+/// chapter-number match is not safe enough for read or delete propagation.
+List<int> duplicateChapterIds(List<ChapterDto> _, int chapterId) =>
+    [chapterId];
+
+List<int> expandIdsForDuplicates(List<ChapterDto>? _, List<int> chapterIds) =>
+    chapterIds;
+
+List<int> reconcileIdsForReadNumbers(List<ChapterDto> _) => const [];

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
@@ -47,9 +47,8 @@ List<ChapterDto> applyPreferredScanlators(
     final kept = keepChapterId == null
         ? null
         : copies.firstWhereOrNull((c) => c.id == keepChapterId);
-    final inProgress = copies.firstWhereOrNull(
-      (c) => !c.isRead && c.lastPageRead > 0,
-    );
+    final inProgress =
+        copies.firstWhereOrNull((c) => !c.isRead && c.lastPageRead > 0);
     final downloaded = copies.firstWhereOrNull((c) => c.isDownloaded);
     String? winner;
     if (kept != null) {
@@ -60,11 +59,9 @@ List<ChapterDto> applyPreferredScanlators(
       winner = scanlatorGroupOf(downloaded);
     } else {
       winner = preferred.firstWhereOrNull(
-        (g) => copies.any((c) => scanlatorGroupOf(c) == g),
-      );
+          (g) => copies.any((c) => scanlatorGroupOf(c) == g));
       winner ??= scanlatorGroupOf(
-        copies.reduce((a, b) => a.sourceOrder <= b.sourceOrder ? a : b),
-      );
+          copies.reduce((a, b) => a.sourceOrder <= b.sourceOrder ? a : b));
     }
     winnersByNumber[entry.key] = winner;
   }
@@ -77,8 +74,10 @@ List<ChapterDto> applyPreferredScanlators(
       else if (scanlatorGroupOf(c) == winnersByNumber[c.chapterNumber])
         c.copyWith(
           isRead: byNumber[c.chapterNumber]!.any((x) => x.isRead),
-          isDownloaded: byNumber[c.chapterNumber]!.any((x) => x.isDownloaded),
-          isBookmarked: byNumber[c.chapterNumber]!.any((x) => x.isBookmarked),
+          isDownloaded:
+              byNumber[c.chapterNumber]!.any((x) => x.isDownloaded),
+          isBookmarked:
+              byNumber[c.chapterNumber]!.any((x) => x.isBookmarked),
         ),
   ];
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
@@ -46,8 +46,9 @@ List<ChapterDto> applyPreferredScanlators(
     final kept = keepChapterId == null
         ? null
         : copies.firstWhereOrNull((c) => c.id == keepChapterId);
-    final inProgress =
-        copies.firstWhereOrNull((c) => !c.isRead && c.lastPageRead > 0);
+    final inProgress = copies.firstWhereOrNull(
+      (c) => !c.isRead && c.lastPageRead > 0,
+    );
     final downloaded = copies.firstWhereOrNull((c) => c.isDownloaded);
     String? winner;
     if (kept != null) {
@@ -58,9 +59,11 @@ List<ChapterDto> applyPreferredScanlators(
       winner = scanlatorGroupOf(downloaded);
     } else {
       winner = preferred.firstWhereOrNull(
-          (g) => copies.any((c) => scanlatorGroupOf(c) == g));
+        (g) => copies.any((c) => scanlatorGroupOf(c) == g),
+      );
       winner ??= scanlatorGroupOf(
-          copies.reduce((a, b) => a.sourceOrder <= b.sourceOrder ? a : b));
+        copies.reduce((a, b) => a.sourceOrder <= b.sourceOrder ? a : b),
+      );
     }
     winnersByNumber[entry.key] = winner;
   }
@@ -73,10 +76,8 @@ List<ChapterDto> applyPreferredScanlators(
       else if (scanlatorGroupOf(c) == winnersByNumber[c.chapterNumber])
         c.copyWith(
           isRead: byNumber[c.chapterNumber]!.any((x) => x.isRead),
-          isDownloaded:
-              byNumber[c.chapterNumber]!.any((x) => x.isDownloaded),
-          isBookmarked:
-              byNumber[c.chapterNumber]!.any((x) => x.isBookmarked),
+          isDownloaded: byNumber[c.chapterNumber]!.any((x) => x.isDownloaded),
+          isBookmarked: byNumber[c.chapterNumber]!.any((x) => x.isBookmarked),
         ),
   ];
 }
@@ -105,6 +106,33 @@ List<int> expandIdsForDuplicates(
     out.addAll(duplicateChapterIds(allChapters, id));
   }
   return out.toList();
+}
+
+/// Keeps one entry for each positive chapter number while navigating the
+/// reader. If the open chapter is one of several same-number releases, it is
+/// retained so the reader does not swap its in-flight chapter underneath it.
+/// Non-positive numbers remain distinct because they are not reliable chapter
+/// numbers.
+List<ChapterDto> skipDuplicateChaptersForNavigation(
+  List<ChapterDto> chapters, {
+  required int keepChapterId,
+}) {
+  final selectedByNumber = <double, ChapterDto>{};
+  for (final chapter in chapters) {
+    if (!(chapter.chapterNumber > 0)) continue;
+    if (chapter.id == keepChapterId) {
+      selectedByNumber[chapter.chapterNumber] = chapter;
+    } else {
+      selectedByNumber.putIfAbsent(chapter.chapterNumber, () => chapter);
+    }
+  }
+
+  return [
+    for (final chapter in chapters)
+      if (!(chapter.chapterNumber > 0) ||
+          selectedByNumber[chapter.chapterNumber]?.id == chapter.id)
+        chapter,
+  ];
 }
 
 /// Unread copies whose chapter number has at least one read copy — the

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
@@ -46,6 +46,46 @@ bool _canConfidentlyMatch(ChapterDto previous, ChapterDto chapter) {
       scanlatorGroupOf(previous) != scanlatorGroupOf(chapter);
 }
 
+/// Groups only releases that satisfy the conservative reader match. Sorting
+/// by source order first keeps otherwise-identical rows independent when an
+/// intervening chapter shows that they belong to different runs.
+List<List<ChapterDto>> _confidentReleaseGroups(List<ChapterDto> chapters) {
+  final sourceOrdered = [...chapters]
+    ..sort((a, b) {
+      final bySourceOrder = a.sourceOrder.compareTo(b.sourceOrder);
+      return bySourceOrder != 0 ? bySourceOrder : a.id.compareTo(b.id);
+    });
+  final releaseGroups = <List<ChapterDto>>[];
+  for (final chapter in sourceOrdered) {
+    if (releaseGroups.isEmpty) {
+      releaseGroups.add([chapter]);
+      continue;
+    }
+    final current = releaseGroups.last;
+    final groupAlreadyPresent = current.any(
+      (candidate) => scanlatorGroupOf(candidate) == scanlatorGroupOf(chapter),
+    );
+    if (!groupAlreadyPresent &&
+        _canConfidentlyMatch(current.last, chapter)) {
+      current.add(chapter);
+    } else {
+      releaseGroups.add([chapter]);
+    }
+  }
+  return releaseGroups;
+}
+
+Map<int, List<int>> _releaseIdsByChapterId(List<ChapterDto> chapters) {
+  final idsByChapter = <int, List<int>>{};
+  for (final releases in _confidentReleaseGroups(chapters)) {
+    final ids = [for (final release in releases) release.id];
+    for (final release in releases) {
+      idsByChapter[release.id] = ids;
+    }
+  }
+  return idsByChapter;
+}
+
 ChapterDto _pickReaderRelease(
   List<ChapterDto> releases, {
   required String scanlatorGroup,
@@ -83,31 +123,8 @@ List<ChapterDto> applyReaderSessionScanlator(
 }) {
   if (chapters.isEmpty) return chapters;
 
-  final sourceOrdered = [...chapters]
-    ..sort((a, b) {
-      final bySourceOrder = a.sourceOrder.compareTo(b.sourceOrder);
-      return bySourceOrder != 0 ? bySourceOrder : a.id.compareTo(b.id);
-    });
-  final releaseGroups = <List<ChapterDto>>[];
-  for (final chapter in sourceOrdered) {
-    if (releaseGroups.isEmpty) {
-      releaseGroups.add([chapter]);
-      continue;
-    }
-    final current = releaseGroups.last;
-    final groupAlreadyPresent = current.any(
-      (candidate) => scanlatorGroupOf(candidate) == scanlatorGroupOf(chapter),
-    );
-    if (!groupAlreadyPresent &&
-        _canConfidentlyMatch(current.last, chapter)) {
-      current.add(chapter);
-    } else {
-      releaseGroups.add([chapter]);
-    }
-  }
-
   final selectedIds = <int>{
-    for (final releases in releaseGroups)
+    for (final releases in _confidentReleaseGroups(chapters))
       _pickReaderRelease(
         releases,
         scanlatorGroup: scanlatorGroup,
@@ -122,12 +139,29 @@ List<ChapterDto> applyReaderSessionScanlator(
   ];
 }
 
-/// The server exposes no stable relation between alternate releases, so a
-/// chapter-number match is not safe enough for read or delete propagation.
-List<int> duplicateChapterIds(List<ChapterDto> _, int chapterId) =>
-    [chapterId];
+/// IDs of releases confidently matched to [chapterId], including itself.
+List<int> duplicateChapterIds(List<ChapterDto> allChapters, int chapterId) =>
+    _releaseIdsByChapterId(allChapters)[chapterId] ?? [chapterId];
 
-List<int> expandIdsForDuplicates(List<ChapterDto>? _, List<int> chapterIds) =>
-    chapterIds;
+/// Expands read/delete mutations across confident alternate-release groups.
+/// Identity when the raw chapter list is unavailable.
+List<int> expandIdsForDuplicates(
+  List<ChapterDto>? allChapters,
+  List<int> chapterIds,
+) {
+  if (allChapters == null) return chapterIds;
+  final idsByChapter = _releaseIdsByChapterId(allChapters);
+  final expanded = <int>{};
+  for (final id in chapterIds) {
+    expanded.addAll(idsByChapter[id] ?? [id]);
+  }
+  return expanded.toList();
+}
 
-List<int> reconcileIdsForReadNumbers(List<ChapterDto> _) => const [];
+/// Unread releases in a confident group that already contains a read release.
+List<int> reconcileIdsForReadNumbers(List<ChapterDto> allChapters) => [
+      for (final releases in _confidentReleaseGroups(allChapters))
+        if (releases.any((chapter) => chapter.isRead))
+          for (final chapter in releases)
+            if (!chapter.isRead) chapter.id,
+    ];

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_dedup.dart
@@ -25,7 +25,8 @@ String scanlatorGroupOf(ChapterDto c) =>
 /// number, else the copy the source lists first. All of the winning group's
 /// entries at that number survive (split chapters / v2 re-uploads share a
 /// number). Rows carry aggregate read/downloaded/bookmarked state across ALL
-/// copies of the number. Entries with chapterNumber <= 0 pass through.
+/// copies of the number. Entries with negative or invalid chapter numbers pass
+/// through.
 List<ChapterDto> applyPreferredScanlators(
   List<ChapterDto> chapters,
   List<String> preferred, {
@@ -35,7 +36,7 @@ List<ChapterDto> applyPreferredScanlators(
 
   final byNumber = <double, List<ChapterDto>>{};
   for (final c in chapters) {
-    if (c.chapterNumber > 0) {
+    if (c.chapterNumber >= 0) {
       byNumber.putIfAbsent(c.chapterNumber, () => []).add(c);
     }
   }
@@ -70,8 +71,8 @@ List<ChapterDto> applyPreferredScanlators(
 
   return [
     for (final c in chapters)
-      // Negated: `!(x > 0)` also catches NaN, unlike `x <= 0`.
-      if (!(c.chapterNumber > 0))
+      // Negated: `!(x >= 0)` also catches NaN, unlike `x < 0`.
+      if (!(c.chapterNumber >= 0))
         c
       else if (scanlatorGroupOf(c) == winnersByNumber[c.chapterNumber])
         c.copyWith(
@@ -83,11 +84,11 @@ List<ChapterDto> applyPreferredScanlators(
 }
 
 /// Ids of every copy sharing [chapterId]'s chapter number (self included).
-/// Number <= 0 or unknown id: just the id itself.
+/// A negative/invalid number or unknown id returns just the id itself.
 List<int> duplicateChapterIds(List<ChapterDto> allChapters, int chapterId) {
   final chapter = allChapters.firstWhereOrNull((c) => c.id == chapterId);
   // Same NaN-safe negation as applyPreferredScanlators.
-  if (chapter == null || !(chapter.chapterNumber > 0)) return [chapterId];
+  if (chapter == null || !(chapter.chapterNumber >= 0)) return [chapterId];
   return [
     for (final c in allChapters)
       if (c.chapterNumber == chapter.chapterNumber) c.id,
@@ -108,18 +109,18 @@ List<int> expandIdsForDuplicates(
   return out.toList();
 }
 
-/// Keeps one entry for each positive chapter number while navigating the
+/// Keeps one entry for each non-negative chapter number while navigating the
 /// reader. If the open chapter is one of several same-number releases, it is
 /// retained so the reader does not swap its in-flight chapter underneath it.
-/// Non-positive numbers remain distinct because they are not reliable chapter
-/// numbers.
+/// Negative or invalid numbers remain distinct because they are not reliable
+/// chapter numbers.
 List<ChapterDto> skipDuplicateChaptersForNavigation(
   List<ChapterDto> chapters, {
   required int keepChapterId,
 }) {
   final selectedByNumber = <double, ChapterDto>{};
   for (final chapter in chapters) {
-    if (!(chapter.chapterNumber > 0)) continue;
+    if (!(chapter.chapterNumber >= 0)) continue;
     if (chapter.id == keepChapterId) {
       selectedByNumber[chapter.chapterNumber] = chapter;
     } else {
@@ -129,7 +130,7 @@ List<ChapterDto> skipDuplicateChaptersForNavigation(
 
   return [
     for (final chapter in chapters)
-      if (!(chapter.chapterNumber > 0) ||
+      if (!(chapter.chapterNumber >= 0) ||
           selectedByNumber[chapter.chapterNumber]?.id == chapter.id)
         chapter,
   ];
@@ -140,7 +141,7 @@ List<ChapterDto> skipDuplicateChaptersForNavigation(
 List<int> reconcileIdsForReadNumbers(List<ChapterDto> allChapters) {
   final readNumbers = <double>{
     for (final c in allChapters)
-      if (c.isRead && c.chapterNumber > 0) c.chapterNumber,
+      if (c.isRead && c.chapterNumber >= 0) c.chapterNumber,
   };
   return [
     for (final c in allChapters)

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
@@ -6,42 +6,12 @@
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../../data/manga_book/manga_book_repository.dart';
-import '../../../domain/chapter_batch/chapter_batch_model.dart';
-import 'manga_details_controller.dart';
-import 'scanlator_dedup.dart';
-
-/// Write-side duplicate expansion for widget call sites.
-///
-/// Preferences only choose which release is shown/read. A read or delete
-/// mutation must always include every same non-negative-number release,
-/// including when no preference has been configured or a chapter-list filter
-/// hides a copy.
+/// Compatibility helper for widget call sites. The server exposes no stable
+/// duplicate relation, so read/delete actions target only the selected rows.
 List<int> expandIdsAcrossScanlators(
-  WidgetRef ref, {
+  WidgetRef _, {
   required int mangaId,
   required List<int> chapterIds,
 }) {
-  return expandIdsForDuplicates(
-    ref.read(mangaChapterListProvider(mangaId: mangaId)).value,
-    chapterIds,
-  );
-}
-
-/// One-time catch-up when a preference is set: copies of already-read numbers
-/// get marked read so badges/other clients converge.
-Future<void> reconcileReadAcrossScanlators(
-  Ref ref, {
-  required int mangaId,
-}) async {
-  final all = ref.read(mangaChapterListProvider(mangaId: mangaId)).value;
-  if (all == null) return;
-  final ids = reconcileIdsForReadNumbers(all);
-  if (ids.isEmpty) return;
-  await ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
-        // lastPageRead reset matches the bulk mark-read action's shape.
-        ChapterBatch(
-            ids: ids, patch: ChapterChange(isRead: true, lastPageRead: 0)),
-      );
-  ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
+  return chapterIds;
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
@@ -6,12 +6,37 @@
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-/// Compatibility helper for widget call sites. The server exposes no stable
-/// duplicate relation, so read/delete actions target only the selected rows.
+import '../../../data/manga_book/manga_book_repository.dart';
+import '../../../domain/chapter_batch/chapter_batch_model.dart';
+import 'manga_details_controller.dart';
+import 'scanlator_dedup.dart';
+
+/// Expands read/delete actions from the unfiltered raw chapter list. Preferred
+/// scanlators only control visibility; they cannot hide a confident match.
 List<int> expandIdsAcrossScanlators(
-  WidgetRef _, {
+  WidgetRef ref, {
   required int mangaId,
   required List<int> chapterIds,
 }) {
-  return chapterIds;
+  return expandIdsForDuplicates(
+    ref.read(mangaChapterListProvider(mangaId: mangaId)).value,
+    chapterIds,
+  );
+}
+
+/// One-time catch-up when a preference is set. Only confident release groups
+/// inherit existing read state; uncertain same-number rows remain separate.
+Future<void> reconcileReadAcrossScanlators(
+  Ref ref, {
+  required int mangaId,
+}) async {
+  final all = ref.read(mangaChapterListProvider(mangaId: mangaId)).value;
+  if (all == null) return;
+  final ids = reconcileIdsForReadNumbers(all);
+  if (ids.isEmpty) return;
+  await ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
+        ChapterBatch(
+            ids: ids, patch: ChapterChange(isRead: true, lastPageRead: 0)),
+      );
+  ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
@@ -14,8 +14,9 @@ import 'scanlator_dedup.dart';
 /// Write-side duplicate expansion for widget call sites.
 ///
 /// Preferences only choose which release is shown/read. A read or delete
-/// mutation must always include every same non-negative-number release, including when no
-/// preference has been configured or a chapter-list filter hides a copy.
+/// mutation must always include every same non-negative-number release,
+/// including when no preference has been configured or a chapter-list filter
+/// hides a copy.
 List<int> expandIdsAcrossScanlators(
   WidgetRef ref, {
   required int mangaId,
@@ -37,14 +38,10 @@ Future<void> reconcileReadAcrossScanlators(
   if (all == null) return;
   final ids = reconcileIdsForReadNumbers(all);
   if (ids.isEmpty) return;
-  await ref
-      .read(mangaBookRepositoryProvider)
-      .modifyBulkChapters(
+  await ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
         // lastPageRead reset matches the bulk mark-read action's shape.
         ChapterBatch(
-          ids: ids,
-          patch: ChapterChange(isRead: true, lastPageRead: 0),
-        ),
+            ids: ids, patch: ChapterChange(isRead: true, lastPageRead: 0)),
       );
   ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
@@ -11,16 +11,16 @@ import '../../../domain/chapter_batch/chapter_batch_model.dart';
 import 'manga_details_controller.dart';
 import 'scanlator_dedup.dart';
 
-/// Write-side counterpart of the deduped view, for widget call sites.
-/// Identity when the series has no preference.
+/// Write-side duplicate expansion for widget call sites.
+///
+/// Preferences only choose which release is shown/read. A read or delete
+/// mutation must always include every same-number release, including when no
+/// preference has been configured or a chapter-list filter hides a copy.
 List<int> expandIdsAcrossScanlators(
   WidgetRef ref, {
   required int mangaId,
   required List<int> chapterIds,
 }) {
-  if (ref.read(mangaPreferredScanlatorsProvider(mangaId: mangaId)).isEmpty) {
-    return chapterIds;
-  }
   return expandIdsForDuplicates(
     ref.read(mangaChapterListProvider(mangaId: mangaId)).value,
     chapterIds,
@@ -37,10 +37,14 @@ Future<void> reconcileReadAcrossScanlators(
   if (all == null) return;
   final ids = reconcileIdsForReadNumbers(all);
   if (ids.isEmpty) return;
-  await ref.read(mangaBookRepositoryProvider).modifyBulkChapters(
+  await ref
+      .read(mangaBookRepositoryProvider)
+      .modifyBulkChapters(
         // lastPageRead reset matches the bulk mark-read action's shape.
         ChapterBatch(
-            ids: ids, patch: ChapterChange(isRead: true, lastPageRead: 0)),
+          ids: ids,
+          patch: ChapterChange(isRead: true, lastPageRead: 0),
+        ),
       );
   ref.invalidate(mangaChapterListProvider(mangaId: mangaId));
 }

--- a/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/controller/scanlator_propagation.dart
@@ -14,7 +14,7 @@ import 'scanlator_dedup.dart';
 /// Write-side duplicate expansion for widget call sites.
 ///
 /// Preferences only choose which release is shown/read. A read or delete
-/// mutation must always include every same-number release, including when no
+/// mutation must always include every same non-negative-number release, including when no
 /// preference has been configured or a chapter-list filter hides a copy.
 List<int> expandIdsAcrossScanlators(
   WidgetRef ref, {

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_download_presets_button.dart
@@ -20,8 +20,8 @@ class ChapterDownloadPresetsButton extends ConsumerWidget {
     required this.refresh,
   });
 
-  /// Chapter list for preset computation: deduped one-row-per-chapter when a
-  /// scanlator preference is active, otherwise the full raw list.
+  /// Chapter list for preset computation: filtered to preferred scanlators
+  /// when a scanlator preference is active, otherwise the full raw list.
   final AsyncValue<List<ChapterDto>?> chapterList;
 
   /// Callback to re-fetch chapters after a successful enqueue.

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_list_tile.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/chapter_list_tile.dart
@@ -38,6 +38,9 @@ class ChapterListTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final showChapterNumber = ref.watch(mangaChapterDisplayModeProvider) ==
         ChapterDisplay.chapterNumber;
+    final scanlator = chapter.scanlator.isNotBlank
+        ? chapter.scanlator!
+        : context.l10n.unknownScanlator;
     return GestureDetector(
       key: Key("manga-${manga.id}-chapter-${chapter.id}"),
       onSecondaryTap: () => toggleSelect(chapter),
@@ -82,16 +85,15 @@ class ChapterListTile extends ConsumerWidget {
                 style: const TextStyle(color: Colors.grey),
                 overflow: TextOverflow.ellipsis,
               ),
-            if (chapter.scanlator.isNotBlank)
-              Expanded(
-                child: Text(
-                  " • ${chapter.scanlator}",
-                  style: TextStyle(
-                    color: chapter.isRead.ifNull() ? Colors.grey : null,
-                  ),
-                  overflow: TextOverflow.ellipsis,
+            Expanded(
+              child: Text(
+                " • $scanlator",
+                style: TextStyle(
+                  color: chapter.isRead.ifNull() ? Colors.grey : null,
                 ),
+                overflow: TextOverflow.ellipsis,
               ),
+            ),
           ],
         ),
         trailing: Row(

--- a/lib/src/features/manga_book/presentation/manga_details/widgets/scanlator_preference_dialog.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/widgets/scanlator_preference_dialog.dart
@@ -15,7 +15,7 @@ import '../controller/scanlator_dedup.dart';
 
 /// Set-once ranking dialog for issue #141's preferred-scanlator-groups
 /// feature: checked groups (in drag order) become the preference; unchecked
-/// groups fall back to source order at dedup time.
+/// groups are hidden from the chapter list and remain reader fallbacks.
 class ScanlatorPreferenceDialog extends HookConsumerWidget {
   const ScanlatorPreferenceDialog({super.key, required this.mangaId});
   final int mangaId;

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -31,6 +31,7 @@ import '../../../settings/presentation/reader/widgets/reader_orientation/reader_
 import '../../../tracking/domain/track_progress_gate.dart';
 import '../../domain/manga/manga_model.dart';
 import '../manga_details/controller/manga_details_controller.dart';
+import '../manga_details/controller/scanlator_dedup.dart';
 import 'controller/auto_webtoon.dart';
 import 'controller/display_cutout.dart';
 import 'controller/reader_controller.dart';
@@ -44,11 +45,13 @@ class ReaderScreen extends HookConsumerWidget {
     super.key,
     required this.mangaId,
     required this.chapterId,
+    this.readerScanlatorGroup,
     this.showReaderLayoutAnimation = false,
     this.openAtEnd = false,
   });
   final int mangaId;
   final int chapterId;
+  final String? readerScanlatorGroup;
   final bool showReaderLayoutAnimation;
   final bool openAtEnd;
   @override
@@ -69,7 +72,8 @@ class ReaderScreen extends HookConsumerWidget {
     // or it isn't long-strip — in which case the per-series/global default
     // takes over below. Auto never picks a page direction (LTR/RTL).
     final mangaData = manga.value;
-    final autoReaderMode = (ref.watch(autoWebtoonModeProvider).ifNull(true) &&
+    final autoReaderMode =
+        (ref.watch(autoWebtoonModeProvider).ifNull(true) &&
             mangaData != null &&
             (mangaData.metaData.readerMode ?? ReaderMode.defaultReader) ==
                 ReaderMode.defaultReader)
@@ -117,12 +121,14 @@ class ReaderScreen extends HookConsumerWidget {
           (currentPage >= (actualPageCount - 1)) && actualPageCount > 0;
 
       if (isReadingCompleted && context.mounted) {
-        unawaited(maybeTrackProgressOnReadFetch(
-          ref.read,
-          mangaId: mangaId,
-          isRead: true,
-          manual: false,
-        ));
+        unawaited(
+          maybeTrackProgressOnReadFetch(
+            ref.read,
+            mangaId: mangaId,
+            isRead: true,
+            manual: false,
+          ),
+        );
       }
 
       // Persist locally first (survives offline + app restart), then push to
@@ -159,57 +165,46 @@ class ReaderScreen extends HookConsumerWidget {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => providerContainer.invalidate(readingHistoryProvider),
       );
-    }, [
-      chapter.value,
-      chapterPages.value,
-      incognitoMode,
-      providerContainer,
-    ]);
+    }, [chapter.value, chapterPages.value, incognitoMode, providerContainer]);
 
-    final onPageChanged = useCallback<AsyncValueSetter<int>>(
-      (int index) async {
-        // Incognito: don't track progress (also avoids needless debounce churn).
-        if (ref.read(incognitoModeProvider)) return;
-        final chapterValue = chapter.value;
-        final chapterPagesValue = chapterPages.value;
-        if (chapterValue == null || chapterPagesValue == null) return;
+    final onPageChanged = useCallback<AsyncValueSetter<int>>((int index) async {
+      // Incognito: don't track progress (also avoids needless debounce churn).
+      if (ref.read(incognitoModeProvider)) return;
+      final chapterValue = chapter.value;
+      final chapterPagesValue = chapterPages.value;
+      if (chapterValue == null || chapterPagesValue == null) return;
 
-        // Consume the initial restore emit — don't record or complete off it.
-        if (!initialEmitConsumed.value) {
-          initialEmitConsumed.value = true;
-          return;
-        }
-
-        // Skip if chapter is already read or if we're going backwards
-        if ((chapterValue.isRead).ifNull() ||
-            (chapterValue.lastPageRead).getValueOnNullOrNegative() >= index) {
-          return;
-        }
-
-        latestPage.value = index;
-        final finalDebounce = debounce.value;
-        if ((finalDebounce?.isActive).ifNull()) {
-          finalDebounce?.cancel();
-        }
-
-        // Use actual loaded pages count instead of chapter metadata
-        final actualPageCount = chapterPagesValue.pages.length;
-
-        if (index >= (actualPageCount - 1) && actualPageCount > 0) {
-          unawaited(updateLastRead(index));
-        } else {
-          debounce.value = Timer(
-            const Duration(seconds: 2),
-            () {
-              if (!context.mounted) return;
-              unawaited(updateLastRead(index));
-            },
-          );
-        }
+      // Consume the initial restore emit — don't record or complete off it.
+      if (!initialEmitConsumed.value) {
+        initialEmitConsumed.value = true;
         return;
-      },
-      [chapter, chapterPages, updateLastRead],
-    );
+      }
+
+      // Skip if chapter is already read or if we're going backwards
+      if ((chapterValue.isRead).ifNull() ||
+          (chapterValue.lastPageRead).getValueOnNullOrNegative() >= index) {
+        return;
+      }
+
+      latestPage.value = index;
+      final finalDebounce = debounce.value;
+      if ((finalDebounce?.isActive).ifNull()) {
+        finalDebounce?.cancel();
+      }
+
+      // Use actual loaded pages count instead of chapter metadata
+      final actualPageCount = chapterPagesValue.pages.length;
+
+      if (index >= (actualPageCount - 1) && actualPageCount > 0) {
+        unawaited(updateLastRead(index));
+      } else {
+        debounce.value = Timer(const Duration(seconds: 2), () {
+          if (!context.mounted) return;
+          unawaited(updateLastRead(index));
+        });
+      }
+      return;
+    }, [chapter, chapterPages, updateLastRead]);
 
     // Hold the latest updateLastRead so the []-deps unmount cleanup below flushes
     // with current chapter data, not the stale callback captured at first build.
@@ -238,7 +233,8 @@ class ReaderScreen extends HookConsumerWidget {
     useEffect(() {
       // Fullscreen OFF keeps the OS bars for the whole session (read once at
       // mount; ReaderChrome handles live changes on chrome transitions).
-      final fullscreen = ref.read(readerFullscreenProvider) ??
+      final fullscreen =
+          ref.read(readerFullscreenProvider) ??
           DBKeys.readerFullscreen.initial as bool;
       SystemChrome.setEnabledSystemUIMode(
         hiddenChromeUiMode(fullscreen: fullscreen),
@@ -252,7 +248,8 @@ class ReaderScreen extends HookConsumerWidget {
 
     // Draw reader content into the display cutout (notch/punch-hole) when opted
     // in; restore the default window mode on exit. Android-only native attr.
-    final underCutout = ref.watch(drawUnderCutoutProvider) ??
+    final underCutout =
+        ref.watch(drawUnderCutoutProvider) ??
         DBKeys.drawUnderCutout.initial as bool;
     useEffect(() {
       setDrawUnderCutout(underCutout);
@@ -266,8 +263,8 @@ class ReaderScreen extends HookConsumerWidget {
     final readerOrientation = mangaData == null
         ? null
         : mangaData.metaData.readerOrientation ??
-            ref.watch(readerOrientationKeyProvider) ??
-            ReaderOrientation.defaultRotation;
+              ref.watch(readerOrientationKeyProvider) ??
+              ReaderOrientation.defaultRotation;
     useEffect(() {
       final lock = readerOrientation?.deviceOrientations;
       if (lock == null) return null;
@@ -320,8 +317,9 @@ class ReaderScreen extends HookConsumerWidget {
             // the Riverpod-3 modify-during-build assert.
             WidgetsBinding.instance.addPostFrameCallback((_) {
               providerContainer.invalidate(chapterProviderWithIndex);
-              providerContainer
-                  .invalidate(mangaChapterListProvider(mangaId: mangaId));
+              providerContainer.invalidate(
+                mangaChapterListProvider(mangaId: mangaId),
+              );
               // Refresh the library's per-category lists so the unread badge
               // updates even when the reader was opened directly (e.g. the
               // continue-reading button), bypassing the manga-details screen
@@ -347,24 +345,119 @@ class ReaderScreen extends HookConsumerWidget {
                 context,
                 (chapterData) {
                   if (chapterData == null) return const SizedBox.shrink();
-                  return chapterPages.showUiWhenData(
-                    context,
-                    (chapterPagesData) {
-                      if (chapterPagesData == null) {
-                        return const SizedBox.shrink();
-                      }
-                      return switch (autoReaderMode ??
-                          data.metaData.readerMode ??
-                          defaultReaderMode) {
-                        ReaderMode.singleVertical => MultiChapterPagedReaderMode(
+                  return chapterPages.showUiWhenData(context, (
+                    chapterPagesData,
+                  ) {
+                    if (chapterPagesData == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return switch (autoReaderMode ??
+                        data.metaData.readerMode ??
+                        defaultReaderMode) {
+                      ReaderMode.singleVertical => MultiChapterPagedReaderMode(
+                        chapter: chapterData,
+                        manga: data,
+                        onPageChanged: onPageChanged,
+                        scrollDirection: Axis.vertical,
+                        showReaderLayoutAnimation: showReaderLayoutAnimation,
+                        chapterPages: chapterPagesData,
+                        openAtEnd: openAtEnd,
+                        readerScanlatorGroup:
+                            readerScanlatorGroup ??
+                            scanlatorGroupOf(chapterData),
+                      ),
+                      ReaderMode.singleHorizontalRTL =>
+                        MultiChapterPagedReaderMode(
+                          chapter: chapterData,
+                          manga: data,
+                          onPageChanged: onPageChanged,
+                          reverse: true,
+                          showReaderLayoutAnimation: showReaderLayoutAnimation,
+                          chapterPages: chapterPagesData,
+                          openAtEnd: openAtEnd,
+                          readerScanlatorGroup:
+                              readerScanlatorGroup ??
+                              scanlatorGroupOf(chapterData),
+                        ),
+                      ReaderMode.singleHorizontalLTR =>
+                        MultiChapterPagedReaderMode(
+                          chapter: chapterData,
+                          manga: data,
+                          onPageChanged: onPageChanged,
+                          chapterPages: chapterPagesData,
+                          openAtEnd: openAtEnd,
+                          readerScanlatorGroup:
+                              readerScanlatorGroup ??
+                              scanlatorGroupOf(chapterData),
+                        ),
+                      ReaderMode.continuousHorizontalRTL =>
+                        MultiChapterContinuousReaderMode(
+                          chapter: chapterData,
+                          manga: data,
+                          onPageChanged: onPageChanged,
+                          scrollDirection: Axis.horizontal,
+                          reverse: true,
+                          effectiveReaderMode:
+                              ReaderMode.continuousHorizontalRTL,
+                          showReaderLayoutAnimation: showReaderLayoutAnimation,
+                          chapterPages: chapterPagesData,
+                          openAtEnd: openAtEnd,
+                          readerScanlatorGroup:
+                              readerScanlatorGroup ??
+                              scanlatorGroupOf(chapterData),
+                        ),
+                      ReaderMode.continuousHorizontalLTR =>
+                        MultiChapterContinuousReaderMode(
+                          chapter: chapterData,
+                          manga: data,
+                          onPageChanged: onPageChanged,
+                          scrollDirection: Axis.horizontal,
+                          effectiveReaderMode:
+                              ReaderMode.continuousHorizontalLTR,
+                          showReaderLayoutAnimation: showReaderLayoutAnimation,
+                          chapterPages: chapterPagesData,
+                          openAtEnd: openAtEnd,
+                          readerScanlatorGroup:
+                              readerScanlatorGroup ??
+                              scanlatorGroupOf(chapterData),
+                        ),
+                      ReaderMode.continuousVertical =>
+                        MultiChapterContinuousReaderMode(
+                          chapter: chapterData,
+                          manga: data,
+                          onPageChanged: onPageChanged,
+                          effectiveReaderMode: ReaderMode.continuousVertical,
+                          showReaderLayoutAnimation: showReaderLayoutAnimation,
+                          chapterPages: chapterPagesData,
+                          openAtEnd: openAtEnd,
+                          readerScanlatorGroup:
+                              readerScanlatorGroup ??
+                              scanlatorGroupOf(chapterData),
+                        ),
+                      ReaderMode.webtoon => MultiChapterContinuousReaderMode(
+                        chapter: chapterData,
+                        manga: data,
+                        onPageChanged: onPageChanged,
+                        showReaderLayoutAnimation: showReaderLayoutAnimation,
+                        chapterPages: chapterPagesData,
+                        openAtEnd: openAtEnd,
+                        readerScanlatorGroup:
+                            readerScanlatorGroup ??
+                            scanlatorGroupOf(chapterData),
+                      ),
+                      ReaderMode.defaultReader ||
+                      null => switch (defaultReaderMode ??
+                          ReaderMode.singleHorizontalRTL) {
+                        ReaderMode.singleHorizontalLTR =>
+                          MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
-                            scrollDirection: Axis.vertical,
-                            showReaderLayoutAnimation:
-                                showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
                           ),
                         ReaderMode.singleHorizontalRTL =>
                           MultiChapterPagedReaderMode(
@@ -376,14 +469,25 @@ class ReaderScreen extends HookConsumerWidget {
                                 showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
                           ),
-                        ReaderMode.singleHorizontalLTR =>
-                          MultiChapterPagedReaderMode(
+                        ReaderMode.continuousHorizontalLTR =>
+                          MultiChapterContinuousReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
+                            scrollDirection: Axis.horizontal,
+                            effectiveReaderMode:
+                                ReaderMode.continuousHorizontalLTR,
+                            showReaderLayoutAnimation:
+                                showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
                           ),
                         ReaderMode.continuousHorizontalRTL =>
                           MultiChapterContinuousReaderMode(
@@ -398,21 +502,26 @@ class ReaderScreen extends HookConsumerWidget {
                                 showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
                           ),
-                        ReaderMode.continuousHorizontalLTR =>
-                          MultiChapterContinuousReaderMode(
+                        ReaderMode.singleVertical =>
+                          MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
-                            scrollDirection: Axis.horizontal,
-                            effectiveReaderMode:
-                                ReaderMode.continuousHorizontalLTR,
+                            scrollDirection: Axis.vertical,
                             showReaderLayoutAnimation:
                                 showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
                           ),
-                        ReaderMode.continuousVertical => MultiChapterContinuousReaderMode(
+                        ReaderMode.continuousVertical =>
+                          MultiChapterContinuousReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
@@ -421,99 +530,25 @@ class ReaderScreen extends HookConsumerWidget {
                                 showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
                           ),
-                        ReaderMode.webtoon => MultiChapterContinuousReaderMode(
-                            chapter: chapterData,
-                            manga: data,
-                            onPageChanged: onPageChanged,
-                            showReaderLayoutAnimation:
-                                showReaderLayoutAnimation,
-                            chapterPages: chapterPagesData,
-                            openAtEnd: openAtEnd,
-                          ),
-                        ReaderMode.defaultReader || null => switch (
-                              defaultReaderMode ?? ReaderMode.singleHorizontalRTL) {
-                            ReaderMode.singleHorizontalLTR =>
-                              MultiChapterPagedReaderMode(
-                                chapter: chapterData,
-                                manga: data,
-                                onPageChanged: onPageChanged,
-                                chapterPages: chapterPagesData,
-                                openAtEnd: openAtEnd,
-                              ),
-                            ReaderMode.singleHorizontalRTL =>
-                              MultiChapterPagedReaderMode(
-                                chapter: chapterData,
-                                manga: data,
-                                onPageChanged: onPageChanged,
-                                reverse: true,
-                                showReaderLayoutAnimation:
-                                    showReaderLayoutAnimation,
-                                chapterPages: chapterPagesData,
-                                openAtEnd: openAtEnd,
-                              ),
-                            ReaderMode.continuousHorizontalLTR =>
-                              MultiChapterContinuousReaderMode(
-                                chapter: chapterData,
-                                manga: data,
-                                onPageChanged: onPageChanged,
-                                scrollDirection: Axis.horizontal,
-                                effectiveReaderMode:
-                                    ReaderMode.continuousHorizontalLTR,
-                                showReaderLayoutAnimation:
-                                    showReaderLayoutAnimation,
-                                chapterPages: chapterPagesData,
-                                openAtEnd: openAtEnd,
-                              ),
-                            ReaderMode.continuousHorizontalRTL =>
-                              MultiChapterContinuousReaderMode(
-                                chapter: chapterData,
-                                manga: data,
-                                onPageChanged: onPageChanged,
-                                scrollDirection: Axis.horizontal,
-                                reverse: true,
-                                effectiveReaderMode:
-                                    ReaderMode.continuousHorizontalRTL,
-                                showReaderLayoutAnimation:
-                                    showReaderLayoutAnimation,
-                                chapterPages: chapterPagesData,
-                                openAtEnd: openAtEnd,
-                              ),
-                            ReaderMode.singleVertical => MultiChapterPagedReaderMode(
-                                chapter: chapterData,
-                                manga: data,
-                                onPageChanged: onPageChanged,
-                                scrollDirection: Axis.vertical,
-                                showReaderLayoutAnimation:
-                                    showReaderLayoutAnimation,
-                                chapterPages: chapterPagesData,
-                                openAtEnd: openAtEnd,
-                              ),
-                            ReaderMode.continuousVertical =>
-                              MultiChapterContinuousReaderMode(
-                                chapter: chapterData,
-                                manga: data,
-                                onPageChanged: onPageChanged,
-                                effectiveReaderMode:
-                                    ReaderMode.continuousVertical,
-                                showReaderLayoutAnimation:
-                                    showReaderLayoutAnimation,
-                                chapterPages: chapterPagesData,
-                                openAtEnd: openAtEnd,
-                              ),
-                            ReaderMode.webtoon || _ => MultiChapterContinuousReaderMode(
-                                chapter: chapterData,
-                                manga: data,
-                                onPageChanged: onPageChanged,
-                                showReaderLayoutAnimation:
-                                    showReaderLayoutAnimation,
-                                chapterPages: chapterPagesData,
-                                openAtEnd: openAtEnd,
-                              ),
-                          }
-                      };
-                    },
-                  );
+                        ReaderMode.webtoon ||
+                        _ => MultiChapterContinuousReaderMode(
+                          chapter: chapterData,
+                          manga: data,
+                          onPageChanged: onPageChanged,
+                          showReaderLayoutAnimation: showReaderLayoutAnimation,
+                          chapterPages: chapterPagesData,
+                          openAtEnd: openAtEnd,
+                          readerScanlatorGroup:
+                              readerScanlatorGroup ??
+                              scanlatorGroupOf(chapterData),
+                        ),
+                      },
+                    };
+                  });
                 },
                 refresh: () => ref.refresh(chapterProviderWithIndex.future),
                 addScaffoldWrapper: true,

--- a/lib/src/features/manga_book/presentation/reader/reader_screen.dart
+++ b/lib/src/features/manga_book/presentation/reader/reader_screen.dart
@@ -72,8 +72,7 @@ class ReaderScreen extends HookConsumerWidget {
     // or it isn't long-strip — in which case the per-series/global default
     // takes over below. Auto never picks a page direction (LTR/RTL).
     final mangaData = manga.value;
-    final autoReaderMode =
-        (ref.watch(autoWebtoonModeProvider).ifNull(true) &&
+    final autoReaderMode = (ref.watch(autoWebtoonModeProvider).ifNull(true) &&
             mangaData != null &&
             (mangaData.metaData.readerMode ?? ReaderMode.defaultReader) ==
                 ReaderMode.defaultReader)
@@ -121,14 +120,12 @@ class ReaderScreen extends HookConsumerWidget {
           (currentPage >= (actualPageCount - 1)) && actualPageCount > 0;
 
       if (isReadingCompleted && context.mounted) {
-        unawaited(
-          maybeTrackProgressOnReadFetch(
-            ref.read,
-            mangaId: mangaId,
-            isRead: true,
-            manual: false,
-          ),
-        );
+        unawaited(maybeTrackProgressOnReadFetch(
+          ref.read,
+          mangaId: mangaId,
+          isRead: true,
+          manual: false,
+        ));
       }
 
       // Persist locally first (survives offline + app restart), then push to
@@ -165,46 +162,57 @@ class ReaderScreen extends HookConsumerWidget {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => providerContainer.invalidate(readingHistoryProvider),
       );
-    }, [chapter.value, chapterPages.value, incognitoMode, providerContainer]);
+    }, [
+      chapter.value,
+      chapterPages.value,
+      incognitoMode,
+      providerContainer,
+    ]);
 
-    final onPageChanged = useCallback<AsyncValueSetter<int>>((int index) async {
-      // Incognito: don't track progress (also avoids needless debounce churn).
-      if (ref.read(incognitoModeProvider)) return;
-      final chapterValue = chapter.value;
-      final chapterPagesValue = chapterPages.value;
-      if (chapterValue == null || chapterPagesValue == null) return;
+    final onPageChanged = useCallback<AsyncValueSetter<int>>(
+      (int index) async {
+        // Incognito: don't track progress (also avoids needless debounce churn).
+        if (ref.read(incognitoModeProvider)) return;
+        final chapterValue = chapter.value;
+        final chapterPagesValue = chapterPages.value;
+        if (chapterValue == null || chapterPagesValue == null) return;
 
-      // Consume the initial restore emit — don't record or complete off it.
-      if (!initialEmitConsumed.value) {
-        initialEmitConsumed.value = true;
-        return;
-      }
+        // Consume the initial restore emit — don't record or complete off it.
+        if (!initialEmitConsumed.value) {
+          initialEmitConsumed.value = true;
+          return;
+        }
 
-      // Skip if chapter is already read or if we're going backwards
-      if ((chapterValue.isRead).ifNull() ||
-          (chapterValue.lastPageRead).getValueOnNullOrNegative() >= index) {
-        return;
-      }
+        // Skip if chapter is already read or if we're going backwards
+        if ((chapterValue.isRead).ifNull() ||
+            (chapterValue.lastPageRead).getValueOnNullOrNegative() >= index) {
+          return;
+        }
 
-      latestPage.value = index;
-      final finalDebounce = debounce.value;
-      if ((finalDebounce?.isActive).ifNull()) {
-        finalDebounce?.cancel();
-      }
+        latestPage.value = index;
+        final finalDebounce = debounce.value;
+        if ((finalDebounce?.isActive).ifNull()) {
+          finalDebounce?.cancel();
+        }
 
-      // Use actual loaded pages count instead of chapter metadata
-      final actualPageCount = chapterPagesValue.pages.length;
+        // Use actual loaded pages count instead of chapter metadata
+        final actualPageCount = chapterPagesValue.pages.length;
 
-      if (index >= (actualPageCount - 1) && actualPageCount > 0) {
-        unawaited(updateLastRead(index));
-      } else {
-        debounce.value = Timer(const Duration(seconds: 2), () {
-          if (!context.mounted) return;
+        if (index >= (actualPageCount - 1) && actualPageCount > 0) {
           unawaited(updateLastRead(index));
-        });
-      }
-      return;
-    }, [chapter, chapterPages, updateLastRead]);
+        } else {
+          debounce.value = Timer(
+            const Duration(seconds: 2),
+            () {
+              if (!context.mounted) return;
+              unawaited(updateLastRead(index));
+            },
+          );
+        }
+        return;
+      },
+      [chapter, chapterPages, updateLastRead],
+    );
 
     // Hold the latest updateLastRead so the []-deps unmount cleanup below flushes
     // with current chapter data, not the stale callback captured at first build.
@@ -233,8 +241,7 @@ class ReaderScreen extends HookConsumerWidget {
     useEffect(() {
       // Fullscreen OFF keeps the OS bars for the whole session (read once at
       // mount; ReaderChrome handles live changes on chrome transitions).
-      final fullscreen =
-          ref.read(readerFullscreenProvider) ??
+      final fullscreen = ref.read(readerFullscreenProvider) ??
           DBKeys.readerFullscreen.initial as bool;
       SystemChrome.setEnabledSystemUIMode(
         hiddenChromeUiMode(fullscreen: fullscreen),
@@ -248,8 +255,7 @@ class ReaderScreen extends HookConsumerWidget {
 
     // Draw reader content into the display cutout (notch/punch-hole) when opted
     // in; restore the default window mode on exit. Android-only native attr.
-    final underCutout =
-        ref.watch(drawUnderCutoutProvider) ??
+    final underCutout = ref.watch(drawUnderCutoutProvider) ??
         DBKeys.drawUnderCutout.initial as bool;
     useEffect(() {
       setDrawUnderCutout(underCutout);
@@ -263,8 +269,8 @@ class ReaderScreen extends HookConsumerWidget {
     final readerOrientation = mangaData == null
         ? null
         : mangaData.metaData.readerOrientation ??
-              ref.watch(readerOrientationKeyProvider) ??
-              ReaderOrientation.defaultRotation;
+            ref.watch(readerOrientationKeyProvider) ??
+            ReaderOrientation.defaultRotation;
     useEffect(() {
       final lock = readerOrientation?.deviceOrientations;
       if (lock == null) return null;
@@ -317,9 +323,8 @@ class ReaderScreen extends HookConsumerWidget {
             // the Riverpod-3 modify-during-build assert.
             WidgetsBinding.instance.addPostFrameCallback((_) {
               providerContainer.invalidate(chapterProviderWithIndex);
-              providerContainer.invalidate(
-                mangaChapterListProvider(mangaId: mangaId),
-              );
+              providerContainer
+                  .invalidate(mangaChapterListProvider(mangaId: mangaId));
               // Refresh the library's per-category lists so the unread badge
               // updates even when the reader was opened directly (e.g. the
               // continue-reading button), bypassing the manga-details screen
@@ -345,114 +350,22 @@ class ReaderScreen extends HookConsumerWidget {
                 context,
                 (chapterData) {
                   if (chapterData == null) return const SizedBox.shrink();
-                  return chapterPages.showUiWhenData(context, (
-                    chapterPagesData,
-                  ) {
-                    if (chapterPagesData == null) {
-                      return const SizedBox.shrink();
-                    }
-                    return switch (autoReaderMode ??
-                        data.metaData.readerMode ??
-                        defaultReaderMode) {
-                      ReaderMode.singleVertical => MultiChapterPagedReaderMode(
-                        chapter: chapterData,
-                        manga: data,
-                        onPageChanged: onPageChanged,
-                        scrollDirection: Axis.vertical,
-                        showReaderLayoutAnimation: showReaderLayoutAnimation,
-                        chapterPages: chapterPagesData,
-                        openAtEnd: openAtEnd,
-                        readerScanlatorGroup:
-                            readerScanlatorGroup ??
-                            scanlatorGroupOf(chapterData),
-                      ),
-                      ReaderMode.singleHorizontalRTL =>
-                        MultiChapterPagedReaderMode(
-                          chapter: chapterData,
-                          manga: data,
-                          onPageChanged: onPageChanged,
-                          reverse: true,
-                          showReaderLayoutAnimation: showReaderLayoutAnimation,
-                          chapterPages: chapterPagesData,
-                          openAtEnd: openAtEnd,
-                          readerScanlatorGroup:
-                              readerScanlatorGroup ??
-                              scanlatorGroupOf(chapterData),
-                        ),
-                      ReaderMode.singleHorizontalLTR =>
-                        MultiChapterPagedReaderMode(
-                          chapter: chapterData,
-                          manga: data,
-                          onPageChanged: onPageChanged,
-                          chapterPages: chapterPagesData,
-                          openAtEnd: openAtEnd,
-                          readerScanlatorGroup:
-                              readerScanlatorGroup ??
-                              scanlatorGroupOf(chapterData),
-                        ),
-                      ReaderMode.continuousHorizontalRTL =>
-                        MultiChapterContinuousReaderMode(
-                          chapter: chapterData,
-                          manga: data,
-                          onPageChanged: onPageChanged,
-                          scrollDirection: Axis.horizontal,
-                          reverse: true,
-                          effectiveReaderMode:
-                              ReaderMode.continuousHorizontalRTL,
-                          showReaderLayoutAnimation: showReaderLayoutAnimation,
-                          chapterPages: chapterPagesData,
-                          openAtEnd: openAtEnd,
-                          readerScanlatorGroup:
-                              readerScanlatorGroup ??
-                              scanlatorGroupOf(chapterData),
-                        ),
-                      ReaderMode.continuousHorizontalLTR =>
-                        MultiChapterContinuousReaderMode(
-                          chapter: chapterData,
-                          manga: data,
-                          onPageChanged: onPageChanged,
-                          scrollDirection: Axis.horizontal,
-                          effectiveReaderMode:
-                              ReaderMode.continuousHorizontalLTR,
-                          showReaderLayoutAnimation: showReaderLayoutAnimation,
-                          chapterPages: chapterPagesData,
-                          openAtEnd: openAtEnd,
-                          readerScanlatorGroup:
-                              readerScanlatorGroup ??
-                              scanlatorGroupOf(chapterData),
-                        ),
-                      ReaderMode.continuousVertical =>
-                        MultiChapterContinuousReaderMode(
-                          chapter: chapterData,
-                          manga: data,
-                          onPageChanged: onPageChanged,
-                          effectiveReaderMode: ReaderMode.continuousVertical,
-                          showReaderLayoutAnimation: showReaderLayoutAnimation,
-                          chapterPages: chapterPagesData,
-                          openAtEnd: openAtEnd,
-                          readerScanlatorGroup:
-                              readerScanlatorGroup ??
-                              scanlatorGroupOf(chapterData),
-                        ),
-                      ReaderMode.webtoon => MultiChapterContinuousReaderMode(
-                        chapter: chapterData,
-                        manga: data,
-                        onPageChanged: onPageChanged,
-                        showReaderLayoutAnimation: showReaderLayoutAnimation,
-                        chapterPages: chapterPagesData,
-                        openAtEnd: openAtEnd,
-                        readerScanlatorGroup:
-                            readerScanlatorGroup ??
-                            scanlatorGroupOf(chapterData),
-                      ),
-                      ReaderMode.defaultReader ||
-                      null => switch (defaultReaderMode ??
-                          ReaderMode.singleHorizontalRTL) {
-                        ReaderMode.singleHorizontalLTR =>
-                          MultiChapterPagedReaderMode(
+                  return chapterPages.showUiWhenData(
+                    context,
+                    (chapterPagesData) {
+                      if (chapterPagesData == null) {
+                        return const SizedBox.shrink();
+                      }
+                      return switch (autoReaderMode ??
+                          data.metaData.readerMode ??
+                          defaultReaderMode) {
+                        ReaderMode.singleVertical => MultiChapterPagedReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
+                            scrollDirection: Axis.vertical,
+                            showReaderLayoutAnimation:
+                                showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
                             openAtEnd: openAtEnd,
                             readerScanlatorGroup:
@@ -465,6 +378,34 @@ class ReaderScreen extends HookConsumerWidget {
                             manga: data,
                             onPageChanged: onPageChanged,
                             reverse: true,
+                            showReaderLayoutAnimation:
+                                showReaderLayoutAnimation,
+                            chapterPages: chapterPagesData,
+                            openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
+                          ),
+                        ReaderMode.singleHorizontalLTR =>
+                          MultiChapterPagedReaderMode(
+                            chapter: chapterData,
+                            manga: data,
+                            onPageChanged: onPageChanged,
+                            chapterPages: chapterPagesData,
+                            openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
+                          ),
+                        ReaderMode.continuousHorizontalRTL =>
+                          MultiChapterContinuousReaderMode(
+                            chapter: chapterData,
+                            manga: data,
+                            onPageChanged: onPageChanged,
+                            scrollDirection: Axis.horizontal,
+                            reverse: true,
+                            effectiveReaderMode:
+                                ReaderMode.continuousHorizontalRTL,
                             showReaderLayoutAnimation:
                                 showReaderLayoutAnimation,
                             chapterPages: chapterPagesData,
@@ -489,39 +430,7 @@ class ReaderScreen extends HookConsumerWidget {
                                 readerScanlatorGroup ??
                                 scanlatorGroupOf(chapterData),
                           ),
-                        ReaderMode.continuousHorizontalRTL =>
-                          MultiChapterContinuousReaderMode(
-                            chapter: chapterData,
-                            manga: data,
-                            onPageChanged: onPageChanged,
-                            scrollDirection: Axis.horizontal,
-                            reverse: true,
-                            effectiveReaderMode:
-                                ReaderMode.continuousHorizontalRTL,
-                            showReaderLayoutAnimation:
-                                showReaderLayoutAnimation,
-                            chapterPages: chapterPagesData,
-                            openAtEnd: openAtEnd,
-                            readerScanlatorGroup:
-                                readerScanlatorGroup ??
-                                scanlatorGroupOf(chapterData),
-                          ),
-                        ReaderMode.singleVertical =>
-                          MultiChapterPagedReaderMode(
-                            chapter: chapterData,
-                            manga: data,
-                            onPageChanged: onPageChanged,
-                            scrollDirection: Axis.vertical,
-                            showReaderLayoutAnimation:
-                                showReaderLayoutAnimation,
-                            chapterPages: chapterPagesData,
-                            openAtEnd: openAtEnd,
-                            readerScanlatorGroup:
-                                readerScanlatorGroup ??
-                                scanlatorGroupOf(chapterData),
-                          ),
-                        ReaderMode.continuousVertical =>
-                          MultiChapterContinuousReaderMode(
+                        ReaderMode.continuousVertical => MultiChapterContinuousReaderMode(
                             chapter: chapterData,
                             manga: data,
                             onPageChanged: onPageChanged,
@@ -534,21 +443,122 @@ class ReaderScreen extends HookConsumerWidget {
                                 readerScanlatorGroup ??
                                 scanlatorGroupOf(chapterData),
                           ),
-                        ReaderMode.webtoon ||
-                        _ => MultiChapterContinuousReaderMode(
-                          chapter: chapterData,
-                          manga: data,
-                          onPageChanged: onPageChanged,
-                          showReaderLayoutAnimation: showReaderLayoutAnimation,
-                          chapterPages: chapterPagesData,
-                          openAtEnd: openAtEnd,
-                          readerScanlatorGroup:
-                              readerScanlatorGroup ??
-                              scanlatorGroupOf(chapterData),
-                        ),
-                      },
-                    };
-                  });
+                        ReaderMode.webtoon => MultiChapterContinuousReaderMode(
+                            chapter: chapterData,
+                            manga: data,
+                            onPageChanged: onPageChanged,
+                            showReaderLayoutAnimation:
+                                showReaderLayoutAnimation,
+                            chapterPages: chapterPagesData,
+                            openAtEnd: openAtEnd,
+                            readerScanlatorGroup:
+                                readerScanlatorGroup ??
+                                scanlatorGroupOf(chapterData),
+                          ),
+                        ReaderMode.defaultReader || null => switch (
+                              defaultReaderMode ?? ReaderMode.singleHorizontalRTL) {
+                            ReaderMode.singleHorizontalLTR =>
+                              MultiChapterPagedReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                                readerScanlatorGroup:
+                                    readerScanlatorGroup ??
+                                    scanlatorGroupOf(chapterData),
+                              ),
+                            ReaderMode.singleHorizontalRTL =>
+                              MultiChapterPagedReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                reverse: true,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                                readerScanlatorGroup:
+                                    readerScanlatorGroup ??
+                                    scanlatorGroupOf(chapterData),
+                              ),
+                            ReaderMode.continuousHorizontalLTR =>
+                              MultiChapterContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.horizontal,
+                                effectiveReaderMode:
+                                    ReaderMode.continuousHorizontalLTR,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                                readerScanlatorGroup:
+                                    readerScanlatorGroup ??
+                                    scanlatorGroupOf(chapterData),
+                              ),
+                            ReaderMode.continuousHorizontalRTL =>
+                              MultiChapterContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.horizontal,
+                                reverse: true,
+                                effectiveReaderMode:
+                                    ReaderMode.continuousHorizontalRTL,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                                readerScanlatorGroup:
+                                    readerScanlatorGroup ??
+                                    scanlatorGroupOf(chapterData),
+                              ),
+                            ReaderMode.singleVertical => MultiChapterPagedReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                scrollDirection: Axis.vertical,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                                readerScanlatorGroup:
+                                    readerScanlatorGroup ??
+                                    scanlatorGroupOf(chapterData),
+                              ),
+                            ReaderMode.continuousVertical =>
+                              MultiChapterContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                effectiveReaderMode:
+                                    ReaderMode.continuousVertical,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                                readerScanlatorGroup:
+                                    readerScanlatorGroup ??
+                                    scanlatorGroupOf(chapterData),
+                              ),
+                            ReaderMode.webtoon || _ => MultiChapterContinuousReaderMode(
+                                chapter: chapterData,
+                                manga: data,
+                                onPageChanged: onPageChanged,
+                                showReaderLayoutAnimation:
+                                    showReaderLayoutAnimation,
+                                chapterPages: chapterPagesData,
+                                openAtEnd: openAtEnd,
+                                readerScanlatorGroup:
+                                    readerScanlatorGroup ??
+                                    scanlatorGroupOf(chapterData),
+                              ),
+                          }
+                      };
+                    },
+                  );
                 },
                 refresh: () => ref.refresh(chapterProviderWithIndex.future),
                 addScaffoldWrapper: true,

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
@@ -181,6 +181,7 @@ class ReaderBottomControls extends ConsumerWidget {
                         context: context,
                         mangaId: chapter.mangaId,
                         currentChapterId: chapter.id,
+                        readerScanlatorGroup: readerScanlatorGroup,
                         transVertical: scrollDirection == Axis.vertical,
                       ),
                     ),
@@ -243,6 +244,7 @@ Future<void> _showChapterPicker({
   required BuildContext context,
   required int mangaId,
   required int currentChapterId,
+  required String readerScanlatorGroup,
   required bool transVertical,
 }) {
   final readerContext = context;
@@ -272,6 +274,7 @@ Future<void> _showChapterPicker({
                   mangaChapterListWithFilterProvider(
                     mangaId: mangaId,
                     keepChapterId: currentChapterId,
+                    readerScanlatorGroup: readerScanlatorGroup,
                   ),
                 );
                 return chapters.showUiWhenData(

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
@@ -170,8 +170,7 @@ class ReaderBottomControls extends ConsumerWidget {
               shape: const RoundedRectangleBorder(),
               margin: EdgeInsets.zero,
               child: Padding(
-                padding:
-                    KEdgeInsets.h16.size +
+                padding: KEdgeInsets.h16.size +
                     EdgeInsets.only(bottom: systemBottomInset),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -223,20 +222,23 @@ class ReaderBottomControls extends ConsumerWidget {
 }
 
 IconData _readerModeIcon(ReaderMode mode) => switch (mode) {
-  ReaderMode.webtoon || ReaderMode.continuousVertical => Icons.public_rounded,
-  ReaderMode.singleHorizontalLTR ||
-  ReaderMode.singleHorizontalRTL ||
-  ReaderMode.singleVertical ||
-  ReaderMode.continuousHorizontalLTR ||
-  ReaderMode.continuousHorizontalRTL => Icons.menu_book_rounded,
-  ReaderMode.defaultReader => Icons.auto_stories_rounded,
-};
+      ReaderMode.webtoon ||
+      ReaderMode.continuousVertical =>
+        Icons.public_rounded,
+      ReaderMode.singleHorizontalLTR ||
+      ReaderMode.singleHorizontalRTL ||
+      ReaderMode.singleVertical ||
+      ReaderMode.continuousHorizontalLTR ||
+      ReaderMode.continuousHorizontalRTL =>
+        Icons.menu_book_rounded,
+      ReaderMode.defaultReader => Icons.auto_stories_rounded,
+    };
 
 IconData _pageLayoutIcon(PageLayout pageLayout) => switch (pageLayout) {
-  PageLayout.singlePage => Icons.menu_book_rounded,
-  PageLayout.doublePages => Icons.chrome_reader_mode_rounded,
-  PageLayout.automatic => Icons.auto_stories_rounded,
-};
+      PageLayout.singlePage => Icons.menu_book_rounded,
+      PageLayout.doublePages => Icons.chrome_reader_mode_rounded,
+      PageLayout.automatic => Icons.auto_stories_rounded,
+    };
 
 Future<void> _showChapterPicker({
   required BuildContext context,
@@ -355,21 +357,18 @@ class _ReaderChapterSheet extends StatelessWidget {
             itemBuilder: (context, index) {
               final chapter = chapters[index];
               final isCurrent = chapter.id == currentChapterId;
-              final lastPageRead = chapter.lastPageRead
-                  .getValueOnNullOrNegative();
+              final lastPageRead =
+                  chapter.lastPageRead.getValueOnNullOrNegative();
               return ListTile(
                 dense: true,
-                visualDensity: const VisualDensity(
-                  horizontal: -1,
-                  vertical: -3,
-                ),
+                visualDensity:
+                    const VisualDensity(horizontal: -1, vertical: -3),
                 minLeadingWidth: 24,
                 minVerticalPadding: 0,
                 contentPadding: const EdgeInsets.only(left: 16, right: 8),
                 selected: isCurrent,
-                selectedTileColor: colorScheme.primaryContainer.withValues(
-                  alpha: 0.55,
-                ),
+                selectedTileColor:
+                    colorScheme.primaryContainer.withValues(alpha: 0.55),
                 selectedColor: colorScheme.onPrimaryContainer,
                 leading: Icon(
                   chapter.isRead.ifNull()

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
@@ -181,7 +181,6 @@ class ReaderBottomControls extends ConsumerWidget {
                         context: context,
                         mangaId: chapter.mangaId,
                         currentChapterId: chapter.id,
-                        readerScanlatorGroup: readerScanlatorGroup,
                         transVertical: scrollDirection == Axis.vertical,
                       ),
                     ),
@@ -244,7 +243,6 @@ Future<void> _showChapterPicker({
   required BuildContext context,
   required int mangaId,
   required int currentChapterId,
-  required String readerScanlatorGroup,
   required bool transVertical,
 }) {
   final readerContext = context;
@@ -268,13 +266,12 @@ Future<void> _showChapterPicker({
             ),
             child: Consumer(
               builder: (context, ref, _) {
-                // keepChapterId: keeps the open chapter visible even if dedup
-                // would otherwise hide it.
+                // Keep the open chapter visible even if its scanlator is not
+                // selected by the preferred-scanlator filter.
                 final chapters = ref.watch(
                   mangaChapterListWithFilterProvider(
                     mangaId: mangaId,
                     keepChapterId: currentChapterId,
-                    readerScanlatorGroup: readerScanlatorGroup,
                   ),
                 );
                 return chapters.showUiWhenData(
@@ -359,6 +356,9 @@ class _ReaderChapterSheet extends StatelessWidget {
               final isCurrent = chapter.id == currentChapterId;
               final lastPageRead =
                   chapter.lastPageRead.getValueOnNullOrNegative();
+              final scanlator = chapter.scanlator.isNotBlank
+                  ? chapter.scanlator!
+                  : context.l10n.unknownScanlator;
               return ListTile(
                 dense: true,
                 visualDensity:
@@ -381,14 +381,16 @@ class _ReaderChapterSheet extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                subtitle: lastPageRead > 0
-                    ? Text(
-                        context.l10n.page(lastPageRead + 1),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: context.textTheme.bodySmall,
-                      )
-                    : null,
+                subtitle: Text(
+                  [
+                    scanlator,
+                    if (lastPageRead > 0)
+                      context.l10n.page(lastPageRead + 1),
+                  ].join(' • '),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.textTheme.bodySmall,
+                ),
                 trailing: IconButtonTheme(
                   data: IconButtonThemeData(
                     style: ButtonStyle(

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_bottom_controls.dart
@@ -20,6 +20,7 @@ import '../../../../domain/chapter/chapter_model.dart';
 import '../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../widgets/download_status_icon.dart';
 import '../../../manga_details/controller/manga_details_controller.dart';
+import '../../../manga_details/controller/scanlator_dedup.dart';
 import '../../utils/reader_mode_kind.dart';
 import '../brand_page_seekbar.dart';
 import '../reader_mode/infinity_continuous/measure_size.dart';
@@ -39,6 +40,7 @@ class ReaderBottomControls extends ConsumerWidget {
     super.key,
     required this.chapter,
     required this.chapterPages,
+    required this.readerScanlatorGroup,
     required this.currentIndex,
     required this.totalPageCount,
     required this.useBottomSeekBar,
@@ -54,6 +56,7 @@ class ReaderBottomControls extends ConsumerWidget {
 
   final ChapterDto chapter;
   final ChapterPagesDto chapterPages;
+  final String readerScanlatorGroup;
   final int currentIndex;
 
   /// For infinity-scroll mode; null means use [chapterPages.chapter.pageCount].
@@ -167,7 +170,8 @@ class ReaderBottomControls extends ConsumerWidget {
               shape: const RoundedRectangleBorder(),
               margin: EdgeInsets.zero,
               child: Padding(
-                padding: KEdgeInsets.h16.size +
+                padding:
+                    KEdgeInsets.h16.size +
                     EdgeInsets.only(bottom: systemBottomInset),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -178,6 +182,7 @@ class ReaderBottomControls extends ConsumerWidget {
                         context: context,
                         mangaId: chapter.mangaId,
                         currentChapterId: chapter.id,
+                        readerScanlatorGroup: readerScanlatorGroup,
                         transVertical: scrollDirection == Axis.vertical,
                       ),
                     ),
@@ -218,28 +223,26 @@ class ReaderBottomControls extends ConsumerWidget {
 }
 
 IconData _readerModeIcon(ReaderMode mode) => switch (mode) {
-      ReaderMode.webtoon ||
-      ReaderMode.continuousVertical =>
-        Icons.public_rounded,
-      ReaderMode.singleHorizontalLTR ||
-      ReaderMode.singleHorizontalRTL ||
-      ReaderMode.singleVertical ||
-      ReaderMode.continuousHorizontalLTR ||
-      ReaderMode.continuousHorizontalRTL =>
-        Icons.menu_book_rounded,
-      ReaderMode.defaultReader => Icons.auto_stories_rounded,
-    };
+  ReaderMode.webtoon || ReaderMode.continuousVertical => Icons.public_rounded,
+  ReaderMode.singleHorizontalLTR ||
+  ReaderMode.singleHorizontalRTL ||
+  ReaderMode.singleVertical ||
+  ReaderMode.continuousHorizontalLTR ||
+  ReaderMode.continuousHorizontalRTL => Icons.menu_book_rounded,
+  ReaderMode.defaultReader => Icons.auto_stories_rounded,
+};
 
 IconData _pageLayoutIcon(PageLayout pageLayout) => switch (pageLayout) {
-      PageLayout.singlePage => Icons.menu_book_rounded,
-      PageLayout.doublePages => Icons.chrome_reader_mode_rounded,
-      PageLayout.automatic => Icons.auto_stories_rounded,
-    };
+  PageLayout.singlePage => Icons.menu_book_rounded,
+  PageLayout.doublePages => Icons.chrome_reader_mode_rounded,
+  PageLayout.automatic => Icons.auto_stories_rounded,
+};
 
 Future<void> _showChapterPicker({
   required BuildContext context,
   required int mangaId,
   required int currentChapterId,
+  required String readerScanlatorGroup,
   required bool transVertical,
 }) {
   final readerContext = context;
@@ -269,6 +272,7 @@ Future<void> _showChapterPicker({
                   mangaChapterListWithFilterProvider(
                     mangaId: mangaId,
                     keepChapterId: currentChapterId,
+                    readerScanlatorGroup: readerScanlatorGroup,
                   ),
                 );
                 return chapters.showUiWhenData(
@@ -351,18 +355,21 @@ class _ReaderChapterSheet extends StatelessWidget {
             itemBuilder: (context, index) {
               final chapter = chapters[index];
               final isCurrent = chapter.id == currentChapterId;
-              final lastPageRead =
-                  chapter.lastPageRead.getValueOnNullOrNegative();
+              final lastPageRead = chapter.lastPageRead
+                  .getValueOnNullOrNegative();
               return ListTile(
                 dense: true,
-                visualDensity:
-                    const VisualDensity(horizontal: -1, vertical: -3),
+                visualDensity: const VisualDensity(
+                  horizontal: -1,
+                  vertical: -3,
+                ),
                 minLeadingWidth: 24,
                 minVerticalPadding: 0,
                 contentPadding: const EdgeInsets.only(left: 16, right: 8),
                 selected: isCurrent,
-                selectedTileColor:
-                    colorScheme.primaryContainer.withValues(alpha: 0.55),
+                selectedTileColor: colorScheme.primaryContainer.withValues(
+                  alpha: 0.55,
+                ),
                 selectedColor: colorScheme.onPrimaryContainer,
                 leading: Icon(
                   chapter.isRead.ifNull()
@@ -419,6 +426,7 @@ class _ReaderChapterSheet extends StatelessWidget {
                     ReaderRoute(
                       mangaId: mangaId,
                       chapterId: chapter.id,
+                      readerScanlatorGroup: scanlatorGroupOf(chapter),
                       showReaderLayoutAnimation: true,
                       transVertical: transVertical,
                     ).pushReplacement(readerContext);

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
@@ -59,6 +59,7 @@ class ReaderChrome extends HookConsumerWidget {
     required this.manga,
     required this.chapter,
     required this.chapterPages,
+    this.readerScanlatorGroup = '',
     required this.currentIndex,
     required this.totalPageCount,
     required this.visibility,
@@ -79,6 +80,7 @@ class ReaderChrome extends HookConsumerWidget {
   final MangaDto manga;
   final ChapterDto chapter;
   final ChapterPagesDto chapterPages;
+  final String readerScanlatorGroup;
   final int currentIndex;
 
   /// For infinity-scroll mode; null means use [chapterPages.chapter.pageCount].
@@ -136,8 +138,9 @@ class ReaderChrome extends HookConsumerWidget {
       statusBarIconBrightness: darkIcons ? Brightness.dark : Brightness.light,
       statusBarBrightness: darkIcons ? Brightness.light : Brightness.dark,
       systemNavigationBarContrastEnforced: false,
-      systemNavigationBarIconBrightness:
-          darkIcons ? Brightness.dark : Brightness.light,
+      systemNavigationBarIconBrightness: darkIcons
+          ? Brightness.dark
+          : Brightness.light,
     );
 
     // ── C1: OS system-bar sync — driven from controller status, not raw bool ──
@@ -156,7 +159,8 @@ class ReaderChrome extends HookConsumerWidget {
     // do not conflict because reader_screen sets on mount (once) while this
     // listener updates only on animation-status transitions.
     // Fullscreen OFF keeps the OS bars up even while the chrome is hidden.
-    final fullscreen = ref.watch(readerFullscreenProvider) ??
+    final fullscreen =
+        ref.watch(readerFullscreenProvider) ??
         DBKeys.readerFullscreen.initial as bool;
     useEffect(() {
       void onStatus(AnimationStatus status) {
@@ -235,10 +239,12 @@ class ReaderChrome extends HookConsumerWidget {
     // When [forceHorizontalSeekbar] is true, the vertical side seekbar is hidden
     // and the horizontal bottom seekbar serves all modes (including webtoon).
     final extents = ref.watch(chromeExtentsProvider);
-    final forceHorizontal =
-        ref.watch(forceHorizontalSeekbarProvider).ifNull(false);
-    final leftHanded =
-        ref.watch(leftHandedVerticalSeekbarProvider).ifNull(false);
+    final forceHorizontal = ref
+        .watch(forceHorizontalSeekbarProvider)
+        .ifNull(false);
+    final leftHanded = ref
+        .watch(leftHandedVerticalSeekbarProvider)
+        .ifNull(false);
     // "Show page number": a subtle "n / m" pill near the bottom, always
     // mounted (outside the animated bars) so it stays visible while reading.
     final showPageNumber = ref.watch(showPageNumberProvider).ifNull(true);
@@ -326,9 +332,7 @@ class ReaderChrome extends HookConsumerWidget {
                           topInset: size.height,
                           bottomInset: current.bottomInset,
                         );
-                        ref
-                            .read(chromeExtentsProvider.notifier)
-                            .update(next);
+                        ref.read(chromeExtentsProvider.notifier).update(next);
                       },
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
@@ -416,6 +420,7 @@ class ReaderChrome extends HookConsumerWidget {
                       end: Offset.zero,
                     ).animate(slide),
                     child: ReaderBottomControls(
+                      readerScanlatorGroup: readerScanlatorGroup,
                       chapter: chapter,
                       chapterPages: chapterPages,
                       currentIndex: currentIndex,

--- a/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/chrome/reader_chrome.dart
@@ -138,9 +138,8 @@ class ReaderChrome extends HookConsumerWidget {
       statusBarIconBrightness: darkIcons ? Brightness.dark : Brightness.light,
       statusBarBrightness: darkIcons ? Brightness.light : Brightness.dark,
       systemNavigationBarContrastEnforced: false,
-      systemNavigationBarIconBrightness: darkIcons
-          ? Brightness.dark
-          : Brightness.light,
+      systemNavigationBarIconBrightness:
+          darkIcons ? Brightness.dark : Brightness.light,
     );
 
     // ── C1: OS system-bar sync — driven from controller status, not raw bool ──
@@ -159,8 +158,7 @@ class ReaderChrome extends HookConsumerWidget {
     // do not conflict because reader_screen sets on mount (once) while this
     // listener updates only on animation-status transitions.
     // Fullscreen OFF keeps the OS bars up even while the chrome is hidden.
-    final fullscreen =
-        ref.watch(readerFullscreenProvider) ??
+    final fullscreen = ref.watch(readerFullscreenProvider) ??
         DBKeys.readerFullscreen.initial as bool;
     useEffect(() {
       void onStatus(AnimationStatus status) {
@@ -239,12 +237,10 @@ class ReaderChrome extends HookConsumerWidget {
     // When [forceHorizontalSeekbar] is true, the vertical side seekbar is hidden
     // and the horizontal bottom seekbar serves all modes (including webtoon).
     final extents = ref.watch(chromeExtentsProvider);
-    final forceHorizontal = ref
-        .watch(forceHorizontalSeekbarProvider)
-        .ifNull(false);
-    final leftHanded = ref
-        .watch(leftHandedVerticalSeekbarProvider)
-        .ifNull(false);
+    final forceHorizontal =
+        ref.watch(forceHorizontalSeekbarProvider).ifNull(false);
+    final leftHanded =
+        ref.watch(leftHandedVerticalSeekbarProvider).ifNull(false);
     // "Show page number": a subtle "n / m" pill near the bottom, always
     // mounted (outside the animated bars) so it stays visible while reading.
     final showPageNumber = ref.watch(showPageNumberProvider).ifNull(true);
@@ -332,7 +328,9 @@ class ReaderChrome extends HookConsumerWidget {
                           topInset: size.height,
                           bottomInset: current.bottomInset,
                         );
-                        ref.read(chromeExtentsProvider.notifier).update(next);
+                        ref
+                            .read(chromeExtentsProvider.notifier)
+                            .update(next);
                       },
                       child: Column(
                         mainAxisSize: MainAxisSize.min,

--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -38,7 +38,6 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
 
   final Widget child;
   final VoidCallback onTap;
-
   /// Null when nothing consumes a long press — [GestureDetector] then skips
   /// the recognizer entirely rather than claiming the gesture for a no-op.
   final void Function(LongPressStartDetails)? onLongPressStart;
@@ -111,28 +110,26 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
     return RawGestureDetector(
       behavior: HitTestBehavior.translucent,
       gestures: <Type, GestureRecognizerFactory>{
-        SingleTouchPanGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<
-              SingleTouchPanGestureRecognizer
-            >(
-              () => SingleTouchPanGestureRecognizer(
-                debugOwner: this,
-                isZoomedIn: isZoomedIn,
-              ),
-              (recognizer) {
-                recognizer.isZoomedIn = isZoomedIn;
-                recognizer.onEnd = (details) {
-                  final swipeDirection =
-                      LastPageSwipeUtils.detectSwipeDirection(details);
-                  if (swipeDirection != null) {
-                    _handleBoundarySwipe(
-                      context: context,
-                      direction: swipeDirection,
-                    );
-                  }
-                };
-              },
-            ),
+        SingleTouchPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+            SingleTouchPanGestureRecognizer>(
+          () => SingleTouchPanGestureRecognizer(
+            debugOwner: this,
+            isZoomedIn: isZoomedIn,
+          ),
+          (recognizer) {
+            recognizer.isZoomedIn = isZoomedIn;
+            recognizer.onEnd = (details) {
+              final swipeDirection =
+                  LastPageSwipeUtils.detectSwipeDirection(details);
+              if (swipeDirection != null) {
+                _handleBoundarySwipe(
+                  context: context,
+                  direction: swipeDirection,
+                );
+              }
+            };
+          },
+        ),
       },
       child: _wrapWithTapAndLongPress(child),
     );
@@ -147,42 +144,40 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
       gestures: <Type, GestureRecognizerFactory>{
         SingleTouchHorizontalDragGestureRecognizer:
             GestureRecognizerFactoryWithHandlers<
-              SingleTouchHorizontalDragGestureRecognizer
-            >(
-              () => SingleTouchHorizontalDragGestureRecognizer(
-                debugOwner: this,
-                isZoomedIn: isZoomedIn,
-              ),
-              (recognizer) {
-                recognizer.isZoomedIn = isZoomedIn;
-                recognizer.onEnd = (details) {
-                  _handleSwipeGesture(
-                    context: context,
-                    details: details,
-                    allowedAxis: Axis.vertical,
-                  );
-                };
-              },
-            ),
+                SingleTouchHorizontalDragGestureRecognizer>(
+          () => SingleTouchHorizontalDragGestureRecognizer(
+            debugOwner: this,
+            isZoomedIn: isZoomedIn,
+          ),
+          (recognizer) {
+            recognizer.isZoomedIn = isZoomedIn;
+            recognizer.onEnd = (details) {
+              _handleSwipeGesture(
+                context: context,
+                details: details,
+                allowedAxis: Axis.vertical,
+              );
+            };
+          },
+        ),
         SingleTouchVerticalDragGestureRecognizer:
             GestureRecognizerFactoryWithHandlers<
-              SingleTouchVerticalDragGestureRecognizer
-            >(
-              () => SingleTouchVerticalDragGestureRecognizer(
-                debugOwner: this,
-                isZoomedIn: isZoomedIn,
-              ),
-              (recognizer) {
-                recognizer.isZoomedIn = isZoomedIn;
-                recognizer.onEnd = (details) {
-                  _handleSwipeGesture(
-                    context: context,
-                    details: details,
-                    allowedAxis: Axis.horizontal,
-                  );
-                };
-              },
-            ),
+                SingleTouchVerticalDragGestureRecognizer>(
+          () => SingleTouchVerticalDragGestureRecognizer(
+            debugOwner: this,
+            isZoomedIn: isZoomedIn,
+          ),
+          (recognizer) {
+            recognizer.isZoomedIn = isZoomedIn;
+            recognizer.onEnd = (details) {
+              _handleSwipeGesture(
+                context: context,
+                details: details,
+                allowedAxis: Axis.horizontal,
+              );
+            };
+          },
+        ),
       },
       child: _wrapWithTapAndLongPress(child),
     );
@@ -205,11 +200,9 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
       chapterPages: chapterPages,
     );
 
-    final isAtLastPage =
-        pagePosition == PagePosition.lastPage ||
+    final isAtLastPage = pagePosition == PagePosition.lastPage ||
         pagePosition == PagePosition.singlePage;
-    final isAtFirstPage =
-        pagePosition == PagePosition.firstPage ||
+    final isAtFirstPage = pagePosition == PagePosition.firstPage ||
         pagePosition == PagePosition.singlePage;
 
     final navigationAction = _determineNavigationAction(
@@ -232,9 +225,8 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
   }) {
     if (!lastPageSwipeEnabled) return NavigationAction.pageNavigation;
 
-    final expectedDirection = LastPageSwipeUtils.getExpectedSwipeDirection(
-      resolvedReaderMode,
-    );
+    final expectedDirection =
+        LastPageSwipeUtils.getExpectedSwipeDirection(resolvedReaderMode);
 
     if (direction == expectedDirection) {
       if (isAtLastPage) {
@@ -369,11 +361,9 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
       chapterPages: chapterPages,
     );
 
-    final isAtLastPage =
-        pagePosition == PagePosition.lastPage ||
+    final isAtLastPage = pagePosition == PagePosition.lastPage ||
         pagePosition == PagePosition.singlePage;
-    final isAtFirstPage =
-        pagePosition == PagePosition.firstPage ||
+    final isAtFirstPage = pagePosition == PagePosition.firstPage ||
         pagePosition == PagePosition.singlePage;
 
     final navigationAction = _determineNavigationAction(

--- a/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/directional_swipe_gesture_handler.dart
@@ -29,6 +29,7 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
     required this.currentIndex,
     required this.chapterPages,
     required this.mangaId,
+    this.readerScanlatorGroup = '',
     required this.prevNextChapterPair,
     required this.onNextPage,
     required this.onPreviousPage,
@@ -37,6 +38,7 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
 
   final Widget child;
   final VoidCallback onTap;
+
   /// Null when nothing consumes a long press — [GestureDetector] then skips
   /// the recognizer entirely rather than claiming the gesture for a no-op.
   final void Function(LongPressStartDetails)? onLongPressStart;
@@ -47,6 +49,7 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
   final int currentIndex;
   final ChapterPagesDto chapterPages;
   final int mangaId;
+  final String readerScanlatorGroup;
   final ({ChapterDto? first, ChapterDto? second})? prevNextChapterPair;
   final VoidCallback onNextPage;
   final VoidCallback onPreviousPage;
@@ -108,26 +111,28 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
     return RawGestureDetector(
       behavior: HitTestBehavior.translucent,
       gestures: <Type, GestureRecognizerFactory>{
-        SingleTouchPanGestureRecognizer: GestureRecognizerFactoryWithHandlers<
-            SingleTouchPanGestureRecognizer>(
-          () => SingleTouchPanGestureRecognizer(
-            debugOwner: this,
-            isZoomedIn: isZoomedIn,
-          ),
-          (recognizer) {
-            recognizer.isZoomedIn = isZoomedIn;
-            recognizer.onEnd = (details) {
-              final swipeDirection =
-                  LastPageSwipeUtils.detectSwipeDirection(details);
-              if (swipeDirection != null) {
-                _handleBoundarySwipe(
-                  context: context,
-                  direction: swipeDirection,
-                );
-              }
-            };
-          },
-        ),
+        SingleTouchPanGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<
+              SingleTouchPanGestureRecognizer
+            >(
+              () => SingleTouchPanGestureRecognizer(
+                debugOwner: this,
+                isZoomedIn: isZoomedIn,
+              ),
+              (recognizer) {
+                recognizer.isZoomedIn = isZoomedIn;
+                recognizer.onEnd = (details) {
+                  final swipeDirection =
+                      LastPageSwipeUtils.detectSwipeDirection(details);
+                  if (swipeDirection != null) {
+                    _handleBoundarySwipe(
+                      context: context,
+                      direction: swipeDirection,
+                    );
+                  }
+                };
+              },
+            ),
       },
       child: _wrapWithTapAndLongPress(child),
     );
@@ -142,40 +147,42 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
       gestures: <Type, GestureRecognizerFactory>{
         SingleTouchHorizontalDragGestureRecognizer:
             GestureRecognizerFactoryWithHandlers<
-                SingleTouchHorizontalDragGestureRecognizer>(
-          () => SingleTouchHorizontalDragGestureRecognizer(
-            debugOwner: this,
-            isZoomedIn: isZoomedIn,
-          ),
-          (recognizer) {
-            recognizer.isZoomedIn = isZoomedIn;
-            recognizer.onEnd = (details) {
-              _handleSwipeGesture(
-                context: context,
-                details: details,
-                allowedAxis: Axis.vertical,
-              );
-            };
-          },
-        ),
+              SingleTouchHorizontalDragGestureRecognizer
+            >(
+              () => SingleTouchHorizontalDragGestureRecognizer(
+                debugOwner: this,
+                isZoomedIn: isZoomedIn,
+              ),
+              (recognizer) {
+                recognizer.isZoomedIn = isZoomedIn;
+                recognizer.onEnd = (details) {
+                  _handleSwipeGesture(
+                    context: context,
+                    details: details,
+                    allowedAxis: Axis.vertical,
+                  );
+                };
+              },
+            ),
         SingleTouchVerticalDragGestureRecognizer:
             GestureRecognizerFactoryWithHandlers<
-                SingleTouchVerticalDragGestureRecognizer>(
-          () => SingleTouchVerticalDragGestureRecognizer(
-            debugOwner: this,
-            isZoomedIn: isZoomedIn,
-          ),
-          (recognizer) {
-            recognizer.isZoomedIn = isZoomedIn;
-            recognizer.onEnd = (details) {
-              _handleSwipeGesture(
-                context: context,
-                details: details,
-                allowedAxis: Axis.horizontal,
-              );
-            };
-          },
-        ),
+              SingleTouchVerticalDragGestureRecognizer
+            >(
+              () => SingleTouchVerticalDragGestureRecognizer(
+                debugOwner: this,
+                isZoomedIn: isZoomedIn,
+              ),
+              (recognizer) {
+                recognizer.isZoomedIn = isZoomedIn;
+                recognizer.onEnd = (details) {
+                  _handleSwipeGesture(
+                    context: context,
+                    details: details,
+                    allowedAxis: Axis.horizontal,
+                  );
+                };
+              },
+            ),
       },
       child: _wrapWithTapAndLongPress(child),
     );
@@ -198,9 +205,11 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
       chapterPages: chapterPages,
     );
 
-    final isAtLastPage = pagePosition == PagePosition.lastPage ||
+    final isAtLastPage =
+        pagePosition == PagePosition.lastPage ||
         pagePosition == PagePosition.singlePage;
-    final isAtFirstPage = pagePosition == PagePosition.firstPage ||
+    final isAtFirstPage =
+        pagePosition == PagePosition.firstPage ||
         pagePosition == PagePosition.singlePage;
 
     final navigationAction = _determineNavigationAction(
@@ -223,8 +232,9 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
   }) {
     if (!lastPageSwipeEnabled) return NavigationAction.pageNavigation;
 
-    final expectedDirection =
-        LastPageSwipeUtils.getExpectedSwipeDirection(resolvedReaderMode);
+    final expectedDirection = LastPageSwipeUtils.getExpectedSwipeDirection(
+      resolvedReaderMode,
+    );
 
     if (direction == expectedDirection) {
       if (isAtLastPage) {
@@ -285,6 +295,7 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
           mangaId: mangaId,
           chapterId: prevNextChapterPair!.first!.id,
           transVertical: scrollDirection == Axis.vertical,
+          readerScanlatorGroup: readerScanlatorGroup,
         ).pushReplacement(context);
       } catch (e) {
         onNextPage();
@@ -303,6 +314,7 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
           toPrev: true,
           transVertical: scrollDirection == Axis.vertical,
           openAtEnd: true,
+          readerScanlatorGroup: readerScanlatorGroup,
         ).pushReplacement(context);
       } catch (e) {
         onPreviousPage();
@@ -357,9 +369,11 @@ class DirectionalSwipeGestureHandler extends HookConsumerWidget {
       chapterPages: chapterPages,
     );
 
-    final isAtLastPage = pagePosition == PagePosition.lastPage ||
+    final isAtLastPage =
+        pagePosition == PagePosition.lastPage ||
         pagePosition == PagePosition.singlePage;
-    final isAtFirstPage = pagePosition == PagePosition.firstPage ||
+    final isAtFirstPage =
+        pagePosition == PagePosition.firstPage ||
         pagePosition == PagePosition.singlePage;
 
     final navigationAction = _determineNavigationAction(

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -40,6 +40,7 @@ import '../../../../../domain/chapter/chapter_model.dart';
 import '../../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../../domain/manga/manga_model.dart';
 import '../../../../manga_details/controller/manga_details_controller.dart';
+import '../../../../manga_details/controller/scanlator_dedup.dart';
 import '../../../controller/auto_scroll_controller.dart';
 import '../../../controller/reader_controller.dart';
 import '../../../utils/flush_progress_on_lifecycle.dart';
@@ -281,6 +282,9 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // recordReadingProgress path so a read made offline is queued, not lost.
     final progressDebounce = useRef<Timer?>(null);
     final latestProgress = useRef<({int chapterId, int rel})?>(null);
+    final allChaptersForFlush = useRef<List<ChapterDto>?>(null);
+    allChaptersForFlush.value =
+        ref.watch(mangaChapterListProvider(mangaId: manga.id)).value;
 
     _LoadedChapter? loadedById(int id) {
       for (final c in loadedRef.value) {
@@ -413,16 +417,24 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         final lc = loadedById(p.chapterId);
         final pageCount = lc?.pages.pages.length ?? 0;
         final isCompletion = pageCount > 0 && p.rel >= pageCount - 1;
-        unawaited(
-          offlineDbForFlush
-              .setChapterProgress(
-                p.chapterId,
-                lastPageRead: isCompletion ? 0 : p.rel,
-                // Never un-read on a teardown flush: only a completion marks read.
-                isRead: isCompletion ? true : null,
+        final chapterIds = isCompletion
+            ? expandIdsForDuplicates(
+                allChaptersForFlush.value,
+                [p.chapterId],
               )
-              .catchError((_) {}),
-        );
+            : [p.chapterId];
+        for (final chapterId in chapterIds) {
+          unawaited(
+            offlineDbForFlush
+                .setChapterProgress(
+                  chapterId,
+                  lastPageRead: isCompletion ? 0 : p.rel,
+                  // Never un-read on a teardown flush: only a completion marks read.
+                  isRead: isCompletion ? true : null,
+                )
+                .catchError((_) {}),
+          );
+        }
       };
     }, const []);
 

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -105,6 +105,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     required this.manga,
     required this.chapter,
     required this.chapterPages,
+    required this.readerScanlatorGroup,
     this.onPageChanged,
     this.scrollDirection = Axis.vertical,
     this.reverse = false,
@@ -116,6 +117,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
   final MangaDto manga;
   final ChapterDto chapter;
   final ChapterPagesDto chapterPages;
+  final String readerScanlatorGroup;
   final ValueSetter<int>? onPageChanged;
   final Axis scrollDirection;
   final bool reverse;
@@ -220,6 +222,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           }
         }
       }
+
       // A microtask (unlike addPostFrameCallback) is guaranteed to drain
       // before this build/dispose call stack unwinds, regardless of whether
       // another frame gets scheduled.
@@ -265,6 +268,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       getNextAndPreviousChaptersProvider(
         mangaId: manga.id,
         chapterId: currentVisibleChapter.value.id,
+        readerScanlatorGroup: readerScanlatorGroup,
       ),
     );
 
@@ -464,8 +468,9 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // below, which still reserves placeholderHeight and measures the cropped
     // strip — the scroll/height math is untouched.
     final bool cropBorders = ref.watch(cropBordersWebtoonProvider).ifNull();
-    final bool alwaysShowTransition =
-        ref.watch(alwaysShowChapterTransitionProvider).ifNull(true);
+    final bool alwaysShowTransition = ref
+        .watch(alwaysShowChapterTransitionProvider)
+        .ifNull(true);
     // Long-strip scale caps the strip width. Render-only, and the decode size
     // follows it so a capped strip isn't decoded at full width.
     final WebtoonScaleType scaleType =
@@ -473,26 +478,28 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // Under originalSize each page caps itself at its native width instead of
     // a strip-wide column, so the width limit has nothing to add there.
     final bool pagesAtNaturalSize = scaleType == WebtoonScaleType.originalSize;
-    final bool widthLimitInPixels =
-        ref.watch(longStripWidthLimitUsePixelsProvider).ifNull();
+    final bool widthLimitInPixels = ref
+        .watch(longStripWidthLimitUsePixelsProvider)
+        .ifNull();
     // Clamped on read: the sliders enforce their ranges but a corrupted pref
     // must not collapse the layout.
     final int widthLimitPercent =
         (ref.watch(longStripWidthLimitPercentProvider) ??
                 DBKeys.longStripWidthLimitPercent.initial as int)
             .clamp(10, 100);
-    final int widthLimitPx = (ref.watch(longStripWidthLimitPxProvider) ??
-            DBKeys.longStripWidthLimitPx.initial as int)
-        .clamp(200, 2000);
+    final int widthLimitPx =
+        (ref.watch(longStripWidthLimitPxProvider) ??
+                DBKeys.longStripWidthLimitPx.initial as int)
+            .clamp(200, 2000);
     // 100% is the off position; a px cap wider than the window is naturally
     // inert through the min() below.
     final double widthLimit = pagesAtNaturalSize
         ? double.infinity
         : widthLimitInPixels
-            ? widthLimitPx.toDouble()
-            : widthLimitPercent >= 100
-                ? double.infinity
-                : context.width * widthLimitPercent / 100;
+        ? widthLimitPx.toDouble()
+        : widthLimitPercent >= 100
+        ? double.infinity
+        : context.width * widthLimitPercent / 100;
     final double maxContentWidth = math.min(
       scaleType.maxContentWidth(context.width, context.height),
       widthLimit,
@@ -506,15 +513,20 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // settings surface exists for continuousHorizontalLTR/RTL, which are
     // legacy-orphan modes), so a horizontal strip simply fills the full
     // viewport height instead.
-    final double crossAxisExtent = isHorizontal ? context.height : maxContentWidth;
+    final double crossAxisExtent = isHorizontal
+        ? context.height
+        : maxContentWidth;
     // Read via ref (like loadedRef) so a once-bound closure — e.g. the
     // positions listener's loadNext/PreviousChapter — can't re-seed heights
     // at a width superseded by a later scale/limit change.
-    final layoutParams =
-        useRef<({bool naturalSize, double columnWidth})>(
-            (naturalSize: pagesAtNaturalSize, columnWidth: crossAxisExtent));
-    layoutParams.value =
-        (naturalSize: pagesAtNaturalSize, columnWidth: crossAxisExtent);
+    final layoutParams = useRef<({bool naturalSize, double columnWidth})>((
+      naturalSize: pagesAtNaturalSize,
+      columnWidth: crossAxisExtent,
+    ));
+    layoutParams.value = (
+      naturalSize: pagesAtNaturalSize,
+      columnWidth: crossAxisExtent,
+    );
     final ReaderScrollAmount scrollAmount =
         ref.watch(readerScrollAmountKeyProvider) ??
         DBKeys.readerScrollAmount.initial as ReaderScrollAmount;
@@ -564,10 +576,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       // The gen re-check matters: a decode that outlives its sweep carries a
       // stale width (scale/limit changed meanwhile), and the containsKey guard
       // above would pin its wrong reservation until the page really renders.
-      if (w > 0 &&
-          h > 0 &&
-          context.mounted &&
-          prefetchGen.value == gen) {
+      if (w > 0 && h > 0 && context.mounted && prefetchGen.value == gen) {
         // Read via layoutParams, not closure capture, so a sweep started by
         // an old build still reserves at the current width.
         final layout = layoutParams.value;
@@ -575,7 +584,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
             ? MediaQuery.sizeOf(context).height
             : MediaQuery.sizeOf(context).width;
         final renderedCrossAxis = layout.naturalSize
-            ? math.min(isHorizontal ? h.toDouble() : w.toDouble(), crossAxisSize)
+            ? math.min(
+                isHorizontal ? h.toDouble() : w.toDouble(),
+                crossAxisSize,
+              )
             : layout.columnWidth;
         // Vertical: cross-axis is width(w), main-axis is height(h). Horizontal
         // is the mirror image — cross-axis is height(h), main-axis is width(w).
@@ -803,7 +815,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         double intoAnchorPixels = 0;
         try {
           if (anchorLeadingEdge < 0) {
-            intoAnchorPixels = -anchorLeadingEdge *
+            intoAnchorPixels =
+                -anchorLeadingEdge *
                 scrollOffsetController.position.viewportDimension;
           }
         } catch (_) {
@@ -836,8 +849,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
                 try {
                   final pos = scrollOffsetController.position;
                   pos.jumpTo(
-                    (pos.pixels + intoAnchorPixels)
-                        .clamp(pos.minScrollExtent, pos.maxScrollExtent),
+                    (pos.pixels + intoAnchorPixels).clamp(
+                      pos.minScrollExtent,
+                      pos.maxScrollExtent,
+                    ),
                   );
                 } catch (_) {}
               });
@@ -943,12 +958,15 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // the raw list if nothing clears the floor (e.g. several short
         // pages sharing the screen, none individually over threshold).
         final strictlyVisible = positions
-            .where((p) =>
-                InfinityContinuousUtils.calculateVisibleArea(p) >=
-                InfinityContinuousConfig.boundaryVisibleAreaThreshold)
+            .where(
+              (p) =>
+                  InfinityContinuousUtils.calculateVisibleArea(p) >=
+                  InfinityContinuousConfig.boundaryVisibleAreaThreshold,
+            )
             .toList();
-        final boundaryPositions =
-            strictlyVisible.isNotEmpty ? strictlyVisible : positions;
+        final boundaryPositions = strictlyVisible.isNotEmpty
+            ? strictlyVisible
+            : positions;
         final minIdx = boundaryPositions
             .map((p) => p.index)
             .reduce((a, b) => a < b ? a : b);
@@ -977,7 +995,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           }
           final double eps = viewportHeight > 0
               ? InfinityContinuousConfig.boundaryScrollDirectionEpsilonPx /
-                  viewportHeight
+                    viewportHeight
               : 0.03;
           if (top.index < prevTop.index) {
             scrollingUp = true;
@@ -1178,32 +1196,35 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
 
     // Jump mode (smoothAutoScroll off): periodic page-advance instead of a
     // per-frame glide.
-    useEffect(() {
-      Timer? timer;
-      if (autoScrollActive && !smoothAutoScroll && !chromeVisible) {
-        timer = Timer.periodic(Duration(seconds: autoScrollIntervalSeconds), (
-          _,
-        ) {
-          if (stripInMotion.value) return;
-          if (atLastLoadedPage()) {
-            ref.read(autoScrollActiveProvider.notifier).stop();
-            return;
-          }
-          programmaticScroll.value = true;
-          try {
-            handlePageNavigation(isNext: true);
-          } finally {
-            programmaticScroll.value = false;
-          }
-        });
-      }
-      return () => timer?.cancel();
-    }, [
-      autoScrollActive,
-      smoothAutoScroll,
-      autoScrollIntervalSeconds,
-      chromeVisible,
-    ]);
+    useEffect(
+      () {
+        Timer? timer;
+        if (autoScrollActive && !smoothAutoScroll && !chromeVisible) {
+          timer = Timer.periodic(Duration(seconds: autoScrollIntervalSeconds), (
+            _,
+          ) {
+            if (stripInMotion.value) return;
+            if (atLastLoadedPage()) {
+              ref.read(autoScrollActiveProvider.notifier).stop();
+              return;
+            }
+            programmaticScroll.value = true;
+            try {
+              handlePageNavigation(isNext: true);
+            } finally {
+              programmaticScroll.value = false;
+            }
+          });
+        }
+        return () => timer?.cancel();
+      },
+      [
+        autoScrollActive,
+        smoothAutoScroll,
+        autoScrollIntervalSeconds,
+        chromeVisible,
+      ],
+    );
 
     // The ticker outlives both effects above (it's created once); stop and
     // dispose it only on the widget's own teardown.
@@ -1269,8 +1290,16 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           measured[loc.imageUrl] ?? avgExtent ?? fallbackMainAxisExtent;
       final fit = isHorizontal ? BoxFit.fitHeight : BoxFit.fitWidth;
       Widget placeholderBox({Widget? child}) => isHorizontal
-          ? SizedBox(width: placeholderExtent, height: double.infinity, child: child)
-          : SizedBox(height: placeholderExtent, width: double.infinity, child: child);
+          ? SizedBox(
+              width: placeholderExtent,
+              height: double.infinity,
+              child: child,
+            )
+          : SizedBox(
+              height: placeholderExtent,
+              width: double.infinity,
+              child: child,
+            );
       return ServerImage(
         showReloadButton: true,
         fit: fit,
@@ -1280,12 +1309,12 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         memCacheWidth: isHorizontal
             ? null
             : (crossAxisExtent * MediaQuery.devicePixelRatioOf(context))
-                .round()
-                .clamp(1, 1 << 20),
+                  .round()
+                  .clamp(1, 1 << 20),
         memCacheHeight: isHorizontal
             ? (crossAxisExtent * MediaQuery.devicePixelRatioOf(context))
-                .round()
-                .clamp(1, 1 << 20)
+                  .round()
+                  .clamp(1, 1 << 20)
             : null,
         imageUrl: loc.imageUrl,
         progressIndicatorBuilder: (_, _, progress) => placeholderBox(
@@ -1475,7 +1504,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       child: autoScrollAwareList,
     );
 
-    final mouseScrollSpeed = ref.watch(readerMouseScrollSpeedKeyProvider) ??
+    final mouseScrollSpeed =
+        ref.watch(readerMouseScrollSpeedKeyProvider) ??
         DBKeys.readerMouseScrollSpeed.initial;
     final wheelAware = isKeyboardRuntime
         ? MouseWheelSpeed(
@@ -1523,6 +1553,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     );
 
     return ReaderWrapper(
+      readerScanlatorGroup: readerScanlatorGroup,
       scrollDirection: scrollDirection,
       chapterPages: InfinityContinuousUtils.createChapterPagesDto(
         loadedChapters.value,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/infinity_continuous/multichapter_continuous_reader_mode.dart
@@ -222,7 +222,6 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           }
         }
       }
-
       // A microtask (unlike addPostFrameCallback) is guaranteed to drain
       // before this build/dispose call stack unwinds, regardless of whether
       // another frame gets scheduled.
@@ -468,9 +467,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // below, which still reserves placeholderHeight and measures the cropped
     // strip — the scroll/height math is untouched.
     final bool cropBorders = ref.watch(cropBordersWebtoonProvider).ifNull();
-    final bool alwaysShowTransition = ref
-        .watch(alwaysShowChapterTransitionProvider)
-        .ifNull(true);
+    final bool alwaysShowTransition =
+        ref.watch(alwaysShowChapterTransitionProvider).ifNull(true);
     // Long-strip scale caps the strip width. Render-only, and the decode size
     // follows it so a capped strip isn't decoded at full width.
     final WebtoonScaleType scaleType =
@@ -478,28 +476,26 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // Under originalSize each page caps itself at its native width instead of
     // a strip-wide column, so the width limit has nothing to add there.
     final bool pagesAtNaturalSize = scaleType == WebtoonScaleType.originalSize;
-    final bool widthLimitInPixels = ref
-        .watch(longStripWidthLimitUsePixelsProvider)
-        .ifNull();
+    final bool widthLimitInPixels =
+        ref.watch(longStripWidthLimitUsePixelsProvider).ifNull();
     // Clamped on read: the sliders enforce their ranges but a corrupted pref
     // must not collapse the layout.
     final int widthLimitPercent =
         (ref.watch(longStripWidthLimitPercentProvider) ??
                 DBKeys.longStripWidthLimitPercent.initial as int)
             .clamp(10, 100);
-    final int widthLimitPx =
-        (ref.watch(longStripWidthLimitPxProvider) ??
-                DBKeys.longStripWidthLimitPx.initial as int)
-            .clamp(200, 2000);
+    final int widthLimitPx = (ref.watch(longStripWidthLimitPxProvider) ??
+            DBKeys.longStripWidthLimitPx.initial as int)
+        .clamp(200, 2000);
     // 100% is the off position; a px cap wider than the window is naturally
     // inert through the min() below.
     final double widthLimit = pagesAtNaturalSize
         ? double.infinity
         : widthLimitInPixels
-        ? widthLimitPx.toDouble()
-        : widthLimitPercent >= 100
-        ? double.infinity
-        : context.width * widthLimitPercent / 100;
+            ? widthLimitPx.toDouble()
+            : widthLimitPercent >= 100
+                ? double.infinity
+                : context.width * widthLimitPercent / 100;
     final double maxContentWidth = math.min(
       scaleType.maxContentWidth(context.width, context.height),
       widthLimit,
@@ -513,20 +509,15 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
     // settings surface exists for continuousHorizontalLTR/RTL, which are
     // legacy-orphan modes), so a horizontal strip simply fills the full
     // viewport height instead.
-    final double crossAxisExtent = isHorizontal
-        ? context.height
-        : maxContentWidth;
+    final double crossAxisExtent = isHorizontal ? context.height : maxContentWidth;
     // Read via ref (like loadedRef) so a once-bound closure — e.g. the
     // positions listener's loadNext/PreviousChapter — can't re-seed heights
     // at a width superseded by a later scale/limit change.
-    final layoutParams = useRef<({bool naturalSize, double columnWidth})>((
-      naturalSize: pagesAtNaturalSize,
-      columnWidth: crossAxisExtent,
-    ));
-    layoutParams.value = (
-      naturalSize: pagesAtNaturalSize,
-      columnWidth: crossAxisExtent,
-    );
+    final layoutParams =
+        useRef<({bool naturalSize, double columnWidth})>(
+            (naturalSize: pagesAtNaturalSize, columnWidth: crossAxisExtent));
+    layoutParams.value =
+        (naturalSize: pagesAtNaturalSize, columnWidth: crossAxisExtent);
     final ReaderScrollAmount scrollAmount =
         ref.watch(readerScrollAmountKeyProvider) ??
         DBKeys.readerScrollAmount.initial as ReaderScrollAmount;
@@ -576,7 +567,10 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       // The gen re-check matters: a decode that outlives its sweep carries a
       // stale width (scale/limit changed meanwhile), and the containsKey guard
       // above would pin its wrong reservation until the page really renders.
-      if (w > 0 && h > 0 && context.mounted && prefetchGen.value == gen) {
+      if (w > 0 &&
+          h > 0 &&
+          context.mounted &&
+          prefetchGen.value == gen) {
         // Read via layoutParams, not closure capture, so a sweep started by
         // an old build still reserves at the current width.
         final layout = layoutParams.value;
@@ -584,10 +578,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
             ? MediaQuery.sizeOf(context).height
             : MediaQuery.sizeOf(context).width;
         final renderedCrossAxis = layout.naturalSize
-            ? math.min(
-                isHorizontal ? h.toDouble() : w.toDouble(),
-                crossAxisSize,
-              )
+            ? math.min(isHorizontal ? h.toDouble() : w.toDouble(), crossAxisSize)
             : layout.columnWidth;
         // Vertical: cross-axis is width(w), main-axis is height(h). Horizontal
         // is the mirror image — cross-axis is height(h), main-axis is width(w).
@@ -815,8 +806,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         double intoAnchorPixels = 0;
         try {
           if (anchorLeadingEdge < 0) {
-            intoAnchorPixels =
-                -anchorLeadingEdge *
+            intoAnchorPixels = -anchorLeadingEdge *
                 scrollOffsetController.position.viewportDimension;
           }
         } catch (_) {
@@ -849,10 +839,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
                 try {
                   final pos = scrollOffsetController.position;
                   pos.jumpTo(
-                    (pos.pixels + intoAnchorPixels).clamp(
-                      pos.minScrollExtent,
-                      pos.maxScrollExtent,
-                    ),
+                    (pos.pixels + intoAnchorPixels)
+                        .clamp(pos.minScrollExtent, pos.maxScrollExtent),
                   );
                 } catch (_) {}
               });
@@ -958,15 +946,12 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         // the raw list if nothing clears the floor (e.g. several short
         // pages sharing the screen, none individually over threshold).
         final strictlyVisible = positions
-            .where(
-              (p) =>
-                  InfinityContinuousUtils.calculateVisibleArea(p) >=
-                  InfinityContinuousConfig.boundaryVisibleAreaThreshold,
-            )
+            .where((p) =>
+                InfinityContinuousUtils.calculateVisibleArea(p) >=
+                InfinityContinuousConfig.boundaryVisibleAreaThreshold)
             .toList();
-        final boundaryPositions = strictlyVisible.isNotEmpty
-            ? strictlyVisible
-            : positions;
+        final boundaryPositions =
+            strictlyVisible.isNotEmpty ? strictlyVisible : positions;
         final minIdx = boundaryPositions
             .map((p) => p.index)
             .reduce((a, b) => a < b ? a : b);
@@ -995,7 +980,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           }
           final double eps = viewportHeight > 0
               ? InfinityContinuousConfig.boundaryScrollDirectionEpsilonPx /
-                    viewportHeight
+                  viewportHeight
               : 0.03;
           if (top.index < prevTop.index) {
             scrollingUp = true;
@@ -1196,35 +1181,32 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
 
     // Jump mode (smoothAutoScroll off): periodic page-advance instead of a
     // per-frame glide.
-    useEffect(
-      () {
-        Timer? timer;
-        if (autoScrollActive && !smoothAutoScroll && !chromeVisible) {
-          timer = Timer.periodic(Duration(seconds: autoScrollIntervalSeconds), (
-            _,
-          ) {
-            if (stripInMotion.value) return;
-            if (atLastLoadedPage()) {
-              ref.read(autoScrollActiveProvider.notifier).stop();
-              return;
-            }
-            programmaticScroll.value = true;
-            try {
-              handlePageNavigation(isNext: true);
-            } finally {
-              programmaticScroll.value = false;
-            }
-          });
-        }
-        return () => timer?.cancel();
-      },
-      [
-        autoScrollActive,
-        smoothAutoScroll,
-        autoScrollIntervalSeconds,
-        chromeVisible,
-      ],
-    );
+    useEffect(() {
+      Timer? timer;
+      if (autoScrollActive && !smoothAutoScroll && !chromeVisible) {
+        timer = Timer.periodic(Duration(seconds: autoScrollIntervalSeconds), (
+          _,
+        ) {
+          if (stripInMotion.value) return;
+          if (atLastLoadedPage()) {
+            ref.read(autoScrollActiveProvider.notifier).stop();
+            return;
+          }
+          programmaticScroll.value = true;
+          try {
+            handlePageNavigation(isNext: true);
+          } finally {
+            programmaticScroll.value = false;
+          }
+        });
+      }
+      return () => timer?.cancel();
+    }, [
+      autoScrollActive,
+      smoothAutoScroll,
+      autoScrollIntervalSeconds,
+      chromeVisible,
+    ]);
 
     // The ticker outlives both effects above (it's created once); stop and
     // dispose it only on the widget's own teardown.
@@ -1290,16 +1272,8 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
           measured[loc.imageUrl] ?? avgExtent ?? fallbackMainAxisExtent;
       final fit = isHorizontal ? BoxFit.fitHeight : BoxFit.fitWidth;
       Widget placeholderBox({Widget? child}) => isHorizontal
-          ? SizedBox(
-              width: placeholderExtent,
-              height: double.infinity,
-              child: child,
-            )
-          : SizedBox(
-              height: placeholderExtent,
-              width: double.infinity,
-              child: child,
-            );
+          ? SizedBox(width: placeholderExtent, height: double.infinity, child: child)
+          : SizedBox(height: placeholderExtent, width: double.infinity, child: child);
       return ServerImage(
         showReloadButton: true,
         fit: fit,
@@ -1309,12 +1283,12 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
         memCacheWidth: isHorizontal
             ? null
             : (crossAxisExtent * MediaQuery.devicePixelRatioOf(context))
-                  .round()
-                  .clamp(1, 1 << 20),
+                .round()
+                .clamp(1, 1 << 20),
         memCacheHeight: isHorizontal
             ? (crossAxisExtent * MediaQuery.devicePixelRatioOf(context))
-                  .round()
-                  .clamp(1, 1 << 20)
+                .round()
+                .clamp(1, 1 << 20)
             : null,
         imageUrl: loc.imageUrl,
         progressIndicatorBuilder: (_, _, progress) => placeholderBox(
@@ -1504,8 +1478,7 @@ class MultiChapterContinuousReaderMode extends HookConsumerWidget {
       child: autoScrollAwareList,
     );
 
-    final mouseScrollSpeed =
-        ref.watch(readerMouseScrollSpeedKeyProvider) ??
+    final mouseScrollSpeed = ref.watch(readerMouseScrollSpeedKeyProvider) ??
         DBKeys.readerMouseScrollSpeed.initial;
     final wheelAware = isKeyboardRuntime
         ? MouseWheelSpeed(

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -58,6 +58,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     required this.manga,
     required this.chapter,
     required this.chapterPages,
+    required this.readerScanlatorGroup,
     this.onPageChanged,
     this.reverse = false,
     this.scrollDirection = Axis.horizontal,
@@ -69,6 +70,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
   final MangaDto manga;
   final ChapterDto chapter;
   final ChapterPagesDto chapterPages;
+  final String readerScanlatorGroup;
 
   /// Accepted for signature parity with the single-chapter reader; this host
   /// owns progress itself (like the webtoon multi-chapter reader) and ignores
@@ -108,20 +110,18 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // own "auto advance" interval, which defaults slower than webtoon scroll,
     // and stops once the last page is reached.
     final autoAdvanceActive = ref.watch(autoScrollActiveProvider);
-    final autoAdvanceInterval = ref.watch(autoAdvanceIntervalSecondsProvider) ??
+    final autoAdvanceInterval =
+        ref.watch(autoAdvanceIntervalSecondsProvider) ??
         DBKeys.autoAdvanceIntervalSeconds.initial as int;
     useEffect(() {
       if (!autoAdvanceActive) return null;
-      final timer = Timer.periodic(
-        Duration(seconds: autoAdvanceInterval),
-        (_) {
-          if (controller.isAtLast) {
-            ref.read(autoScrollActiveProvider.notifier).stop();
-            return;
-          }
-          controller.next();
-        },
-      );
+      final timer = Timer.periodic(Duration(seconds: autoAdvanceInterval), (_) {
+        if (controller.isAtLast) {
+          ref.read(autoScrollActiveProvider.notifier).stop();
+          return;
+        }
+        controller.next();
+      });
       return timer.cancel;
     }, [autoAdvanceActive, autoAdvanceInterval]);
 
@@ -141,7 +141,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // "Dual page spread in landscape" only augments Automatic, and respects
     // landscape — otherwise it forced dual everywhere and made the toggle a
     // no-op.
-    final wantDouble = isHorizontal &&
+    final wantDouble =
+        isHorizontal &&
         switch (settings.pageLayout) {
           PageLayout.doublePages => true,
           PageLayout.singlePage => false,
@@ -150,8 +151,10 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     final splitWide = settings.dualPageSplitPaged && isHorizontal;
     final splitInvert = settings.dualPageInvertPaged;
     final reversePair = settings.invertDoublePages != reverse;
-    final (pageFit, pageSize) =
-        settings.imageScaleType.pagedFit(context.width, context.height);
+    final (pageFit, pageSize) = settings.imageScaleType.pagedFit(
+      context.width,
+      context.height,
+    );
 
     final loadedChapters = useState<List<_LoadedChapter>>([
       (pages: chapterPages, chapter: chapter, chapterId: chapter.id),
@@ -206,6 +209,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           }
         }
       }
+
       // Record the initial chapter on a microtask — modifying Riverpod state
       // synchronously during a build (even inside useEffect) is not allowed.
       // A microtask (unlike addPostFrameCallback) is guaranteed to drain
@@ -252,6 +256,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       getNextAndPreviousChaptersProvider(
         mangaId: manga.id,
         chapterId: currentVisibleChapter.value.id,
+        readerScanlatorGroup: readerScanlatorGroup,
       ),
     );
 
@@ -294,14 +299,27 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       // Online-only users have no dirty row to retry, so a failed push would
       // vanish — surface it instead of losing progress silently.
       if (progressResult.hasError) {
-        ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+        ref
+            .read(toastProvider)
+            ?.showError(context.l10n.errorSomethingWentWrong);
       }
       if (completed && !completedChapterIds.value.contains(chapterId)) {
         completedChapterIds.value = {...completedChapterIds.value, chapterId};
-        unawaited(maybeTrackProgressOnReadFetch(ref.read,
-            mangaId: manga.id, isRead: true, manual: false));
-        unawaited(noteChapterFinishedInReader(ref,
-            mangaId: manga.id, chapterId: chapterId));
+        unawaited(
+          maybeTrackProgressOnReadFetch(
+            ref.read,
+            mangaId: manga.id,
+            isRead: true,
+            manual: false,
+          ),
+        );
+        unawaited(
+          noteChapterFinishedInReader(
+            ref,
+            mangaId: manga.id,
+            chapterId: chapterId,
+          ),
+        );
       }
       // Fired off a scroll/visibility notification — defer past the frame or
       // it trips the Riverpod-3 modify-during-build assert.
@@ -335,7 +353,9 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         return null;
       }
       scheduleVisibleProgress(
-          currentVisibleChapter.value.id, currentChapterPageIndex.value);
+        currentVisibleChapter.value.id,
+        currentChapterPageIndex.value,
+      );
       return null;
     }, [currentChapterPageIndex.value, currentVisibleChapter.value.id]);
 
@@ -343,8 +363,9 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // device catalog (captured at build so it never touches ref while
     // disposing). Ported verbatim from the webtoon reader.
     final offlineEnabledForFlush = ref.read(offlineEnabledProvider);
-    final offlineDbForFlush =
-        offlineEnabledForFlush ? ref.read(offlineDatabaseProvider) : null;
+    final offlineDbForFlush = offlineEnabledForFlush
+        ? ref.read(offlineDatabaseProvider)
+        : null;
     final repoForFlush = ref.read(mangaBookRepositoryProvider);
     final incognitoForFlush = ref.read(incognitoModeProvider);
     useEffect(() {
@@ -383,10 +404,16 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       // for the neighbour, so an unheld read gets disposed mid-fetch under
       // Riverpod 3. Closed in finally so retries can't leak subscriptions.
       final sub = ref.listenManual(
-          chapterPagesProvider(chapterId: next.id), (_, _) {});
+        chapterPagesProvider(chapterId: next.id),
+        (_, _) {},
+      );
       try {
-        deferFeedback(() => InfinityContinuousFeedback
-            .showLoadingNextChapterFeedback(context, next.name));
+        deferFeedback(
+          () => InfinityContinuousFeedback.showLoadingNextChapterFeedback(
+            context,
+            next.name,
+          ),
+        );
         final ChapterPagesDto? pages;
         try {
           pages = await ref
@@ -408,8 +435,12 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           ...base,
           (pages: pages, chapter: next, chapterId: next.id),
         ];
-        deferFeedback(() => InfinityContinuousFeedback
-            .showNextChapterLoadedFeedback(context, next.name));
+        deferFeedback(
+          () => InfinityContinuousFeedback.showNextChapterLoadedFeedback(
+            context,
+            next.name,
+          ),
+        );
       } catch (_) {
         // Transient failure — leave unlatched and refetchable so the next
         // gesture retries instead of dead-ending the boundary for the session.
@@ -430,10 +461,16 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       loadingPrevious.value = true;
       // Same held-subscription + finally-close treatment as loadNextChapter.
       final sub = ref.listenManual(
-          chapterPagesProvider(chapterId: prev.id), (_, _) {});
+        chapterPagesProvider(chapterId: prev.id),
+        (_, _) {},
+      );
       try {
-        deferFeedback(() => InfinityContinuousFeedback
-            .showLoadingPreviousChapterFeedback(context, prev.name));
+        deferFeedback(
+          () => InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
+            context,
+            prev.name,
+          ),
+        );
         final ChapterPagesDto? pages;
         try {
           pages = await ref
@@ -453,8 +490,12 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           (pages: pages, chapter: prev, chapterId: prev.id),
           ...base,
         ];
-        deferFeedback(() => InfinityContinuousFeedback
-            .showPreviousChapterLoadedFeedback(context, prev.name));
+        deferFeedback(
+          () => InfinityContinuousFeedback.showPreviousChapterLoadedFeedback(
+            context,
+            prev.name,
+          ),
+        );
       } catch (_) {
         // Transient failure — leave unlatched and refetchable.
         if (context.mounted) {
@@ -482,47 +523,53 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
 
     // Preload the neighbour the user is reading toward, Komikku-style: within
     // ~5 pages of the visible chapter's far edge and moving that way.
-    useEffect(() {
-      final visibleId = currentVisibleChapter.value.id;
-      final rel = currentChapterPageIndex.value;
-      final prev = lastProgress.value;
-      lastProgress.value = (id: visibleId, rel: rel);
-      final lc = loadedById(visibleId);
-      if (lc == null || prev == null) return null; // no direction yet
-      final count = lc.pages.pages.length;
-      final pair = nextPrevChapterPair.value;
+    useEffect(
+      () {
+        final visibleId = currentVisibleChapter.value.id;
+        final rel = currentChapterPageIndex.value;
+        final prev = lastProgress.value;
+        lastProgress.value = (id: visibleId, rel: rel);
+        final lc = loadedById(visibleId);
+        if (lc == null || prev == null) return null; // no direction yet
+        final count = lc.pages.pages.length;
+        final pair = nextPrevChapterPair.value;
 
-      int posOf(int id) => loadedRef.value.indexWhere((e) => e.chapterId == id);
-      final curPos = posOf(visibleId);
-      final prevPos = posOf(prev.id);
-      final movingForward =
-          curPos != prevPos ? curPos > prevPos : rel > prev.rel;
-      final movingBackward =
-          curPos != prevPos ? curPos < prevPos : rel < prev.rel;
+        int posOf(int id) =>
+            loadedRef.value.indexWhere((e) => e.chapterId == id);
+        final curPos = posOf(visibleId);
+        final prevPos = posOf(prev.id);
+        final movingForward = curPos != prevPos
+            ? curPos > prevPos
+            : rel > prev.rel;
+        final movingBackward = curPos != prevPos
+            ? curPos < prevPos
+            : rel < prev.rel;
 
-      if (movingForward &&
-          loadedRef.value.isNotEmpty &&
-          loadedRef.value.last.chapterId == visibleId &&
-          rel >= count - 5 &&
-          pair?.first != null) {
-        unawaited(loadNextChapter(pair!.first!));
-      }
-      if (movingBackward &&
-          loadedRef.value.isNotEmpty &&
-          loadedRef.value.first.chapterId == visibleId &&
-          rel <= 4 &&
-          pair?.second != null) {
-        unawaited(loadPreviousChapter(pair!.second!));
-      }
-      return null;
-      // Also keyed on neighbour ids: cold open has the pair null while the
-      // filtered list loads, so this reruns once it resolves.
-    }, [
-      currentChapterPageIndex.value,
-      currentVisibleChapter.value.id,
-      nextPrevChapterPair.value?.first?.id,
-      nextPrevChapterPair.value?.second?.id,
-    ]);
+        if (movingForward &&
+            loadedRef.value.isNotEmpty &&
+            loadedRef.value.last.chapterId == visibleId &&
+            rel >= count - 5 &&
+            pair?.first != null) {
+          unawaited(loadNextChapter(pair!.first!));
+        }
+        if (movingBackward &&
+            loadedRef.value.isNotEmpty &&
+            loadedRef.value.first.chapterId == visibleId &&
+            rel <= 4 &&
+            pair?.second != null) {
+          unawaited(loadPreviousChapter(pair!.second!));
+        }
+        return null;
+        // Also keyed on neighbour ids: cold open has the pair null while the
+        // filtered list loads, so this reruns once it resolves.
+      },
+      [
+        currentChapterPageIndex.value,
+        currentVisibleChapter.value.id,
+        nextPrevChapterPair.value?.first?.id,
+        nextPrevChapterPair.value?.second?.id,
+      ],
+    );
 
     // --- display window --------------------------------------------------
 
@@ -530,10 +577,20 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // / after the last loaded chapter, so we show a boundary card there.
     final firstLoadedId = loadedChapters.value.first.chapterId;
     final lastLoadedId = loadedChapters.value.last.chapterId;
-    final headAdjacency = ref.watch(getNextAndPreviousChaptersProvider(
-        mangaId: manga.id, chapterId: firstLoadedId));
-    final tailAdjacency = ref.watch(getNextAndPreviousChaptersProvider(
-        mangaId: manga.id, chapterId: lastLoadedId));
+    final headAdjacency = ref.watch(
+      getNextAndPreviousChaptersProvider(
+        mangaId: manga.id,
+        chapterId: firstLoadedId,
+        readerScanlatorGroup: readerScanlatorGroup,
+      ),
+    );
+    final tailAdjacency = ref.watch(
+      getNextAndPreviousChaptersProvider(
+        mangaId: manga.id,
+        chapterId: lastLoadedId,
+        readerScanlatorGroup: readerScanlatorGroup,
+      ),
+    );
     final prevChapterExists = headAdjacency?.second != null;
     final nextChapterExists = tailAdjacency?.first != null;
 
@@ -595,8 +652,12 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           // Forward boundary crossing: the chapter just left is finished.
           if (prevPos >= 0 && newPos > prevPos) {
             _markChapterRead(
-                ref, manga.id, loaded[prevPos].chapter, completedChapterIds,
-                context);
+              ref,
+              manga.id,
+              loaded[prevPos].chapter,
+              completedChapterIds,
+              context,
+            );
           }
         }
       }
@@ -627,15 +688,19 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       if (nextToLoad != null && !hasReachedEnd.value) {
         // onIdle already fired when the edge bounce settled, before the fetch
         // finished — commit explicitly or the swap waits for the next swipe.
-        unawaited(loadNextChapter(nextToLoad).then((_) {
-          if (context.mounted) commitPendingIfAny();
-        }));
+        unawaited(
+          loadNextChapter(nextToLoad).then((_) {
+            if (context.mounted) commitPendingIfAny();
+          }),
+        );
         return;
       }
       if (nextChapterExists) return; // more to load — no end feedback
       if (!context.mounted || !readerToastsEnabled()) return;
       InfinityContinuousFeedback.showEndOfMangaFeedback(
-          context, lastEndFeedbackTime);
+        context,
+        lastEndFeedbackTime,
+      );
     }
 
     void onReachedStartEdge() {
@@ -644,15 +709,19 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       final prevToLoad = headAdjacency?.second;
       if (prevToLoad != null && !hasReachedStart.value) {
         // Commit once the fetch lands (see onReachedEndEdge).
-        unawaited(loadPreviousChapter(prevToLoad).then((_) {
-          if (context.mounted) commitPendingIfAny();
-        }));
+        unawaited(
+          loadPreviousChapter(prevToLoad).then((_) {
+            if (context.mounted) commitPendingIfAny();
+          }),
+        );
         return;
       }
       if (prevChapterExists) return;
       if (!context.mounted || !readerToastsEnabled()) return;
       InfinityContinuousFeedback.showStartOfMangaFeedback(
-          context, lastStartFeedbackTime);
+        context,
+        lastStartFeedbackTime,
+      );
     }
 
     String nameForChapter(int? id) {
@@ -678,11 +747,15 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // --- ReaderWrapper (fed the VISIBLE-chapter view) --------------------
 
     final visibleChapterPages = InfinityContinuousUtils.createChapterPagesDto(
-        loadedChapters.value, currentVisibleChapter.value, chapterPages);
+      loadedChapters.value,
+      currentVisibleChapter.value,
+      chapterPages,
+    );
 
     List<int>? spreadPageIndexes;
-    final visibleWindowChapter =
-        window.chapterById(currentVisibleChapter.value.id);
+    final visibleWindowChapter = window.chapterById(
+      currentVisibleChapter.value.id,
+    );
     if (visibleWindowChapter != null && !visibleWindowChapter.mapping.isEmpty) {
       final mapping = visibleWindowChapter.mapping;
       final entry =
@@ -699,6 +772,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         effectiveReaderMode ?? _pagedReaderMode(scrollDirection, reverse);
 
     return ReaderWrapper(
+      readerScanlatorGroup: readerScanlatorGroup,
       scrollDirection: scrollDirection,
       chapter: currentVisibleChapter.value,
       manga: manga,
@@ -714,14 +788,16 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       onToggleAutoScroll: () =>
           ref.read(autoScrollActiveProvider.notifier).toggle(),
       onAutoScrollFaster: () {
-        final cur = ref.read(autoAdvanceIntervalSecondsProvider) ??
+        final cur =
+            ref.read(autoAdvanceIntervalSecondsProvider) ??
             DBKeys.autoAdvanceIntervalSeconds.initial as int;
         ref
             .read(autoAdvanceIntervalSecondsProvider.notifier)
             .update((cur - 1).clamp(1, 30));
       },
       onAutoScrollSlower: () {
-        final cur = ref.read(autoAdvanceIntervalSecondsProvider) ??
+        final cur =
+            ref.read(autoAdvanceIntervalSecondsProvider) ??
             DBKeys.autoAdvanceIntervalSeconds.initial as int;
         ref
             .read(autoAdvanceIntervalSecondsProvider.notifier)
@@ -749,7 +825,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         pageFit: pageFit,
         pageSize: pageSize,
         pagesAtNaturalSize: settings.imageScaleType.pagesAtNaturalSize,
-        mouseScrollSpeed: ref.watch(readerMouseScrollSpeedKeyProvider) ??
+        mouseScrollSpeed:
+            ref.watch(readerMouseScrollSpeedKeyProvider) ??
             DBKeys.readerMouseScrollSpeed.initial,
         centerMargin: settings.centerMarginType,
         rotateWide: settings.rotateWidePages,
@@ -793,30 +870,38 @@ void _markChapterRead(
   if (chapter.isRead.ifNull()) return;
   if (completedChapterIds.value.contains(chapter.id)) return;
   completedChapterIds.value = {...completedChapterIds.value, chapter.id};
-  unawaited(recordReadingProgress(
-    ref,
-    mangaId: mangaId,
-    chapterId: chapter.id,
-    lastPageRead: 0,
-    isRead: true,
-  ).then((progressResult) {
-    if (!context.mounted) return;
-    // A failed boundary push has no dirty row to retry for online-only users.
-    if (progressResult.hasError) {
-      ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
-    }
-    unawaited(maybeTrackProgressOnReadFetch(
-      ref.read,
-      mangaId: mangaId,
-      isRead: true,
-      manual: false,
-    ));
-    unawaited(noteChapterFinishedInReader(
+  unawaited(
+    recordReadingProgress(
       ref,
       mangaId: mangaId,
       chapterId: chapter.id,
-    ));
-  }));
+      lastPageRead: 0,
+      isRead: true,
+    ).then((progressResult) {
+      if (!context.mounted) return;
+      // A failed boundary push has no dirty row to retry for online-only users.
+      if (progressResult.hasError) {
+        ref
+            .read(toastProvider)
+            ?.showError(context.l10n.errorSomethingWentWrong);
+      }
+      unawaited(
+        maybeTrackProgressOnReadFetch(
+          ref.read,
+          mangaId: mangaId,
+          isRead: true,
+          manual: false,
+        ),
+      );
+      unawaited(
+        noteChapterFinishedInReader(
+          ref,
+          mangaId: mangaId,
+          chapterId: chapter.id,
+        ),
+      );
+    }),
+  );
   // Deliberately do NOT invalidate chapterProvider / mangaChapterList here —
   // that would remount the reader mid-read. Read-state is tracked in-session
   // via completedChapterIds; ReaderScreen refreshes on exit (its PopScope).

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -110,18 +110,20 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // own "auto advance" interval, which defaults slower than webtoon scroll,
     // and stops once the last page is reached.
     final autoAdvanceActive = ref.watch(autoScrollActiveProvider);
-    final autoAdvanceInterval =
-        ref.watch(autoAdvanceIntervalSecondsProvider) ??
+    final autoAdvanceInterval = ref.watch(autoAdvanceIntervalSecondsProvider) ??
         DBKeys.autoAdvanceIntervalSeconds.initial as int;
     useEffect(() {
       if (!autoAdvanceActive) return null;
-      final timer = Timer.periodic(Duration(seconds: autoAdvanceInterval), (_) {
-        if (controller.isAtLast) {
-          ref.read(autoScrollActiveProvider.notifier).stop();
-          return;
-        }
-        controller.next();
-      });
+      final timer = Timer.periodic(
+        Duration(seconds: autoAdvanceInterval),
+        (_) {
+          if (controller.isAtLast) {
+            ref.read(autoScrollActiveProvider.notifier).stop();
+            return;
+          }
+          controller.next();
+        },
+      );
       return timer.cancel;
     }, [autoAdvanceActive, autoAdvanceInterval]);
 
@@ -141,8 +143,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // "Dual page spread in landscape" only augments Automatic, and respects
     // landscape — otherwise it forced dual everywhere and made the toggle a
     // no-op.
-    final wantDouble =
-        isHorizontal &&
+    final wantDouble = isHorizontal &&
         switch (settings.pageLayout) {
           PageLayout.doublePages => true,
           PageLayout.singlePage => false,
@@ -151,10 +152,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     final splitWide = settings.dualPageSplitPaged && isHorizontal;
     final splitInvert = settings.dualPageInvertPaged;
     final reversePair = settings.invertDoublePages != reverse;
-    final (pageFit, pageSize) = settings.imageScaleType.pagedFit(
-      context.width,
-      context.height,
-    );
+    final (pageFit, pageSize) =
+        settings.imageScaleType.pagedFit(context.width, context.height);
 
     final loadedChapters = useState<List<_LoadedChapter>>([
       (pages: chapterPages, chapter: chapter, chapterId: chapter.id),
@@ -209,7 +208,6 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           }
         }
       }
-
       // Record the initial chapter on a microtask — modifying Riverpod state
       // synchronously during a build (even inside useEffect) is not allowed.
       // A microtask (unlike addPostFrameCallback) is guaranteed to drain
@@ -299,27 +297,14 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       // Online-only users have no dirty row to retry, so a failed push would
       // vanish — surface it instead of losing progress silently.
       if (progressResult.hasError) {
-        ref
-            .read(toastProvider)
-            ?.showError(context.l10n.errorSomethingWentWrong);
+        ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
       }
       if (completed && !completedChapterIds.value.contains(chapterId)) {
         completedChapterIds.value = {...completedChapterIds.value, chapterId};
-        unawaited(
-          maybeTrackProgressOnReadFetch(
-            ref.read,
-            mangaId: manga.id,
-            isRead: true,
-            manual: false,
-          ),
-        );
-        unawaited(
-          noteChapterFinishedInReader(
-            ref,
-            mangaId: manga.id,
-            chapterId: chapterId,
-          ),
-        );
+        unawaited(maybeTrackProgressOnReadFetch(ref.read,
+            mangaId: manga.id, isRead: true, manual: false));
+        unawaited(noteChapterFinishedInReader(ref,
+            mangaId: manga.id, chapterId: chapterId));
       }
       // Fired off a scroll/visibility notification — defer past the frame or
       // it trips the Riverpod-3 modify-during-build assert.
@@ -353,9 +338,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         return null;
       }
       scheduleVisibleProgress(
-        currentVisibleChapter.value.id,
-        currentChapterPageIndex.value,
-      );
+          currentVisibleChapter.value.id, currentChapterPageIndex.value);
       return null;
     }, [currentChapterPageIndex.value, currentVisibleChapter.value.id]);
 
@@ -363,9 +346,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // device catalog (captured at build so it never touches ref while
     // disposing). Ported verbatim from the webtoon reader.
     final offlineEnabledForFlush = ref.read(offlineEnabledProvider);
-    final offlineDbForFlush = offlineEnabledForFlush
-        ? ref.read(offlineDatabaseProvider)
-        : null;
+    final offlineDbForFlush =
+        offlineEnabledForFlush ? ref.read(offlineDatabaseProvider) : null;
     final repoForFlush = ref.read(mangaBookRepositoryProvider);
     final incognitoForFlush = ref.read(incognitoModeProvider);
     useEffect(() {
@@ -404,16 +386,10 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       // for the neighbour, so an unheld read gets disposed mid-fetch under
       // Riverpod 3. Closed in finally so retries can't leak subscriptions.
       final sub = ref.listenManual(
-        chapterPagesProvider(chapterId: next.id),
-        (_, _) {},
-      );
+          chapterPagesProvider(chapterId: next.id), (_, _) {});
       try {
-        deferFeedback(
-          () => InfinityContinuousFeedback.showLoadingNextChapterFeedback(
-            context,
-            next.name,
-          ),
-        );
+        deferFeedback(() => InfinityContinuousFeedback
+            .showLoadingNextChapterFeedback(context, next.name));
         final ChapterPagesDto? pages;
         try {
           pages = await ref
@@ -435,12 +411,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           ...base,
           (pages: pages, chapter: next, chapterId: next.id),
         ];
-        deferFeedback(
-          () => InfinityContinuousFeedback.showNextChapterLoadedFeedback(
-            context,
-            next.name,
-          ),
-        );
+        deferFeedback(() => InfinityContinuousFeedback
+            .showNextChapterLoadedFeedback(context, next.name));
       } catch (_) {
         // Transient failure — leave unlatched and refetchable so the next
         // gesture retries instead of dead-ending the boundary for the session.
@@ -461,16 +433,10 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       loadingPrevious.value = true;
       // Same held-subscription + finally-close treatment as loadNextChapter.
       final sub = ref.listenManual(
-        chapterPagesProvider(chapterId: prev.id),
-        (_, _) {},
-      );
+          chapterPagesProvider(chapterId: prev.id), (_, _) {});
       try {
-        deferFeedback(
-          () => InfinityContinuousFeedback.showLoadingPreviousChapterFeedback(
-            context,
-            prev.name,
-          ),
-        );
+        deferFeedback(() => InfinityContinuousFeedback
+            .showLoadingPreviousChapterFeedback(context, prev.name));
         final ChapterPagesDto? pages;
         try {
           pages = await ref
@@ -490,12 +456,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           (pages: pages, chapter: prev, chapterId: prev.id),
           ...base,
         ];
-        deferFeedback(
-          () => InfinityContinuousFeedback.showPreviousChapterLoadedFeedback(
-            context,
-            prev.name,
-          ),
-        );
+        deferFeedback(() => InfinityContinuousFeedback
+            .showPreviousChapterLoadedFeedback(context, prev.name));
       } catch (_) {
         // Transient failure — leave unlatched and refetchable.
         if (context.mounted) {
@@ -523,53 +485,47 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
 
     // Preload the neighbour the user is reading toward, Komikku-style: within
     // ~5 pages of the visible chapter's far edge and moving that way.
-    useEffect(
-      () {
-        final visibleId = currentVisibleChapter.value.id;
-        final rel = currentChapterPageIndex.value;
-        final prev = lastProgress.value;
-        lastProgress.value = (id: visibleId, rel: rel);
-        final lc = loadedById(visibleId);
-        if (lc == null || prev == null) return null; // no direction yet
-        final count = lc.pages.pages.length;
-        final pair = nextPrevChapterPair.value;
+    useEffect(() {
+      final visibleId = currentVisibleChapter.value.id;
+      final rel = currentChapterPageIndex.value;
+      final prev = lastProgress.value;
+      lastProgress.value = (id: visibleId, rel: rel);
+      final lc = loadedById(visibleId);
+      if (lc == null || prev == null) return null; // no direction yet
+      final count = lc.pages.pages.length;
+      final pair = nextPrevChapterPair.value;
 
-        int posOf(int id) =>
-            loadedRef.value.indexWhere((e) => e.chapterId == id);
-        final curPos = posOf(visibleId);
-        final prevPos = posOf(prev.id);
-        final movingForward = curPos != prevPos
-            ? curPos > prevPos
-            : rel > prev.rel;
-        final movingBackward = curPos != prevPos
-            ? curPos < prevPos
-            : rel < prev.rel;
+      int posOf(int id) => loadedRef.value.indexWhere((e) => e.chapterId == id);
+      final curPos = posOf(visibleId);
+      final prevPos = posOf(prev.id);
+      final movingForward =
+          curPos != prevPos ? curPos > prevPos : rel > prev.rel;
+      final movingBackward =
+          curPos != prevPos ? curPos < prevPos : rel < prev.rel;
 
-        if (movingForward &&
-            loadedRef.value.isNotEmpty &&
-            loadedRef.value.last.chapterId == visibleId &&
-            rel >= count - 5 &&
-            pair?.first != null) {
-          unawaited(loadNextChapter(pair!.first!));
-        }
-        if (movingBackward &&
-            loadedRef.value.isNotEmpty &&
-            loadedRef.value.first.chapterId == visibleId &&
-            rel <= 4 &&
-            pair?.second != null) {
-          unawaited(loadPreviousChapter(pair!.second!));
-        }
-        return null;
-        // Also keyed on neighbour ids: cold open has the pair null while the
-        // filtered list loads, so this reruns once it resolves.
-      },
-      [
-        currentChapterPageIndex.value,
-        currentVisibleChapter.value.id,
-        nextPrevChapterPair.value?.first?.id,
-        nextPrevChapterPair.value?.second?.id,
-      ],
-    );
+      if (movingForward &&
+          loadedRef.value.isNotEmpty &&
+          loadedRef.value.last.chapterId == visibleId &&
+          rel >= count - 5 &&
+          pair?.first != null) {
+        unawaited(loadNextChapter(pair!.first!));
+      }
+      if (movingBackward &&
+          loadedRef.value.isNotEmpty &&
+          loadedRef.value.first.chapterId == visibleId &&
+          rel <= 4 &&
+          pair?.second != null) {
+        unawaited(loadPreviousChapter(pair!.second!));
+      }
+      return null;
+      // Also keyed on neighbour ids: cold open has the pair null while the
+      // filtered list loads, so this reruns once it resolves.
+    }, [
+      currentChapterPageIndex.value,
+      currentVisibleChapter.value.id,
+      nextPrevChapterPair.value?.first?.id,
+      nextPrevChapterPair.value?.second?.id,
+    ]);
 
     // --- display window --------------------------------------------------
 
@@ -577,20 +533,16 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // / after the last loaded chapter, so we show a boundary card there.
     final firstLoadedId = loadedChapters.value.first.chapterId;
     final lastLoadedId = loadedChapters.value.last.chapterId;
-    final headAdjacency = ref.watch(
-      getNextAndPreviousChaptersProvider(
+    final headAdjacency = ref.watch(getNextAndPreviousChaptersProvider(
         mangaId: manga.id,
         chapterId: firstLoadedId,
         readerScanlatorGroup: readerScanlatorGroup,
-      ),
-    );
-    final tailAdjacency = ref.watch(
-      getNextAndPreviousChaptersProvider(
+      ));
+    final tailAdjacency = ref.watch(getNextAndPreviousChaptersProvider(
         mangaId: manga.id,
         chapterId: lastLoadedId,
         readerScanlatorGroup: readerScanlatorGroup,
-      ),
-    );
+      ));
     final prevChapterExists = headAdjacency?.second != null;
     final nextChapterExists = tailAdjacency?.first != null;
 
@@ -652,12 +604,8 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           // Forward boundary crossing: the chapter just left is finished.
           if (prevPos >= 0 && newPos > prevPos) {
             _markChapterRead(
-              ref,
-              manga.id,
-              loaded[prevPos].chapter,
-              completedChapterIds,
-              context,
-            );
+                ref, manga.id, loaded[prevPos].chapter, completedChapterIds,
+                context);
           }
         }
       }
@@ -688,19 +636,15 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       if (nextToLoad != null && !hasReachedEnd.value) {
         // onIdle already fired when the edge bounce settled, before the fetch
         // finished — commit explicitly or the swap waits for the next swipe.
-        unawaited(
-          loadNextChapter(nextToLoad).then((_) {
-            if (context.mounted) commitPendingIfAny();
-          }),
-        );
+        unawaited(loadNextChapter(nextToLoad).then((_) {
+          if (context.mounted) commitPendingIfAny();
+        }));
         return;
       }
       if (nextChapterExists) return; // more to load — no end feedback
       if (!context.mounted || !readerToastsEnabled()) return;
       InfinityContinuousFeedback.showEndOfMangaFeedback(
-        context,
-        lastEndFeedbackTime,
-      );
+          context, lastEndFeedbackTime);
     }
 
     void onReachedStartEdge() {
@@ -709,19 +653,15 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       final prevToLoad = headAdjacency?.second;
       if (prevToLoad != null && !hasReachedStart.value) {
         // Commit once the fetch lands (see onReachedEndEdge).
-        unawaited(
-          loadPreviousChapter(prevToLoad).then((_) {
-            if (context.mounted) commitPendingIfAny();
-          }),
-        );
+        unawaited(loadPreviousChapter(prevToLoad).then((_) {
+          if (context.mounted) commitPendingIfAny();
+        }));
         return;
       }
       if (prevChapterExists) return;
       if (!context.mounted || !readerToastsEnabled()) return;
       InfinityContinuousFeedback.showStartOfMangaFeedback(
-        context,
-        lastStartFeedbackTime,
-      );
+          context, lastStartFeedbackTime);
     }
 
     String nameForChapter(int? id) {
@@ -747,15 +687,11 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // --- ReaderWrapper (fed the VISIBLE-chapter view) --------------------
 
     final visibleChapterPages = InfinityContinuousUtils.createChapterPagesDto(
-      loadedChapters.value,
-      currentVisibleChapter.value,
-      chapterPages,
-    );
+        loadedChapters.value, currentVisibleChapter.value, chapterPages);
 
     List<int>? spreadPageIndexes;
-    final visibleWindowChapter = window.chapterById(
-      currentVisibleChapter.value.id,
-    );
+    final visibleWindowChapter =
+        window.chapterById(currentVisibleChapter.value.id);
     if (visibleWindowChapter != null && !visibleWindowChapter.mapping.isEmpty) {
       final mapping = visibleWindowChapter.mapping;
       final entry =
@@ -788,16 +724,14 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
       onToggleAutoScroll: () =>
           ref.read(autoScrollActiveProvider.notifier).toggle(),
       onAutoScrollFaster: () {
-        final cur =
-            ref.read(autoAdvanceIntervalSecondsProvider) ??
+        final cur = ref.read(autoAdvanceIntervalSecondsProvider) ??
             DBKeys.autoAdvanceIntervalSeconds.initial as int;
         ref
             .read(autoAdvanceIntervalSecondsProvider.notifier)
             .update((cur - 1).clamp(1, 30));
       },
       onAutoScrollSlower: () {
-        final cur =
-            ref.read(autoAdvanceIntervalSecondsProvider) ??
+        final cur = ref.read(autoAdvanceIntervalSecondsProvider) ??
             DBKeys.autoAdvanceIntervalSeconds.initial as int;
         ref
             .read(autoAdvanceIntervalSecondsProvider.notifier)
@@ -825,8 +759,7 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         pageFit: pageFit,
         pageSize: pageSize,
         pagesAtNaturalSize: settings.imageScaleType.pagesAtNaturalSize,
-        mouseScrollSpeed:
-            ref.watch(readerMouseScrollSpeedKeyProvider) ??
+        mouseScrollSpeed: ref.watch(readerMouseScrollSpeedKeyProvider) ??
             DBKeys.readerMouseScrollSpeed.initial,
         centerMargin: settings.centerMarginType,
         rotateWide: settings.rotateWidePages,
@@ -870,38 +803,30 @@ void _markChapterRead(
   if (chapter.isRead.ifNull()) return;
   if (completedChapterIds.value.contains(chapter.id)) return;
   completedChapterIds.value = {...completedChapterIds.value, chapter.id};
-  unawaited(
-    recordReadingProgress(
+  unawaited(recordReadingProgress(
+    ref,
+    mangaId: mangaId,
+    chapterId: chapter.id,
+    lastPageRead: 0,
+    isRead: true,
+  ).then((progressResult) {
+    if (!context.mounted) return;
+    // A failed boundary push has no dirty row to retry for online-only users.
+    if (progressResult.hasError) {
+      ref.read(toastProvider)?.showError(context.l10n.errorSomethingWentWrong);
+    }
+    unawaited(maybeTrackProgressOnReadFetch(
+      ref.read,
+      mangaId: mangaId,
+      isRead: true,
+      manual: false,
+    ));
+    unawaited(noteChapterFinishedInReader(
       ref,
       mangaId: mangaId,
       chapterId: chapter.id,
-      lastPageRead: 0,
-      isRead: true,
-    ).then((progressResult) {
-      if (!context.mounted) return;
-      // A failed boundary push has no dirty row to retry for online-only users.
-      if (progressResult.hasError) {
-        ref
-            .read(toastProvider)
-            ?.showError(context.l10n.errorSomethingWentWrong);
-      }
-      unawaited(
-        maybeTrackProgressOnReadFetch(
-          ref.read,
-          mangaId: mangaId,
-          isRead: true,
-          manual: false,
-        ),
-      );
-      unawaited(
-        noteChapterFinishedInReader(
-          ref,
-          mangaId: mangaId,
-          chapterId: chapter.id,
-        ),
-      );
-    }),
-  );
+    ));
+  }));
   // Deliberately do NOT invalidate chapterProvider / mangaChapterList here —
   // that would remount the reader mid-read. Read-state is tracked in-session
   // via completedChapterIds; ReaderScreen refreshes on exit (its PopScope).

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/multichapter_paged_reader_mode.dart
@@ -27,6 +27,7 @@ import '../../../../domain/chapter/chapter_model.dart';
 import '../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../domain/manga/manga_model.dart';
 import '../../../manga_details/controller/manga_details_controller.dart';
+import '../../../manga_details/controller/scanlator_dedup.dart';
 import '../../controller/auto_scroll_controller.dart';
 import '../../controller/reader_controller.dart';
 import '../../controller/reader_settings_model.dart';
@@ -271,6 +272,9 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
     // through the offline-safe recordReadingProgress path.
     final progressDebounce = useRef<Timer?>(null);
     final latestProgress = useRef<({int chapterId, int rel})?>(null);
+    final allChaptersForFlush = useRef<List<ChapterDto>?>(null);
+    allChaptersForFlush.value =
+        ref.watch(mangaChapterListProvider(mangaId: manga.id)).value;
 
     Future<void> writeVisibleProgress(int chapterId, int rel) async {
       if (ref.read(incognitoModeProvider)) return;
@@ -360,9 +364,9 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
         final lc = loadedById(p.chapterId);
         final pageCount = lc?.pages.pages.length ?? 0;
         final isCompletion = pageCount > 0 && p.rel >= pageCount - 1;
-        // Fire-and-forget so leaving mid-chapter still saves the spot; no
-        // scanlator-duplicate expansion here since this only persists a
-        // position, not a completion.
+        // Fire-and-forget so leaving mid-chapter still saves the spot. A
+        // completion carries the same conservative release expansion as the
+        // normal reader path; a partial position remains scoped to this row.
         recordReadingProgressWithDependencies(
           offlineEnabled: offlineEnabledForFlush,
           offlineDatabase: offlineDbForFlush,
@@ -370,6 +374,12 @@ class MultiChapterPagedReaderMode extends HookConsumerWidget {
           chapterId: p.chapterId,
           lastPageRead: isCompletion ? 0 : p.rel,
           isRead: isCompletion,
+          completionChapterIds: isCompletion
+              ? expandIdsForDuplicates(
+                  allChaptersForFlush.value,
+                  [p.chapterId],
+                )
+              : null,
         ).ignore();
       };
     }, const []);

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
@@ -18,6 +18,7 @@ import '../../../../../settings/presentation/reader/widgets/reader_mouse_scroll_
 import '../../../../domain/chapter/chapter_model.dart';
 import '../../../../domain/chapter_page/chapter_page_model.dart';
 import '../../../../domain/manga/manga_model.dart';
+import '../../../manga_details/controller/scanlator_dedup.dart';
 import '../../controller/reader_settings_model.dart';
 import '../../utils/reader_initial_page.dart';
 import '../reader_wrapper.dart';
@@ -72,7 +73,8 @@ class SinglePageReaderMode extends HookConsumerWidget {
     final centerMargin = settings.centerMarginType;
     final isLandscape = context.width > context.height;
     final isHorizontal = scrollDirection == Axis.horizontal;
-    final wantDouble = isHorizontal &&
+    final wantDouble =
+        isHorizontal &&
         (pageLayout == PageLayout.doublePages ||
             (pageLayout == PageLayout.automatic && isLandscape) ||
             trueDual);
@@ -121,8 +123,9 @@ class SinglePageReaderMode extends HookConsumerWidget {
       openAtEnd: openAtEnd,
     );
     final rawToDisplay = window.chapterRawToDisplay(chapter.id, initialRaw);
-    final initialDisplay =
-        rawToDisplay >= 0 ? rawToDisplay : window.firstDisplayOf(chapter.id);
+    final initialDisplay = rawToDisplay >= 0
+        ? rawToDisplay
+        : window.firstDisplayOf(chapter.id);
     // Seed the tracked page from the initial spread's furthest page so the
     // viewport's mount emit (which reports that page) doesn't rewind the
     // seekbar or double-fire onPageChanged.
@@ -137,7 +140,7 @@ class SinglePageReaderMode extends HookConsumerWidget {
         for (final page in {
           currentPage - 1,
           currentPage + 1,
-          currentPage + 2
+          currentPage + 2,
         }) {
           if (page >= 0 && page < chapterPages.pages.length) {
             cacheManager.getServerFile(ref, chapterPages.pages[page]);
@@ -155,8 +158,10 @@ class SinglePageReaderMode extends HookConsumerWidget {
       });
     }
 
-    final (pageFit, pageSize) =
-        settings.imageScaleType.pagedFit(context.width, context.height);
+    final (pageFit, pageSize) = settings.imageScaleType.pagedFit(
+      context.width,
+      context.height,
+    );
     final reversePair = invertDouble != reverse;
     final spreadPageIndexes = _spreadPageIndexes(
       mapping,
@@ -167,6 +172,7 @@ class SinglePageReaderMode extends HookConsumerWidget {
         effectiveReaderMode ?? _singlePageReaderMode(scrollDirection, reverse);
 
     return ReaderWrapper(
+      readerScanlatorGroup: scanlatorGroupOf(chapter),
       scrollDirection: scrollDirection,
       chapter: chapter,
       manga: manga,
@@ -193,7 +199,8 @@ class SinglePageReaderMode extends HookConsumerWidget {
         pageFit: pageFit,
         pageSize: pageSize,
         pagesAtNaturalSize: settings.imageScaleType.pagesAtNaturalSize,
-        mouseScrollSpeed: ref.watch(readerMouseScrollSpeedKeyProvider) ??
+        mouseScrollSpeed:
+            ref.watch(readerMouseScrollSpeedKeyProvider) ??
             DBKeys.readerMouseScrollSpeed.initial,
         centerMargin: centerMargin,
         rotateWide: settings.rotateWidePages,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_mode/single_page_reader_mode.dart
@@ -73,8 +73,7 @@ class SinglePageReaderMode extends HookConsumerWidget {
     final centerMargin = settings.centerMarginType;
     final isLandscape = context.width > context.height;
     final isHorizontal = scrollDirection == Axis.horizontal;
-    final wantDouble =
-        isHorizontal &&
+    final wantDouble = isHorizontal &&
         (pageLayout == PageLayout.doublePages ||
             (pageLayout == PageLayout.automatic && isLandscape) ||
             trueDual);
@@ -123,9 +122,8 @@ class SinglePageReaderMode extends HookConsumerWidget {
       openAtEnd: openAtEnd,
     );
     final rawToDisplay = window.chapterRawToDisplay(chapter.id, initialRaw);
-    final initialDisplay = rawToDisplay >= 0
-        ? rawToDisplay
-        : window.firstDisplayOf(chapter.id);
+    final initialDisplay =
+        rawToDisplay >= 0 ? rawToDisplay : window.firstDisplayOf(chapter.id);
     // Seed the tracked page from the initial spread's furthest page so the
     // viewport's mount emit (which reports that page) doesn't rewind the
     // seekbar or double-fire onPageChanged.
@@ -140,7 +138,7 @@ class SinglePageReaderMode extends HookConsumerWidget {
         for (final page in {
           currentPage - 1,
           currentPage + 1,
-          currentPage + 2,
+          currentPage + 2
         }) {
           if (page >= 0 && page < chapterPages.pages.length) {
             cacheManager.getServerFile(ref, chapterPages.pages[page]);
@@ -158,10 +156,8 @@ class SinglePageReaderMode extends HookConsumerWidget {
       });
     }
 
-    final (pageFit, pageSize) = settings.imageScaleType.pagedFit(
-      context.width,
-      context.height,
-    );
+    final (pageFit, pageSize) =
+        settings.imageScaleType.pagedFit(context.width, context.height);
     final reversePair = invertDouble != reverse;
     final spreadPageIndexes = _spreadPageIndexes(
       mapping,
@@ -199,8 +195,7 @@ class SinglePageReaderMode extends HookConsumerWidget {
         pageFit: pageFit,
         pageSize: pageSize,
         pagesAtNaturalSize: settings.imageScaleType.pagesAtNaturalSize,
-        mouseScrollSpeed:
-            ref.watch(readerMouseScrollSpeedKeyProvider) ??
+        mouseScrollSpeed: ref.watch(readerMouseScrollSpeedKeyProvider) ??
             DBKeys.readerMouseScrollSpeed.initial,
         centerMargin: centerMargin,
         rotateWide: settings.rotateWidePages,

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -110,7 +110,8 @@ bool _noBoundaryNavigation() => false;
 
 /// Whether the reader chrome is on screen. Public so the long strip can hold
 /// auto-scroll while it is up.
-final readerChromeVisibleProvider = StateProvider.autoDispose<bool?>((Ref ref) {
+final readerChromeVisibleProvider =
+    StateProvider.autoDispose<bool?>((Ref ref) {
   final link = ref.keepAlive();
   Timer? timer;
   ref
@@ -224,14 +225,11 @@ class ReaderWrapper extends HookConsumerWidget {
     final screenSize = MediaQuery.sizeOf(context);
     final isLandscapePhone =
         screenSize.shortestSide < 600 && screenSize.width > screenSize.height;
-    final forceHorizontalSeekbar = ref
-        .watch(forceHorizontalSeekbarProvider)
-        .ifNull(false);
-    final landscapeVerticalSeekbar = ref
-        .watch(landscapeVerticalSeekbarProvider)
-        .ifNull(false);
-    final showSideSeekBar =
-        scrollDirection == Axis.vertical &&
+    final forceHorizontalSeekbar =
+        ref.watch(forceHorizontalSeekbarProvider).ifNull(false);
+    final landscapeVerticalSeekbar =
+        ref.watch(landscapeVerticalSeekbarProvider).ifNull(false);
+    final showSideSeekBar = scrollDirection == Axis.vertical &&
         !forceHorizontalSeekbar &&
         (!isLandscapePhone || landscapeVerticalSeekbar);
     // Exactly one seekbar: whenever the side seekbar is out, the horizontal
@@ -247,8 +245,7 @@ class ReaderWrapper extends HookConsumerWidget {
     final bool readerSwipeChapterToggle =
         ref.watch(swipeChapterToggleProvider) ?? DBKeys.swipeToggle.initial;
 
-    final bool lastPageSwipeEnabled =
-        ref.watch(lastPageSwipeEnabledProvider) ??
+    final bool lastPageSwipeEnabled = ref.watch(lastPageSwipeEnabledProvider) ??
         DBKeys.lastPageSwipeEnabled.initial;
 
     final sessionVisibility = ref.watch(readerChromeVisibleProvider);
@@ -258,14 +255,12 @@ class ReaderWrapper extends HookConsumerWidget {
     // Komikku-style utils bar (auto-scroll control): starts collapsed each
     // reader open, unlike chrome visibility which persists across chapters.
     final utilsBarExpanded = useState(false);
-    final mangaReaderPadding = useState(
-      manga.metaData.readerPadding ?? localMangaReaderPadding,
-    );
+    final mangaReaderPadding =
+        useState(manga.metaData.readerPadding ?? localMangaReaderPadding);
 
     final mangaReaderMode =
         manga.metaData.readerMode ?? ReaderMode.defaultReader;
-    final mangaReaderNavigationLayout =
-        manga.metaData.readerNavigationLayout ??
+    final mangaReaderNavigationLayout = manga.metaData.readerNavigationLayout ??
         ReaderNavigationLayout.defaultNavigation;
     // Per-series 4-value tap-invert; null lets the layout fall back to the
     // global compat value (new key ?? legacy bool).
@@ -296,9 +291,7 @@ class ReaderWrapper extends HookConsumerWidget {
           onChange: (enumValue) async {
             if (context.mounted) Navigator.pop(context);
             await AsyncValue.guard(
-              () => ref
-                  .read(mangaBookRepositoryProvider)
-                  .patchMangaMeta(
+              () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
                     mangaId: manga.id,
                     key: MangaMetaKeys.readerMode.key,
                     value: enumValue.name,
@@ -340,70 +333,67 @@ class ReaderWrapper extends HookConsumerWidget {
       };
     }, []);
 
-    useEffect(
-      () {
-        final adjacentIds = <int>{};
+    useEffect(() {
+      final adjacentIds = <int>{};
 
-        final pair = nextPrevChapterPair;
-        final pageCount = chapterPages.pages.length;
-        if (isPagedReaderMode(resolvedReaderMode) &&
-            pair != null &&
-            pageCount > 0) {
-          if (currentIndex >= pageCount - 2) {
-            final next = pair.first;
-            if (next != null) adjacentIds.add(next.id);
-          }
-          if (currentIndex <= 1) {
-            final previous = pair.second;
-            if (previous != null) adjacentIds.add(previous.id);
-          }
+      final pair = nextPrevChapterPair;
+      final pageCount = chapterPages.pages.length;
+      if (isPagedReaderMode(resolvedReaderMode) &&
+          pair != null &&
+          pageCount > 0) {
+        if (currentIndex >= pageCount - 2) {
+          final next = pair.first;
+          if (next != null) adjacentIds.add(next.id);
         }
+        if (currentIndex <= 1) {
+          final previous = pair.second;
+          if (previous != null) adjacentIds.add(previous.id);
+        }
+      }
 
-        void closePrefetch(int chapterId) {
-          final closers = prefetchClosers.value.remove(chapterId);
-          if (closers == null) return;
-          for (final close in closers) {
-            close();
-          }
+      void closePrefetch(int chapterId) {
+        final closers = prefetchClosers.value.remove(chapterId);
+        if (closers == null) return;
+        for (final close in closers) {
+          close();
         }
+      }
 
-        for (final chapterId in [...prefetchClosers.value.keys]) {
-          if (!adjacentIds.contains(chapterId)) closePrefetch(chapterId);
-        }
+      for (final chapterId in [...prefetchClosers.value.keys]) {
+        if (!adjacentIds.contains(chapterId)) closePrefetch(chapterId);
+      }
 
-        void prefetchChapter(int chapterId) {
-          if (prefetchClosers.value.containsKey(chapterId)) return;
-          final chapterSubscription = providerContainer
-              .listen<AsyncValue<ChapterDto?>>(
-                chapterProvider(chapterId: chapterId),
-                (_, _) {},
-                fireImmediately: true,
-              );
-          final pagesSubscription = providerContainer
-              .listen<AsyncValue<ChapterPagesDto?>>(
-                chapterPagesProvider(chapterId: chapterId),
-                (_, _) {},
-                fireImmediately: true,
-              );
-          prefetchClosers.value[chapterId] = [
-            chapterSubscription.close,
-            pagesSubscription.close,
-          ];
-        }
+      void prefetchChapter(int chapterId) {
+        if (prefetchClosers.value.containsKey(chapterId)) return;
+        final chapterSubscription =
+            providerContainer.listen<AsyncValue<ChapterDto?>>(
+          chapterProvider(chapterId: chapterId),
+          (_, _) {},
+          fireImmediately: true,
+        );
+        final pagesSubscription =
+            providerContainer.listen<AsyncValue<ChapterPagesDto?>>(
+          chapterPagesProvider(chapterId: chapterId),
+          (_, _) {},
+          fireImmediately: true,
+        );
+        prefetchClosers.value[chapterId] = [
+          chapterSubscription.close,
+          pagesSubscription.close,
+        ];
+      }
 
-        for (final chapterId in adjacentIds) {
-          prefetchChapter(chapterId);
-        }
-        return null;
-      },
-      [
-        resolvedReaderMode,
-        nextPrevChapterPair?.first?.id,
-        nextPrevChapterPair?.second?.id,
-        currentIndex,
-        chapterPages.pages.length,
-      ],
-    );
+      for (final chapterId in adjacentIds) {
+        prefetchChapter(chapterId);
+      }
+      return null;
+    }, [
+      resolvedReaderMode,
+      nextPrevChapterPair?.first?.id,
+      nextPrevChapterPair?.second?.id,
+      currentIndex,
+      chapterPages.pages.length,
+    ]);
 
     // NOTE: The visibility→SystemUiMode transition is now driven by
     // ReaderChrome's AnimationController status listener (Inc-1), not here.
@@ -462,46 +452,39 @@ class ReaderWrapper extends HookConsumerWidget {
       return pushPreviousChapter(openAtEnd: true);
     }
 
-    final onReaderNext = useCallback(
-      () {
-        final isAtLastPage =
-            isAtLastBoundary?.call() ??
-            currentIndex >= chapterPages.pages.length - 1;
-        if (isAtLastPage && tryNextChapter()) {
-          return;
-        }
-        onNext();
-      },
-      [
-        lastPageSwipeEnabled,
-        readerSwipeChapterToggle,
-        currentIndex,
-        chapterPages.pages.length,
-        nextPrevChapterPair,
-        isAtLastBoundary,
-        tryNextChapter,
-        onNext,
-      ],
-    );
+    final onReaderNext = useCallback(() {
+      final isAtLastPage = isAtLastBoundary?.call() ??
+          currentIndex >= chapterPages.pages.length - 1;
+      if (isAtLastPage && tryNextChapter()) {
+        return;
+      }
+      onNext();
+    }, [
+      lastPageSwipeEnabled,
+      readerSwipeChapterToggle,
+      currentIndex,
+      chapterPages.pages.length,
+      nextPrevChapterPair,
+      isAtLastBoundary,
+      tryNextChapter,
+      onNext,
+    ]);
 
-    final onReaderPrevious = useCallback(
-      () {
-        final isAtFirstPage = isAtFirstBoundary?.call() ?? currentIndex <= 0;
-        if (isAtFirstPage && tryPreviousChapter()) {
-          return;
-        }
-        onPrevious();
-      },
-      [
-        lastPageSwipeEnabled,
-        readerSwipeChapterToggle,
-        currentIndex,
-        nextPrevChapterPair,
-        isAtFirstBoundary,
-        tryPreviousChapter,
-        onPrevious,
-      ],
-    );
+    final onReaderPrevious = useCallback(() {
+      final isAtFirstPage = isAtFirstBoundary?.call() ?? currentIndex <= 0;
+      if (isAtFirstPage && tryPreviousChapter()) {
+        return;
+      }
+      onPrevious();
+    }, [
+      lastPageSwipeEnabled,
+      readerSwipeChapterToggle,
+      currentIndex,
+      nextPrevChapterPair,
+      isAtFirstBoundary,
+      tryPreviousChapter,
+      onPrevious,
+    ]);
 
     final onNextChapter = useCallback(() {
       pushNextChapter();
@@ -550,22 +533,18 @@ class ReaderWrapper extends HookConsumerWidget {
       ),
       child: Scaffold(
         // Reader background pref; default black.
-        backgroundColor:
-            (ref.watch(readerBackgroundColorKeyProvider) ??
-                    DBKeys.readerBackgroundColor.initial
-                        as ReaderBackgroundColor)
-                .color(context),
+        backgroundColor: (ref.watch(readerBackgroundColorKeyProvider) ??
+                DBKeys.readerBackgroundColor.initial as ReaderBackgroundColor)
+            .color(context),
         extendBodyBehindAppBar: true,
         extendBody: true,
         body: Stack(
           children: [
             Positioned.fill(
               child: Shortcuts.manager(
-                manager: readerShortcutManager(
-                  scrollDirection,
-                  isRtl: isRTLReaderMode(resolvedReaderMode),
-                  autoScrollSupported: onToggleAutoScroll != null,
-                ),
+                manager: readerShortcutManager(scrollDirection,
+                    isRtl: isRTLReaderMode(resolvedReaderMode),
+                    autoScrollSupported: onToggleAutoScroll != null),
                 child: Actions(
                   actions: {
                     PreviousScrollIntent: CallbackAction<PreviousScrollIntent>(
@@ -578,11 +557,11 @@ class ReaderWrapper extends HookConsumerWidget {
                     ),
                     PreviousChapterIntent:
                         CallbackAction<PreviousChapterIntent>(
-                          onInvoke: (intent) {
-                            if (!pushPreviousChapter()) onReaderPrevious();
-                            return null;
-                          },
-                        ),
+                      onInvoke: (intent) {
+                        if (!pushPreviousChapter()) onReaderPrevious();
+                        return null;
+                      },
+                    ),
                     NextChapterIntent: CallbackAction<NextChapterIntent>(
                       onInvoke: (intent) {
                         if (!pushNextChapter()) onReaderNext();
@@ -600,41 +579,41 @@ class ReaderWrapper extends HookConsumerWidget {
                     // ignores invertTap — arrow-down always scrolls down.
                     ViewportScrollForwardIntent:
                         CallbackAction<ViewportScrollForwardIntent>(
-                          onInvoke: (intent) {
-                            (onViewportScrollForward ?? onReaderNext)();
-                            return null;
-                          },
-                        ),
+                      onInvoke: (intent) {
+                        (onViewportScrollForward ?? onReaderNext)();
+                        return null;
+                      },
+                    ),
                     ViewportScrollBackwardIntent:
                         CallbackAction<ViewportScrollBackwardIntent>(
-                          onInvoke: (intent) {
-                            (onViewportScrollBackward ?? onReaderPrevious)();
-                            return null;
-                          },
-                        ),
+                      onInvoke: (intent) {
+                        (onViewportScrollBackward ?? onReaderPrevious)();
+                        return null;
+                      },
+                    ),
                     // Nullable callbacks: any non-continuous vertical mode
                     // that doesn't supply these is a safe no-op.
                     AutoScrollToggleIntent:
                         CallbackAction<AutoScrollToggleIntent>(
-                          onInvoke: (intent) {
-                            onToggleAutoScroll?.call();
-                            return null;
-                          },
-                        ),
+                      onInvoke: (intent) {
+                        onToggleAutoScroll?.call();
+                        return null;
+                      },
+                    ),
                     AutoScrollFasterIntent:
                         CallbackAction<AutoScrollFasterIntent>(
-                          onInvoke: (intent) {
-                            onAutoScrollFaster?.call();
-                            return null;
-                          },
-                        ),
+                      onInvoke: (intent) {
+                        onAutoScrollFaster?.call();
+                        return null;
+                      },
+                    ),
                     AutoScrollSlowerIntent:
                         CallbackAction<AutoScrollSlowerIntent>(
-                          onInvoke: (intent) {
-                            onAutoScrollSlower?.call();
-                            return null;
-                          },
-                        ),
+                      onInvoke: (intent) {
+                        onAutoScrollSlower?.call();
+                        return null;
+                      },
+                    ),
                     FirstPageIntent: CallbackAction<FirstPageIntent>(
                       onInvoke: (intent) {
                         onJumpToFirst?.call();
@@ -654,9 +633,8 @@ class ReaderWrapper extends HookConsumerWidget {
                       child: RepaintBoundary(
                         child: ReaderView(
                           toggleVisibility: () {
-                            final gate = ref.read(
-                              readerTapArrestsFlingProvider.notifier,
-                            );
+                            final gate =
+                                ref.read(readerTapArrestsFlingProvider.notifier);
                             // Cleared on use: only the long strip arms it, so a
                             // stale true would swallow taps in the paged reader.
                             if (gate.state) {
@@ -729,9 +707,8 @@ class ReaderWrapper extends HookConsumerWidget {
                 onPreviousChapter: nextPrevChapterPair?.second != null
                     ? () => pushPreviousChapter()
                     : null,
-                onNextChapter: nextPrevChapterPair?.first != null
-                    ? pushNextChapter
-                    : null,
+                onNextChapter:
+                    nextPrevChapterPair?.first != null ? pushNextChapter : null,
                 resolvedReaderMode: resolvedReaderMode,
                 autoScrollSupported: onToggleAutoScroll != null,
                 reverseSeekBar: isRTLReaderMode(resolvedReaderMode),
@@ -1020,18 +997,15 @@ class ReaderView extends HookConsumerWidget {
 
     Widget content = Padding(
       padding: EdgeInsets.symmetric(
-        vertical:
-            context.height *
+        vertical: context.height *
             (scrollDirection != Axis.vertical ? mangaReaderPadding : 0),
-        horizontal:
-            context.width *
+        horizontal: context.width *
             (scrollDirection == Axis.vertical ? mangaReaderPadding : 0),
       ),
       child: child,
     );
 
-    final PageController? controller =
-        pageController ??
+    final PageController? controller = pageController ??
         (PrimaryScrollController.of(context) is PageController
             ? PrimaryScrollController.of(context) as PageController
             : null);
@@ -1041,17 +1015,15 @@ class ReaderView extends HookConsumerWidget {
         return;
       }
       pageActionsOpen.value = true;
-      unawaited(
-        showReaderPageActionsSheet(
-          context: context,
-          ref: ref,
-          chapterPages: chapterPages,
-          pageIndex: currentIndex,
-          spreadPageIndexes: spreadPageIndexes,
-        ).whenComplete(() {
-          if (context.mounted) pageActionsOpen.value = false;
-        }),
-      );
+      unawaited(showReaderPageActionsSheet(
+        context: context,
+        ref: ref,
+        chapterPages: chapterPages,
+        pageIndex: currentIndex,
+        spreadPageIndexes: spreadPageIndexes,
+      ).whenComplete(() {
+        if (context.mounted) pageActionsOpen.value = false;
+      }));
     }
 
     void handleLongPressCancel() {
@@ -1081,8 +1053,7 @@ class ReaderView extends HookConsumerWidget {
     // No point spending the one-shot on a layout that draws nothing.
     final zonesAreVisible =
         resolvedNavigationLayout != ReaderNavigationLayout.disabled;
-    final showZonesOnOpen =
-        showReaderLayoutAnimation &&
+    final showZonesOnOpen = showReaderLayoutAnimation &&
         zonesAreVisible &&
         (overlayAlways || unseenAtOpen.value!);
     useEffect(() {

--- a/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
+++ b/lib/src/features/manga_book/presentation/reader/widgets/reader_wrapper.dart
@@ -110,8 +110,7 @@ bool _noBoundaryNavigation() => false;
 
 /// Whether the reader chrome is on screen. Public so the long strip can hold
 /// auto-scroll while it is up.
-final readerChromeVisibleProvider =
-    StateProvider.autoDispose<bool?>((Ref ref) {
+final readerChromeVisibleProvider = StateProvider.autoDispose<bool?>((Ref ref) {
   final link = ref.keepAlive();
   Timer? timer;
   ref
@@ -146,6 +145,7 @@ class ReaderWrapper extends HookConsumerWidget {
     required this.scrollDirection,
     this.showReaderLayoutAnimation = false,
     required this.chapterPages,
+    this.readerScanlatorGroup,
     this.pageController,
     this.totalPageCount,
     this.childHandlesGestures = false,
@@ -172,6 +172,7 @@ class ReaderWrapper extends HookConsumerWidget {
   final Axis scrollDirection;
   final bool showReaderLayoutAnimation;
   final ChapterPagesDto chapterPages;
+  final String? readerScanlatorGroup;
   final PageController? pageController;
   final int? totalPageCount;
   final bool childHandlesGestures;
@@ -210,6 +211,7 @@ class ReaderWrapper extends HookConsumerWidget {
       getNextAndPreviousChaptersProvider(
         mangaId: manga.id,
         chapterId: chapter.id,
+        readerScanlatorGroup: readerScanlatorGroup,
       ),
     );
     final invertTap = ref.watch(invertTapProvider).ifNull();
@@ -222,11 +224,14 @@ class ReaderWrapper extends HookConsumerWidget {
     final screenSize = MediaQuery.sizeOf(context);
     final isLandscapePhone =
         screenSize.shortestSide < 600 && screenSize.width > screenSize.height;
-    final forceHorizontalSeekbar =
-        ref.watch(forceHorizontalSeekbarProvider).ifNull(false);
-    final landscapeVerticalSeekbar =
-        ref.watch(landscapeVerticalSeekbarProvider).ifNull(false);
-    final showSideSeekBar = scrollDirection == Axis.vertical &&
+    final forceHorizontalSeekbar = ref
+        .watch(forceHorizontalSeekbarProvider)
+        .ifNull(false);
+    final landscapeVerticalSeekbar = ref
+        .watch(landscapeVerticalSeekbarProvider)
+        .ifNull(false);
+    final showSideSeekBar =
+        scrollDirection == Axis.vertical &&
         !forceHorizontalSeekbar &&
         (!isLandscapePhone || landscapeVerticalSeekbar);
     // Exactly one seekbar: whenever the side seekbar is out, the horizontal
@@ -242,7 +247,8 @@ class ReaderWrapper extends HookConsumerWidget {
     final bool readerSwipeChapterToggle =
         ref.watch(swipeChapterToggleProvider) ?? DBKeys.swipeToggle.initial;
 
-    final bool lastPageSwipeEnabled = ref.watch(lastPageSwipeEnabledProvider) ??
+    final bool lastPageSwipeEnabled =
+        ref.watch(lastPageSwipeEnabledProvider) ??
         DBKeys.lastPageSwipeEnabled.initial;
 
     final sessionVisibility = ref.watch(readerChromeVisibleProvider);
@@ -252,12 +258,14 @@ class ReaderWrapper extends HookConsumerWidget {
     // Komikku-style utils bar (auto-scroll control): starts collapsed each
     // reader open, unlike chrome visibility which persists across chapters.
     final utilsBarExpanded = useState(false);
-    final mangaReaderPadding =
-        useState(manga.metaData.readerPadding ?? localMangaReaderPadding);
+    final mangaReaderPadding = useState(
+      manga.metaData.readerPadding ?? localMangaReaderPadding,
+    );
 
     final mangaReaderMode =
         manga.metaData.readerMode ?? ReaderMode.defaultReader;
-    final mangaReaderNavigationLayout = manga.metaData.readerNavigationLayout ??
+    final mangaReaderNavigationLayout =
+        manga.metaData.readerNavigationLayout ??
         ReaderNavigationLayout.defaultNavigation;
     // Per-series 4-value tap-invert; null lets the layout fall back to the
     // global compat value (new key ?? legacy bool).
@@ -288,7 +296,9 @@ class ReaderWrapper extends HookConsumerWidget {
           onChange: (enumValue) async {
             if (context.mounted) Navigator.pop(context);
             await AsyncValue.guard(
-              () => ref.read(mangaBookRepositoryProvider).patchMangaMeta(
+              () => ref
+                  .read(mangaBookRepositoryProvider)
+                  .patchMangaMeta(
                     mangaId: manga.id,
                     key: MangaMetaKeys.readerMode.key,
                     value: enumValue.name,
@@ -330,67 +340,70 @@ class ReaderWrapper extends HookConsumerWidget {
       };
     }, []);
 
-    useEffect(() {
-      final adjacentIds = <int>{};
+    useEffect(
+      () {
+        final adjacentIds = <int>{};
 
-      final pair = nextPrevChapterPair;
-      final pageCount = chapterPages.pages.length;
-      if (isPagedReaderMode(resolvedReaderMode) &&
-          pair != null &&
-          pageCount > 0) {
-        if (currentIndex >= pageCount - 2) {
-          final next = pair.first;
-          if (next != null) adjacentIds.add(next.id);
+        final pair = nextPrevChapterPair;
+        final pageCount = chapterPages.pages.length;
+        if (isPagedReaderMode(resolvedReaderMode) &&
+            pair != null &&
+            pageCount > 0) {
+          if (currentIndex >= pageCount - 2) {
+            final next = pair.first;
+            if (next != null) adjacentIds.add(next.id);
+          }
+          if (currentIndex <= 1) {
+            final previous = pair.second;
+            if (previous != null) adjacentIds.add(previous.id);
+          }
         }
-        if (currentIndex <= 1) {
-          final previous = pair.second;
-          if (previous != null) adjacentIds.add(previous.id);
+
+        void closePrefetch(int chapterId) {
+          final closers = prefetchClosers.value.remove(chapterId);
+          if (closers == null) return;
+          for (final close in closers) {
+            close();
+          }
         }
-      }
 
-      void closePrefetch(int chapterId) {
-        final closers = prefetchClosers.value.remove(chapterId);
-        if (closers == null) return;
-        for (final close in closers) {
-          close();
+        for (final chapterId in [...prefetchClosers.value.keys]) {
+          if (!adjacentIds.contains(chapterId)) closePrefetch(chapterId);
         }
-      }
 
-      for (final chapterId in [...prefetchClosers.value.keys]) {
-        if (!adjacentIds.contains(chapterId)) closePrefetch(chapterId);
-      }
+        void prefetchChapter(int chapterId) {
+          if (prefetchClosers.value.containsKey(chapterId)) return;
+          final chapterSubscription = providerContainer
+              .listen<AsyncValue<ChapterDto?>>(
+                chapterProvider(chapterId: chapterId),
+                (_, _) {},
+                fireImmediately: true,
+              );
+          final pagesSubscription = providerContainer
+              .listen<AsyncValue<ChapterPagesDto?>>(
+                chapterPagesProvider(chapterId: chapterId),
+                (_, _) {},
+                fireImmediately: true,
+              );
+          prefetchClosers.value[chapterId] = [
+            chapterSubscription.close,
+            pagesSubscription.close,
+          ];
+        }
 
-      void prefetchChapter(int chapterId) {
-        if (prefetchClosers.value.containsKey(chapterId)) return;
-        final chapterSubscription =
-            providerContainer.listen<AsyncValue<ChapterDto?>>(
-          chapterProvider(chapterId: chapterId),
-          (_, _) {},
-          fireImmediately: true,
-        );
-        final pagesSubscription =
-            providerContainer.listen<AsyncValue<ChapterPagesDto?>>(
-          chapterPagesProvider(chapterId: chapterId),
-          (_, _) {},
-          fireImmediately: true,
-        );
-        prefetchClosers.value[chapterId] = [
-          chapterSubscription.close,
-          pagesSubscription.close,
-        ];
-      }
-
-      for (final chapterId in adjacentIds) {
-        prefetchChapter(chapterId);
-      }
-      return null;
-    }, [
-      resolvedReaderMode,
-      nextPrevChapterPair?.first?.id,
-      nextPrevChapterPair?.second?.id,
-      currentIndex,
-      chapterPages.pages.length,
-    ]);
+        for (final chapterId in adjacentIds) {
+          prefetchChapter(chapterId);
+        }
+        return null;
+      },
+      [
+        resolvedReaderMode,
+        nextPrevChapterPair?.first?.id,
+        nextPrevChapterPair?.second?.id,
+        currentIndex,
+        chapterPages.pages.length,
+      ],
+    );
 
     // NOTE: The visibility→SystemUiMode transition is now driven by
     // ReaderChrome's AnimationController status listener (Inc-1), not here.
@@ -411,6 +424,7 @@ class ReaderWrapper extends HookConsumerWidget {
         chapterId: nextPrevChapterPair!.first!.id,
         transVertical: transVertical,
         toPrev: toPrev,
+        readerScanlatorGroup: readerScanlatorGroup,
       ).pushReplacement(context);
       return true;
     }
@@ -429,6 +443,7 @@ class ReaderWrapper extends HookConsumerWidget {
         transVertical: transVertical,
         toPrev: toPrev,
         openAtEnd: openAtEnd,
+        readerScanlatorGroup: readerScanlatorGroup,
       ).pushReplacement(context);
       return true;
     }
@@ -447,39 +462,46 @@ class ReaderWrapper extends HookConsumerWidget {
       return pushPreviousChapter(openAtEnd: true);
     }
 
-    final onReaderNext = useCallback(() {
-      final isAtLastPage = isAtLastBoundary?.call() ??
-          currentIndex >= chapterPages.pages.length - 1;
-      if (isAtLastPage && tryNextChapter()) {
-        return;
-      }
-      onNext();
-    }, [
-      lastPageSwipeEnabled,
-      readerSwipeChapterToggle,
-      currentIndex,
-      chapterPages.pages.length,
-      nextPrevChapterPair,
-      isAtLastBoundary,
-      tryNextChapter,
-      onNext,
-    ]);
+    final onReaderNext = useCallback(
+      () {
+        final isAtLastPage =
+            isAtLastBoundary?.call() ??
+            currentIndex >= chapterPages.pages.length - 1;
+        if (isAtLastPage && tryNextChapter()) {
+          return;
+        }
+        onNext();
+      },
+      [
+        lastPageSwipeEnabled,
+        readerSwipeChapterToggle,
+        currentIndex,
+        chapterPages.pages.length,
+        nextPrevChapterPair,
+        isAtLastBoundary,
+        tryNextChapter,
+        onNext,
+      ],
+    );
 
-    final onReaderPrevious = useCallback(() {
-      final isAtFirstPage = isAtFirstBoundary?.call() ?? currentIndex <= 0;
-      if (isAtFirstPage && tryPreviousChapter()) {
-        return;
-      }
-      onPrevious();
-    }, [
-      lastPageSwipeEnabled,
-      readerSwipeChapterToggle,
-      currentIndex,
-      nextPrevChapterPair,
-      isAtFirstBoundary,
-      tryPreviousChapter,
-      onPrevious,
-    ]);
+    final onReaderPrevious = useCallback(
+      () {
+        final isAtFirstPage = isAtFirstBoundary?.call() ?? currentIndex <= 0;
+        if (isAtFirstPage && tryPreviousChapter()) {
+          return;
+        }
+        onPrevious();
+      },
+      [
+        lastPageSwipeEnabled,
+        readerSwipeChapterToggle,
+        currentIndex,
+        nextPrevChapterPair,
+        isAtFirstBoundary,
+        tryPreviousChapter,
+        onPrevious,
+      ],
+    );
 
     final onNextChapter = useCallback(() {
       pushNextChapter();
@@ -528,18 +550,22 @@ class ReaderWrapper extends HookConsumerWidget {
       ),
       child: Scaffold(
         // Reader background pref; default black.
-        backgroundColor: (ref.watch(readerBackgroundColorKeyProvider) ??
-                DBKeys.readerBackgroundColor.initial as ReaderBackgroundColor)
-            .color(context),
+        backgroundColor:
+            (ref.watch(readerBackgroundColorKeyProvider) ??
+                    DBKeys.readerBackgroundColor.initial
+                        as ReaderBackgroundColor)
+                .color(context),
         extendBodyBehindAppBar: true,
         extendBody: true,
         body: Stack(
           children: [
             Positioned.fill(
               child: Shortcuts.manager(
-                manager: readerShortcutManager(scrollDirection,
-                    isRtl: isRTLReaderMode(resolvedReaderMode),
-                    autoScrollSupported: onToggleAutoScroll != null),
+                manager: readerShortcutManager(
+                  scrollDirection,
+                  isRtl: isRTLReaderMode(resolvedReaderMode),
+                  autoScrollSupported: onToggleAutoScroll != null,
+                ),
                 child: Actions(
                   actions: {
                     PreviousScrollIntent: CallbackAction<PreviousScrollIntent>(
@@ -552,11 +578,11 @@ class ReaderWrapper extends HookConsumerWidget {
                     ),
                     PreviousChapterIntent:
                         CallbackAction<PreviousChapterIntent>(
-                      onInvoke: (intent) {
-                        if (!pushPreviousChapter()) onReaderPrevious();
-                        return null;
-                      },
-                    ),
+                          onInvoke: (intent) {
+                            if (!pushPreviousChapter()) onReaderPrevious();
+                            return null;
+                          },
+                        ),
                     NextChapterIntent: CallbackAction<NextChapterIntent>(
                       onInvoke: (intent) {
                         if (!pushNextChapter()) onReaderNext();
@@ -574,41 +600,41 @@ class ReaderWrapper extends HookConsumerWidget {
                     // ignores invertTap — arrow-down always scrolls down.
                     ViewportScrollForwardIntent:
                         CallbackAction<ViewportScrollForwardIntent>(
-                      onInvoke: (intent) {
-                        (onViewportScrollForward ?? onReaderNext)();
-                        return null;
-                      },
-                    ),
+                          onInvoke: (intent) {
+                            (onViewportScrollForward ?? onReaderNext)();
+                            return null;
+                          },
+                        ),
                     ViewportScrollBackwardIntent:
                         CallbackAction<ViewportScrollBackwardIntent>(
-                      onInvoke: (intent) {
-                        (onViewportScrollBackward ?? onReaderPrevious)();
-                        return null;
-                      },
-                    ),
+                          onInvoke: (intent) {
+                            (onViewportScrollBackward ?? onReaderPrevious)();
+                            return null;
+                          },
+                        ),
                     // Nullable callbacks: any non-continuous vertical mode
                     // that doesn't supply these is a safe no-op.
                     AutoScrollToggleIntent:
                         CallbackAction<AutoScrollToggleIntent>(
-                      onInvoke: (intent) {
-                        onToggleAutoScroll?.call();
-                        return null;
-                      },
-                    ),
+                          onInvoke: (intent) {
+                            onToggleAutoScroll?.call();
+                            return null;
+                          },
+                        ),
                     AutoScrollFasterIntent:
                         CallbackAction<AutoScrollFasterIntent>(
-                      onInvoke: (intent) {
-                        onAutoScrollFaster?.call();
-                        return null;
-                      },
-                    ),
+                          onInvoke: (intent) {
+                            onAutoScrollFaster?.call();
+                            return null;
+                          },
+                        ),
                     AutoScrollSlowerIntent:
                         CallbackAction<AutoScrollSlowerIntent>(
-                      onInvoke: (intent) {
-                        onAutoScrollSlower?.call();
-                        return null;
-                      },
-                    ),
+                          onInvoke: (intent) {
+                            onAutoScrollSlower?.call();
+                            return null;
+                          },
+                        ),
                     FirstPageIntent: CallbackAction<FirstPageIntent>(
                       onInvoke: (intent) {
                         onJumpToFirst?.call();
@@ -628,8 +654,9 @@ class ReaderWrapper extends HookConsumerWidget {
                       child: RepaintBoundary(
                         child: ReaderView(
                           toggleVisibility: () {
-                            final gate =
-                                ref.read(readerTapArrestsFlingProvider.notifier);
+                            final gate = ref.read(
+                              readerTapArrestsFlingProvider.notifier,
+                            );
                             // Cleared on use: only the long strip arms it, so a
                             // stale true would swallow taps in the paged reader.
                             if (gate.state) {
@@ -640,6 +667,7 @@ class ReaderWrapper extends HookConsumerWidget {
                           },
                           scrollDirection: scrollDirection,
                           mangaId: manga.id,
+                          readerScanlatorGroup: readerScanlatorGroup ?? '',
                           mangaReaderPadding: mangaReaderPadding.value,
                           onNext: onReaderNext,
                           onPrevious: onReaderPrevious,
@@ -687,6 +715,7 @@ class ReaderWrapper extends HookConsumerWidget {
             // synchronized animation is a later increment).
             Positioned.fill(
               child: ReaderChrome(
+                readerScanlatorGroup: readerScanlatorGroup ?? '',
                 manga: manga,
                 chapter: chapter,
                 chapterPages: chapterPages,
@@ -700,8 +729,9 @@ class ReaderWrapper extends HookConsumerWidget {
                 onPreviousChapter: nextPrevChapterPair?.second != null
                     ? () => pushPreviousChapter()
                     : null,
-                onNextChapter:
-                    nextPrevChapterPair?.first != null ? pushNextChapter : null,
+                onNextChapter: nextPrevChapterPair?.first != null
+                    ? pushNextChapter
+                    : null,
                 resolvedReaderMode: resolvedReaderMode,
                 autoScrollSupported: onToggleAutoScroll != null,
                 reverseSeekBar: isRTLReaderMode(resolvedReaderMode),
@@ -931,6 +961,7 @@ class ReaderView extends HookConsumerWidget {
     required this.toggleVisibility,
     required this.scrollDirection,
     required this.mangaId,
+    required this.readerScanlatorGroup,
     required this.mangaReaderPadding,
     required this.onNext,
     required this.onPrevious,
@@ -956,6 +987,7 @@ class ReaderView extends HookConsumerWidget {
   final VoidCallback toggleVisibility;
   final Axis scrollDirection;
   final int mangaId;
+  final String readerScanlatorGroup;
   final double mangaReaderPadding;
   final VoidCallback onNext;
   final VoidCallback onPrevious;
@@ -988,15 +1020,18 @@ class ReaderView extends HookConsumerWidget {
 
     Widget content = Padding(
       padding: EdgeInsets.symmetric(
-        vertical: context.height *
+        vertical:
+            context.height *
             (scrollDirection != Axis.vertical ? mangaReaderPadding : 0),
-        horizontal: context.width *
+        horizontal:
+            context.width *
             (scrollDirection == Axis.vertical ? mangaReaderPadding : 0),
       ),
       child: child,
     );
 
-    final PageController? controller = pageController ??
+    final PageController? controller =
+        pageController ??
         (PrimaryScrollController.of(context) is PageController
             ? PrimaryScrollController.of(context) as PageController
             : null);
@@ -1006,15 +1041,17 @@ class ReaderView extends HookConsumerWidget {
         return;
       }
       pageActionsOpen.value = true;
-      unawaited(showReaderPageActionsSheet(
-        context: context,
-        ref: ref,
-        chapterPages: chapterPages,
-        pageIndex: currentIndex,
-        spreadPageIndexes: spreadPageIndexes,
-      ).whenComplete(() {
-        if (context.mounted) pageActionsOpen.value = false;
-      }));
+      unawaited(
+        showReaderPageActionsSheet(
+          context: context,
+          ref: ref,
+          chapterPages: chapterPages,
+          pageIndex: currentIndex,
+          spreadPageIndexes: spreadPageIndexes,
+        ).whenComplete(() {
+          if (context.mounted) pageActionsOpen.value = false;
+        }),
+      );
     }
 
     void handleLongPressCancel() {
@@ -1044,7 +1081,8 @@ class ReaderView extends HookConsumerWidget {
     // No point spending the one-shot on a layout that draws nothing.
     final zonesAreVisible =
         resolvedNavigationLayout != ReaderNavigationLayout.disabled;
-    final showZonesOnOpen = showReaderLayoutAnimation &&
+    final showZonesOnOpen =
+        showReaderLayoutAnimation &&
         zonesAreVisible &&
         (overlayAlways || unseenAtOpen.value!);
     useEffect(() {
@@ -1091,6 +1129,7 @@ class ReaderView extends HookConsumerWidget {
       );
     } else {
       content = DirectionalSwipeGestureHandler(
+        readerScanlatorGroup: readerScanlatorGroup,
         onTap: toggleVisibility,
         // Null when nothing consumes it, so the recognizer is never registered
         // and a slow tap isn't lost to the long-press arena.

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -52,7 +52,8 @@ class MultiChaptersActionIcon extends ConsumerWidget {
         // a container obtained now stays valid regardless.
         final containerRead = ProviderScope.containerOf(context, listen: false).read;
         final ids = [for (final c in chapters) c.id];
-        // Read/unread and other patches stay scoped to the selected releases.
+        // Read/unread expands across confidently matched releases; unrelated
+        // patches stay scoped to the selected rows.
         final expandedByManga = <int, List<int>>{
           if (change.isRead != null)
             for (final mangaId in {for (final c in chapters) c.mangaId})

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_action_icon.dart
@@ -52,8 +52,7 @@ class MultiChaptersActionIcon extends ConsumerWidget {
         // a container obtained now stays valid regardless.
         final containerRead = ProviderScope.containerOf(context, listen: false).read;
         final ids = [for (final c in chapters) c.id];
-        // Read/unread expands to every scanlator duplicate; other patches
-        // stay per-copy.
+        // Read/unread and other patches stay scoped to the selected releases.
         final expandedByManga = <int, List<int>>{
           if (change.isRead != null)
             for (final mangaId in {for (final c in chapters) c.mangaId})

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -151,7 +151,7 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
             // it only depends on the already-selected chapters, nothing the
             // dialog reveals, so there is no reason for this `ref` use to
             // wait behind an await that could outlive the widget.
-            // Delete expands to every scanlator duplicate, grouped per manga.
+            // Delete stays scoped to the selected releases, grouped per manga.
             final deleteIds = <int>[
               for (final entry
                   in {for (final c in selectedChapterDtos) c.mangaId: true}

--- a/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
+++ b/lib/src/features/manga_book/widgets/chapter_actions/multi_chapters_actions_bottom_app_bar.dart
@@ -151,7 +151,7 @@ class MultiChaptersActionsBottomAppBar extends HookConsumerWidget {
             // it only depends on the already-selected chapters, nothing the
             // dialog reveals, so there is no reason for this `ref` use to
             // wait behind an await that could outlive the widget.
-            // Delete stays scoped to the selected releases, grouped per manga.
+            // Delete includes confidently matched releases, grouped per manga.
             final deleteIds = <int>[
               for (final entry
                   in {for (final c in selectedChapterDtos) c.mangaId: true}

--- a/lib/src/features/manga_book/widgets/download_status_icon.dart
+++ b/lib/src/features/manga_book/widgets/download_status_icon.dart
@@ -146,7 +146,7 @@ class DownloadStatusIcon extends HookConsumerWidget {
               );
               result.showToastOnError(toast);
               if (!result.hasError) {
-                // Same expanded set (device ⊆ server).
+                // Same selected set (device ⊆ server).
                 await cascadeServerDeleteToDevice(containerRead, deleteIds);
               }
               await newUpdatePair(ref, (value) => isLoading.value = value);

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -31,7 +31,6 @@ import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import '../../manga_book/presentation/manga_details/controller/scanlator_dedup.dart';
-import '../../manga_book/presentation/manga_details/controller/scanlator_propagation.dart';
 import '../../notifications/controller/notifications_controller.dart';
 import '../../settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
 import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
@@ -321,34 +320,6 @@ Future<AsyncValue<void>> recordReadingProgress(
     lastPageRead: lastPageRead,
     isRead: isRead,
   );
-  // Completing a chapter also marks its hidden scanlator duplicates read, or
-  // they'd corrupt counts and resume on other clients.
-  if (isRead && !result.hasError) {
-    final siblings = expandIdsAcrossScanlators(
-      ref,
-      mangaId: mangaId,
-      chapterIds: [chapterId],
-    )..remove(chapterId);
-    if (siblings.isNotEmpty) {
-      final siblingsOk = await recordReadStateWithDependencies(
-        offlineEnabled: offline,
-        offlineDatabase: offline ? ref.read(offlineDatabaseProvider) : null,
-        repository: ref.read(mangaBookRepositoryProvider),
-        chapterIds: siblings,
-        isRead: true,
-        // Match the bulk mark-read action: siblings drop stale progress too.
-        resetPosition: true,
-      );
-      // Offline, siblings are dirty-flagged like the chapter and retried later;
-      // only an online-only failure has no fallback and must surface.
-      if (!siblingsOk && !offline) {
-        return AsyncValue.error(
-          Exception('marking duplicate copies read failed'),
-          StackTrace.current,
-        );
-      }
-    }
-  }
   return result;
 }
 
@@ -537,11 +508,11 @@ Future<int?> whileReadingDeleteTarget(
     final showAll = read(
       mangaShowAllScanlatorVersionsProvider(mangaId: mangaId),
     );
-    // Pinned to the chapter actually being read: without it dedup can keep a
-    // different group's copy of that number and drop this id from the list.
-    final deduped = preferred.isEmpty || showAll
+    // Keep the chapter actually being read even if its scanlator is hidden by
+    // the preferred-scanlator filter.
+    final visible = preferred.isEmpty || showAll
         ? chapters
-        : applyPreferredScanlators(
+        : filterPreferredScanlators(
             chapters,
             preferred,
             keepChapterId: readChapterId,
@@ -549,7 +520,7 @@ Future<int?> whileReadingDeleteTarget(
 
     // Tie-broken by id: List.sort is unstable, so duplicate source orders would
     // otherwise let the Nth-back target move between reads.
-    final inReadingOrder = [...deduped]
+    final inReadingOrder = [...visible]
       ..sort((a, b) {
         final byOrder = a.sourceOrder.compareTo(b.sourceOrder);
         return byOrder != 0 ? byOrder : a.id.compareTo(b.id);
@@ -644,7 +615,7 @@ class PendingReadDeletes extends Notifier<Set<PendingReadDelete>> {
 }
 
 /// Queues while-reading deletes when a chapter is finished in the reader.
-/// Targets resolve NOW, not at exit — the list/dedup state can shift by then
+/// Targets resolve NOW, not at exit — the visible list can shift by then
 /// and pick the wrong chapter. Session protection is handled separately by the
 /// reader widget registering open chapters via [sessionReadChaptersProvider].
 Future<void> noteChapterFinishedInReader(

--- a/lib/src/features/offline/data/offline_download_providers.dart
+++ b/lib/src/features/offline/data/offline_download_providers.dart
@@ -31,6 +31,7 @@ import '../../manga_book/data/manga_book/manga_book_repository.dart';
 import '../../manga_book/domain/chapter_batch/chapter_batch_model.dart';
 import '../../manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import '../../manga_book/presentation/manga_details/controller/scanlator_dedup.dart';
+import '../../manga_book/presentation/manga_details/controller/scanlator_propagation.dart';
 import '../../notifications/controller/notifications_controller.dart';
 import '../../settings/presentation/downloads/data/delete_chapters_settings_repository.dart';
 import '../../settings/presentation/server/widget/client/server_port_tile/server_port_tile.dart';
@@ -312,6 +313,13 @@ Future<AsyncValue<void>> recordReadingProgress(
   required bool isRead,
 }) async {
   final offline = ref.read(offlineActiveProvider);
+  final completionChapterIds = isRead
+      ? expandIdsAcrossScanlators(
+          ref,
+          mangaId: mangaId,
+          chapterIds: [chapterId],
+        )
+      : null;
   final result = await recordReadingProgressWithDependencies(
     offlineEnabled: offline,
     offlineDatabase: offline ? ref.read(offlineDatabaseProvider) : null,
@@ -319,6 +327,7 @@ Future<AsyncValue<void>> recordReadingProgress(
     chapterId: chapterId,
     lastPageRead: lastPageRead,
     isRead: isRead,
+    completionChapterIds: completionChapterIds,
   );
   return result;
 }
@@ -333,7 +342,28 @@ Future<AsyncValue<void>> recordReadingProgressWithDependencies({
   required int chapterId,
   required int lastPageRead,
   required bool isRead,
+  List<int>? completionChapterIds,
 }) async {
+  if (isRead &&
+      completionChapterIds != null &&
+      completionChapterIds.length > 1) {
+    final result = await _recordReadStateResultWithDependencies(
+      offlineEnabled: offlineEnabled,
+      offlineDatabase: offlineDatabase,
+      repository: repository,
+      chapterIds: completionChapterIds,
+      isRead: true,
+      resetPosition: true,
+      manual: false,
+    );
+    if (result.hasError && offlineEnabled && offlineDatabase != null) {
+      final e = result.error!;
+      final cause = e is OperationMessageException ? e.exception : e;
+      if (isConnectionError(cause)) return const AsyncValue.data(null);
+    }
+    return result;
+  }
+
   // Reading forward never un-reads: partial writes record position only (isRead
   // omitted); only completion marks read. Mark-unread is a separate path.
   final bool? markRead = isRead ? true : null;
@@ -421,6 +451,27 @@ Future<bool> recordReadStateWithDependencies({
   required bool isRead,
   bool resetPosition = false,
 }) async {
+  final result = await _recordReadStateResultWithDependencies(
+    offlineEnabled: offlineEnabled,
+    offlineDatabase: offlineDatabase,
+    repository: repository,
+    chapterIds: chapterIds,
+    isRead: isRead,
+    resetPosition: resetPosition,
+    manual: true,
+  );
+  return !result.hasError;
+}
+
+Future<AsyncValue<void>> _recordReadStateResultWithDependencies({
+  required bool offlineEnabled,
+  required OfflineDatabase? offlineDatabase,
+  required MangaBookRepository repository,
+  required List<int> chapterIds,
+  required bool isRead,
+  required bool resetPosition,
+  required bool manual,
+}) async {
   final db = offlineDatabase;
   if (offlineEnabled && db != null) {
     for (final id in chapterIds) {
@@ -429,7 +480,7 @@ Future<bool> recordReadStateWithDependencies({
           id,
           lastPageRead: 0,
           isRead: isRead,
-          manual: true,
+          manual: manual,
         );
       } else {
         await db.setChapterReadState(id, isRead);
@@ -454,7 +505,7 @@ Future<bool> recordReadStateWithDependencies({
       }
     }
   }
-  return !result.hasError;
+  return result;
 }
 
 /// Widget entry point for [recordReadStateWithDependencies] — resolves the

--- a/lib/src/features/offline/data/offline_dto_mappers.dart
+++ b/lib/src/features/offline/data/offline_dto_mappers.dart
@@ -195,8 +195,7 @@ ChapterDto offlineChapterToDto(OfflineChapter c) => Fragment$ChapterDto(
       id: c.id,
       mangaId: c.mangaId,
       name: c.name,
-      // Real number when synced (lets dedup group duplicates offline, #141);
-      // index fallback for pre-v9 rows keeps numbers unique = no collapse.
+      // Real number when synced; index fallback supports pre-v9 rows.
       chapterNumber: c.chapterNumber ?? c.chapterIndex.toDouble(),
       sourceOrder: c.chapterIndex,
       isRead: c.isRead,

--- a/lib/src/routes/sub_routes/common_routes.dart
+++ b/lib/src/routes/sub_routes/common_routes.dart
@@ -22,7 +22,10 @@ class RecommendsRoute extends GoRouteData with $RecommendsRoute {
 }
 
 class RecommendsBrowseRoute extends GoRouteData with $RecommendsBrowseRoute {
-  const RecommendsBrowseRoute({required this.mangaId, required this.providerName});
+  const RecommendsBrowseRoute({
+    required this.mangaId,
+    required this.providerName,
+  });
   final int mangaId;
   final String providerName;
 
@@ -44,6 +47,7 @@ class ReaderRoute extends GoRouteData with $ReaderRoute {
     required this.chapterId,
     this.transVertical,
     this.toPrev,
+    this.readerScanlatorGroup,
     this.showReaderLayoutAnimation = false,
     this.openAtEnd = false,
   });
@@ -51,6 +55,7 @@ class ReaderRoute extends GoRouteData with $ReaderRoute {
   final int chapterId;
   final bool? transVertical;
   final bool? toPrev;
+  final String? readerScanlatorGroup;
   final bool showReaderLayoutAnimation;
   final bool openAtEnd;
 
@@ -63,6 +68,7 @@ class ReaderRoute extends GoRouteData with $ReaderRoute {
       child: ReaderScreen(
         mangaId: mangaId,
         chapterId: chapterId,
+        readerScanlatorGroup: readerScanlatorGroup,
         showReaderLayoutAnimation: showReaderLayoutAnimation,
         openAtEnd: openAtEnd,
       ),
@@ -97,7 +103,8 @@ class _ReaderRouteTransition extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final background = ref.watch(readerBackgroundColorKeyProvider) ??
+    final background =
+        ref.watch(readerBackgroundColorKeyProvider) ??
         DBKeys.readerBackgroundColor.initial as ReaderBackgroundColor;
     return ColoredBox(
       color: background.color(context),

--- a/lib/src/routes/sub_routes/common_routes.dart
+++ b/lib/src/routes/sub_routes/common_routes.dart
@@ -22,10 +22,7 @@ class RecommendsRoute extends GoRouteData with $RecommendsRoute {
 }
 
 class RecommendsBrowseRoute extends GoRouteData with $RecommendsBrowseRoute {
-  const RecommendsBrowseRoute({
-    required this.mangaId,
-    required this.providerName,
-  });
+  const RecommendsBrowseRoute({required this.mangaId, required this.providerName});
   final int mangaId;
   final String providerName;
 
@@ -103,8 +100,7 @@ class _ReaderRouteTransition extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final background =
-        ref.watch(readerBackgroundColorKeyProvider) ??
+    final background = ref.watch(readerBackgroundColorKeyProvider) ??
         DBKeys.readerBackgroundColor.initial as ReaderBackgroundColor;
     return ColoredBox(
       color: background.color(context),

--- a/test/src/features/manga_book/manga_details/chapter_list_dedup_wiring_test.dart
+++ b/test/src/features/manga_book/manga_details/chapter_list_dedup_wiring_test.dart
@@ -84,21 +84,25 @@ Future<ProviderContainer> _container({
   return c;
 }
 
-List<int> _ids(ProviderContainer c, {int? keepChapterId}) =>
+List<int> _ids(
+  ProviderContainer c, {
+  int? keepChapterId,
+  String? readerScanlatorGroup,
+}) =>
     c
         .read(mangaChapterListWithFilterProvider(
-            mangaId: 1, keepChapterId: keepChapterId))
+            mangaId: 1,
+            keepChapterId: keepChapterId,
+            readerScanlatorGroup: readerScanlatorGroup))
         .value!
         .map((e) => e.id)
         .toList();
 
 void main() {
-  test('dedup runs before filters: unread filter sees aggregate state',
+  test('preferred scanlators filter rows without aggregating read state',
       () async {
-    // preference ['B'], unread filter ON: ch3's B row aggregates isRead=true
-    // from A's read copy (id 4) -> filtered OUT. Survivors: ch1-B(2), ch2-B(3).
     final c = await _container(preference: const ['B'], unreadFilter: true);
-    expect(_ids(c), [3, 2]);
+    expect(_ids(c), [5, 3, 2]);
   });
 
   test('no preference -> identical to today (all copies)', () async {
@@ -111,11 +115,7 @@ void main() {
     expect(_ids(c), [5, 4, 3, 2, 1]);
   });
 
-  test('catalog-shaped rows (unique fabricated numbers) never collapse',
-      () async {
-    // The offline catalog fabricates chapterNumber from the list index, so
-    // every row has a distinct number and dedup structurally no-ops — this is
-    // the offline safety property (there is no offlineActive gate).
+  test('preferred scanlator filtering behaves the same offline', () async {
     final catalogShaped = [
       ch(id: 1, number: 0, scanlator: 'A', sourceOrder: 0),
       ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
@@ -124,22 +124,39 @@ void main() {
     ];
     final c = await _container(
         chapters: catalogShaped, preference: const ['B'], offline: true);
-    expect(_ids(c), [4, 3, 2, 1]);
+    expect(_ids(c), [4, 2]);
   });
 
   test('keepChapterId surfaces a hidden copy', () async {
-    // preference ['B'], keepChapterId = ch1-A's id (1) -> ch1's row is A's
-    // copy instead of B's; ch2/ch3 dedup normally (B wins both).
     final c = await _container(preference: const ['B']);
-    expect(_ids(c, keepChapterId: 1), [5, 3, 1]);
+    expect(_ids(c, keepChapterId: 1), [5, 3, 2, 1]);
+  });
+
+  test('keepChapterId bypasses unread filter for reader navigation', () async {
+    final c = await _container(
+      preference: const ['B'],
+      unreadFilter: true,
+    );
+    expect(_ids(c, keepChapterId: 4), [5, 4, 3, 2]);
+  });
+
+  test('same-number specials and restarted seasons are never folded',
+      () async {
+    final c = await _container(
+      preference: const ['A'],
+      chapters: [
+        ch(id: 1, number: 6, name: 'Chapter 6', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 6, name: 'Special 6', scanlator: 'A', sourceOrder: 1),
+        ch(id: 3, number: 1, name: 'Season 1 Chapter 1', scanlator: 'A', sourceOrder: 2),
+        ch(id: 4, number: 1, name: 'Season 2 Chapter 1', scanlator: 'A', sourceOrder: 3),
+      ],
+    );
+    expect(_ids(c), [4, 3, 2, 1]);
   });
 
   test('getNextAndPreviousChapters resolves neighbours from a hidden copy',
       () async {
-    // n1: A(id 1) + B(id 2); n2: B(id 3) only. Preference ['B'] would
-    // normally hide id 1 (A loses n1 to B), but the reader chain passes
-    // its own chapterId as keepChapterId, forcing id 1 to win n1 instead
-    // -> deduped chain is [id 1, id 3].
+    // The reader follows A for chapter 1 and falls back to B for chapter 2.
     final hiddenCopyChapters = [
       ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
       ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
@@ -150,7 +167,11 @@ void main() {
       preference: const ['B'],
     );
     final pair = c.read(
-      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1),
+      getNextAndPreviousChaptersProvider(
+        mangaId: 1,
+        chapterId: 1,
+        readerScanlatorGroup: 'A',
+      ),
     );
     expect(pair, isNotNull);
     // Default sort is source-order descending (id 3 first, id 1 last), so
@@ -159,7 +180,8 @@ void main() {
     expect(pair.second, isNull);
   });
 
-  test('bulk-actions list dedups but stays unfiltered', () async {
+  test('bulk-actions list filters preferred groups but stays unfiltered',
+      () async {
     final c = await _container(preference: const ['B']);
     final rows = c
         .read(mangaChapterListForBulkActionsProvider(mangaId: 1))

--- a/test/src/features/manga_book/manga_details/chapter_test_helpers.dart
+++ b/test/src/features/manga_book/manga_details/chapter_test_helpers.dart
@@ -9,6 +9,7 @@ import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generat
 Fragment$ChapterDto ch({
   required int id,
   required double number,
+  String? name,
   String? scanlator,
   bool isRead = false,
   bool isDownloaded = false,
@@ -19,7 +20,7 @@ Fragment$ChapterDto ch({
     Fragment$ChapterDto(
       id: id,
       mangaId: 1,
-      name: 'Chapter $number',
+      name: name ?? 'Chapter $number',
       chapterNumber: number,
       sourceOrder: sourceOrder,
       isRead: isRead,

--- a/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
@@ -162,15 +162,15 @@ void main() {
     });
   });
 
-  group('mutation identity', () {
-    test('same-number releases stay independent for read/delete actions', () {
+  group('mutation release matching', () {
+    test('uses the reader match for read/delete and reconciliation', () {
       final rows = [
-        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 1, number: 1, scanlator: 'A', isRead: true),
         ch(id: 2, number: 1, scanlator: 'B'),
       ];
-      expect(duplicateChapterIds(rows, 1), [1]);
-      expect(expandIdsForDuplicates(rows, [1]), [1]);
-      expect(reconcileIdsForReadNumbers(rows), isEmpty);
+      expect(duplicateChapterIds(rows, 1), [1, 2]);
+      expect(expandIdsForDuplicates(rows, [1]), [1, 2]);
+      expect(reconcileIdsForReadNumbers(rows), [2]);
     });
   });
 }

--- a/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
@@ -12,25 +12,33 @@ import 'chapter_test_helpers.dart';
 void main() {
   group('applyPreferredScanlators', () {
     test('empty preference returns list unchanged', () {
-      final list = [ch(id: 1, number: 1, scanlator: 'A'),
-                    ch(id: 2, number: 1, scanlator: 'B')];
+      final list = [
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ];
       expect(applyPreferredScanlators(list, const []), same(list));
     });
 
     test('highest-ranked group wins its chapters', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
-        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
-        ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
-      ], const ['B', 'A']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+          ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+          ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
+        ],
+        const ['B', 'A'],
+      );
       expect(rows.map((c) => c.id), [2, 3]);
     });
 
     test('falls back to next rank, then source order, when unranked', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 1),
-        ch(id: 2, number: 1, scanlator: 'C', sourceOrder: 0),
-      ], const ['B']); // B has nothing; C is listed first by the source
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 1),
+          ch(id: 2, number: 1, scanlator: 'C', sourceOrder: 0),
+        ],
+        const ['B'],
+      ); // B has nothing; C is listed first by the source
       expect(rows.single.id, 2);
     });
 
@@ -39,123 +47,175 @@ void main() {
         ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
         ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
       ]) {
-        final rows = applyPreferredScanlators([
-          favored,
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ], const ['B']);
+        final rows = applyPreferredScanlators(
+          [favored, ch(id: 2, number: 1, scanlator: 'B')],
+          const ['B'],
+        );
         expect(rows.single.id, 1);
       }
     });
 
     test('a read copy does NOT beat rank (aggregate covers it)', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', isRead: true),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A', isRead: true),
+          ch(id: 2, number: 1, scanlator: 'B'),
+        ],
+        const ['B'],
+      );
       expect(rows.single.id, 2);
       expect(rows.single.isRead, isTrue); // aggregate
     });
 
     test('aggregate state unions read/downloaded/bookmarked across copies', () {
-      final row = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A',
-            isRead: true, isBookmarked: true),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B']).single;
-      expect((row.isRead, row.isBookmarked, row.isDownloaded),
-          (true, true, false));
+      final row = applyPreferredScanlators(
+        [
+          ch(
+            id: 1,
+            number: 1,
+            scanlator: 'A',
+            isRead: true,
+            isBookmarked: true,
+          ),
+          ch(id: 2, number: 1, scanlator: 'B'),
+        ],
+        const ['B'],
+      ).single;
+      expect(
+        (row.isRead, row.isBookmarked, row.isDownloaded),
+        (true, true, false),
+      );
     });
 
     test('same-group siblings (split chapters/v2) all survive', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 10, scanlator: 'A', sourceOrder: 0),
-        ch(id: 2, number: 10, scanlator: 'A', sourceOrder: 1),
-        ch(id: 3, number: 10, scanlator: 'B', sourceOrder: 2),
-      ], const ['A']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 10, scanlator: 'A', sourceOrder: 0),
+          ch(id: 2, number: 10, scanlator: 'A', sourceOrder: 1),
+          ch(id: 3, number: 10, scanlator: 'B', sourceOrder: 2),
+        ],
+        const ['A'],
+      );
       expect(rows.map((c) => c.id), [1, 2]);
     });
 
     test('Chapter 0 dedups like every other numbered chapter', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 0, scanlator: 'A'),
-        ch(id: 2, number: 0, scanlator: 'B'),
-        ch(id: 3, number: -1, scanlator: 'A'),
-      ], const ['A']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 0, scanlator: 'A'),
+          ch(id: 2, number: 0, scanlator: 'B'),
+          ch(id: 3, number: -1, scanlator: 'A'),
+        ],
+        const ['A'],
+      );
       expect(rows.map((chapter) => chapter.id), [1, 3]);
     });
 
     test('blank scanlator is rankable as the Unknown group', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: null),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const [kUnknownScanlatorGroup, 'B']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: null),
+          ch(id: 2, number: 1, scanlator: 'B'),
+        ],
+        const [kUnknownScanlatorGroup, 'B'],
+      );
       expect(rows.single.id, 1);
     });
 
     test('keepChapterId forces the in-flight copy\'s group to win', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A'),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B'], keepChapterId: 1);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A'),
+          ch(id: 2, number: 1, scanlator: 'B'),
+        ],
+        const ['B'],
+        keepChapterId: 1,
+      );
       expect(rows.single.id, 1);
     });
 
     test('preserves input order of surviving rows', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 2, scanlator: 'A', sourceOrder: 5),
-        ch(id: 2, number: 1, scanlator: 'A', sourceOrder: 0),
-      ], const ['A']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 2, scanlator: 'A', sourceOrder: 5),
+          ch(id: 2, number: 1, scanlator: 'A', sourceOrder: 0),
+        ],
+        const ['A'],
+      );
       expect(rows.map((c) => c.id), [1, 2]);
     });
 
     test('tied in-progress copies resolve to the first in input order', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 3),
-        ch(id: 2, number: 1, scanlator: 'B', lastPageRead: 7),
-      ], const ['B']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 3),
+          ch(id: 2, number: 1, scanlator: 'B', lastPageRead: 7),
+        ],
+        const ['B'],
+      );
       expect(rows.single.id, 1);
     });
 
     test('keepChapterId outranks in-progress and downloaded copies', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
-        ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
-        ch(id: 3, number: 1, scanlator: 'C'),
-      ], const ['A'], keepChapterId: 3);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
+          ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
+          ch(id: 3, number: 1, scanlator: 'C'),
+        ],
+        const ['A'],
+        keepChapterId: 3,
+      );
       expect(rows.single.id, 3);
     });
 
     test('unknown keepChapterId falls back to normal rules', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A'),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B'], keepChapterId: 99);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A'),
+          ch(id: 2, number: 1, scanlator: 'B'),
+        ],
+        const ['B'],
+        keepChapterId: 99,
+      );
       expect(rows.single.id, 2);
     });
 
     test('keepChapterId on Chapter 0 retains the in-flight copy', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 0, scanlator: 'A'),
-        ch(id: 2, number: 0, scanlator: 'B'),
-        ch(id: 3, number: 1, scanlator: 'B'),
-      ], const ['B'], keepChapterId: 1);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 0, scanlator: 'A'),
+          ch(id: 2, number: 0, scanlator: 'B'),
+          ch(id: 3, number: 1, scanlator: 'B'),
+        ],
+        const ['B'],
+        keepChapterId: 1,
+      );
       expect(rows.map((c) => c.id), [1, 3]);
     });
 
     test('aggregation preserves the winner copy\'s other fields', () {
-      final row = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', isRead: true, sourceOrder: 4),
-        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 9),
-      ], const ['B']).single;
-      expect((row.id, row.scanlator, row.sourceOrder, row.name),
-          (2, 'B', 9, 'Chapter 1.0'));
+      final row = applyPreferredScanlators(
+        [
+          ch(id: 1, number: 1, scanlator: 'A', isRead: true, sourceOrder: 4),
+          ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 9),
+        ],
+        const ['B'],
+      ).single;
+      expect(
+        (row.id, row.scanlator, row.sourceOrder, row.name),
+        (2, 'B', 9, 'Chapter 1.0'),
+      );
     });
 
     test('NaN chapter number passes through instead of vanishing', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: double.nan, scanlator: 'A'),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B']);
+      final rows = applyPreferredScanlators(
+        [
+          ch(id: 1, number: double.nan, scanlator: 'A'),
+          ch(id: 2, number: 1, scanlator: 'B'),
+        ],
+        const ['B'],
+      );
       expect(rows.map((c) => c.id), [1, 2]);
     });
   });
@@ -181,5 +241,25 @@ void main() {
       final withNan = [...list, ch(id: 6, number: double.nan, scanlator: 'A')];
       expect(duplicateChapterIds(withNan, 6), [6]);
     });
+  });
+
+  group('applyReaderSessionScanlator', () {
+    test(
+      'uses the opening scanlator and falls back when it is unavailable',
+      () {
+        final rows = applyReaderSessionScanlator(
+          [
+            ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+            ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+            ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
+            ch(id: 4, number: 2, scanlator: 'A', sourceOrder: 3),
+            ch(id: 5, number: 3, scanlator: 'B', sourceOrder: 4),
+          ],
+          scanlatorGroup: 'A',
+          keepChapterId: 1,
+        );
+        expect(rows.map((chapter) => chapter.id), [1, 4, 5]);
+      },
+    );
   });
 }

--- a/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
@@ -12,33 +12,25 @@ import 'chapter_test_helpers.dart';
 void main() {
   group('applyPreferredScanlators', () {
     test('empty preference returns list unchanged', () {
-      final list = [
-        ch(id: 1, number: 1, scanlator: 'A'),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ];
+      final list = [ch(id: 1, number: 1, scanlator: 'A'),
+                    ch(id: 2, number: 1, scanlator: 'B')];
       expect(applyPreferredScanlators(list, const []), same(list));
     });
 
     test('highest-ranked group wins its chapters', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
-          ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
-          ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
-        ],
-        const ['B', 'A'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+        ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
+      ], const ['B', 'A']);
       expect(rows.map((c) => c.id), [2, 3]);
     });
 
     test('falls back to next rank, then source order, when unranked', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 1),
-          ch(id: 2, number: 1, scanlator: 'C', sourceOrder: 0),
-        ],
-        const ['B'],
-      ); // B has nothing; C is listed first by the source
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 1),
+        ch(id: 2, number: 1, scanlator: 'C', sourceOrder: 0),
+      ], const ['B']); // B has nothing; C is listed first by the source
       expect(rows.single.id, 2);
     });
 
@@ -47,175 +39,123 @@ void main() {
         ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
         ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
       ]) {
-        final rows = applyPreferredScanlators(
-          [favored, ch(id: 2, number: 1, scanlator: 'B')],
-          const ['B'],
-        );
+        final rows = applyPreferredScanlators([
+          favored,
+          ch(id: 2, number: 1, scanlator: 'B'),
+        ], const ['B']);
         expect(rows.single.id, 1);
       }
     });
 
     test('a read copy does NOT beat rank (aggregate covers it)', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A', isRead: true),
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ],
-        const ['B'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', isRead: true),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']);
       expect(rows.single.id, 2);
       expect(rows.single.isRead, isTrue); // aggregate
     });
 
     test('aggregate state unions read/downloaded/bookmarked across copies', () {
-      final row = applyPreferredScanlators(
-        [
-          ch(
-            id: 1,
-            number: 1,
-            scanlator: 'A',
-            isRead: true,
-            isBookmarked: true,
-          ),
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ],
-        const ['B'],
-      ).single;
-      expect(
-        (row.isRead, row.isBookmarked, row.isDownloaded),
-        (true, true, false),
-      );
+      final row = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A',
+            isRead: true, isBookmarked: true),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']).single;
+      expect((row.isRead, row.isBookmarked, row.isDownloaded),
+          (true, true, false));
     });
 
     test('same-group siblings (split chapters/v2) all survive', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 10, scanlator: 'A', sourceOrder: 0),
-          ch(id: 2, number: 10, scanlator: 'A', sourceOrder: 1),
-          ch(id: 3, number: 10, scanlator: 'B', sourceOrder: 2),
-        ],
-        const ['A'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 10, scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 10, scanlator: 'A', sourceOrder: 1),
+        ch(id: 3, number: 10, scanlator: 'B', sourceOrder: 2),
+      ], const ['A']);
       expect(rows.map((c) => c.id), [1, 2]);
     });
 
     test('Chapter 0 dedups like every other numbered chapter', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 0, scanlator: 'A'),
-          ch(id: 2, number: 0, scanlator: 'B'),
-          ch(id: 3, number: -1, scanlator: 'A'),
-        ],
-        const ['A'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 0, scanlator: 'A'),
+        ch(id: 2, number: 0, scanlator: 'B'),
+        ch(id: 3, number: -1, scanlator: 'A'),
+      ], const ['A']);
       expect(rows.map((chapter) => chapter.id), [1, 3]);
     });
 
     test('blank scanlator is rankable as the Unknown group', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: null),
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ],
-        const [kUnknownScanlatorGroup, 'B'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: null),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const [kUnknownScanlatorGroup, 'B']);
       expect(rows.single.id, 1);
     });
 
     test('keepChapterId forces the in-flight copy\'s group to win', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A'),
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ],
-        const ['B'],
-        keepChapterId: 1,
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B'], keepChapterId: 1);
       expect(rows.single.id, 1);
     });
 
     test('preserves input order of surviving rows', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 2, scanlator: 'A', sourceOrder: 5),
-          ch(id: 2, number: 1, scanlator: 'A', sourceOrder: 0),
-        ],
-        const ['A'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 2, scanlator: 'A', sourceOrder: 5),
+        ch(id: 2, number: 1, scanlator: 'A', sourceOrder: 0),
+      ], const ['A']);
       expect(rows.map((c) => c.id), [1, 2]);
     });
 
     test('tied in-progress copies resolve to the first in input order', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 3),
-          ch(id: 2, number: 1, scanlator: 'B', lastPageRead: 7),
-        ],
-        const ['B'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 3),
+        ch(id: 2, number: 1, scanlator: 'B', lastPageRead: 7),
+      ], const ['B']);
       expect(rows.single.id, 1);
     });
 
     test('keepChapterId outranks in-progress and downloaded copies', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
-          ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
-          ch(id: 3, number: 1, scanlator: 'C'),
-        ],
-        const ['A'],
-        keepChapterId: 3,
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
+        ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
+        ch(id: 3, number: 1, scanlator: 'C'),
+      ], const ['A'], keepChapterId: 3);
       expect(rows.single.id, 3);
     });
 
     test('unknown keepChapterId falls back to normal rules', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A'),
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ],
-        const ['B'],
-        keepChapterId: 99,
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B'], keepChapterId: 99);
       expect(rows.single.id, 2);
     });
 
     test('keepChapterId on Chapter 0 retains the in-flight copy', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 0, scanlator: 'A'),
-          ch(id: 2, number: 0, scanlator: 'B'),
-          ch(id: 3, number: 1, scanlator: 'B'),
-        ],
-        const ['B'],
-        keepChapterId: 1,
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: 0, scanlator: 'A'),
+        ch(id: 2, number: 0, scanlator: 'B'),
+        ch(id: 3, number: 1, scanlator: 'B'),
+      ], const ['B'], keepChapterId: 1);
       expect(rows.map((c) => c.id), [1, 3]);
     });
 
     test('aggregation preserves the winner copy\'s other fields', () {
-      final row = applyPreferredScanlators(
-        [
-          ch(id: 1, number: 1, scanlator: 'A', isRead: true, sourceOrder: 4),
-          ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 9),
-        ],
-        const ['B'],
-      ).single;
-      expect(
-        (row.id, row.scanlator, row.sourceOrder, row.name),
-        (2, 'B', 9, 'Chapter 1.0'),
-      );
+      final row = applyPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A', isRead: true, sourceOrder: 4),
+        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 9),
+      ], const ['B']).single;
+      expect((row.id, row.scanlator, row.sourceOrder, row.name),
+          (2, 'B', 9, 'Chapter 1.0'));
     });
 
     test('NaN chapter number passes through instead of vanishing', () {
-      final rows = applyPreferredScanlators(
-        [
-          ch(id: 1, number: double.nan, scanlator: 'A'),
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ],
-        const ['B'],
-      );
+      final rows = applyPreferredScanlators([
+        ch(id: 1, number: double.nan, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ], const ['B']);
       expect(rows.map((c) => c.id), [1, 2]);
     });
   });
@@ -259,7 +199,6 @@ void main() {
           keepChapterId: 1,
         );
         expect(rows.map((chapter) => chapter.id), [1, 4, 5]);
-      },
-    );
+      });
   });
 }

--- a/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
@@ -75,13 +75,13 @@ void main() {
       expect(rows.map((c) => c.id), [1, 2]);
     });
 
-    test('chapterNumber <= 0 passes through undeduped', () {
+    test('Chapter 0 dedups like every other numbered chapter', () {
       final rows = applyPreferredScanlators([
         ch(id: 1, number: 0, scanlator: 'A'),
         ch(id: 2, number: 0, scanlator: 'B'),
         ch(id: 3, number: -1, scanlator: 'A'),
       ], const ['A']);
-      expect(rows.length, 3);
+      expect(rows.map((chapter) => chapter.id), [1, 3]);
     });
 
     test('blank scanlator is rankable as the Unknown group', () {
@@ -133,13 +133,13 @@ void main() {
       expect(rows.single.id, 2);
     });
 
-    test('keepChapterId on a passthrough (<= 0) row changes nothing', () {
+    test('keepChapterId on Chapter 0 retains the in-flight copy', () {
       final rows = applyPreferredScanlators([
         ch(id: 1, number: 0, scanlator: 'A'),
         ch(id: 2, number: 0, scanlator: 'B'),
         ch(id: 3, number: 1, scanlator: 'B'),
       ], const ['B'], keepChapterId: 1);
-      expect(rows.map((c) => c.id), [1, 2, 3]);
+      expect(rows.map((c) => c.id), [1, 3]);
     });
 
     test('aggregation preserves the winner copy\'s other fields', () {
@@ -171,8 +171,8 @@ void main() {
     test('returns every copy of the chapter number, self included', () {
       expect(duplicateChapterIds(list, 1), unorderedEquals([1, 2]));
     });
-    test('number <= 0 returns only self', () {
-      expect(duplicateChapterIds(list, 4), [4]);
+    test('Chapter 0 returns every copy', () {
+      expect(duplicateChapterIds(list, 4), unorderedEquals([4, 5]));
     });
     test('unknown id returns only itself', () {
       expect(duplicateChapterIds(list, 99), [99]);

--- a/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_dedup_test.dart
@@ -10,195 +10,167 @@ import 'package:tsumiru/src/features/manga_book/presentation/manga_details/contr
 import 'chapter_test_helpers.dart';
 
 void main() {
-  group('applyPreferredScanlators', () {
+  group('filterPreferredScanlators', () {
     test('empty preference returns list unchanged', () {
-      final list = [ch(id: 1, number: 1, scanlator: 'A'),
-                    ch(id: 2, number: 1, scanlator: 'B')];
-      expect(applyPreferredScanlators(list, const []), same(list));
+      final list = [
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ];
+      expect(filterPreferredScanlators(list, const []), same(list));
     });
 
-    test('highest-ranked group wins its chapters', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
-        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
-        ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
-      ], const ['B', 'A']);
-      expect(rows.map((c) => c.id), [2, 3]);
+    test('keeps every row from every selected group without folding', () {
+      final rows = filterPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+        ch(id: 3, number: 1, scanlator: 'A'),
+        ch(id: 4, number: 2, scanlator: 'C'),
+      ], const ['A', 'B']);
+      expect(rows.map((c) => c.id), [1, 2, 3]);
     });
 
-    test('falls back to next rank, then source order, when unranked', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 1),
-        ch(id: 2, number: 1, scanlator: 'C', sourceOrder: 0),
-      ], const ['B']); // B has nothing; C is listed first by the source
-      expect(rows.single.id, 2);
+    test('preserves regular and special chapters with the same number', () {
+      final rows = filterPreferredScanlators([
+        ch(id: 1, number: 6, name: 'Chapter 6', scanlator: 'A'),
+        ch(id: 2, number: 6, name: 'Special 6', scanlator: 'A'),
+        ch(id: 3, number: 6, name: 'Chapter 6', scanlator: 'B'),
+      ], const ['A']);
+      expect(rows.map((c) => c.id), [1, 2]);
     });
 
-    test('in-progress or downloaded copy beats rank', () {
-      for (final favored in [
-        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
-        ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
-      ]) {
-        final rows = applyPreferredScanlators([
-          favored,
-          ch(id: 2, number: 1, scanlator: 'B'),
-        ], const ['B']);
-        expect(rows.single.id, 1);
-      }
+    test('preserves every season when chapter numbering restarts', () {
+      final rows = filterPreferredScanlators([
+        ch(id: 1, number: 0, name: 'Season 1 Chapter 0', scanlator: 'A'),
+        ch(id: 2, number: 1, name: 'Season 1 Chapter 1', scanlator: 'A'),
+        ch(id: 3, number: 0, name: 'Season 2 Chapter 0', scanlator: 'A'),
+        ch(id: 4, number: 1, name: 'Season 2 Chapter 1', scanlator: 'A'),
+      ], const ['A']);
+      expect(rows.map((c) => c.id), [1, 2, 3, 4]);
     });
 
-    test('a read copy does NOT beat rank (aggregate covers it)', () {
-      final rows = applyPreferredScanlators([
+    test('preserves all 536 rows in a large restarted-numbering series', () {
+      final chapters = [
+        for (var id = 0; id < 536; id++)
+          ch(
+            id: id,
+            number: (id % 183).toDouble(),
+            name: 'Season ${id ~/ 183 + 1} Chapter ${id % 183}',
+            scanlator: 'A',
+            sourceOrder: id,
+          ),
+      ];
+      expect(filterPreferredScanlators(chapters, const ['A']), hasLength(536));
+    });
+
+    test('keeps an open row from an unselected group', () {
+      final rows = filterPreferredScanlators([
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+        ch(id: 3, number: 2, scanlator: 'B'),
+      ], const ['B'], keepChapterId: 1);
+      expect(rows.map((c) => c.id), [1, 2, 3]);
+    });
+
+    test('blank scanlator is selectable as Unknown', () {
+      final rows = filterPreferredScanlators([
+        ch(id: 1, number: 1),
+        ch(id: 2, number: 2, scanlator: 'A'),
+      ], const [kUnknownScanlatorGroup]);
+      expect(rows.map((c) => c.id), [1]);
+    });
+
+    test('does not aggregate state between same-number rows', () {
+      final rows = filterPreferredScanlators([
         ch(id: 1, number: 1, scanlator: 'A', isRead: true),
         ch(id: 2, number: 1, scanlator: 'B'),
       ], const ['B']);
       expect(rows.single.id, 2);
-      expect(rows.single.isRead, isTrue); // aggregate
-    });
-
-    test('aggregate state unions read/downloaded/bookmarked across copies', () {
-      final row = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A',
-            isRead: true, isBookmarked: true),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B']).single;
-      expect((row.isRead, row.isBookmarked, row.isDownloaded),
-          (true, true, false));
-    });
-
-    test('same-group siblings (split chapters/v2) all survive', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 10, scanlator: 'A', sourceOrder: 0),
-        ch(id: 2, number: 10, scanlator: 'A', sourceOrder: 1),
-        ch(id: 3, number: 10, scanlator: 'B', sourceOrder: 2),
-      ], const ['A']);
-      expect(rows.map((c) => c.id), [1, 2]);
-    });
-
-    test('Chapter 0 dedups like every other numbered chapter', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 0, scanlator: 'A'),
-        ch(id: 2, number: 0, scanlator: 'B'),
-        ch(id: 3, number: -1, scanlator: 'A'),
-      ], const ['A']);
-      expect(rows.map((chapter) => chapter.id), [1, 3]);
-    });
-
-    test('blank scanlator is rankable as the Unknown group', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: null),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const [kUnknownScanlatorGroup, 'B']);
-      expect(rows.single.id, 1);
-    });
-
-    test('keepChapterId forces the in-flight copy\'s group to win', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A'),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B'], keepChapterId: 1);
-      expect(rows.single.id, 1);
-    });
-
-    test('preserves input order of surviving rows', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 2, scanlator: 'A', sourceOrder: 5),
-        ch(id: 2, number: 1, scanlator: 'A', sourceOrder: 0),
-      ], const ['A']);
-      expect(rows.map((c) => c.id), [1, 2]);
-    });
-
-    test('tied in-progress copies resolve to the first in input order', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 3),
-        ch(id: 2, number: 1, scanlator: 'B', lastPageRead: 7),
-      ], const ['B']);
-      expect(rows.single.id, 1);
-    });
-
-    test('keepChapterId outranks in-progress and downloaded copies', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', lastPageRead: 5),
-        ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
-        ch(id: 3, number: 1, scanlator: 'C'),
-      ], const ['A'], keepChapterId: 3);
-      expect(rows.single.id, 3);
-    });
-
-    test('unknown keepChapterId falls back to normal rules', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A'),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B'], keepChapterId: 99);
-      expect(rows.single.id, 2);
-    });
-
-    test('keepChapterId on Chapter 0 retains the in-flight copy', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: 0, scanlator: 'A'),
-        ch(id: 2, number: 0, scanlator: 'B'),
-        ch(id: 3, number: 1, scanlator: 'B'),
-      ], const ['B'], keepChapterId: 1);
-      expect(rows.map((c) => c.id), [1, 3]);
-    });
-
-    test('aggregation preserves the winner copy\'s other fields', () {
-      final row = applyPreferredScanlators([
-        ch(id: 1, number: 1, scanlator: 'A', isRead: true, sourceOrder: 4),
-        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 9),
-      ], const ['B']).single;
-      expect((row.id, row.scanlator, row.sourceOrder, row.name),
-          (2, 'B', 9, 'Chapter 1.0'));
-    });
-
-    test('NaN chapter number passes through instead of vanishing', () {
-      final rows = applyPreferredScanlators([
-        ch(id: 1, number: double.nan, scanlator: 'A'),
-        ch(id: 2, number: 1, scanlator: 'B'),
-      ], const ['B']);
-      expect(rows.map((c) => c.id), [1, 2]);
-    });
-  });
-
-  group('duplicateChapterIds', () {
-    final list = [
-      ch(id: 1, number: 1, scanlator: 'A'),
-      ch(id: 2, number: 1, scanlator: 'B'),
-      ch(id: 3, number: 2, scanlator: 'A'),
-      ch(id: 4, number: 0, scanlator: 'A'),
-      ch(id: 5, number: 0, scanlator: 'B'),
-    ];
-    test('returns every copy of the chapter number, self included', () {
-      expect(duplicateChapterIds(list, 1), unorderedEquals([1, 2]));
-    });
-    test('Chapter 0 returns every copy', () {
-      expect(duplicateChapterIds(list, 4), unorderedEquals([4, 5]));
-    });
-    test('unknown id returns only itself', () {
-      expect(duplicateChapterIds(list, 99), [99]);
-    });
-    test('NaN number returns only self, never an empty list', () {
-      final withNan = [...list, ch(id: 6, number: double.nan, scanlator: 'A')];
-      expect(duplicateChapterIds(withNan, 6), [6]);
+      expect(rows.single.isRead, isFalse);
     });
   });
 
   group('applyReaderSessionScanlator', () {
-    test(
-      'uses the opening scanlator and falls back when it is unavailable',
-      () {
-        final rows = applyReaderSessionScanlator(
-          [
-            ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
-            ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
-            ch(id: 3, number: 2, scanlator: 'B', sourceOrder: 2),
-            ch(id: 4, number: 2, scanlator: 'A', sourceOrder: 3),
-            ch(id: 5, number: 3, scanlator: 'B', sourceOrder: 4),
-          ],
-          scanlatorGroup: 'A',
-          keepChapterId: 1,
-        );
-        expect(rows.map((chapter) => chapter.id), [1, 4, 5]);
-      });
+    test('follows the opening scanlator for confident alternate releases', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, name: 'Chapter 1', scanlator: 'B', sourceOrder: 1),
+        ch(id: 3, number: 2, name: 'Chapter 2', scanlator: 'B', sourceOrder: 2),
+        ch(id: 4, number: 2, name: 'Chapter 2', scanlator: 'A', sourceOrder: 3),
+      ], scanlatorGroup: 'A', keepChapterId: 1);
+      expect(rows.map((c) => c.id), [1, 4]);
+    });
+
+    test('uses saved preferences before source order when session group is missing', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, name: 'Chapter 1', scanlator: 'B', sourceOrder: 1),
+      ], scanlatorGroup: 'C', preferred: const ['B', 'A']);
+      expect(rows.single.id, 2);
+    });
+
+    test('offline selects the actually downloaded release without copying flags', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, name: 'Chapter 1', scanlator: 'B', sourceOrder: 1,
+            isDownloaded: true),
+      ], scanlatorGroup: 'A', offline: true);
+      expect(rows.single.id, 2);
+      expect(rows.single.isDownloaded, isTrue);
+    });
+
+    test('keeps regular and special same-number chapters independent', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 6, name: 'Chapter 6', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 6, name: 'Special 6', scanlator: 'A', sourceOrder: 1),
+      ], scanlatorGroup: 'A');
+      expect(rows.map((c) => c.id), [1, 2]);
+    });
+
+    test('different names across scanlators are not assumed duplicates', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 1, name: 'Season 1 Chapter 1', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, name: 'Season 2 Chapter 1', scanlator: 'B', sourceOrder: 1),
+      ], scanlatorGroup: 'A');
+      expect(rows.map((c) => c.id), [1, 2]);
+    });
+
+    test('same-scanlator equal-name rows are kept independent', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 1),
+      ], scanlatorGroup: 'A');
+      expect(rows.map((c) => c.id), [1, 2]);
+    });
+
+    test('preserves repeated chapter numbers from separate seasons', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, name: 'Chapter 1', scanlator: 'B', sourceOrder: 1),
+        ch(id: 3, number: 2, name: 'Chapter 2', scanlator: 'A', sourceOrder: 2),
+        ch(id: 4, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 3),
+        ch(id: 5, number: 1, name: 'Chapter 1', scanlator: 'B', sourceOrder: 4),
+      ], scanlatorGroup: 'A');
+      expect(rows.map((c) => c.id), [1, 3, 4]);
+    });
+
+    test('keeps the exact open release', () {
+      final rows = applyReaderSessionScanlator([
+        ch(id: 1, number: 1, name: 'Chapter 1', scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, name: 'Chapter 1', scanlator: 'B', sourceOrder: 1),
+      ], scanlatorGroup: 'A', keepChapterId: 2);
+      expect(rows.single.id, 2);
+    });
+  });
+
+  group('mutation identity', () {
+    test('same-number releases stay independent for read/delete actions', () {
+      final rows = [
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ];
+      expect(duplicateChapterIds(rows, 1), [1]);
+      expect(expandIdsForDuplicates(rows, [1]), [1]);
+      expect(reconcileIdsForReadNumbers(rows), isEmpty);
+    });
   });
 }

--- a/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
@@ -20,11 +20,19 @@ void main() {
   group('expandIdsForDuplicates', () {
     test('unions sibling ids per chapter number', () {
       expect(expandIdsForDuplicates(chapters, [1]), unorderedEquals([1, 2]));
-      expect(expandIdsForDuplicates(chapters, [1, 3]),
-          unorderedEquals([1, 2, 3, 4]));
+      expect(
+        expandIdsForDuplicates(chapters, [1, 3]),
+        unorderedEquals([1, 2, 3, 4]),
+      );
     });
     test('identity when the raw list is unavailable', () {
       expect(expandIdsForDuplicates(null, [1, 3]), [1, 3]);
+    });
+
+    test('expands duplicate reads without a scanlator preference', () {
+      // The raw chapter list, rather than the display preference, is the
+      // source of truth for mutations.
+      expect(expandIdsForDuplicates(chapters, [3]), unorderedEquals([3, 4]));
     });
   });
 
@@ -36,8 +44,7 @@ void main() {
     });
     test('empty when nothing to mark', () {
       expect(
-        reconcileIdsForReadNumbers(
-            [ch(id: 1, number: 1, scanlator: 'A')]),
+        reconcileIdsForReadNumbers([ch(id: 1, number: 1, scanlator: 'A')]),
         isEmpty,
       );
     });
@@ -49,8 +56,26 @@ void main() {
         ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
         ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
       ];
-      expect(
-          expandIdsForDuplicates(downloaded, [1]), unorderedEquals([1, 2]));
+      expect(expandIdsForDuplicates(downloaded, [1]), unorderedEquals([1, 2]));
+    });
+  });
+
+  group('skipDuplicateChaptersForNavigation', () {
+    test('keeps the open copy and skips same-number releases', () {
+      final navigation = skipDuplicateChaptersForNavigation([
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'B'),
+        ch(id: 3, number: 2, scanlator: 'A'),
+      ], keepChapterId: 2);
+      expect(navigation.map((chapter) => chapter.id), [2, 3]);
+    });
+
+    test('leaves unnumbered chapters independent', () {
+      final navigation = skipDuplicateChaptersForNavigation([
+        ch(id: 1, number: 0),
+        ch(id: 2, number: 0),
+      ], keepChapterId: 1);
+      expect(navigation.map((chapter) => chapter.id), [1, 2]);
     });
   });
 }

--- a/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
@@ -20,10 +20,8 @@ void main() {
   group('expandIdsForDuplicates', () {
     test('unions sibling ids per chapter number', () {
       expect(expandIdsForDuplicates(chapters, [1]), unorderedEquals([1, 2]));
-      expect(
-        expandIdsForDuplicates(chapters, [1, 3]),
-        unorderedEquals([1, 2, 3, 4]),
-      );
+      expect(expandIdsForDuplicates(chapters, [1, 3]),
+          unorderedEquals([1, 2, 3, 4]));
     });
     test('identity when the raw list is unavailable', () {
       expect(expandIdsForDuplicates(null, [1, 3]), [1, 3]);
@@ -55,7 +53,8 @@ void main() {
     });
     test('empty when nothing to mark', () {
       expect(
-        reconcileIdsForReadNumbers([ch(id: 1, number: 1, scanlator: 'A')]),
+        reconcileIdsForReadNumbers(
+            [ch(id: 1, number: 1, scanlator: 'A')]),
         isEmpty,
       );
     });
@@ -67,7 +66,8 @@ void main() {
         ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
         ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
       ];
-      expect(expandIdsForDuplicates(downloaded, [1]), unorderedEquals([1, 2]));
+      expect(
+          expandIdsForDuplicates(downloaded, [1]), unorderedEquals([1, 2]));
     });
   });
 

--- a/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
@@ -10,92 +10,45 @@ import 'package:tsumiru/src/features/manga_book/presentation/manga_details/contr
 import 'chapter_test_helpers.dart';
 
 void main() {
-  final chapters = [
-    ch(id: 1, number: 1, scanlator: 'A', isRead: true),
-    ch(id: 2, number: 1, scanlator: 'B'),
-    ch(id: 3, number: 2, scanlator: 'A'),
-    ch(id: 4, number: 2, scanlator: 'B'),
-  ];
-
-  group('expandIdsForDuplicates', () {
-    test('unions sibling ids per chapter number', () {
-      expect(expandIdsForDuplicates(chapters, [1]), unorderedEquals([1, 2]));
-      expect(expandIdsForDuplicates(chapters, [1, 3]),
-          unorderedEquals([1, 2, 3, 4]));
-    });
-    test('identity when the raw list is unavailable', () {
-      expect(expandIdsForDuplicates(null, [1, 3]), [1, 3]);
-    });
-
-    test('expands duplicate reads without a scanlator preference', () {
-      // The raw chapter list, rather than the display preference, is the
-      // source of truth for mutations.
-      expect(expandIdsForDuplicates(chapters, [3]), unorderedEquals([3, 4]));
-    });
-
-    test('expands duplicate Chapter 0 releases', () {
-      final zeroChapters = [
-        ch(id: 5, number: 0, scanlator: 'A'),
-        ch(id: 6, number: 0, scanlator: 'B'),
-      ];
-      expect(
-        expandIdsForDuplicates(zeroChapters, [5]),
-        unorderedEquals([5, 6]),
-      );
-    });
-  });
-
-  group('reconcileIdsForReadNumbers', () {
-    test('returns unread copies of read numbers only', () {
-      // number 1 has a read copy (id 1) → its unread sibling id 2 qualifies;
-      // number 2 has no read copy → ids 3,4 untouched.
-      expect(reconcileIdsForReadNumbers(chapters), [2]);
-    });
-    test('empty when nothing to mark', () {
-      expect(
-        reconcileIdsForReadNumbers(
-            [ch(id: 1, number: 1, scanlator: 'A')]),
-        isEmpty,
-      );
-    });
-  });
-
-  group('expandIdsForDuplicates (delete propagation)', () {
-    test('covers a hidden downloaded copy', () {
-      final downloaded = [
-        ch(id: 1, number: 1, scanlator: 'A', isDownloaded: true),
-        ch(id: 2, number: 1, scanlator: 'B', isDownloaded: true),
-      ];
-      expect(
-          expandIdsForDuplicates(downloaded, [1]), unorderedEquals([1, 2]));
-    });
-  });
-
-  group('skipDuplicateChaptersForNavigation', () {
-    test('keeps the open copy and skips same-number releases', () {
-      final navigation = skipDuplicateChaptersForNavigation([
+  group('read/delete mutation matching', () {
+    test('does not propagate across same-number scanlators', () {
+      final chapters = [
         ch(id: 1, number: 1, scanlator: 'A'),
         ch(id: 2, number: 1, scanlator: 'B'),
-        ch(id: 3, number: 2, scanlator: 'A'),
-      ], keepChapterId: 2);
-      expect(navigation.map((chapter) => chapter.id), [2, 3]);
+      ];
+      expect(expandIdsForDuplicates(chapters, [1]), [1]);
     });
 
-    test('skips duplicate Chapter 0 releases', () {
-      final navigation = skipDuplicateChaptersForNavigation([
+    test('does not propagate between a regular and special chapter', () {
+      final chapters = [
+        ch(id: 1, number: 6, name: 'Chapter 6', scanlator: 'A'),
+        ch(id: 2, number: 6, name: 'Special 6', scanlator: 'A'),
+      ];
+      expect(expandIdsForDuplicates(chapters, [1]), [1]);
+    });
+
+    test('does not propagate across restarted season numbering', () {
+      final chapters = [
+        ch(id: 1, number: 1, name: 'Season 1 Chapter 1', scanlator: 'A'),
+        ch(id: 2, number: 1, name: 'Season 2 Chapter 1', scanlator: 'B'),
+      ];
+      expect(expandIdsForDuplicates(chapters, [1]), [1]);
+    });
+
+    test('does not propagate Chapter 0 by number alone', () {
+      final chapters = [
         ch(id: 1, number: 0, scanlator: 'A'),
         ch(id: 2, number: 0, scanlator: 'B'),
-        ch(id: 3, number: 1, scanlator: 'A'),
-      ], keepChapterId: 1);
-      expect(navigation.map((chapter) => chapter.id), [1, 3]);
+      ];
+      expect(expandIdsForDuplicates(chapters, [1]), [1]);
     });
 
-    test('leaves negative-numbered chapters independent', () {
-      final navigation = skipDuplicateChaptersForNavigation([
-        ch(id: 1, number: -1),
-        ch(id: 2, number: -1),
-      ], keepChapterId: 1);
-      expect(navigation.map((chapter) => chapter.id), [1, 2]);
+    test('never reconciles read state by chapter number', () {
+      final chapters = [
+        ch(id: 1, number: 1, scanlator: 'A', isRead: true),
+        ch(id: 2, number: 1, scanlator: 'B'),
+      ];
+      expect(reconcileIdsForReadNumbers(chapters), isEmpty);
     });
   });
 }

--- a/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
@@ -34,6 +34,17 @@ void main() {
       // source of truth for mutations.
       expect(expandIdsForDuplicates(chapters, [3]), unorderedEquals([3, 4]));
     });
+
+    test('expands duplicate Chapter 0 releases', () {
+      final zeroChapters = [
+        ch(id: 5, number: 0, scanlator: 'A'),
+        ch(id: 6, number: 0, scanlator: 'B'),
+      ];
+      expect(
+        expandIdsForDuplicates(zeroChapters, [5]),
+        unorderedEquals([5, 6]),
+      );
+    });
   });
 
   group('reconcileIdsForReadNumbers', () {
@@ -70,10 +81,19 @@ void main() {
       expect(navigation.map((chapter) => chapter.id), [2, 3]);
     });
 
-    test('leaves unnumbered chapters independent', () {
+    test('skips duplicate Chapter 0 releases', () {
       final navigation = skipDuplicateChaptersForNavigation([
-        ch(id: 1, number: 0),
-        ch(id: 2, number: 0),
+        ch(id: 1, number: 0, scanlator: 'A'),
+        ch(id: 2, number: 0, scanlator: 'B'),
+        ch(id: 3, number: 1, scanlator: 'A'),
+      ], keepChapterId: 1);
+      expect(navigation.map((chapter) => chapter.id), [1, 3]);
+    });
+
+    test('leaves negative-numbered chapters independent', () {
+      final navigation = skipDuplicateChaptersForNavigation([
+        ch(id: 1, number: -1),
+        ch(id: 2, number: -1),
       ], keepChapterId: 1);
       expect(navigation.map((chapter) => chapter.id), [1, 2]);
     });

--- a/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
+++ b/test/src/features/manga_book/manga_details/scanlator_propagation_test.dart
@@ -11,12 +11,13 @@ import 'chapter_test_helpers.dart';
 
 void main() {
   group('read/delete mutation matching', () {
-    test('does not propagate across same-number scanlators', () {
+    test('propagates across confident alternate releases', () {
       final chapters = [
         ch(id: 1, number: 1, scanlator: 'A'),
         ch(id: 2, number: 1, scanlator: 'B'),
       ];
-      expect(expandIdsForDuplicates(chapters, [1]), [1]);
+      expect(expandIdsForDuplicates(chapters, [1]), [1, 2]);
+      expect(expandIdsForDuplicates(chapters, [2]), [1, 2]);
     });
 
     test('does not propagate between a regular and special chapter', () {
@@ -35,18 +36,66 @@ void main() {
       expect(expandIdsForDuplicates(chapters, [1]), [1]);
     });
 
-    test('does not propagate Chapter 0 by number alone', () {
+    test('propagates a confidently matched Chapter 0', () {
       final chapters = [
         ch(id: 1, number: 0, scanlator: 'A'),
         ch(id: 2, number: 0, scanlator: 'B'),
       ];
+      expect(expandIdsForDuplicates(chapters, [1]), [1, 2]);
+    });
+
+    test('does not propagate same-scanlator rows', () {
+      final chapters = [
+        ch(id: 1, number: 1, scanlator: 'A'),
+        ch(id: 2, number: 1, scanlator: 'A'),
+      ];
       expect(expandIdsForDuplicates(chapters, [1]), [1]);
     });
 
-    test('never reconciles read state by chapter number', () {
+    test('does not propagate otherwise-identical non-adjacent rows', () {
+      final chapters = [
+        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 2, scanlator: 'C', sourceOrder: 1),
+        ch(id: 3, number: 1, scanlator: 'B', sourceOrder: 2),
+      ];
+      expect(expandIdsForDuplicates(chapters, [1]), [1]);
+      expect(expandIdsForDuplicates(chapters, [3]), [3]);
+    });
+
+    test('unions matches for bulk read/delete actions', () {
+      final chapters = [
+        ch(id: 1, number: 1, scanlator: 'A', sourceOrder: 0),
+        ch(id: 2, number: 1, scanlator: 'B', sourceOrder: 1),
+        ch(id: 3, number: 2, scanlator: 'A', sourceOrder: 2),
+        ch(id: 4, number: 2, scanlator: 'B', sourceOrder: 3),
+      ];
+      expect(expandIdsForDuplicates(chapters, [1, 3]), [1, 2, 3, 4]);
+    });
+
+    test('identity when the raw chapter list is unavailable', () {
+      expect(expandIdsForDuplicates(null, [1, 3]), [1, 3]);
+    });
+  });
+
+  group('read-state reconciliation', () {
+    test('marks only unread releases in confident groups', () {
       final chapters = [
         ch(id: 1, number: 1, scanlator: 'A', isRead: true),
         ch(id: 2, number: 1, scanlator: 'B'),
+        ch(id: 3, number: 2, scanlator: 'A'),
+        ch(id: 4, number: 2, scanlator: 'B'),
+      ];
+      expect(reconcileIdsForReadNumbers(chapters), [2]);
+    });
+
+    test('does not reconcile uncertain same-number rows', () {
+      final chapters = [
+        ch(id: 1, number: 6, name: 'Chapter 6', scanlator: 'A',
+            isRead: true),
+        ch(id: 2, number: 6, name: 'Special 6', scanlator: 'B'),
+        ch(id: 3, number: 1, name: 'Season 1 Chapter 1', scanlator: 'A',
+            isRead: true),
+        ch(id: 4, number: 1, name: 'Season 2 Chapter 1', scanlator: 'B'),
       ];
       expect(reconcileIdsForReadNumbers(chapters), isEmpty);
     });

--- a/test/src/features/manga_book/next_prev_chapter_test.dart
+++ b/test/src/features/manga_book/next_prev_chapter_test.dart
@@ -9,24 +9,28 @@ import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generat
 import 'package:tsumiru/src/features/manga_book/presentation/manga_details/controller/manga_details_controller.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
 
-ChapterDto _chapter({required int id, required String name, int sourceOrder = 0}) =>
-    Fragment$ChapterDto(
-      chapterNumber: 0,
-      fetchedAt: '0',
-      id: id,
-      isBookmarked: false,
-      isDownloaded: false,
-      isRead: false,
-      lastPageRead: 0,
-      lastReadAt: '0',
-      mangaId: 1,
-      name: name,
-      pageCount: 0,
-      sourceOrder: sourceOrder,
-      uploadDate: '0',
-      url: '',
-      meta: const [],
-    );
+ChapterDto _chapter({
+  required int id,
+  required String name,
+  int sourceOrder = 0,
+  double number = 0,
+}) => Fragment$ChapterDto(
+  chapterNumber: number,
+  fetchedAt: '0',
+  id: id,
+  isBookmarked: false,
+  isDownloaded: false,
+  isRead: false,
+  lastPageRead: 0,
+  lastReadAt: '0',
+  mangaId: 1,
+  name: name,
+  pageCount: 0,
+  sourceOrder: sourceOrder,
+  uploadDate: '0',
+  url: '',
+  meta: const [],
+);
 
 class _FakeChapterList extends MangaChapterList {
   _FakeChapterList(this.chapters);
@@ -42,8 +46,9 @@ Future<ProviderContainer> _container(List<ChapterDto> chapters) async {
   final c = ProviderContainer(
     overrides: [
       sharedPreferencesProvider.overrideWithValue(prefs),
-      mangaChapterListProvider(mangaId: 1)
-          .overrideWith(() => _FakeChapterList(chapters)),
+      mangaChapterListProvider(
+        mangaId: 1,
+      ).overrideWith(() => _FakeChapterList(chapters)),
     ],
   );
   addTearDown(c.dispose);
@@ -60,10 +65,9 @@ void main() {
 
   test('a chapter absent from the filtered list has NO neighbours', () async {
     final c = await _container(chapters);
-    final pair = c.read(getNextAndPreviousChaptersProvider(
-      mangaId: 1,
-      chapterId: 9999,
-    ));
+    final pair = c.read(
+      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 9999),
+    );
     expect(pair, isNotNull);
     // Before the fix, indexWhere == -1 resolved one side to filteredList[0].
     expect(pair!.first, isNull);
@@ -72,10 +76,9 @@ void main() {
 
   test('a middle chapter resolves both neighbours', () async {
     final c = await _container(chapters);
-    final pair = c.read(getNextAndPreviousChaptersProvider(
-      mangaId: 1,
-      chapterId: 2,
-    ));
+    final pair = c.read(
+      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2),
+    );
     expect(pair, isNotNull);
     expect(pair!.first, isNotNull);
     expect(pair.second, isNotNull);
@@ -83,12 +86,25 @@ void main() {
 
   test('an edge chapter resolves exactly one neighbour', () async {
     final c = await _container(chapters);
-    final pair = c.read(getNextAndPreviousChaptersProvider(
-      mangaId: 1,
-      chapterId: 3,
-    ));
+    final pair = c.read(
+      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 3),
+    );
     expect(pair, isNotNull);
     // One side present, one absent — never two, never zero for an in-list edge.
     expect([pair!.first, pair.second].where((e) => e != null).length, 1);
+  });
+
+  test('reader navigation skips duplicate chapter-number releases', () async {
+    final c = await _container([
+      _chapter(id: 1, name: 'One A', number: 1, sourceOrder: 1),
+      _chapter(id: 2, name: 'One B', number: 1, sourceOrder: 2),
+      _chapter(id: 3, name: 'Two', number: 2, sourceOrder: 3),
+    ]);
+    final pair = c.read(
+      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1),
+    );
+    // Default source order is descending, so moving forward from Chapter 1
+    // reaches Chapter 2 directly rather than its duplicate release.
+    expect(pair!.first?.id, 3);
   });
 }

--- a/test/src/features/manga_book/next_prev_chapter_test.dart
+++ b/test/src/features/manga_book/next_prev_chapter_test.dart
@@ -58,9 +58,9 @@ Future<ProviderContainer> _container(List<ChapterDto> chapters) async {
 
 void main() {
   final chapters = [
-    _chapter(id: 1, name: 'One', sourceOrder: 1),
-    _chapter(id: 2, name: 'Two', sourceOrder: 2),
-    _chapter(id: 3, name: 'Three', sourceOrder: 3),
+    _chapter(id: 1, name: 'One', number: 1, sourceOrder: 1),
+    _chapter(id: 2, name: 'Two', number: 2, sourceOrder: 2),
+    _chapter(id: 3, name: 'Three', number: 3, sourceOrder: 3),
   ];
 
   test('a chapter absent from the filtered list has NO neighbours', () async {

--- a/test/src/features/manga_book/next_prev_chapter_test.dart
+++ b/test/src/features/manga_book/next_prev_chapter_test.dart
@@ -14,23 +14,24 @@ ChapterDto _chapter({
   required String name,
   int sourceOrder = 0,
   double number = 0,
-}) => Fragment$ChapterDto(
-  chapterNumber: number,
-  fetchedAt: '0',
-  id: id,
-  isBookmarked: false,
-  isDownloaded: false,
-  isRead: false,
-  lastPageRead: 0,
-  lastReadAt: '0',
-  mangaId: 1,
-  name: name,
-  pageCount: 0,
-  sourceOrder: sourceOrder,
-  uploadDate: '0',
-  url: '',
-  meta: const [],
-);
+}) =>
+    Fragment$ChapterDto(
+      chapterNumber: number,
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: name,
+      pageCount: 0,
+      sourceOrder: sourceOrder,
+      uploadDate: '0',
+      url: '',
+      meta: const [],
+    );
 
 class _FakeChapterList extends MangaChapterList {
   _FakeChapterList(this.chapters);
@@ -46,9 +47,8 @@ Future<ProviderContainer> _container(List<ChapterDto> chapters) async {
   final c = ProviderContainer(
     overrides: [
       sharedPreferencesProvider.overrideWithValue(prefs),
-      mangaChapterListProvider(
-        mangaId: 1,
-      ).overrideWith(() => _FakeChapterList(chapters)),
+      mangaChapterListProvider(mangaId: 1)
+          .overrideWith(() => _FakeChapterList(chapters)),
     ],
   );
   addTearDown(c.dispose);
@@ -65,9 +65,10 @@ void main() {
 
   test('a chapter absent from the filtered list has NO neighbours', () async {
     final c = await _container(chapters);
-    final pair = c.read(
-      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 9999),
-    );
+    final pair = c.read(getNextAndPreviousChaptersProvider(
+      mangaId: 1,
+      chapterId: 9999,
+    ));
     expect(pair, isNotNull);
     // Before the fix, indexWhere == -1 resolved one side to filteredList[0].
     expect(pair!.first, isNull);
@@ -76,9 +77,10 @@ void main() {
 
   test('a middle chapter resolves both neighbours', () async {
     final c = await _container(chapters);
-    final pair = c.read(
-      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2),
-    );
+    final pair = c.read(getNextAndPreviousChaptersProvider(
+      mangaId: 1,
+      chapterId: 2,
+    ));
     expect(pair, isNotNull);
     expect(pair!.first, isNotNull);
     expect(pair.second, isNotNull);
@@ -86,9 +88,10 @@ void main() {
 
   test('an edge chapter resolves exactly one neighbour', () async {
     final c = await _container(chapters);
-    final pair = c.read(
-      getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 3),
-    );
+    final pair = c.read(getNextAndPreviousChaptersProvider(
+      mangaId: 1,
+      chapterId: 3,
+    ));
     expect(pair, isNotNull);
     // One side present, one absent — never two, never zero for an in-list edge.
     expect([pair!.first, pair.second].where((e) => e != null).length, 1);

--- a/test/src/features/manga_book/next_prev_chapter_test.dart
+++ b/test/src/features/manga_book/next_prev_chapter_test.dart
@@ -14,6 +14,7 @@ ChapterDto _chapter({
   required String name,
   int sourceOrder = 0,
   double number = 0,
+  String? scanlator,
 }) =>
     Fragment$ChapterDto(
       chapterNumber: number,
@@ -30,6 +31,7 @@ ChapterDto _chapter({
       sourceOrder: sourceOrder,
       uploadDate: '0',
       url: '',
+      scanlator: scanlator,
       meta: const [],
     );
 
@@ -97,7 +99,7 @@ void main() {
     expect([pair!.first, pair.second].where((e) => e != null).length, 1);
   });
 
-  test('reader navigation skips duplicate chapter-number releases', () async {
+  test('reader navigation preserves uncertain same-number chapters', () async {
     final c = await _container([
       _chapter(id: 1, name: 'One A', number: 1, sourceOrder: 1),
       _chapter(id: 2, name: 'One B', number: 1, sourceOrder: 2),
@@ -106,8 +108,23 @@ void main() {
     final pair = c.read(
       getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1),
     );
-    // Default source order is descending, so moving forward from Chapter 1
-    // reaches Chapter 2 directly rather than its duplicate release.
+    expect(pair!.first?.id, 2);
+  });
+
+  test('reader follows the opening scanlator for confident releases', () async {
+    final c = await _container([
+      _chapter(id: 1, name: 'Chapter 1', number: 1, sourceOrder: 1,
+          scanlator: 'A'),
+      _chapter(id: 2, name: 'Chapter 1', number: 1, sourceOrder: 2,
+          scanlator: 'B'),
+      _chapter(id: 3, name: 'Chapter 2', number: 2, sourceOrder: 3,
+          scanlator: 'A'),
+    ]);
+    final pair = c.read(getNextAndPreviousChaptersProvider(
+      mangaId: 1,
+      chapterId: 1,
+      readerScanlatorGroup: 'A',
+    ));
     expect(pair!.first?.id, 3);
   });
 }

--- a/test/src/features/manga_book/reader/infinity_continuous_horizontal_test.dart
+++ b/test/src/features/manga_book/reader/infinity_continuous_horizontal_test.dart
@@ -49,8 +49,10 @@ class _FakeMangaWithId extends MangaWithId {
   Future<MangaDto?> build({required int mangaId}) async => manga;
 }
 
-GraphQLClient _dummyClient() =>
-    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
 
 class _FakeTrackerRepository extends TrackerRepository {
   _FakeTrackerRepository() : super(_dummyClient());
@@ -67,9 +69,8 @@ class _QuietRepo extends Fake implements MangaBookRepository {
 }
 
 List<String> _localPages(int count, String tag) {
-  final dir = Directory.systemTemp.createTempSync(
-    'tsumiru-scrollback-horiz-$tag-',
-  );
+  final dir =
+      Directory.systemTemp.createTempSync('tsumiru-scrollback-horiz-$tag-');
   addTearDown(() {
     if (dir.existsSync()) dir.deleteSync(recursive: true);
   });
@@ -81,26 +82,30 @@ List<String> _localPages(int count, String tag) {
 }
 
 MangaDto _horizontalContinuousManga(ReaderMode mode) => Fragment$MangaDto(
-  id: 1,
-  title: 'Test Horizontal Continuous',
-  bookmarkCount: 0,
-  chapters: Fragment$MangaDto$chapters(totalCount: 2),
-  downloadCount: 0,
-  genre: const [],
-  inLibrary: true,
-  inLibraryAt: '0',
-  initialized: true,
-  meta: [
-    Fragment$MangaDto$meta(key: MangaMetaKeys.readerMode.key, value: mode.name),
-  ],
-  sourceId: '1',
-  status: Enum$MangaStatus.ONGOING,
-  categories: Fragment$MangaDto$categories(nodes: const []),
-  trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
-  unreadCount: 2,
-  updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
-  url: '/manga/1',
-);
+      id: 1,
+      title: 'Test Horizontal Continuous',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 2),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: mode.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 2,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
 
 ChapterDto _chapter({required int id, required int sourceOrder}) =>
     Fragment$ChapterDto(
@@ -122,9 +127,9 @@ ChapterDto _chapter({required int id, required int sourceOrder}) =>
     );
 
 ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
-  chapter: ChapterPagesChapterDto(id: id, pageCount: count),
-  pages: _localPages(count, 'c$id'),
-);
+      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+      pages: _localPages(count, 'c$id'),
+    );
 
 /// Pumps the reader open on chapter 2 page 0 (chapter 1 is its previous), in
 /// [mode] (continuousHorizontalLTR/RTL).
@@ -149,22 +154,15 @@ Future<void> _pumpReaderOnChapter2(
         sharedPreferencesProvider.overrideWithValue(prefs),
         mangaBookRepositoryProvider.overrideWithValue(_QuietRepo()),
         mangaWithIdProvider(mangaId: 1).overrideWith(
-          () => _FakeMangaWithId(_horizontalContinuousManga(mode)),
-        ),
+            () => _FakeMangaWithId(_horizontalContinuousManga(mode))),
         chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
         chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
         chapterPagesProvider(chapterId: 1).overrideWith((ref) => prevPages()),
         chapterPagesProvider(chapterId: 2).overrideWith((ref) => _pages(2, 3)),
-        getNextAndPreviousChaptersProvider(
-          mangaId: 1,
-          chapterId: 2,
-          readerScanlatorGroup: '',
-        ).overrideWithValue((first: null, second: ch1)),
-        getNextAndPreviousChaptersProvider(
-          mangaId: 1,
-          chapterId: 1,
-          readerScanlatorGroup: '',
-        ).overrideWithValue((first: ch2, second: null)),
+        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2, readerScanlatorGroup: '')
+            .overrideWithValue((first: null, second: ch1)),
+        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1, readerScanlatorGroup: '')
+            .overrideWithValue((first: ch2, second: null)),
         trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
       ],
       child: MaterialApp(
@@ -201,9 +199,8 @@ void main() {
     MultiChapterContinuousReaderMode.edgeAttemptCooldown = Duration.zero;
   });
   tearDown(() {
-    MultiChapterContinuousReaderMode.edgeAttemptCooldown = const Duration(
-      seconds: 4,
-    );
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown =
+        const Duration(seconds: 4);
   });
 
   for (final mode in [
@@ -211,58 +208,50 @@ void main() {
     ReaderMode.continuousHorizontalRTL,
   ]) {
     testWidgets(
-      '$mode: mounts as a real horizontal continuous strip (never the '
-      'paged pager)',
-      (tester) async {
-        await _pumpReaderOnChapter2(
-          tester,
-          mode: mode,
-          prevPages: () async => _pages(1, 3),
-        );
+        '$mode: mounts as a real horizontal continuous strip (never the '
+        'paged pager)', (tester) async {
+      await _pumpReaderOnChapter2(
+        tester,
+        mode: mode,
+        prevPages: () async => _pages(1, 3),
+      );
 
-        final widget = tester.widget<MultiChapterContinuousReaderMode>(
-          find.byType(MultiChapterContinuousReaderMode),
-        );
-        expect(widget.scrollDirection, Axis.horizontal);
-        expect(widget.reverse, mode == ReaderMode.continuousHorizontalRTL);
-        expect(tester.takeException(), isNull);
-      },
-    );
+      final widget = tester.widget<MultiChapterContinuousReaderMode>(
+        find.byType(MultiChapterContinuousReaderMode),
+      );
+      expect(widget.scrollDirection, Axis.horizontal);
+      expect(widget.reverse, mode == ReaderMode.continuousHorizontalRTL);
+      expect(tester.takeException(), isNull);
+    });
 
     testWidgets(
-      '$mode: resume at page 0, a drag at the clamp loads the previous '
-      'chapter',
-      (tester) async {
-        var prevFetches = 0;
-        await _pumpReaderOnChapter2(
-          tester,
-          mode: mode,
-          prevPages: () async {
-            prevFetches++;
-            // Real delay: an unheld autoDispose fetch would get disposed
-            // mid-flight and never complete.
-            await Future<void>.delayed(const Duration(milliseconds: 100));
-            return _pages(1, 3);
-          },
-        );
+        '$mode: resume at page 0, a drag at the clamp loads the previous '
+        'chapter', (tester) async {
+      var prevFetches = 0;
+      await _pumpReaderOnChapter2(
+        tester,
+        mode: mode,
+        prevPages: () async {
+          prevFetches++;
+          // Real delay: an unheld autoDispose fetch would get disposed
+          // mid-flight and never complete.
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return _pages(1, 3);
+        },
+      );
 
-        await _dragTowardPreviousChapter(
-          tester,
-          reverse: mode == ReaderMode.continuousHorizontalRTL,
-        );
-        await tester.pump(const Duration(milliseconds: 200));
-        await tester.pumpAndSettle();
+      await _dragTowardPreviousChapter(
+        tester,
+        reverse: mode == ReaderMode.continuousHorizontalRTL,
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
 
-        expect(
-          prevFetches,
-          greaterThanOrEqualTo(1),
-          reason:
-              'edge drag on the horizontal strip never asked for the '
+      expect(prevFetches, greaterThanOrEqualTo(1),
+          reason: 'edge drag on the horizontal strip never asked for the '
               'previous chapter — the boundary trigger only works on the '
-              'vertical axis',
-        );
-        expect(tester.takeException(), isNull);
-      },
-    );
+              'vertical axis');
+      expect(tester.takeException(), isNull);
+    });
   }
 }

--- a/test/src/features/manga_book/reader/infinity_continuous_horizontal_test.dart
+++ b/test/src/features/manga_book/reader/infinity_continuous_horizontal_test.dart
@@ -49,10 +49,8 @@ class _FakeMangaWithId extends MangaWithId {
   Future<MangaDto?> build({required int mangaId}) async => manga;
 }
 
-GraphQLClient _dummyClient() => GraphQLClient(
-      link: HttpLink('http://localhost:0'),
-      cache: GraphQLCache(),
-    );
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
 
 class _FakeTrackerRepository extends TrackerRepository {
   _FakeTrackerRepository() : super(_dummyClient());
@@ -69,8 +67,9 @@ class _QuietRepo extends Fake implements MangaBookRepository {
 }
 
 List<String> _localPages(int count, String tag) {
-  final dir =
-      Directory.systemTemp.createTempSync('tsumiru-scrollback-horiz-$tag-');
+  final dir = Directory.systemTemp.createTempSync(
+    'tsumiru-scrollback-horiz-$tag-',
+  );
   addTearDown(() {
     if (dir.existsSync()) dir.deleteSync(recursive: true);
   });
@@ -82,30 +81,26 @@ List<String> _localPages(int count, String tag) {
 }
 
 MangaDto _horizontalContinuousManga(ReaderMode mode) => Fragment$MangaDto(
-      id: 1,
-      title: 'Test Horizontal Continuous',
-      bookmarkCount: 0,
-      chapters: Fragment$MangaDto$chapters(totalCount: 2),
-      downloadCount: 0,
-      genre: const [],
-      inLibrary: true,
-      inLibraryAt: '0',
-      initialized: true,
-      meta: [
-        Fragment$MangaDto$meta(
-          key: MangaMetaKeys.readerMode.key,
-          value: mode.name,
-        ),
-      ],
-      sourceId: '1',
-      status: Enum$MangaStatus.ONGOING,
-      categories: Fragment$MangaDto$categories(nodes: const []),
-      trackRecords:
-          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
-      unreadCount: 2,
-      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
-      url: '/manga/1',
-    );
+  id: 1,
+  title: 'Test Horizontal Continuous',
+  bookmarkCount: 0,
+  chapters: Fragment$MangaDto$chapters(totalCount: 2),
+  downloadCount: 0,
+  genre: const [],
+  inLibrary: true,
+  inLibraryAt: '0',
+  initialized: true,
+  meta: [
+    Fragment$MangaDto$meta(key: MangaMetaKeys.readerMode.key, value: mode.name),
+  ],
+  sourceId: '1',
+  status: Enum$MangaStatus.ONGOING,
+  categories: Fragment$MangaDto$categories(nodes: const []),
+  trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+  unreadCount: 2,
+  updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+  url: '/manga/1',
+);
 
 ChapterDto _chapter({required int id, required int sourceOrder}) =>
     Fragment$ChapterDto(
@@ -127,9 +122,9 @@ ChapterDto _chapter({required int id, required int sourceOrder}) =>
     );
 
 ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
-      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
-      pages: _localPages(count, 'c$id'),
-    );
+  chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+  pages: _localPages(count, 'c$id'),
+);
 
 /// Pumps the reader open on chapter 2 page 0 (chapter 1 is its previous), in
 /// [mode] (continuousHorizontalLTR/RTL).
@@ -154,15 +149,22 @@ Future<void> _pumpReaderOnChapter2(
         sharedPreferencesProvider.overrideWithValue(prefs),
         mangaBookRepositoryProvider.overrideWithValue(_QuietRepo()),
         mangaWithIdProvider(mangaId: 1).overrideWith(
-            () => _FakeMangaWithId(_horizontalContinuousManga(mode))),
+          () => _FakeMangaWithId(_horizontalContinuousManga(mode)),
+        ),
         chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
         chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
         chapterPagesProvider(chapterId: 1).overrideWith((ref) => prevPages()),
         chapterPagesProvider(chapterId: 2).overrideWith((ref) => _pages(2, 3)),
-        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
-            .overrideWithValue((first: null, second: ch1)),
-        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
-            .overrideWithValue((first: ch2, second: null)),
+        getNextAndPreviousChaptersProvider(
+          mangaId: 1,
+          chapterId: 2,
+          readerScanlatorGroup: '',
+        ).overrideWithValue((first: null, second: ch1)),
+        getNextAndPreviousChaptersProvider(
+          mangaId: 1,
+          chapterId: 1,
+          readerScanlatorGroup: '',
+        ).overrideWithValue((first: ch2, second: null)),
         trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
       ],
       child: MaterialApp(
@@ -199,8 +201,9 @@ void main() {
     MultiChapterContinuousReaderMode.edgeAttemptCooldown = Duration.zero;
   });
   tearDown(() {
-    MultiChapterContinuousReaderMode.edgeAttemptCooldown =
-        const Duration(seconds: 4);
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown = const Duration(
+      seconds: 4,
+    );
   });
 
   for (final mode in [
@@ -208,50 +211,58 @@ void main() {
     ReaderMode.continuousHorizontalRTL,
   ]) {
     testWidgets(
-        '$mode: mounts as a real horizontal continuous strip (never the '
-        'paged pager)', (tester) async {
-      await _pumpReaderOnChapter2(
-        tester,
-        mode: mode,
-        prevPages: () async => _pages(1, 3),
-      );
+      '$mode: mounts as a real horizontal continuous strip (never the '
+      'paged pager)',
+      (tester) async {
+        await _pumpReaderOnChapter2(
+          tester,
+          mode: mode,
+          prevPages: () async => _pages(1, 3),
+        );
 
-      final widget = tester.widget<MultiChapterContinuousReaderMode>(
-        find.byType(MultiChapterContinuousReaderMode),
-      );
-      expect(widget.scrollDirection, Axis.horizontal);
-      expect(widget.reverse, mode == ReaderMode.continuousHorizontalRTL);
-      expect(tester.takeException(), isNull);
-    });
+        final widget = tester.widget<MultiChapterContinuousReaderMode>(
+          find.byType(MultiChapterContinuousReaderMode),
+        );
+        expect(widget.scrollDirection, Axis.horizontal);
+        expect(widget.reverse, mode == ReaderMode.continuousHorizontalRTL);
+        expect(tester.takeException(), isNull);
+      },
+    );
 
     testWidgets(
-        '$mode: resume at page 0, a drag at the clamp loads the previous '
-        'chapter', (tester) async {
-      var prevFetches = 0;
-      await _pumpReaderOnChapter2(
-        tester,
-        mode: mode,
-        prevPages: () async {
-          prevFetches++;
-          // Real delay: an unheld autoDispose fetch would get disposed
-          // mid-flight and never complete.
-          await Future<void>.delayed(const Duration(milliseconds: 100));
-          return _pages(1, 3);
-        },
-      );
+      '$mode: resume at page 0, a drag at the clamp loads the previous '
+      'chapter',
+      (tester) async {
+        var prevFetches = 0;
+        await _pumpReaderOnChapter2(
+          tester,
+          mode: mode,
+          prevPages: () async {
+            prevFetches++;
+            // Real delay: an unheld autoDispose fetch would get disposed
+            // mid-flight and never complete.
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+            return _pages(1, 3);
+          },
+        );
 
-      await _dragTowardPreviousChapter(
-        tester,
-        reverse: mode == ReaderMode.continuousHorizontalRTL,
-      );
-      await tester.pump(const Duration(milliseconds: 200));
-      await tester.pumpAndSettle();
+        await _dragTowardPreviousChapter(
+          tester,
+          reverse: mode == ReaderMode.continuousHorizontalRTL,
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+        await tester.pumpAndSettle();
 
-      expect(prevFetches, greaterThanOrEqualTo(1),
-          reason: 'edge drag on the horizontal strip never asked for the '
+        expect(
+          prevFetches,
+          greaterThanOrEqualTo(1),
+          reason:
+              'edge drag on the horizontal strip never asked for the '
               'previous chapter — the boundary trigger only works on the '
-              'vertical axis');
-      expect(tester.takeException(), isNull);
-    });
+              'vertical axis',
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
   }
 }

--- a/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
+++ b/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
@@ -47,10 +47,8 @@ class _FakeMangaWithId extends MangaWithId {
   Future<MangaDto?> build({required int mangaId}) async => manga;
 }
 
-GraphQLClient _dummyClient() => GraphQLClient(
-      link: HttpLink('http://localhost:0'),
-      cache: GraphQLCache(),
-    );
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
 
 class _FakeTrackerRepository extends TrackerRepository {
   _FakeTrackerRepository() : super(_dummyClient());
@@ -88,30 +86,29 @@ List<String> _localPages(int count, String tag) {
 }
 
 MangaDto _webtoonManga() => Fragment$MangaDto(
-      id: 1,
-      title: 'Test Webtoon',
-      bookmarkCount: 0,
-      chapters: Fragment$MangaDto$chapters(totalCount: 2),
-      downloadCount: 0,
-      genre: const [],
-      inLibrary: true,
-      inLibraryAt: '0',
-      initialized: true,
-      meta: [
-        Fragment$MangaDto$meta(
-          key: MangaMetaKeys.readerMode.key,
-          value: ReaderMode.webtoon.name,
-        ),
-      ],
-      sourceId: '1',
-      status: Enum$MangaStatus.ONGOING,
-      categories: Fragment$MangaDto$categories(nodes: const []),
-      trackRecords:
-          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
-      unreadCount: 2,
-      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
-      url: '/manga/1',
-    );
+  id: 1,
+  title: 'Test Webtoon',
+  bookmarkCount: 0,
+  chapters: Fragment$MangaDto$chapters(totalCount: 2),
+  downloadCount: 0,
+  genre: const [],
+  inLibrary: true,
+  inLibraryAt: '0',
+  initialized: true,
+  meta: [
+    Fragment$MangaDto$meta(
+      key: MangaMetaKeys.readerMode.key,
+      value: ReaderMode.webtoon.name,
+    ),
+  ],
+  sourceId: '1',
+  status: Enum$MangaStatus.ONGOING,
+  categories: Fragment$MangaDto$categories(nodes: const []),
+  trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+  unreadCount: 2,
+  updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+  url: '/manga/1',
+);
 
 ChapterDto _chapter({required int id, required int sourceOrder}) =>
     Fragment$ChapterDto(
@@ -133,9 +130,9 @@ ChapterDto _chapter({required int id, required int sourceOrder}) =>
     );
 
 ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
-      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
-      pages: _localPages(count, 'c$id'),
-    );
+  chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+  pages: _localPages(count, 'c$id'),
+);
 
 /// Pumps the reader open on chapter 2 page 0 (chapter 1 is its previous).
 /// [prevPages] controls what chapterPagesProvider(1) produces per fetch.
@@ -160,22 +157,34 @@ Future<void> _pumpReaderOnChapter2(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
         mangaBookRepositoryProvider.overrideWithValue(_QuietRepo()),
-        mangaWithIdProvider(mangaId: 1)
-            .overrideWith(() => _FakeMangaWithId(_webtoonManga())),
+        mangaWithIdProvider(
+          mangaId: 1,
+        ).overrideWith(() => _FakeMangaWithId(_webtoonManga())),
         chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
         chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
         chapterPagesProvider(chapterId: 1).overrideWith((ref) => prevPages()),
         chapterPagesProvider(chapterId: 2).overrideWith((ref) => _pages(2, 3)),
         if (coldOpenPair)
-          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
-              .overrideWith((ref) => ref.watch(_pairReadyProvider)
-                  ? (first: null, second: ch1)
-                  : null)
+          getNextAndPreviousChaptersProvider(
+            mangaId: 1,
+            chapterId: 2,
+            readerScanlatorGroup: '',
+          ).overrideWith(
+            (ref) => ref.watch(_pairReadyProvider)
+                ? (first: null, second: ch1)
+                : null,
+          )
         else
-          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
-              .overrideWithValue((first: null, second: ch1)),
-        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
-            .overrideWithValue((first: ch2, second: null)),
+          getNextAndPreviousChaptersProvider(
+            mangaId: 1,
+            chapterId: 2,
+            readerScanlatorGroup: '',
+          ).overrideWithValue((first: null, second: ch1)),
+        getNextAndPreviousChaptersProvider(
+          mangaId: 1,
+          chapterId: 1,
+          readerScanlatorGroup: '',
+        ).overrideWithValue((first: ch2, second: null)),
         trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
       ],
       child: MaterialApp(
@@ -207,99 +216,120 @@ void main() {
     MultiChapterContinuousReaderMode.edgeAttemptCooldown = Duration.zero;
   });
   tearDown(() {
-    MultiChapterContinuousReaderMode.edgeAttemptCooldown =
-        const Duration(seconds: 4);
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown = const Duration(
+      seconds: 4,
+    );
   });
 
   testWidgets(
-      'resume at page 0: an upward drag at the clamp loads the previous chapter',
-      (tester) async {
-    var prevFetches = 0;
-    await _pumpReaderOnChapter2(
-      tester,
-      // Async with a real delay: an unheld autoDispose fetch gets disposed
-      // mid-flight and never completes (the "loading… that never loads").
-      prevPages: () async {
-        prevFetches++;
-        await Future<void>.delayed(const Duration(milliseconds: 100));
-        return _pages(1, 3);
-      },
-    );
+    'resume at page 0: an upward drag at the clamp loads the previous chapter',
+    (tester) async {
+      var prevFetches = 0;
+      await _pumpReaderOnChapter2(
+        tester,
+        // Async with a real delay: an unheld autoDispose fetch gets disposed
+        // mid-flight and never completes (the "loading… that never loads").
+        prevPages: () async {
+          prevFetches++;
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return _pages(1, 3);
+        },
+      );
 
-    // No downward movement first — the deadlock precondition.
-    await _dragUp(tester);
-    await tester.pump(const Duration(milliseconds: 200));
-    await tester.pumpAndSettle();
+      // No downward movement first — the deadlock precondition.
+      await _dragUp(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
 
-    expect(prevFetches, greaterThanOrEqualTo(1),
-        reason: 'blocked upward drag at page 0 never asked for the previous '
-            'chapter (the resume deadlock)');
+      expect(
+        prevFetches,
+        greaterThanOrEqualTo(1),
+        reason:
+            'blocked upward drag at page 0 never asked for the previous '
+            'chapter (the resume deadlock)',
+      );
 
-    // A second pull must be a no-op: the chapter LOADED, so the engine's
-    // already-loaded guard stops a refetch. If the fetch had been disposed
-    // mid-flight (never completing), this drag would fetch again.
-    await _dragUp(tester);
-    await tester.pump(const Duration(milliseconds: 200));
-    await tester.pumpAndSettle();
-    expect(prevFetches, 1,
-        reason: 'previous chapter never finished loading; the fetch was '
-            'disposed mid-flight and the gesture refetched');
-    expect(tester.takeException(), isNull);
-  });
-
-  testWidgets('a failed previous-chapter fetch does not latch for the session',
-      (tester) async {
-    var prevFetches = 0;
-    await _pumpReaderOnChapter2(
-      tester,
-      prevPages: () {
-        prevFetches++;
-        // First fetch fails (returns nothing); later fetches succeed.
-        if (prevFetches == 1) return null;
-        return _pages(1, 3);
-      },
-    );
-
-    // The gesture must retry past the failed fetch instead of latching a
-    // "reached start" state (pre-fix, the count froze at 1 forever).
-    await _dragUp(tester);
-    await _dragUp(tester);
-    expect(prevFetches, greaterThanOrEqualTo(2),
-        reason: 'failed fetch latched the boundary; no retry happened');
-    expect(tester.takeException(), isNull);
-  });
+      // A second pull must be a no-op: the chapter LOADED, so the engine's
+      // already-loaded guard stops a refetch. If the fetch had been disposed
+      // mid-flight (never completing), this drag would fetch again.
+      await _dragUp(tester);
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+      expect(
+        prevFetches,
+        1,
+        reason:
+            'previous chapter never finished loading; the fetch was '
+            'disposed mid-flight and the gesture refetched',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets(
-      'cold open: neighbours resolving after mount still enable the boundary',
-      (tester) async {
-    var prevFetches = 0;
+    'a failed previous-chapter fetch does not latch for the session',
+    (tester) async {
+      var prevFetches = 0;
+      await _pumpReaderOnChapter2(
+        tester,
+        prevPages: () {
+          prevFetches++;
+          // First fetch fails (returns nothing); later fetches succeed.
+          if (prevFetches == 1) return null;
+          return _pages(1, 3);
+        },
+      );
 
-    await _pumpReaderOnChapter2(
-      tester,
-      prevPages: () {
-        prevFetches++;
-        return _pages(1, 3);
-      },
-      // Pair is null (chapter list "still loading") until the switch flips.
-      coldOpenPair: true,
-    );
+      // The gesture must retry past the failed fetch instead of latching a
+      // "reached start" state (pre-fix, the count froze at 1 forever).
+      await _dragUp(tester);
+      await _dragUp(tester);
+      expect(
+        prevFetches,
+        greaterThanOrEqualTo(2),
+        reason: 'failed fetch latched the boundary; no retry happened',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 
-    // While unresolved, an upward drag can't load anything — and must not latch.
-    await _dragUp(tester);
-    expect(prevFetches, 0);
+  testWidgets(
+    'cold open: neighbours resolving after mount still enable the boundary',
+    (tester) async {
+      var prevFetches = 0;
 
-    // The chapter list "finishes loading".
-    final container = ProviderScope.containerOf(
-        tester.element(find.byType(ReaderScreen)));
-    container.read(_pairReadyProvider.notifier).set(true);
-    await tester.pumpAndSettle();
+      await _pumpReaderOnChapter2(
+        tester,
+        prevPages: () {
+          prevFetches++;
+          return _pages(1, 3);
+        },
+        // Pair is null (chapter list "still loading") until the switch flips.
+        coldOpenPair: true,
+      );
 
-    // The same gesture now works — the reader watched the pair instead of
-    // reading it once at mount.
-    await _dragUp(tester);
-    expect(prevFetches, greaterThanOrEqualTo(1),
-        reason: 'neighbours resolved after mount were never picked up '
-            '(the cold-open race)');
-    expect(tester.takeException(), isNull);
-  });
+      // While unresolved, an upward drag can't load anything — and must not latch.
+      await _dragUp(tester);
+      expect(prevFetches, 0);
+
+      // The chapter list "finishes loading".
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ReaderScreen)),
+      );
+      container.read(_pairReadyProvider.notifier).set(true);
+      await tester.pumpAndSettle();
+
+      // The same gesture now works — the reader watched the pair instead of
+      // reading it once at mount.
+      await _dragUp(tester);
+      expect(
+        prevFetches,
+        greaterThanOrEqualTo(1),
+        reason:
+            'neighbours resolved after mount were never picked up '
+            '(the cold-open race)',
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 }

--- a/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
+++ b/test/src/features/manga_book/reader/infinity_scrollback_regression_test.dart
@@ -47,8 +47,10 @@ class _FakeMangaWithId extends MangaWithId {
   Future<MangaDto?> build({required int mangaId}) async => manga;
 }
 
-GraphQLClient _dummyClient() =>
-    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
 
 class _FakeTrackerRepository extends TrackerRepository {
   _FakeTrackerRepository() : super(_dummyClient());
@@ -86,29 +88,30 @@ List<String> _localPages(int count, String tag) {
 }
 
 MangaDto _webtoonManga() => Fragment$MangaDto(
-  id: 1,
-  title: 'Test Webtoon',
-  bookmarkCount: 0,
-  chapters: Fragment$MangaDto$chapters(totalCount: 2),
-  downloadCount: 0,
-  genre: const [],
-  inLibrary: true,
-  inLibraryAt: '0',
-  initialized: true,
-  meta: [
-    Fragment$MangaDto$meta(
-      key: MangaMetaKeys.readerMode.key,
-      value: ReaderMode.webtoon.name,
-    ),
-  ],
-  sourceId: '1',
-  status: Enum$MangaStatus.ONGOING,
-  categories: Fragment$MangaDto$categories(nodes: const []),
-  trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
-  unreadCount: 2,
-  updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
-  url: '/manga/1',
-);
+      id: 1,
+      title: 'Test Webtoon',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 2),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: ReaderMode.webtoon.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 2,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
 
 ChapterDto _chapter({required int id, required int sourceOrder}) =>
     Fragment$ChapterDto(
@@ -130,9 +133,9 @@ ChapterDto _chapter({required int id, required int sourceOrder}) =>
     );
 
 ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
-  chapter: ChapterPagesChapterDto(id: id, pageCount: count),
-  pages: _localPages(count, 'c$id'),
-);
+      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+      pages: _localPages(count, 'c$id'),
+    );
 
 /// Pumps the reader open on chapter 2 page 0 (chapter 1 is its previous).
 /// [prevPages] controls what chapterPagesProvider(1) produces per fetch.
@@ -157,34 +160,22 @@ Future<void> _pumpReaderOnChapter2(
       overrides: [
         sharedPreferencesProvider.overrideWithValue(prefs),
         mangaBookRepositoryProvider.overrideWithValue(_QuietRepo()),
-        mangaWithIdProvider(
-          mangaId: 1,
-        ).overrideWith(() => _FakeMangaWithId(_webtoonManga())),
+        mangaWithIdProvider(mangaId: 1)
+            .overrideWith(() => _FakeMangaWithId(_webtoonManga())),
         chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
         chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
         chapterPagesProvider(chapterId: 1).overrideWith((ref) => prevPages()),
         chapterPagesProvider(chapterId: 2).overrideWith((ref) => _pages(2, 3)),
         if (coldOpenPair)
-          getNextAndPreviousChaptersProvider(
-            mangaId: 1,
-            chapterId: 2,
-            readerScanlatorGroup: '',
-          ).overrideWith(
-            (ref) => ref.watch(_pairReadyProvider)
-                ? (first: null, second: ch1)
-                : null,
-          )
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2, readerScanlatorGroup: '')
+              .overrideWith((ref) => ref.watch(_pairReadyProvider)
+                  ? (first: null, second: ch1)
+                  : null)
         else
-          getNextAndPreviousChaptersProvider(
-            mangaId: 1,
-            chapterId: 2,
-            readerScanlatorGroup: '',
-          ).overrideWithValue((first: null, second: ch1)),
-        getNextAndPreviousChaptersProvider(
-          mangaId: 1,
-          chapterId: 1,
-          readerScanlatorGroup: '',
-        ).overrideWithValue((first: ch2, second: null)),
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2, readerScanlatorGroup: '')
+              .overrideWithValue((first: null, second: ch1)),
+        getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1, readerScanlatorGroup: '')
+            .overrideWithValue((first: ch2, second: null)),
         trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
       ],
       child: MaterialApp(
@@ -216,120 +207,99 @@ void main() {
     MultiChapterContinuousReaderMode.edgeAttemptCooldown = Duration.zero;
   });
   tearDown(() {
-    MultiChapterContinuousReaderMode.edgeAttemptCooldown = const Duration(
-      seconds: 4,
-    );
+    MultiChapterContinuousReaderMode.edgeAttemptCooldown =
+        const Duration(seconds: 4);
   });
 
   testWidgets(
-    'resume at page 0: an upward drag at the clamp loads the previous chapter',
-    (tester) async {
-      var prevFetches = 0;
-      await _pumpReaderOnChapter2(
-        tester,
-        // Async with a real delay: an unheld autoDispose fetch gets disposed
-        // mid-flight and never completes (the "loading… that never loads").
-        prevPages: () async {
-          prevFetches++;
-          await Future<void>.delayed(const Duration(milliseconds: 100));
-          return _pages(1, 3);
-        },
-      );
+      'resume at page 0: an upward drag at the clamp loads the previous chapter',
+      (tester) async {
+    var prevFetches = 0;
+    await _pumpReaderOnChapter2(
+      tester,
+      // Async with a real delay: an unheld autoDispose fetch gets disposed
+      // mid-flight and never completes (the "loading… that never loads").
+      prevPages: () async {
+        prevFetches++;
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return _pages(1, 3);
+      },
+    );
 
-      // No downward movement first — the deadlock precondition.
-      await _dragUp(tester);
-      await tester.pump(const Duration(milliseconds: 200));
-      await tester.pumpAndSettle();
+    // No downward movement first — the deadlock precondition.
+    await _dragUp(tester);
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
 
-      expect(
-        prevFetches,
-        greaterThanOrEqualTo(1),
-        reason:
-            'blocked upward drag at page 0 never asked for the previous '
-            'chapter (the resume deadlock)',
-      );
+    expect(prevFetches, greaterThanOrEqualTo(1),
+        reason: 'blocked upward drag at page 0 never asked for the previous '
+            'chapter (the resume deadlock)');
 
-      // A second pull must be a no-op: the chapter LOADED, so the engine's
-      // already-loaded guard stops a refetch. If the fetch had been disposed
-      // mid-flight (never completing), this drag would fetch again.
-      await _dragUp(tester);
-      await tester.pump(const Duration(milliseconds: 200));
-      await tester.pumpAndSettle();
-      expect(
-        prevFetches,
-        1,
-        reason:
-            'previous chapter never finished loading; the fetch was '
-            'disposed mid-flight and the gesture refetched',
-      );
-      expect(tester.takeException(), isNull);
-    },
-  );
+    // A second pull must be a no-op: the chapter LOADED, so the engine's
+    // already-loaded guard stops a refetch. If the fetch had been disposed
+    // mid-flight (never completing), this drag would fetch again.
+    await _dragUp(tester);
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+    expect(prevFetches, 1,
+        reason: 'previous chapter never finished loading; the fetch was '
+            'disposed mid-flight and the gesture refetched');
+    expect(tester.takeException(), isNull);
+  });
 
-  testWidgets(
-    'a failed previous-chapter fetch does not latch for the session',
-    (tester) async {
-      var prevFetches = 0;
-      await _pumpReaderOnChapter2(
-        tester,
-        prevPages: () {
-          prevFetches++;
-          // First fetch fails (returns nothing); later fetches succeed.
-          if (prevFetches == 1) return null;
-          return _pages(1, 3);
-        },
-      );
+  testWidgets('a failed previous-chapter fetch does not latch for the session',
+      (tester) async {
+    var prevFetches = 0;
+    await _pumpReaderOnChapter2(
+      tester,
+      prevPages: () {
+        prevFetches++;
+        // First fetch fails (returns nothing); later fetches succeed.
+        if (prevFetches == 1) return null;
+        return _pages(1, 3);
+      },
+    );
 
-      // The gesture must retry past the failed fetch instead of latching a
-      // "reached start" state (pre-fix, the count froze at 1 forever).
-      await _dragUp(tester);
-      await _dragUp(tester);
-      expect(
-        prevFetches,
-        greaterThanOrEqualTo(2),
-        reason: 'failed fetch latched the boundary; no retry happened',
-      );
-      expect(tester.takeException(), isNull);
-    },
-  );
+    // The gesture must retry past the failed fetch instead of latching a
+    // "reached start" state (pre-fix, the count froze at 1 forever).
+    await _dragUp(tester);
+    await _dragUp(tester);
+    expect(prevFetches, greaterThanOrEqualTo(2),
+        reason: 'failed fetch latched the boundary; no retry happened');
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
-    'cold open: neighbours resolving after mount still enable the boundary',
-    (tester) async {
-      var prevFetches = 0;
+      'cold open: neighbours resolving after mount still enable the boundary',
+      (tester) async {
+    var prevFetches = 0;
 
-      await _pumpReaderOnChapter2(
-        tester,
-        prevPages: () {
-          prevFetches++;
-          return _pages(1, 3);
-        },
-        // Pair is null (chapter list "still loading") until the switch flips.
-        coldOpenPair: true,
-      );
+    await _pumpReaderOnChapter2(
+      tester,
+      prevPages: () {
+        prevFetches++;
+        return _pages(1, 3);
+      },
+      // Pair is null (chapter list "still loading") until the switch flips.
+      coldOpenPair: true,
+    );
 
-      // While unresolved, an upward drag can't load anything — and must not latch.
-      await _dragUp(tester);
-      expect(prevFetches, 0);
+    // While unresolved, an upward drag can't load anything — and must not latch.
+    await _dragUp(tester);
+    expect(prevFetches, 0);
 
-      // The chapter list "finishes loading".
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(ReaderScreen)),
-      );
-      container.read(_pairReadyProvider.notifier).set(true);
-      await tester.pumpAndSettle();
+    // The chapter list "finishes loading".
+    final container = ProviderScope.containerOf(
+        tester.element(find.byType(ReaderScreen)));
+    container.read(_pairReadyProvider.notifier).set(true);
+    await tester.pumpAndSettle();
 
-      // The same gesture now works — the reader watched the pair instead of
-      // reading it once at mount.
-      await _dragUp(tester);
-      expect(
-        prevFetches,
-        greaterThanOrEqualTo(1),
-        reason:
-            'neighbours resolved after mount were never picked up '
-            '(the cold-open race)',
-      );
-      expect(tester.takeException(), isNull);
-    },
-  );
+    // The same gesture now works — the reader watched the pair instead of
+    // reading it once at mount.
+    await _dragUp(tester);
+    expect(prevFetches, greaterThanOrEqualTo(1),
+        reason: 'neighbours resolved after mount were never picked up '
+            '(the cold-open race)');
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
+++ b/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
@@ -40,8 +40,10 @@ class _FakeMangaWithId extends MangaWithId {
   Future<MangaDto?> build({required int mangaId}) async => manga;
 }
 
-GraphQLClient _dummyClient() =>
-    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
 
 class _FakeTrackerRepository extends TrackerRepository {
   _FakeTrackerRepository() : super(_dummyClient());
@@ -80,61 +82,62 @@ List<String> _localPages(int count, String tag) {
 }
 
 MangaDto _manga() => Fragment$MangaDto(
-  id: 1,
-  title: 'Test Manga',
-  bookmarkCount: 0,
-  chapters: Fragment$MangaDto$chapters(totalCount: 2),
-  downloadCount: 0,
-  genre: const [],
-  inLibrary: true,
-  inLibraryAt: '0',
-  initialized: true,
-  meta: [
-    Fragment$MangaDto$meta(
-      key: MangaMetaKeys.readerMode.key,
-      value: ReaderMode.singleHorizontalLTR.name,
-    ),
-  ],
-  sourceId: '1',
-  status: Enum$MangaStatus.ONGOING,
-  categories: Fragment$MangaDto$categories(nodes: const []),
-  trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
-  unreadCount: 2,
-  updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
-  url: '/manga/1',
-);
+      id: 1,
+      title: 'Test Manga',
+      bookmarkCount: 0,
+      chapters: Fragment$MangaDto$chapters(totalCount: 2),
+      downloadCount: 0,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: [
+        Fragment$MangaDto$meta(
+          key: MangaMetaKeys.readerMode.key,
+          value: ReaderMode.singleHorizontalLTR.name,
+        ),
+      ],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      categories: Fragment$MangaDto$categories(nodes: const []),
+      trackRecords:
+          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+      unreadCount: 2,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
 
 ChapterDto _chapter({
   required int id,
   required int sourceOrder,
   required int pageCount,
-}) => Fragment$ChapterDto(
-  chapterNumber: sourceOrder.toDouble(),
-  fetchedAt: '0',
-  id: id,
-  isBookmarked: false,
-  isDownloaded: false,
-  isRead: false,
-  lastPageRead: 0,
-  lastReadAt: '0',
-  mangaId: 1,
-  name: 'Chapter $id',
-  pageCount: pageCount,
-  sourceOrder: sourceOrder,
-  uploadDate: '0',
-  url: '/chapter/$id',
-  meta: const [],
-);
+}) =>
+    Fragment$ChapterDto(
+      chapterNumber: sourceOrder.toDouble(),
+      fetchedAt: '0',
+      id: id,
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: 'Chapter $id',
+      pageCount: pageCount,
+      sourceOrder: sourceOrder,
+      uploadDate: '0',
+      url: '/chapter/$id',
+      meta: const [],
+    );
 
 ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
-  chapter: ChapterPagesChapterDto(id: id, pageCount: count),
-  pages: _localPages(count, 'c$id'),
-);
+      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+      pages: _localPages(count, 'c$id'),
+    );
 
 void main() {
-  testWidgets('paged reader loads and crosses into the next chapter in-place', (
-    tester,
-  ) async {
+  testWidgets('paged reader loads and crosses into the next chapter in-place',
+      (tester) async {
     tester.view.physicalSize = const Size(800, 1600);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -151,33 +154,22 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           mangaBookRepositoryProvider.overrideWithValue(repo),
-          mangaWithIdProvider(
-            mangaId: 1,
-          ).overrideWith(() => _FakeMangaWithId(_manga())),
+          mangaWithIdProvider(mangaId: 1)
+              .overrideWith(() => _FakeMangaWithId(_manga())),
           chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
           chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
-          chapterPagesProvider(
-            chapterId: 1,
-          ).overrideWith((ref) => _pages(1, 3)),
-          chapterPagesProvider(
-            chapterId: 2,
-          ).overrideWith((ref) => _pages(2, 2)),
+          chapterPagesProvider(chapterId: 1)
+              .overrideWith((ref) => _pages(1, 3)),
+          chapterPagesProvider(chapterId: 2)
+              .overrideWith((ref) => _pages(2, 2)),
           // Chapter 1 has a next (chapter 2); chapter 2 has a previous (1).
-          getNextAndPreviousChaptersProvider(
-            mangaId: 1,
-            chapterId: 1,
-            readerScanlatorGroup: '',
-          ).overrideWithValue((first: ch2, second: null)),
-          getNextAndPreviousChaptersProvider(
-            mangaId: 1,
-            chapterId: 2,
-            readerScanlatorGroup: '',
-          ).overrideWithValue((first: null, second: ch1)),
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1, readerScanlatorGroup: '')
+              .overrideWithValue((first: ch2, second: null)),
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2, readerScanlatorGroup: '')
+              .overrideWithValue((first: null, second: ch1)),
           // Keep the external tracker path inert in the test.
           trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
-          updateProgressAfterReadingProvider.overrideWith(
-            () => _FixedToggle(false),
-          ),
+          updateProgressAfterReadingProvider.overrideWith(() => _FixedToggle(false)),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -209,17 +201,12 @@ void main() {
 
     // We must have crossed into chapter 2 — its page count (2) now drives the
     // seekbar, which never shows "/ 2" while reading the 3-page chapter 1.
-    expect(
-      find.textContaining('/ 2'),
-      findsOneWidget,
-      reason: 'reader never crossed into chapter 2',
-    );
+    expect(find.textContaining('/ 2'), findsOneWidget,
+        reason: 'reader never crossed into chapter 2');
 
     // Crossing the boundary forward marks chapter 1 read.
     expect(
-      repo.putChapterCalls.any(
-        (c) => c.chapterId == 1 && c.patch.isRead == true,
-      ),
+      repo.putChapterCalls.any((c) => c.chapterId == 1 && c.patch.isRead == true),
       isTrue,
       reason: 'chapter 1 was not marked read on the forward crossing',
     );
@@ -240,21 +227,16 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           mangaBookRepositoryProvider.overrideWithValue(repo),
-          mangaWithIdProvider(
-            mangaId: 1,
-          ).overrideWith(() => _FakeMangaWithId(_manga())),
+          mangaWithIdProvider(mangaId: 1)
+              .overrideWith(() => _FakeMangaWithId(_manga())),
           chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
-          chapterPagesProvider(
-            chapterId: 1,
-          ).overrideWith((ref) => _pages(1, 3)),
-          getNextAndPreviousChaptersProvider(
-            mangaId: 1,
-            chapterId: 1,
-          ).overrideWithValue(null),
+          chapterPagesProvider(chapterId: 1)
+              .overrideWith((ref) => _pages(1, 3)),
+          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
+              .overrideWithValue(null),
           trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
-          updateProgressAfterReadingProvider.overrideWith(
-            () => _FixedToggle(false),
-          ),
+          updateProgressAfterReadingProvider
+              .overrideWith(() => _FixedToggle(false)),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -271,11 +253,8 @@ void main() {
     final repo = await pumpSingleChapter(tester);
 
     // Turn to page 2 (index 1).
-    await tester.timedDrag(
-      find.byType(PagedReaderViewport),
-      const Offset(-400, 0),
-      const Duration(milliseconds: 80),
-    );
+    await tester.timedDrag(find.byType(PagedReaderViewport),
+        const Offset(-400, 0), const Duration(milliseconds: 80));
     await tester.pumpAndSettle();
     expect(find.text('2 / 3'), findsOneWidget);
 
@@ -284,28 +263,19 @@ void main() {
 
     expect(
       // Partial read: position is saved, read-state is omitted (never un-reads).
-      repo.putChapterCalls.any(
-        (c) =>
-            c.chapterId == 1 &&
-            c.patch.lastPageRead == 1 &&
-            c.patch.isRead == null,
-      ),
+      repo.putChapterCalls.any((c) =>
+          c.chapterId == 1 && c.patch.lastPageRead == 1 && c.patch.isRead == null),
       isTrue,
-      reason:
-          'debounced progress for page 2 was not saved; ${repo.putChapterCalls}',
+      reason: 'debounced progress for page 2 was not saved; ${repo.putChapterCalls}',
     );
   });
 
-  testWidgets('flushes the visible page on exit before the debounce fires', (
-    tester,
-  ) async {
+  testWidgets('flushes the visible page on exit before the debounce fires',
+      (tester) async {
     final repo = await pumpSingleChapter(tester);
 
-    await tester.timedDrag(
-      find.byType(PagedReaderViewport),
-      const Offset(-400, 0),
-      const Duration(milliseconds: 80),
-    );
+    await tester.timedDrag(find.byType(PagedReaderViewport),
+        const Offset(-400, 0), const Duration(milliseconds: 80));
     await tester.pumpAndSettle();
     expect(find.text('2 / 3'), findsOneWidget);
 
@@ -314,9 +284,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
 
     expect(
-      repo.putChapterCalls.any(
-        (c) => c.chapterId == 1 && c.patch.lastPageRead == 1,
-      ),
+      repo.putChapterCalls.any((c) => c.chapterId == 1 && c.patch.lastPageRead == 1),
       isTrue,
       reason: 'progress was not flushed on exit; ${repo.putChapterCalls}',
     );

--- a/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
+++ b/test/src/features/manga_book/reader/multichapter_paged_reader_e2e_test.dart
@@ -40,10 +40,8 @@ class _FakeMangaWithId extends MangaWithId {
   Future<MangaDto?> build({required int mangaId}) async => manga;
 }
 
-GraphQLClient _dummyClient() => GraphQLClient(
-      link: HttpLink('http://localhost:0'),
-      cache: GraphQLCache(),
-    );
+GraphQLClient _dummyClient() =>
+    GraphQLClient(link: HttpLink('http://localhost:0'), cache: GraphQLCache());
 
 class _FakeTrackerRepository extends TrackerRepository {
   _FakeTrackerRepository() : super(_dummyClient());
@@ -82,62 +80,61 @@ List<String> _localPages(int count, String tag) {
 }
 
 MangaDto _manga() => Fragment$MangaDto(
-      id: 1,
-      title: 'Test Manga',
-      bookmarkCount: 0,
-      chapters: Fragment$MangaDto$chapters(totalCount: 2),
-      downloadCount: 0,
-      genre: const [],
-      inLibrary: true,
-      inLibraryAt: '0',
-      initialized: true,
-      meta: [
-        Fragment$MangaDto$meta(
-          key: MangaMetaKeys.readerMode.key,
-          value: ReaderMode.singleHorizontalLTR.name,
-        ),
-      ],
-      sourceId: '1',
-      status: Enum$MangaStatus.ONGOING,
-      categories: Fragment$MangaDto$categories(nodes: const []),
-      trackRecords:
-          Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
-      unreadCount: 2,
-      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
-      url: '/manga/1',
-    );
+  id: 1,
+  title: 'Test Manga',
+  bookmarkCount: 0,
+  chapters: Fragment$MangaDto$chapters(totalCount: 2),
+  downloadCount: 0,
+  genre: const [],
+  inLibrary: true,
+  inLibraryAt: '0',
+  initialized: true,
+  meta: [
+    Fragment$MangaDto$meta(
+      key: MangaMetaKeys.readerMode.key,
+      value: ReaderMode.singleHorizontalLTR.name,
+    ),
+  ],
+  sourceId: '1',
+  status: Enum$MangaStatus.ONGOING,
+  categories: Fragment$MangaDto$categories(nodes: const []),
+  trackRecords: Fragment$MangaDto$trackRecords(totalCount: 0, nodes: const []),
+  unreadCount: 2,
+  updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+  url: '/manga/1',
+);
 
 ChapterDto _chapter({
   required int id,
   required int sourceOrder,
   required int pageCount,
-}) =>
-    Fragment$ChapterDto(
-      chapterNumber: sourceOrder.toDouble(),
-      fetchedAt: '0',
-      id: id,
-      isBookmarked: false,
-      isDownloaded: false,
-      isRead: false,
-      lastPageRead: 0,
-      lastReadAt: '0',
-      mangaId: 1,
-      name: 'Chapter $id',
-      pageCount: pageCount,
-      sourceOrder: sourceOrder,
-      uploadDate: '0',
-      url: '/chapter/$id',
-      meta: const [],
-    );
+}) => Fragment$ChapterDto(
+  chapterNumber: sourceOrder.toDouble(),
+  fetchedAt: '0',
+  id: id,
+  isBookmarked: false,
+  isDownloaded: false,
+  isRead: false,
+  lastPageRead: 0,
+  lastReadAt: '0',
+  mangaId: 1,
+  name: 'Chapter $id',
+  pageCount: pageCount,
+  sourceOrder: sourceOrder,
+  uploadDate: '0',
+  url: '/chapter/$id',
+  meta: const [],
+);
 
 ChapterPagesDto _pages(int id, int count) => ChapterPagesDto(
-      chapter: ChapterPagesChapterDto(id: id, pageCount: count),
-      pages: _localPages(count, 'c$id'),
-    );
+  chapter: ChapterPagesChapterDto(id: id, pageCount: count),
+  pages: _localPages(count, 'c$id'),
+);
 
 void main() {
-  testWidgets('paged reader loads and crosses into the next chapter in-place',
-      (tester) async {
+  testWidgets('paged reader loads and crosses into the next chapter in-place', (
+    tester,
+  ) async {
     tester.view.physicalSize = const Size(800, 1600);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -154,22 +151,33 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           mangaBookRepositoryProvider.overrideWithValue(repo),
-          mangaWithIdProvider(mangaId: 1)
-              .overrideWith(() => _FakeMangaWithId(_manga())),
+          mangaWithIdProvider(
+            mangaId: 1,
+          ).overrideWith(() => _FakeMangaWithId(_manga())),
           chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
           chapterProvider(chapterId: 2).overrideWith((ref) => ch2),
-          chapterPagesProvider(chapterId: 1)
-              .overrideWith((ref) => _pages(1, 3)),
-          chapterPagesProvider(chapterId: 2)
-              .overrideWith((ref) => _pages(2, 2)),
+          chapterPagesProvider(
+            chapterId: 1,
+          ).overrideWith((ref) => _pages(1, 3)),
+          chapterPagesProvider(
+            chapterId: 2,
+          ).overrideWith((ref) => _pages(2, 2)),
           // Chapter 1 has a next (chapter 2); chapter 2 has a previous (1).
-          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
-              .overrideWithValue((first: ch2, second: null)),
-          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 2)
-              .overrideWithValue((first: null, second: ch1)),
+          getNextAndPreviousChaptersProvider(
+            mangaId: 1,
+            chapterId: 1,
+            readerScanlatorGroup: '',
+          ).overrideWithValue((first: ch2, second: null)),
+          getNextAndPreviousChaptersProvider(
+            mangaId: 1,
+            chapterId: 2,
+            readerScanlatorGroup: '',
+          ).overrideWithValue((first: null, second: ch1)),
           // Keep the external tracker path inert in the test.
           trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
-          updateProgressAfterReadingProvider.overrideWith(() => _FixedToggle(false)),
+          updateProgressAfterReadingProvider.overrideWith(
+            () => _FixedToggle(false),
+          ),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -201,12 +209,17 @@ void main() {
 
     // We must have crossed into chapter 2 — its page count (2) now drives the
     // seekbar, which never shows "/ 2" while reading the 3-page chapter 1.
-    expect(find.textContaining('/ 2'), findsOneWidget,
-        reason: 'reader never crossed into chapter 2');
+    expect(
+      find.textContaining('/ 2'),
+      findsOneWidget,
+      reason: 'reader never crossed into chapter 2',
+    );
 
     // Crossing the boundary forward marks chapter 1 read.
     expect(
-      repo.putChapterCalls.any((c) => c.chapterId == 1 && c.patch.isRead == true),
+      repo.putChapterCalls.any(
+        (c) => c.chapterId == 1 && c.patch.isRead == true,
+      ),
       isTrue,
       reason: 'chapter 1 was not marked read on the forward crossing',
     );
@@ -227,16 +240,21 @@ void main() {
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
           mangaBookRepositoryProvider.overrideWithValue(repo),
-          mangaWithIdProvider(mangaId: 1)
-              .overrideWith(() => _FakeMangaWithId(_manga())),
+          mangaWithIdProvider(
+            mangaId: 1,
+          ).overrideWith(() => _FakeMangaWithId(_manga())),
           chapterProvider(chapterId: 1).overrideWith((ref) => ch1),
-          chapterPagesProvider(chapterId: 1)
-              .overrideWith((ref) => _pages(1, 3)),
-          getNextAndPreviousChaptersProvider(mangaId: 1, chapterId: 1)
-              .overrideWithValue(null),
+          chapterPagesProvider(
+            chapterId: 1,
+          ).overrideWith((ref) => _pages(1, 3)),
+          getNextAndPreviousChaptersProvider(
+            mangaId: 1,
+            chapterId: 1,
+          ).overrideWithValue(null),
           trackerRepositoryProvider.overrideWithValue(_FakeTrackerRepository()),
-          updateProgressAfterReadingProvider
-              .overrideWith(() => _FixedToggle(false)),
+          updateProgressAfterReadingProvider.overrideWith(
+            () => _FixedToggle(false),
+          ),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -253,8 +271,11 @@ void main() {
     final repo = await pumpSingleChapter(tester);
 
     // Turn to page 2 (index 1).
-    await tester.timedDrag(find.byType(PagedReaderViewport),
-        const Offset(-400, 0), const Duration(milliseconds: 80));
+    await tester.timedDrag(
+      find.byType(PagedReaderViewport),
+      const Offset(-400, 0),
+      const Duration(milliseconds: 80),
+    );
     await tester.pumpAndSettle();
     expect(find.text('2 / 3'), findsOneWidget);
 
@@ -263,19 +284,28 @@ void main() {
 
     expect(
       // Partial read: position is saved, read-state is omitted (never un-reads).
-      repo.putChapterCalls.any((c) =>
-          c.chapterId == 1 && c.patch.lastPageRead == 1 && c.patch.isRead == null),
+      repo.putChapterCalls.any(
+        (c) =>
+            c.chapterId == 1 &&
+            c.patch.lastPageRead == 1 &&
+            c.patch.isRead == null,
+      ),
       isTrue,
-      reason: 'debounced progress for page 2 was not saved; ${repo.putChapterCalls}',
+      reason:
+          'debounced progress for page 2 was not saved; ${repo.putChapterCalls}',
     );
   });
 
-  testWidgets('flushes the visible page on exit before the debounce fires',
-      (tester) async {
+  testWidgets('flushes the visible page on exit before the debounce fires', (
+    tester,
+  ) async {
     final repo = await pumpSingleChapter(tester);
 
-    await tester.timedDrag(find.byType(PagedReaderViewport),
-        const Offset(-400, 0), const Duration(milliseconds: 80));
+    await tester.timedDrag(
+      find.byType(PagedReaderViewport),
+      const Offset(-400, 0),
+      const Duration(milliseconds: 80),
+    );
     await tester.pumpAndSettle();
     expect(find.text('2 / 3'), findsOneWidget);
 
@@ -284,7 +314,9 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
 
     expect(
-      repo.putChapterCalls.any((c) => c.chapterId == 1 && c.patch.lastPageRead == 1),
+      repo.putChapterCalls.any(
+        (c) => c.chapterId == 1 && c.patch.lastPageRead == 1,
+      ),
       isTrue,
       reason: 'progress was not flushed on exit; ${repo.putChapterCalls}',
     );

--- a/test/src/features/manga_book/reader/reader_page_actions_long_tap_test.dart
+++ b/test/src/features/manga_book/reader/reader_page_actions_long_tap_test.dart
@@ -28,13 +28,13 @@ class _FakeReadWithLongTap extends ReadWithLongTap {
 }
 
 ChapterPagesDto _pages() => ChapterPagesDto(
-      chapter: ChapterPagesChapterDto(id: 1, pageCount: 3),
-      pages: const [
-        '/manga/1/chapter/0/page/0',
-        '/manga/1/chapter/0/page/1',
-        '/manga/1/chapter/0/page/2',
-      ],
-    );
+  chapter: ChapterPagesChapterDto(id: 1, pageCount: 3),
+  pages: const [
+    '/manga/1/chapter/0/page/0',
+    '/manga/1/chapter/0/page/1',
+    '/manga/1/chapter/0/page/2',
+  ],
+);
 
 const _copyKey = ValueKey('reader-page-action-copy-image');
 const _shareKey = ValueKey('reader-page-action-share');
@@ -67,6 +67,7 @@ Future<void> _pumpReader(
             toggleVisibility: onTap ?? () {},
             scrollDirection: Axis.vertical,
             mangaId: 1,
+            readerScanlatorGroup: '',
             mangaReaderPadding: 0,
             onNext: () {},
             onPrevious: () {},
@@ -77,9 +78,7 @@ Future<void> _pumpReader(
             resolvedReaderMode: ReaderMode.webtoon,
             currentIndex: 0,
             chapterPages: _pages(),
-            child: const SizedBox.expand(
-              child: ColoredBox(color: Colors.grey),
-            ),
+            child: const SizedBox.expand(child: ColoredBox(color: Colors.grey)),
           ),
         ),
       ),
@@ -89,8 +88,9 @@ Future<void> _pumpReader(
 }
 
 void main() {
-  testWidgets('pref ON: long-press opens the page-actions sheet',
-      (tester) async {
+  testWidgets('pref ON: long-press opens the page-actions sheet', (
+    tester,
+  ) async {
     await _pumpReader(tester, longTapOn: true);
 
     expect(find.byKey(_copyKey), findsNothing);
@@ -106,8 +106,9 @@ void main() {
   testWidgets('pref OFF: long-press is a no-op', (tester) async {
     await _pumpReader(tester, longTapOn: false);
 
-    final gesture =
-        await tester.startGesture(tester.getCenter(find.byType(ReaderView)));
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(ReaderView)),
+    );
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pump();
 
@@ -126,8 +127,9 @@ void main() {
     var taps = 0;
     await _pumpReader(tester, longTapOn: false, onTap: () => taps++);
 
-    final gesture =
-        await tester.startGesture(tester.getCenter(find.byType(ReaderView)));
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(ReaderView)),
+    );
     await tester.pump(const Duration(milliseconds: 600));
     await gesture.up();
     await tester.pumpAndSettle();

--- a/test/src/features/manga_book/reader/reader_page_actions_long_tap_test.dart
+++ b/test/src/features/manga_book/reader/reader_page_actions_long_tap_test.dart
@@ -28,13 +28,13 @@ class _FakeReadWithLongTap extends ReadWithLongTap {
 }
 
 ChapterPagesDto _pages() => ChapterPagesDto(
-  chapter: ChapterPagesChapterDto(id: 1, pageCount: 3),
-  pages: const [
-    '/manga/1/chapter/0/page/0',
-    '/manga/1/chapter/0/page/1',
-    '/manga/1/chapter/0/page/2',
-  ],
-);
+      chapter: ChapterPagesChapterDto(id: 1, pageCount: 3),
+      pages: const [
+        '/manga/1/chapter/0/page/0',
+        '/manga/1/chapter/0/page/1',
+        '/manga/1/chapter/0/page/2',
+      ],
+    );
 
 const _copyKey = ValueKey('reader-page-action-copy-image');
 const _shareKey = ValueKey('reader-page-action-share');
@@ -78,7 +78,9 @@ Future<void> _pumpReader(
             resolvedReaderMode: ReaderMode.webtoon,
             currentIndex: 0,
             chapterPages: _pages(),
-            child: const SizedBox.expand(child: ColoredBox(color: Colors.grey)),
+            child: const SizedBox.expand(
+              child: ColoredBox(color: Colors.grey),
+            ),
           ),
         ),
       ),
@@ -88,9 +90,8 @@ Future<void> _pumpReader(
 }
 
 void main() {
-  testWidgets('pref ON: long-press opens the page-actions sheet', (
-    tester,
-  ) async {
+  testWidgets('pref ON: long-press opens the page-actions sheet',
+      (tester) async {
     await _pumpReader(tester, longTapOn: true);
 
     expect(find.byKey(_copyKey), findsNothing);
@@ -106,9 +107,8 @@ void main() {
   testWidgets('pref OFF: long-press is a no-op', (tester) async {
     await _pumpReader(tester, longTapOn: false);
 
-    final gesture = await tester.startGesture(
-      tester.getCenter(find.byType(ReaderView)),
-    );
+    final gesture =
+        await tester.startGesture(tester.getCenter(find.byType(ReaderView)));
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pump();
 
@@ -127,9 +127,8 @@ void main() {
     var taps = 0;
     await _pumpReader(tester, longTapOn: false, onTap: () => taps++);
 
-    final gesture = await tester.startGesture(
-      tester.getCenter(find.byType(ReaderView)),
-    );
+    final gesture =
+        await tester.startGesture(tester.getCenter(find.byType(ReaderView)));
     await tester.pump(const Duration(milliseconds: 600));
     await gesture.up();
     await tester.pumpAndSettle();

--- a/test/src/features/offline/reading_never_unreads_test.dart
+++ b/test/src/features/offline/reading_never_unreads_test.dart
@@ -21,6 +21,7 @@ GraphQLClient _dummyClient() => GraphQLClient(
 class _CapturingRepo extends MangaBookRepository {
   _CapturingRepo() : super(_dummyClient());
   ChapterChange? lastPatch;
+  ChapterBatch? lastBatch;
 
   @override
   Future<void> putChapter({
@@ -28,6 +29,11 @@ class _CapturingRepo extends MangaBookRepository {
     required ChapterChange patch,
   }) async {
     lastPatch = patch;
+  }
+
+  @override
+  Future<void> modifyBulkChapters(ChapterBatch batch) async {
+    lastBatch = batch;
   }
 }
 
@@ -64,6 +70,49 @@ void main() {
 
       final json = repo.lastPatch!.toJson();
       expect(json['isRead'], true);
+    });
+
+    test('reader completion marks every confidently matched release read',
+        () async {
+      final db = testOfflineDatabase();
+      addTearDown(db.close);
+      for (final id in [11, 12]) {
+        await db.upsertChapterMetadata(
+          id: id,
+          mangaId: 1,
+          name: 'Chapter 1',
+          chapterIndex: id,
+          isRead: false,
+          lastPageRead: 9,
+          isBookmarked: false,
+          serverIsDownloaded: true,
+          pageCount: 10,
+          updatedAt: DateTime(2026),
+        );
+      }
+      final repo = _CapturingRepo();
+
+      await recordReadingProgressWithDependencies(
+        offlineEnabled: true,
+        offlineDatabase: db,
+        repository: repo,
+        chapterId: 11,
+        lastPageRead: 0,
+        isRead: true,
+        completionChapterIds: [11, 12],
+      );
+
+      expect(repo.lastBatch!.ids, [11, 12]);
+      expect(repo.lastBatch!.patch.isRead, isTrue);
+      expect(repo.lastBatch!.patch.lastPageRead, 0);
+      for (final id in [11, 12]) {
+        final row = (await db.chapterById(id))!;
+        expect(row.isRead, isTrue);
+        expect(row.lastPageRead, 0);
+        expect(row.readStateManual, isFalse);
+        expect(row.readStateDirty, isFalse);
+        expect(row.progressDirty, isFalse);
+      }
     });
 
     test('offline: a partial read does NOT flip a read chapter to unread',


### PR DESCRIPTION
# Note
The same PR was filed before but some like app called pull closed it automatically so i reopened it here
Also both of the issues are still issues but they are closed accidentally

## Summary

Fixes duplicate chapter behavior across scanlator releases.

- Marking a chapter read or deleting it now applies to every release with the same positive chapter number, even when no preferred scanlator is configured.
- Reader navigation skips repeated chapter-number releases and moves to the next actual chapter.
- Keeps the currently open release in the reader, so navigation does not swap the chapter being read.
- Leaves chapters with non-positive/unknown numbers independent.

Fixes #365  
Fixes #401

## Testing

- `flutter test test/src/features/manga_book/manga_details/scanlator_propagation_test.dart test/src/features/manga_book/next_prev_chapter_test.dart`
- Focused `flutter analyze` on changed source and test files