### PR TITLE
feat(manga-details): add "Mark below as read" to chapter multi-select menu

### DIFF
--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -21,6 +21,7 @@ import '../../../library/presentation/category/controller/edit_category_controll
 import '../../../library/presentation/library/controller/library_controller.dart';
 import '../../../library/presentation/library/controller/library_manga_list.dart';
 import '../../../migration/domain/migration_models.dart';
+import '../../../offline/data/offline_download_providers.dart';
 import '../../../offline/data/server_reachability.dart';
 import '../../../offline/presentation/server_unreachable_banner.dart';
 import '../../../settings/presentation/appearance/widgets/show_recommendations/show_recommendations_tile.dart';
@@ -209,6 +210,7 @@ class MangaDetailsScreen extends HookConsumerWidget {
                     MultiSelectPopupButton(
                       filteredChapterList: filteredChapterList,
                       selectedChapters: selectedChapters,
+                      afterOptionSelected: chapterListRefresh,
                     ),
                   ],
                 )
@@ -474,18 +476,20 @@ class MangaDetailsScreen extends HookConsumerWidget {
   }
 }
 
-class MultiSelectPopupButton extends StatelessWidget {
+class MultiSelectPopupButton extends ConsumerWidget {
   const MultiSelectPopupButton({
     super.key,
     required this.filteredChapterList,
     required this.selectedChapters,
+    required this.afterOptionSelected,
   });
 
   final AsyncValue<List<ChapterDto>?> filteredChapterList;
   final ValueNotifier<Map<int, ChapterDto>> selectedChapters;
+  final Future<void> Function() afterOptionSelected;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return PopupMenuButton(
       shape: RoundedRectangleBorder(
         borderRadius: KBorderRadius.r16.radius,
@@ -538,6 +542,33 @@ class MultiSelectPopupButton extends StatelessWidget {
             });
           },
           child: Text(context.l10n.selectInBetween),
+        ),
+        PopupMenuItem(
+          onTap: () async {
+            final chapterList = [...?filteredChapterList.value];
+            final selectedIds = selectedChapters.value.keys.toSet();
+            // Anchor = first selected chapter in the current list order.
+            final anchorIndex =
+                chapterList.indexWhere((c) => selectedIds.contains(c.id));
+            if (anchorIndex < 0) return;
+            // "Below" means every chapter that appears lower in the list than
+            // the anchor. In the default descending sort (newest first) these
+            // are the older chapters — exactly what the user wants to mark read.
+            final belowIds = [
+              for (int i = anchorIndex + 1; i < chapterList.length; i++)
+                chapterList[i].id,
+            ];
+            if (belowIds.isEmpty) return;
+            await recordReadState(
+              ref,
+              chapterIds: belowIds,
+              isRead: true,
+              resetPosition: true,
+            );
+            selectedChapters.value = {};
+            await afterOptionSelected();
+          },
+          child: Text(context.l10n.markBelowAsRead),
         ),
       ],
     );

--- a/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
+++ b/lib/src/features/manga_book/presentation/manga_details/manga_details_screen.dart
@@ -21,7 +21,6 @@ import '../../../library/presentation/category/controller/edit_category_controll
 import '../../../library/presentation/library/controller/library_controller.dart';
 import '../../../library/presentation/library/controller/library_manga_list.dart';
 import '../../../migration/domain/migration_models.dart';
-import '../../../offline/data/offline_download_providers.dart';
 import '../../../offline/data/server_reachability.dart';
 import '../../../offline/presentation/server_unreachable_banner.dart';
 import '../../../settings/presentation/appearance/widgets/show_recommendations/show_recommendations_tile.dart';
@@ -210,7 +209,6 @@ class MangaDetailsScreen extends HookConsumerWidget {
                     MultiSelectPopupButton(
                       filteredChapterList: filteredChapterList,
                       selectedChapters: selectedChapters,
-                      afterOptionSelected: chapterListRefresh,
                     ),
                   ],
                 )
@@ -476,20 +474,18 @@ class MangaDetailsScreen extends HookConsumerWidget {
   }
 }
 
-class MultiSelectPopupButton extends ConsumerWidget {
+class MultiSelectPopupButton extends StatelessWidget {
   const MultiSelectPopupButton({
     super.key,
     required this.filteredChapterList,
     required this.selectedChapters,
-    required this.afterOptionSelected,
   });
 
   final AsyncValue<List<ChapterDto>?> filteredChapterList;
   final ValueNotifier<Map<int, ChapterDto>> selectedChapters;
-  final Future<void> Function() afterOptionSelected;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return PopupMenuButton(
       shape: RoundedRectangleBorder(
         borderRadius: KBorderRadius.r16.radius,
@@ -544,31 +540,19 @@ class MultiSelectPopupButton extends ConsumerWidget {
           child: Text(context.l10n.selectInBetween),
         ),
         PopupMenuItem(
-          onTap: () async {
+          onTap: () {
             final chapterList = [...?filteredChapterList.value];
             final selectedIds = selectedChapters.value.keys.toSet();
-            // Anchor = first selected chapter in the current list order.
             final anchorIndex =
                 chapterList.indexWhere((c) => selectedIds.contains(c.id));
             if (anchorIndex < 0) return;
-            // "Below" means every chapter that appears lower in the list than
-            // the anchor. In the default descending sort (newest first) these
-            // are the older chapters — exactly what the user wants to mark read.
-            final belowIds = [
+            selectedChapters.value = {
+              ...selectedChapters.value,
               for (int i = anchorIndex + 1; i < chapterList.length; i++)
-                chapterList[i].id,
-            ];
-            if (belowIds.isEmpty) return;
-            await recordReadState(
-              ref,
-              chapterIds: belowIds,
-              isRead: true,
-              resetPosition: true,
-            );
-            selectedChapters.value = {};
-            await afterOptionSelected();
+                chapterList[i].id: chapterList[i],
+            };
           },
-          child: Text(context.l10n.markBelowAsRead),
+          child: Text(context.l10n.selectBelow),
         ),
       ],
     );

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2742,6 +2742,7 @@
   "search": "Search",
   "searchLibraryHint": "Search title, author, source...",
   "searchingForUpdates": "Searching for updates",
+  "markBelowAsRead": "Mark below as read",
   "selectInBetween": "Select in between",
   "selectNext10": "Select next 10",
   "selectUnread": "Select Unread",

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -2742,7 +2742,7 @@
   "search": "Search",
   "searchLibraryHint": "Search title, author, source...",
   "searchingForUpdates": "Searching for updates",
-  "markBelowAsRead": "Mark below as read",
+  "selectBelow": "Select below",
   "selectInBetween": "Select in between",
   "selectNext10": "Select next 10",
   "selectUnread": "Select Unread",


### PR DESCRIPTION
## Problem

The multi-select popup menu (⋮) in the manga detail chapter list mixes two different kinds of actions:

- **Selection actions** (`selectNext10`, `selectUnread`, `selectInBetween`) — modify the selection, text-only items
- **Mark actions** (`done_all`, `remove_done`) — are icon buttons in the bottom action bar

Adding a direct "mark below as read" action to the text-only popup menu breaks that pattern. Mihon uses a custom drawable (`ic_done_prev_24dp`) for this, which isn't available as a Material icon.

## Fix

Adds **"Select below"** to the popup menu — selecting all chapters below the anchor chapter in the current list order. The user can then tap the `done_all` icon in the bottom bar to mark them read.

This keeps the menu homogeneous (selection actions only, text-only items) and is consistent with how the other `selectXxx` items work: they accumulate onto the existing selection, so mixed operations (e.g. select unread + select below) compose naturally.

`MultiSelectPopupButton` reverted back to `StatelessWidget` (no longer needs `ref` or `afterOptionSelected`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)