### PR TITLE
Start on Linux when the system bus is unreachable

### DIFF
--- a/flatpak/io.github.aaronbamblett.tsumiru.yml
+++ b/flatpak/io.github.aaronbamblett.tsumiru.yml
@@ -18,6 +18,9 @@ finish-args:
   - --device=dri               # GPU-accelerated rendering
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets   # libsecret credential store (host keyring)
+  # connectivity_plus watches NetworkManager to notice a network change
+  # and re-check whether the LAN server address is reachable.
+  - --system-talk-name=org.freedesktop.NetworkManager
 
 modules:
   # flutter_secure_storage_linux needs libsecret, which isn't in the

--- a/lib/src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart
+++ b/lib/src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart
@@ -157,6 +157,21 @@ Future<bool> serverUrlIsReachable(String url, {http.Client? client}) async {
   }
 }
 
+/// Subscribes to connectivity changes without letting a platform failure
+/// escape. On a sandboxed Linux build there is no system D-Bus to reach
+/// NetworkManager through, and that failure arrives after listen() returns,
+/// so a try/catch around the call cannot see it. An uncaught async error
+/// before the first frame is treated as a fatal startup failure.
+@visibleForTesting
+StreamSubscription<List<ConnectivityResult>> listenToConnectivity(
+  Stream<List<ConnectivityResult>> changes,
+  void Function() onChange,
+) => changes.listen(
+  (_) => onChange(),
+  onError: (_) {},
+  cancelOnError: false,
+);
+
 /// Keeps [serverUrlProvider] pointed at the preferred endpoint. It runs at
 /// startup and each interface change, so moving between Wi-Fi and mobile data
 /// automatically re-evaluates the LAN address.
@@ -170,12 +185,17 @@ class ServerEndpointResolver extends _$ServerEndpointResolver {
     final external =
         ref.watch(serverExternalUrlProvider) ?? DBKeys.serverUrl.initial;
     ref.watch(serverLanUrlProvider);
-    // Desktop and widget-test platforms may not register connectivity_plus.
-    // Startup selection still works there; they simply cannot receive later
-    // interface-change callbacks.
+    // Desktop and widget-test platforms may not register connectivity_plus,
+    // and a sandboxed Linux build (Flatpak) has no system D-Bus to reach
+    // NetworkManager through. That failure arrives asynchronously, after
+    // listen() returns, so it needs onError rather than a try/catch: an
+    // uncaught async error before the first frame is treated as a fatal
+    // startup failure. Startup selection still works without the stream;
+    // only later interface-change callbacks are lost.
     try {
-      _connectivitySubscription ??= Connectivity().onConnectivityChanged.listen(
-        (_) => unawaited(refresh()),
+      _connectivitySubscription ??= listenToConnectivity(
+        Connectivity().onConnectivityChanged,
+        () => unawaited(refresh()),
       );
     } catch (_) {}
     ref.onDispose(() => _connectivitySubscription?.cancel());

--- a/test/src/features/settings/connectivity_listen_test.dart
+++ b/test/src/features/settings/connectivity_listen_test.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// v1.2.0 would not start under Flatpak. The sandbox has no system D-Bus, so
+// connectivity_plus failed while reaching NetworkManager. That failure lands
+// after listen() returns, escaped the try/catch around it, and an uncaught
+// async error before the first frame shows the "couldn't start" screen.
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tsumiru/src/features/settings/presentation/server/widget/client/server_url_tile/server_url_tile.dart';
+
+void main() {
+  test('a connectivity stream failure never reaches the zone', () async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    final zoneErrors = <Object>[];
+
+    await runZonedGuarded(() async {
+      final sub = listenToConnectivity(controller.stream, () {});
+      controller.addError(
+        const SocketException('no system bus'),
+      );
+      await pumpEventQueue();
+      await sub.cancel();
+    }, (error, _) => zoneErrors.add(error));
+
+    expect(
+      zoneErrors,
+      isEmpty,
+      reason:
+          'an unreachable NetworkManager must not become a fatal startup '
+          'error the way it did under Flatpak in v1.2.0',
+    );
+  });
+
+  test('a failure does not stop later connectivity changes', () async {
+    final controller = StreamController<List<ConnectivityResult>>();
+    var changes = 0;
+
+    final sub = listenToConnectivity(controller.stream, () => changes++);
+    controller.addError(const SocketException('no system bus'));
+    await pumpEventQueue();
+    controller.add([ConnectivityResult.wifi]);
+    await pumpEventQueue();
+    await sub.cancel();
+
+    expect(changes, 1, reason: 'the subscription must survive an error');
+  });
+}
+
+class SocketException implements Exception {
+  const SocketException(this.message);
+  final String message;
+  @override
+  String toString() => 'SocketException: $message';
+}


### PR DESCRIPTION
v1.2.0 does not open at all under Flatpak. It shows the "Tsumiru couldn't start" screen with a SocketException for `/var/run/dbus/system_bus_socket`. The AppImage is unaffected.

## Cause

The endpoint resolver added in #397 subscribes to connectivity changes so it can re-check the LAN address when the network moves. On Linux that means reaching NetworkManager over the **system** D-Bus. The Flatpak manifest grants session-bus access for notifications and the keyring, but has never granted the system bus, so the call fails.

Two things make that fatal rather than cosmetic:

- The failure arrives **after** `listen()` returns, so the `try/catch` written around the call cannot catch it. It escapes as an uncaught async error.
- `_onFatalError` treats an uncaught error before the first frame as a failed startup (`main.dart:517`). The socket is missing, so the failure is immediate: in the reported log it lands at `21:27:00.043` against a first frame at `21:27:00.276`.

The AppImage is not sandboxed, reaches the bus, never errors, and starts normally. That is why only one Linux package broke.

## Fix

- The subscription now handles its own errors, so an unreachable NetworkManager costs the later network-change callbacks and nothing else. Startup selection already works without the stream. This covers any Linux without NetworkManager, not only the sandbox.
- The manifest asks for `org.freedesktop.NetworkManager` by name, the narrow grant rather than opening the system bus, so the feature works inside the sandbox instead of failing quietly.

## Verification

Built and installed locally as a Flatpak from this branch and confirmed the app starts. The stock 1.2.0 build on the same machine still fails.

Two regression tests, both confirmed to fail without the fix: a stream error must not reach the zone, and the subscription must survive one. `flutter analyze` clean, full suite passes.