### PR TITLE
fix(updates/library): live-patch Updates list on background library check; fix Library missed-true edge

### DIFF
--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -127,7 +127,14 @@ class LibraryScreen extends HookConsumerWidget {
     // chapters it found appear without a manual refresh. Tracks the last
     // known running state and fires on the running→idle edge, ignoring the
     // transient null frames a socket reconnect emits.
-    final lastRunning = useRef<bool>(false);
+    //
+    // Seeded from the socket's current value so an update already in progress
+    // when this widget mounts (e.g. user navigates to Library mid-update)
+    // correctly triggers the invalidate when it finishes, instead of missing
+    // the true→false edge because lastRunning started at false.
+    final lastRunning = useRef<bool>(
+      ref.read(updateRunningSocketProvider).value ?? false,
+    );
     ref.listen(updateRunningSocketProvider, (_, next) {
       final running = next.value;
       if (running == null) return;

--- a/lib/src/features/manga_book/presentation/updates/updates_screen.dart
+++ b/lib/src/features/manga_book/presentation/updates/updates_screen.dart
@@ -255,6 +255,25 @@ Future<ChapterDto?> refetchChapter(WidgetRef ref, int chapterId) async {
   }
 }
 
+/// Extracts new items from a single fetched page when live-patching the
+/// Updates list after a background library check.
+///
+/// Returns all items from [nodes] that are not in [existingIds], stopping
+/// before the first known ID. [boundaryFound] is true when a known ID was
+/// encountered, meaning the caller has collected all new items up to the
+/// existing list and can stop fetching further pages.
+({List<ChapterWithMangaDto> items, bool boundaryFound})
+    extractNewUpdatesFromPage(
+  List<ChapterWithMangaDto> nodes,
+  Set<int> existingIds,
+) {
+  final knownIndex = nodes.indexWhere((c) => existingIds.contains(c.id));
+  if (knownIndex >= 0) {
+    return (items: nodes.take(knownIndex).toList(), boundaryFound: true);
+  }
+  return (items: nodes.toList(), boundaryFound: false);
+}
+
 class UpdatesScreen extends HookConsumerWidget {
   const UpdatesScreen({super.key});
 
@@ -306,9 +325,6 @@ class UpdatesScreen extends HookConsumerWidget {
     // post-await guards ask this one whether the screen itself is still alive.
     final screenContext = context;
     final updatesRepository = ref.watch(updatesRepositoryProvider);
-    final isUpdatesChecking = ref
-        .watch(updatesSocketProvider.select((value) => value.value?.isRunning))
-        .ifNull();
     final lastUpdated = ref.watch(libraryLastUpdatedProvider).value;
     final selectedChapters = useState<Map<int, ChapterDto>>({});
     final filter = ref.watch(updatesFilterProvider);
@@ -340,6 +356,56 @@ class UpdatesScreen extends HookConsumerWidget {
       );
       return;
     }, []);
+    // Use the lightweight running-only socket (not updatesSocketProvider, the
+    // heavy feed that goes silent mid-run on large updates and can miss the
+    // true→false edge). Pattern mirrors LibraryScreen's own update listener.
+    //
+    // On the true→false edge, fetch page 0 and prepend only the items that
+    // aren't already in the list, so the user keeps their scroll position.
+    // Falls back to doing nothing on error (pull-to-refresh still works).
+    final lastRunningUpdates = useRef<bool>(false);
+    Future<void> liveUpdate() async {
+      final gen = generation.value;
+      final existingIds = {
+        for (final item in controller.itemList ?? <ChapterWithMangaDto>[])
+          item.id,
+      };
+      final newItems = <ChapterWithMangaDto>[];
+      // Walk pages until we hit a known ID (the boundary) or run out of pages.
+      // Cap at 3 pages: beyond that the list is so stale that a full reset is
+      // cleaner than prepending dozens of out-of-context entries.
+      const maxPages = 3;
+      for (var pageNo = 0; pageNo < maxPages; pageNo++) {
+        final snapshot = await AsyncValue.guard(
+          () => updatesRepository.getRecentChaptersPage(
+            pageNo: pageNo,
+            filter: latestFilter.value,
+          ),
+        );
+        if (generation.value != gen) return;
+        final page = snapshot.asData?.value;
+        if (page == null) return;
+        final result = extractNewUpdatesFromPage(page.nodes, existingIds);
+        newItems.addAll(result.items);
+        if (result.boundaryFound) break;
+        if (!page.pageInfo.hasNextPage) break;
+        if (pageNo == maxPages - 1) {
+          resetList();
+          return;
+        }
+      }
+      if (newItems.isEmpty) return;
+      controller.itemList = [...newItems, ...?controller.itemList];
+    }
+
+    ref.listen(updateRunningSocketProvider, (_, next) {
+      final running = next.value;
+      if (running == null) return;
+      if (lastRunningUpdates.value && !running) {
+        liveUpdate();
+      }
+      lastRunningUpdates.value = running;
+    });
     // Filtering happens server-side, so a changed filter invalidates every page
     // already loaded. Skip the mount run or page 0 would be fetched twice.
     final isFilterMount = useRef(true);
@@ -351,16 +417,6 @@ class UpdatesScreen extends HookConsumerWidget {
       resetList();
       return null;
     }, [filter]);
-    useEffect(() {
-      if (!isUpdatesChecking) {
-        try {
-          resetList();
-        } catch (e) {
-          //
-        }
-      }
-      return null;
-    }, [isUpdatesChecking]);
     return Scaffold(
       floatingActionButton: selectedChapters.value.isEmpty
           ? const UpdateStatusFab()

--- a/test/src/features/manga_book/updates/updates_live_patch_test.dart
+++ b/test/src/features/manga_book/updates/updates_live_patch_test.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/domain/manga/graphql/__generated__/fragment.graphql.dart';
+import 'package:tsumiru/src/features/manga_book/presentation/updates/updates_screen.dart';
+import 'package:tsumiru/src/graphql/__generated__/schema.graphql.dart';
+
+Fragment$MangaBaseDto _manga() => Fragment$MangaBaseDto(
+      id: 1,
+      genre: const [],
+      inLibrary: true,
+      inLibraryAt: '0',
+      initialized: true,
+      meta: const [],
+      sourceId: '1',
+      status: Enum$MangaStatus.ONGOING,
+      thumbnailUrl: '/thumb/1',
+      title: 'Series',
+      unreadCount: 0,
+      updateStrategy: Enum$UpdateStrategy.ALWAYS_UPDATE,
+      url: '/manga/1',
+    );
+
+Fragment$ChapterWithMangaDto _chapter(int id) => Fragment$ChapterWithMangaDto(
+      id: id,
+      chapterNumber: id.toDouble(),
+      fetchedAt: '0',
+      isBookmarked: false,
+      isDownloaded: false,
+      isRead: false,
+      lastPageRead: 0,
+      lastReadAt: '0',
+      mangaId: 1,
+      name: 'Chapter $id',
+      pageCount: 10,
+      sourceOrder: id,
+      uploadDate: '0',
+      url: '/c/$id',
+      meta: const [],
+      manga: _manga(),
+    );
+
+void main() {
+  group('extractNewUpdatesFromPage', () {
+    test('boundary in the middle — returns items before it, boundaryFound=true',
+        () {
+      final nodes = [_chapter(5), _chapter(4), _chapter(3), _chapter(2)];
+      final existing = {2, 1};
+
+      final result = extractNewUpdatesFromPage(nodes, existing);
+
+      expect(result.boundaryFound, isTrue);
+      expect(result.items.map((c) => c.id), [5, 4, 3]);
+    });
+
+    test('boundary at index 0 — returns empty list, boundaryFound=true', () {
+      final nodes = [_chapter(3), _chapter(2), _chapter(1)];
+      final existing = {3, 2, 1};
+
+      final result = extractNewUpdatesFromPage(nodes, existing);
+
+      expect(result.boundaryFound, isTrue);
+      expect(result.items, isEmpty);
+    });
+
+    test('boundary at last index — returns all but last, boundaryFound=true',
+        () {
+      final nodes = [_chapter(5), _chapter(4), _chapter(3)];
+      final existing = {3};
+
+      final result = extractNewUpdatesFromPage(nodes, existing);
+
+      expect(result.boundaryFound, isTrue);
+      expect(result.items.map((c) => c.id), [5, 4]);
+    });
+
+    test('no boundary — returns all items, boundaryFound=false', () {
+      final nodes = [_chapter(5), _chapter(4), _chapter(3)];
+      final existing = {2, 1};
+
+      final result = extractNewUpdatesFromPage(nodes, existing);
+
+      expect(result.boundaryFound, isFalse);
+      expect(result.items.map((c) => c.id), [5, 4, 3]);
+    });
+
+    test('empty page — returns empty list, boundaryFound=false', () {
+      final result = extractNewUpdatesFromPage([], {1, 2});
+
+      expect(result.boundaryFound, isFalse);
+      expect(result.items, isEmpty);
+    });
+
+    test('empty existing set — returns all items, boundaryFound=false', () {
+      final nodes = [_chapter(3), _chapter(2), _chapter(1)];
+
+      final result = extractNewUpdatesFromPage(nodes, {});
+
+      expect(result.boundaryFound, isFalse);
+      expect(result.items.map((c) => c.id), [3, 2, 1]);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

When a background library check completes (either server-scheduled or user-triggered) while the app is open:

1. **Updates screen** never refreshed — it was listening to `updatesSocketProvider`, the heavy WebSocket feed that [goes silent mid-run on large updates](lib/src/features/manga_book/presentation/updates/widgets/update_progress_banner.dart#L34). On a big library, the `true→false` running-state edge was never delivered, so the list never reset.

2. **Library screen** had a narrower edge case: `lastRunning` was initialised to `false`, so if the user navigated to the Library screen *while an update was already in progress*, the `lastRunning.value && !running` guard could never fire (it had never seen `true`), and `libraryMangaListProvider` was never invalidated at the end.

## Fix

### Updates screen — switch to the lightweight socket + live patch

Replace `updatesSocketProvider` with `ref.listen(updateRunningSocketProvider, …)`, the same lightweight bool-only socket already used by the Library screen (documented to be reliable where the heavy feed is not).

Rather than calling `resetList()` on the `true→false` edge (which would blank the list, wipe scroll position, and re-fetch everything from scratch), the handler fetches pages 0, 1, … and **prepends only the new entries** to the existing `PagingController.itemList`. The user stays at their position in the list; new chapters appear at the top:

- Pages are walked in order until a chapter ID already present in the list is found (the boundary). Only entries before that boundary are prepended.
- Capped at 3 pages: if no boundary is found after 3 pages, the list is clearly very stale and `resetList()` is called instead — a full refresh is more appropriate than prepending dozens of out-of-context entries.
- On network error the handler returns silently; pull-to-refresh still works as a manual fallback.

The per-page boundary logic is extracted as a top-level function `extractNewUpdatesFromPage` so it can be unit-tested without mounting the widget.

### Library screen — seed `lastRunning` from the socket's current value

Initialise `lastRunning` from `ref.read(updateRunningSocketProvider).value ?? false` instead of a hard-coded `false`. If the socket already reports `true` at mount time (the user navigated to Library mid-update), `lastRunning` starts at `true` and the invalidation fires correctly when the update finishes.

## Tests

Added `test/src/features/manga_book/updates/updates_live_patch_test.dart` — 6 unit tests for `extractNewUpdatesFromPage` covering: boundary in the middle of a page, boundary at index 0, boundary at the last index, no boundary (all items new), empty page, empty existing-ID set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)