### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A manga reader client for Suwayomi Server.
 publish_to: "none"
 # Public version matches the Tsumiru release line; build number keeps
 # climbing from the inherited 0.6.4+28 so Android upgrades stay monotonic.
-version: 1.2.0+52
+version: 1.2.1+53
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
Hotfix release. v1.2.0 does not start at all under the Linux Flatpak.

- Linux Flatpak startup failure (#445)
- Pull to refresh now reloads categories (#446)
- Windows storage-cap scan and file-locking fixes (#443)