### PR TITLE
Reload categories on pull to refresh

### DIFF
--- a/lib/src/features/library/presentation/library/library_screen.dart
+++ b/lib/src/features/library/presentation/library/library_screen.dart
@@ -1039,6 +1039,9 @@ class _GroupedMangaList extends ConsumerWidget {
                   .fetchUpdates()
                   .catchError((Object _) {}),
             );
+            // Categories are fetched once per launch, so one added in the
+            // WebUI could not appear without restarting the app.
+            ref.invalidate(categoryControllerProvider);
             ref.invalidate(libraryMangaListProvider);
             await ref.read(libraryMangaListProvider.future);
           },


### PR DESCRIPTION
Pull to refresh on the Library screen reloads the manga list but never the categories.

`categoryControllerProvider` is fetched once per launch and is only invalidated on the two error-retry paths (`library_screen.dart:401` and `:574`). In normal use nothing rebuilds it, so a category created in the WebUI cannot appear in the app until it is fully closed and reopened.

Reported on Discord by a user migrating a library across from another app: the categories they had just created stayed missing until they force-restarted, and nothing in the UI would bring them in.

Pull to refresh now invalidates the category list alongside the manga list.

## Verification

`flutter analyze` clean, full suite passes.

Not covered by a test: the refresh callback is inline in the Library screen and there is no existing harness for it, so a test would mean standing one up for a one-line change. Worth doing when that screen next gets attention.