### PR TITLE
fix(offline/notifications): recover background auth on in-band 401; nudge deferred catch-up

### DIFF
--- a/lib/src/features/notifications/data/background/notification_background_client.dart
+++ b/lib/src/features/notifications/data/background/notification_background_client.dart
@@ -10,8 +10,13 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 
 import '../../../../constants/endpoints.dart';
+import '../../../../utils/crash/diagnostics.dart';
 import '../../../offline/data/background/background_token_record.dart'
-    show BackgroundTokenRecord, TokenBroker, applyIsolateCustomHeaders;
+    show
+        BackgroundTokenRecord,
+        TokenBroker,
+        applyIsolateCustomHeaders,
+        isGraphqlAuthError;
 
 /// Where + how the background worker reaches the server. Persisted so the
 /// WorkManager isolate (no Riverpod, no widget tree) can rebuild it.
@@ -96,11 +101,30 @@ class NotificationBackgroundClient {
     Map<String, Object?> variables,
   ) async {
     var res = await _raw(query, variables, _record.accessToken);
-    if (identical(res, _authError) && _record.authType == 'uiLogin') {
-      final fresh = await broker.resolveAfter401(_record.accessToken ?? '');
-      if (fresh != null) {
-        _record = await broker.read();
-        res = await _raw(query, variables, fresh);
+    if (identical(res, _authError)) {
+      if (_record.authType == 'uiLogin') {
+        final fresh = await broker.resolveAfter401(_record.accessToken ?? '');
+        if (fresh != null) {
+          _record = await broker.read();
+          res = await _raw(query, variables, fresh);
+        } else {
+          // The access token was rejected AND the refresh did not yield a new
+          // one. transient=true means the refresh call itself couldn't reach
+          // the server (retry later); transient=false means the server
+          // rejected the refresh token — auth is genuinely dead until the app
+          // is reopened and re-authenticates. This is the single most likely
+          // reason a background run that worked once fails on every wake after
+          // the access token expires.
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-graphql: '
+            'refresh-failed transient=${broker.lastRefreshTransient}\n',
+          );
+        }
+      } else {
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-graphql: '
+          'auth-rejected authType=${_record.authType} (no refresh path)\n',
+        );
       }
     }
     return res is Map<String, Object?> ? res : null;
@@ -122,12 +146,42 @@ class NotificationBackgroundClient {
           )
           .timeout(const Duration(seconds: 10));
       if (res.statusCode == 401 || res.statusCode == 403) return _authError;
-      if (res.statusCode != 200) return _networkError;
+      if (res.statusCode != 200) {
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-graphql: '
+          'http-error status=${res.statusCode}\n',
+        );
+        return _networkError;
+      }
       final decoded = jsonDecode(res.body) as Map<String, Object?>;
+      // Suwayomi returns an expired/invalid access token as HTTP 200 with a
+      // GraphQL auth error (extensions.http.status == 401, or an "unauthorized"
+      // message), NOT an HTTP 401 — verifyJwt downgrades a bad token to Visitor
+      // and the @requireAuth field errors IN-BAND. The foreground
+      // SuwayomiAuthLink detects exactly this; the background must too. Without
+      // it the broker refresh below never fires, so every background run past
+      // the server's 5-minute access-token lifetime fails — the notification
+      // check and download resolution both return null and the worker reports
+      // ok=false forever until the app is reopened. This was THE overnight bug.
+      if (isGraphqlAuthError(decoded['errors'])) return _authError;
       return decoded['data'] as Map<String, Object?>?;
-    } on SocketException {
+    } on SocketException catch (e) {
+      // Server unreachable (self-hosted server asleep, off the LAN/VPN, DNS) —
+      // distinct from an auth failure. Recorded so a background run that fails
+      // because the server is simply not reachable overnight is not mistaken
+      // for an expired-token problem.
+      recordDiagnostic(
+        '[${DateTime.now().toIso8601String()}] offline-graphql: '
+        'socket-error ${e.osError?.message ?? e.message}\n',
+      );
       return _networkError;
-    } catch (_) {
+    } catch (e) {
+      // Includes TimeoutException from the 10s cap above — a slow/unreachable
+      // server rather than a rejection.
+      recordDiagnostic(
+        '[${DateTime.now().toIso8601String()}] offline-graphql: '
+        'request-error $e\n',
+      );
       return _networkError;
     }
   }

--- a/lib/src/features/notifications/data/background/notification_background_entry.dart
+++ b/lib/src/features/notifications/data/background/notification_background_entry.dart
@@ -17,6 +17,14 @@ const kNewChapterCheckTask = 'tsumiru.newChapterCheck';
 const kNewChapterPeriodicName = 'tsumiru.newChapterCheck.periodic';
 const kNewChapterCheckNowName = 'tsumiru.newChapterCheck.now';
 
+/// A short-fuse follow-up wake, scheduled when a run leaves chapters waiting on
+/// the server's own download (the two-hop server-fetch). Its own unique name,
+/// so it never replaces or suppresses the periodic schedule. Without it, the
+/// second hop waits for the next 1-6h period — or, if the app is force-closed,
+/// until the next launch — which is the "a chapter is regularly forgotten in
+/// catch-up" symptom.
+const kNewChapterFollowUpName = 'tsumiru.newChapterCheck.followup';
+
 /// The isolate entry point registered with `Workmanager().initialize`. Must be a
 /// top-level `vm:entry-point` function — the OS spawns a fresh isolate here.
 @pragma('vm:entry-point')

--- a/lib/src/features/notifications/data/background/notification_worker.dart
+++ b/lib/src/features/notifications/data/background/notification_worker.dart
@@ -541,14 +541,30 @@ TokenBroker _brokerFor(NotificationStateStore store, NotificationEndpoint ep) {
         if (isGatewayStatus(res.statusCode)) {
           return (tokens: null, transient: true);
         }
-        if (res.statusCode != 200) return (tokens: null, transient: false);
-        final data =
-            (jsonDecode(res.body) as Map<String, Object?>)['data']
-                as Map<String, Object?>?;
+        if (res.statusCode != 200) {
+          // The server was reached and rejected the refresh (e.g. 401/403 =
+          // refresh token no longer accepted). This is the decisive line for
+          // "the background worker worked once then fails every wake": if it
+          // shows up, the fix is on the auth side, not Doze/scheduling.
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-refresh: '
+            'rejected status=${res.statusCode}\n',
+          );
+          return (tokens: null, transient: false);
+        }
+        final decoded = jsonDecode(res.body) as Map<String, Object?>;
+        final data = decoded['data'] as Map<String, Object?>?;
         final access =
             (data?['refreshToken'] as Map<String, Object?>?)?['accessToken']
                 as String?;
         if (access == null || access.isEmpty) {
+          // HTTP 200 but no token — usually a GraphQL `errors` payload
+          // (invalid/expired refresh token reported in-band). Surface the
+          // errors so the reason is visible in the log.
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-refresh: '
+            'no-token errors=${decoded['errors']}\n',
+          );
           return (tokens: null, transient: false);
         }
         // Suwayomi doesn't rotate the refresh token — reuse it.

--- a/lib/src/features/offline/data/background/background_chapter_fetch.dart
+++ b/lib/src/features/offline/data/background/background_chapter_fetch.dart
@@ -120,6 +120,10 @@ Future<Object?> postBackgroundGraphql({
     if (isGatewayStatus(res.statusCode)) return gqlNetworkError;
     if (res.statusCode != 200) return null;
     final decoded = jsonDecode(res.body) as Map<String, Object?>;
+    // Expired token comes back as HTTP 200 with an in-band GraphQL 401, not a
+    // real 401 (see isGraphqlAuthError) — route it to the broker refresh above
+    // instead of treating a null data payload as "no result".
+    if (isGraphqlAuthError(decoded['errors'])) return gqlAuthError;
     return decoded['data'];
   } on SocketException {
     return gqlNetworkError;

--- a/lib/src/features/offline/data/background/background_schedule_io.dart
+++ b/lib/src/features/offline/data/background/background_schedule_io.dart
@@ -62,18 +62,46 @@ Future<void> reconcileBackgroundSchedule() =>
       final downloadDemand = queue || catchup;
       final wifiOnly =
           (!notices || config!.wifiOnly) && (!downloadDemand || spec!.wifiOnly);
+      final networkType = wifiOnly
+          ? NetworkType.unmetered
+          : NetworkType.connected;
       await Workmanager().registerPeriodicTask(
         kNewChapterPeriodicName,
         kNewChapterCheckTask,
         frequency: Duration(hours: (config?.intervalHours ?? 6).clamp(1, 6)),
         constraints: Constraints(
-          networkType: wifiOnly ? NetworkType.unmetered : NetworkType.connected,
+          networkType: networkType,
           requiresCharging: !downloadDemand && (config?.chargingOnly ?? false),
           requiresBatteryNotLow: true,
         ),
         existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
       );
+      // A freshly-published upstream chapter is usually not yet downloaded on
+      // the server, so the last run asked the server to fetch it and deferred
+      // the device pull to a later wake. Nudge that wake to happen in minutes
+      // instead of the next full period (or the next app launch) so the second
+      // hop completes promptly — this is the "a chapter is regularly forgotten
+      // in catch-up" case. It's a one-off (not periodic), so it needs no
+      // explicit cancel: while the obligation persists each run re-arms it
+      // (replace), and once pendingServerFetch drains — the download lands, or
+      // the executor's retry budget exhausts the entry — we simply stop
+      // re-arming and the last queued one fires once more, harmlessly.
+      if (downloadDemand &&
+          state.readLedger(spec!.serverId).pendingServerFetch.isNotEmpty) {
+        await Workmanager().registerOneOffTask(
+          kNewChapterFollowUpName,
+          kNewChapterCheckTask,
+          initialDelay: _followUpDelay,
+          constraints: Constraints(networkType: networkType),
+          existingWorkPolicy: ExistingWorkPolicy.replace,
+        );
+      }
     });
+
+/// How long after a run leaves a server-fetch pending before the follow-up wake
+/// retries the second hop. Long enough for the server to finish its own
+/// download of a typical chapter, short enough to beat the 1-6h periodic gap.
+const _followUpDelay = Duration(minutes: 15);
 
 bool queuedChapterTerminal(List<LogEntry> entries, QueuedChapterSpec chapter) {
   var generation = -1;

--- a/lib/src/features/offline/data/background/background_token_record.dart
+++ b/lib/src/features/offline/data/background/background_token_record.dart
@@ -83,6 +83,30 @@ Map<String, String> applyIsolateCustomHeaders(
   return headers;
 }
 
+/// Suwayomi reports an expired/invalid access token as HTTP **200** with a
+/// GraphQL error carrying `extensions.http.status == 401` (or an "unauthorized"
+/// message), NOT an HTTP 401 — `verifyJwt` downgrades a bad token to a Visitor
+/// and the `@requireAuth` field errors in-band. Every background GraphQL path
+/// must treat this like a 401 so the broker refresh fires; the foreground
+/// `SuwayomiAuthLink` already does. Without it, once the server's short
+/// (default 5-minute) access token expires, every background run fails silently
+/// and never refreshes. Shared by the notification client and the catch-up
+/// fetch path so both detect it identically.
+bool isGraphqlAuthError(Object? errors) {
+  if (errors is! List) return false;
+  for (final err in errors) {
+    if (err is! Map) continue;
+    final ext = err['extensions'];
+    final http = ext is Map ? ext['http'] : null;
+    if (http is Map && http['status'] == 401) return true;
+    final message = err['message'];
+    if (message is String && message.toLowerCase().contains('unauthor')) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Outcome of one refresh attempt: the new tokens on success, or a failure
 /// that distinguishes "the refresh call itself couldn't reach the server"
 /// (transient — retry later, auth may still be fine) from "the server

--- a/test/offline/background/background_schedule_test.dart
+++ b/test/offline/background/background_schedule_test.dart
@@ -68,6 +68,26 @@ class _Schedule extends WorkmanagerPlatform {
     if (refuseRegistration) throw StateError('Scheduler unavailable');
   }
 
+  final oneOffRegistrations = <({String name, Duration? initialDelay})>[];
+
+  @override
+  Future<void> registerOneOffTask(
+    String uniqueName,
+    String taskName, {
+    String? tag,
+    ExistingWorkPolicy? existingWorkPolicy,
+    Duration? initialDelay,
+    Constraints? constraints,
+    BackoffPolicy? backoffPolicy,
+    Duration? backoffPolicyDelay,
+    OutOfQuotaPolicy? outOfQuotaPolicy,
+    Map<String, dynamic>? inputData,
+    ForegroundServiceConfig? foregroundServiceConfig,
+    bool expedited = false,
+  }) async {
+    oneOffRegistrations.add((name: uniqueName, initialDelay: initialDelay));
+  }
+
   @override
   Future<void> cancelByUniqueName(String uniqueName) async {
     cancellations.add(uniqueName);
@@ -335,6 +355,38 @@ void main() {
       expect(CatchupStateStore(prefs).downloadEnabled, isFalse);
       expect(NotificationStateStore(prefs).readConfig()!.anyEnabled, isFalse);
       expect(schedule.registrations.single.networkType, NetworkType.connected);
+      expect(schedule.cancellations, isEmpty);
+    },
+  );
+
+  test(
+    'a pending server-fetch arms a short follow-up wake that stops re-arming when it clears',
+    () async {
+      await config();
+      await writeCatchupWorkSpec(container.read);
+      await CatchupStateStore(prefs).writeLedger(
+        'catalog',
+        const CatchupLedger(pendingServerFetch: {99: 1}),
+      );
+      await reconcileBackgroundSchedule();
+
+      expect(schedule.oneOffRegistrations, hasLength(1));
+      expect(schedule.oneOffRegistrations.single.name, kNewChapterFollowUpName);
+      expect(
+        schedule.oneOffRegistrations.single.initialDelay,
+        const Duration(minutes: 15),
+      );
+
+      // The obligation clears (download landed, or the retry budget drained):
+      // a one-off self-expires after one fire, so reconcile must simply stop
+      // re-arming it — no new registration, and no spurious cancellation that
+      // would pollute the periodic-schedule bookkeeping.
+      await CatchupStateStore(
+        prefs,
+      ).writeLedger('catalog', const CatchupLedger());
+      await reconcileBackgroundSchedule();
+
+      expect(schedule.oneOffRegistrations, hasLength(1));
       expect(schedule.cancellations, isEmpty);
     },
   );

--- a/test/src/features/notifications/notification_background_auth_refresh_test.dart
+++ b/test/src/features/notifications/notification_background_auth_refresh_test.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:tsumiru/src/features/notifications/data/background/notification_background_client.dart';
+import 'package:tsumiru/src/features/offline/data/background/background_token_record.dart';
+
+void main() {
+  group('isGraphqlAuthError', () {
+    test('detects an in-band 401 via extensions.http.status', () {
+      expect(
+        isGraphqlAuthError([
+          {
+            'message': 'Access denied',
+            'extensions': {
+              'http': {'status': 401},
+            },
+          },
+        ]),
+        isTrue,
+      );
+    });
+
+    test('detects an "unauthorized" message with no extensions', () {
+      expect(
+        isGraphqlAuthError([
+          {'message': 'Unauthorized'},
+        ]),
+        isTrue,
+      );
+    });
+
+    test('a non-auth error is not treated as auth', () {
+      expect(
+        isGraphqlAuthError([
+          {
+            'message': 'Some field error',
+            'extensions': {
+              'http': {'status': 500},
+            },
+          },
+        ]),
+        isFalse,
+      );
+    });
+
+    test('null / empty is not auth', () {
+      expect(isGraphqlAuthError(null), isFalse);
+      expect(isGraphqlAuthError(const []), isFalse);
+    });
+  });
+
+  test(
+    'a uiLogin 200-with-errors auth response refreshes the token and retries',
+    () async {
+      // The server reports an expired access token as HTTP 200 carrying a
+      // GraphQL 401, not a real HTTP 401. The client must still route it to the
+      // broker refresh and retry with the fresh token — the background overnight
+      // fix.
+      var stored = const BackgroundTokenRecord(
+        gen: 0,
+        authType: 'uiLogin',
+        endpoint: 'e',
+        accessToken: 'expired',
+        refreshToken: 'rt',
+      );
+      var refreshCalls = 0;
+      final broker = TokenBroker(
+        read: () async => stored,
+        write: (r) async => stored = r,
+        refreshFn: (rt) async {
+          refreshCalls++;
+          return (tokens: (access: 'fresh', refresh: rt), transient: false);
+        },
+      );
+
+      var queryPosts = 0;
+      final mock = MockClient((req) async {
+        queryPosts++;
+        final auth = req.headers['Authorization'] ?? req.headers['authorization'];
+        if (auth == 'Bearer fresh') {
+          return http.Response(
+            jsonEncode({
+              'data': {
+                'chapters': {
+                  'pageInfo': {'hasNextPage': false, 'endCursor': null},
+                  'nodes': const [],
+                },
+              },
+            }),
+            200,
+          );
+        }
+        // Expired token → HTTP 200 with an in-band GraphQL 401.
+        return http.Response(
+          jsonEncode({
+            'errors': [
+              {
+                'message': 'Access denied',
+                'extensions': {
+                  'http': {'status': 401},
+                },
+              },
+            ],
+            'data': null,
+          }),
+          200,
+        );
+      });
+
+      final client = NotificationBackgroundClient(
+        endpoint: const NotificationEndpoint(
+          baseUrl: 'http://server.test',
+          addPort: false,
+        ),
+        record: stored,
+        broker: broker,
+        httpClient: mock,
+      );
+
+      final page = await client.fetchNewChaptersPage(fetchedAtGte: '0');
+
+      expect(page, isNotNull, reason: 'the retry after refresh should succeed');
+      expect(refreshCalls, 1, reason: 'the in-band 401 must trigger one refresh');
+      expect(queryPosts, 2, reason: 'one failing call + one retry');
+      expect(client.currentRecord().accessToken, 'fresh');
+    },
+  );
+}


### PR DESCRIPTION
## Root cause

Suwayomi Server's `verifyJwt()` silently downgrades an expired or invalid access token to `Visitor` (HTTP 200) instead of returning a real HTTP 401. Fields protected by `@requireAuth` then error **in-band** in the GraphQL response, carrying `extensions.http.status: 401` (or an `"Unauthorized"` message string) — never as a transport-level 401.

The access token TTL is **5 minutes** by default (`ServerConfig.kt`). The first background wake after that window fires correctly. Every subsequent one — including all overnight runs — sends an expired token, gets a 200-with-errors back, and fails silently because:

- `NotificationBackgroundClient._raw()` only checked the HTTP status code; a 200 body was returned as-is, never triggering the broker refresh.
- `postBackgroundGraphql()` similarly returned `null` (treated as a network error) rather than routing to `resolveAfter401`.

WorkManager interprets `ok=false` as a retriable failure and schedules exponential-backoff retries, producing a visible cluster of rapid re-fires in `adb dumpsys jobscheduler` — silently never downloading or sending notifications.

The foreground `SuwayomiAuthLink._is401()` already detects both forms correctly. This PR mirrors that logic for the background.

## Fix

### 1. Shared `isGraphqlAuthError` helper (`background_token_record.dart`)
Mirrors `SuwayomiAuthLink._is401()` for the headless/isolate context: checks `extensions.http.status == 401` and `message.toLowerCase().contains('unauthor')`. Shared by both background GraphQL paths so detection is identical everywhere.

### 2. In-band 401 detection in `NotificationBackgroundClient._raw()`
After decoding a 200 body, calls `isGraphqlAuthError(decoded['errors'])` and returns the auth-error sentinel, routing to the existing `TokenBroker.resolveAfter401()` which uses the 60-day refresh token to obtain a fresh access token.

### 3. In-band 401 detection in `postBackgroundGraphql()`
Same fix for the catch-up download path: 200-with-auth-errors now returns `gqlAuthError` instead of `null`, directing the caller to `resolveAfter401`.

### 4. Follow-up one-off wake for deferred catch-up (`background_schedule_io.dart`)
A freshly-published chapter is often not yet downloaded on the Suwayomi server at notification time. The first run triggers a server-side fetch and defers the device pull (`pendingServerFetch`). Without this, the chapter waits the full 1–6 h periodic gap — the "chapter regularly forgotten in catch-up" symptom.

`reconcileBackgroundSchedule()` now registers a short one-off wake (`tsumiru.newChapterCheck.followup`, 15 min) when `pendingServerFetch` is non-empty. `ExistingWorkPolicy.replace` makes re-arming idempotent; once the obligation drains, runs stop re-arming and the last queued one fires harmlessly.

### 5. Diagnostic breadcrumbs
`notification_background_client.dart` and `notification_worker.dart` now append named breadcrumbs to `crash.log` on failure (`refresh-failed`, `auth-rejected`, `http-error`, `socket-error`, `offline-refresh: rejected status=…`, `offline-refresh: no-token`). Future overnight failures are immediately identifiable without another investigation cycle.

## Tests

**`notification_background_auth_refresh_test.dart`** (new):
- 4 unit tests for `isGraphqlAuthError` (extensions.http.status 401, "Unauthorized" message, non-auth 500, null/empty)
- End-to-end integration test: mock HTTP client returns 200-with-auth-errors for the expired token, then success for the fresh token; asserts `refreshCalls == 1`, `queryPosts == 2`, `client.currentRecord().accessToken == 'fresh'`

**`background_schedule_test.dart`** (extended):
- New test: "a pending server-fetch arms a short follow-up wake that stops re-arming when it clears" — verifies 15-min delay and `kNewChapterFollowUpName`, then verifies a second reconcile with an empty ledger does not add another registration.

## Files changed

| File | Change |
|---|---|
| `background_token_record.dart` | +`isGraphqlAuthError()` shared helper |
| `notification_background_client.dart` | in-band 401 detection + diagnostic breadcrumbs |
| `background_chapter_fetch.dart` | in-band 401 detection |
| `background_schedule_io.dart` | follow-up one-off wake registration |
| `notification_background_entry.dart` | +`kNewChapterFollowUpName` constant |
| `notification_worker.dart` | diagnostic breadcrumbs for refresh path |
| `notification_background_auth_refresh_test.dart` | new test file |
| `background_schedule_test.dart` | extended with follow-up-wake test |

> **Draft — pending overnight verification on device before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)