### PR TITLE
fix(offline): sync chapters before reconciling on bulk keep-rule change

### DIFF
--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -23,6 +23,7 @@ import '../../../manga_book/domain/chapter/chapter_model.dart';
 import '../../../manga_book/domain/manga/manga_model.dart';
 import '../../../manga_book/presentation/manga_details/widgets/edit_manga_category_dialog.dart';
 import '../../../migration/domain/migration_models.dart';
+import '../../../offline/data/offline_chapter_catchup.dart';
 import '../../../offline/data/offline_download_providers.dart';
 import '../../../offline/data/offline_repository.dart';
 import '../../../offline/data/server_reachability.dart';
@@ -222,6 +223,12 @@ class CategoryMangaList extends HookConsumerWidget {
                   onMarkUnread: () => markSelection(false),
                   onKeepOffline: () async {
                     final ids = selection.value.toList();
+                    // Captured before any await — context is guaranteed mounted here.
+                    // After the dialog awaits below it may no longer be.
+                    final container = ProviderScope.containerOf(
+                      context,
+                      listen: false,
+                    );
                     // Let the user choose how much to keep (next-N / all-unread
                     // / all) instead of silently downloading every chapter —
                     // picking "all" across a read library can queue thousands.
@@ -238,17 +245,33 @@ class CategoryMangaList extends HookConsumerWidget {
                     }
                     selection.value = const {};
                     final db = ref.read(offlineDatabaseProvider);
+                    // Manga whose chapter list has never been mirrored into
+                    // the local DB (never opened in manga details) can't be
+                    // reconciled immediately — the reconciler finds an empty
+                    // chapter list and silently does nothing. Collect them
+                    // for a background sync+reconcile instead.
+                    final needsSync = <int>{};
                     for (final id in ids) {
                       await db.setKeepRule(id, picked.rule, picked.count);
                       // Queue only — starting per manga let the FGS drain and
                       // stop between each one, so its "X/Y" notification never
                       // showed the whole selection's real total. One start
                       // below, after every manga in the selection is queued.
-                      await reconcileMangaWidget(ref, id, startDownload: false);
+                      final chapters = await db.chaptersForManga(id);
+                      if (chapters.isEmpty) {
+                        needsSync.add(id);
+                      } else {
+                        await reconcileMangaWidget(ref, id, startDownload: false);
+                      }
                     }
                     await ref.read(downloadStarterProvider)(
                       userInitiated: true,
                     );
+                    // Manga needing chapter sync: fetch from server in the
+                    // background, then reconcile and start downloading.
+                    if (needsSync.isNotEmpty) {
+                      unawaited(syncAndReconcileMangaSet(container, needsSync));
+                    }
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(

--- a/lib/src/features/library/presentation/library/category_manga_list.dart
+++ b/lib/src/features/library/presentation/library/category_manga_list.dart
@@ -245,33 +245,37 @@ class CategoryMangaList extends HookConsumerWidget {
                     }
                     selection.value = const {};
                     final db = ref.read(offlineDatabaseProvider);
-                    // Manga whose chapter list has never been mirrored into
-                    // the local DB (never opened in manga details) can't be
-                    // reconciled immediately — the reconciler finds an empty
-                    // chapter list and silently does nothing. Collect them
-                    // for a background sync+reconcile instead.
-                    final needsSync = <int>{};
-                    for (final id in ids) {
-                      await db.setKeepRule(id, picked.rule, picked.count);
-                      // Queue only — starting per manga let the FGS drain and
-                      // stop between each one, so its "X/Y" notification never
-                      // showed the whole selection's real total. One start
-                      // below, after every manga in the selection is queued.
-                      final chapters = await db.chaptersForManga(id);
-                      if (chapters.isEmpty) {
-                        needsSync.add(id);
-                      } else {
-                        await reconcileMangaWidget(ref, id, startDownload: false);
-                      }
+                    final sync = ref.read(offlineSyncProvider);
+                    // setKeepRule is a pure UPDATE: with no offlineMangas row it
+                    // silently touches nothing, so the rule never persists and
+                    // the reconciler later early-exits on the missing row. A
+                    // library row is only mirrored lazily (unawaited, and only
+                    // when the list came from the server), so it can be absent
+                    // here. Mirror it now from the DTO we already hold, then set
+                    // the rule against a row that is guaranteed to exist.
+                    final selected =
+                        items.where((m) => ids.contains(m.id)).toList();
+                    for (final manga in selected) {
+                      await sync?.syncManga(
+                        manga,
+                        fetchedAtGen: sync.syncGeneration,
+                      );
+                      await db.setKeepRule(manga.id, picked.rule, picked.count);
                     }
-                    await ref.read(downloadStarterProvider)(
-                      userInitiated: true,
+                    // Always fetch fresh chapter state before reconciling — the
+                    // stored serverIsDownloaded mirror the reconciler routes on
+                    // goes stale, which otherwise sends chapters to a device-only
+                    // download (bypassing the server) or to a server re-enqueue
+                    // that never pulls to the device. syncAndReconcileMangaSet
+                    // re-syncs, reconciles, registers the second-hop pull, and
+                    // starts the download in the background.
+                    unawaited(
+                      syncAndReconcileMangaSet(
+                        container,
+                        ids.toSet(),
+                        userInitiated: true,
+                      ),
                     );
-                    // Manga needing chapter sync: fetch from server in the
-                    // background, then reconcile and start downloading.
-                    if (needsSync.isNotEmpty) {
-                      unawaited(syncAndReconcileMangaSet(container, needsSync));
-                    }
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -28,7 +28,6 @@ import 'offline_background_downloads.dart';
 import 'offline_database.dart';
 import 'offline_download_providers.dart';
 import 'offline_repository.dart';
-import 'offline_types.dart';
 
 /// Closes the #310 gap: a library update told the SERVER to find new chapters,
 /// but nothing on the client synced or downloaded them for keep-rule manga —
@@ -329,6 +328,26 @@ touchedSinceWatermark({
     }
   }
   return (touched: touched, newestFetchedAt: newest, sawWatermark: false);
+}
+
+/// Sync chapters from the server for [mangaIds] that have no [OfflineChapters]
+/// rows yet, then reconcile each one. Called from the bulk keep-rule change
+/// path when a manga's chapter list has never been mirrored locally (e.g. the
+/// user changed the keep rule from the library without ever opening the manga
+/// details screen). Without this step the reconciler finds an empty chapter
+/// list and silently does nothing — no server download, no device download.
+///
+/// Mirrors [_syncAndReconcile] but also kicks the download starter so the
+/// freshly-queued chapters begin transferring without waiting for the next
+/// library update.
+Future<void> syncAndReconcileMangaSet(
+  ProviderContainer container,
+  Set<int> mangaIds,
+) async {
+  if (mangaIds.isEmpty) return;
+  if (!container.read(offlineActiveProvider)) return;
+  await _syncAndReconcile(container, mangaIds);
+  await container.read(downloadStarterProvider)();
 }
 
 /// The manga-details chain, minus the screen: stored chapters from the server,

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -330,24 +330,29 @@ touchedSinceWatermark({
   return (touched: touched, newestFetchedAt: newest, sawWatermark: false);
 }
 
-/// Sync chapters from the server for [mangaIds] that have no [OfflineChapters]
-/// rows yet, then reconcile each one. Called from the bulk keep-rule change
-/// path when a manga's chapter list has never been mirrored locally (e.g. the
-/// user changed the keep rule from the library without ever opening the manga
-/// details screen). Without this step the reconciler finds an empty chapter
-/// list and silently does nothing — no server download, no device download.
+/// Fetch each manga's chapter list from the server, mirror it into drift, then
+/// reconcile. Called from the bulk keep-rule change path.
+///
+/// The server fetch is not optional even for a manga whose chapters are already
+/// mirrored: the reconciler routes purely on the stored `serverIsDownloaded`
+/// flag, and that mirror goes stale between syncs. A stale-true value routes a
+/// chapter straight to a device download that bypasses the server; a stale-false
+/// value re-enqueues a chapter the server already holds, which drains with no
+/// edge and never pulls to the device. Re-syncing first (syncChapters writes the
+/// server's current isDownloaded) is what keeps both hops correct.
 ///
 /// Mirrors [_syncAndReconcile] but also kicks the download starter so the
 /// freshly-queued chapters begin transferring without waiting for the next
 /// library update.
 Future<void> syncAndReconcileMangaSet(
   ProviderContainer container,
-  Set<int> mangaIds,
-) async {
+  Set<int> mangaIds, {
+  bool userInitiated = false,
+}) async {
   if (mangaIds.isEmpty) return;
   if (!container.read(offlineActiveProvider)) return;
   await _syncAndReconcile(container, mangaIds);
-  await container.read(downloadStarterProvider)();
+  await container.read(downloadStarterProvider)(userInitiated: userInitiated);
 }
 
 /// The manga-details chain, minus the screen: stored chapters from the server,

--- a/test/src/features/offline/data/bulk_keep_rule_chapter_sync_test.dart
+++ b/test/src/features/offline/data/bulk_keep_rule_chapter_sync_test.dart
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Contributors to the Suwayomi project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Tests for the fix that ensures bulk keep-rule changes also trigger chapter
+// syncs for manga whose chapter list has never been loaded into the local DB.
+//
+// Root cause of the original bug: for manga never opened in manga details,
+// offlineChapters has no rows. reconcileMangaCore sees an empty chapter list,
+// desiredChapterIds returns {}, and silently does nothing — no server enqueue,
+// no device download. syncAndReconcileMangaSet is the fix: it runs the full
+// fetch→sync→reconcile chain for exactly these manga.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tsumiru/src/features/manga_book/data/manga_book/manga_book_repository.dart';
+import 'package:tsumiru/src/features/manga_book/domain/chapter/chapter_model.dart';
+import 'package:tsumiru/src/features/offline/data/offline_chapter_catchup.dart';
+import 'package:tsumiru/src/features/offline/data/offline_database.dart';
+import 'package:tsumiru/src/features/offline/data/offline_download_providers.dart';
+import 'package:tsumiru/src/features/offline/data/offline_repository.dart';
+import 'package:tsumiru/src/global_providers/global_providers.dart';
+
+import '../../../../helpers/offline_test_db.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+GraphQLClient _dummyClient() => GraphQLClient(
+      link: HttpLink('http://localhost:0'),
+      cache: GraphQLCache(),
+    );
+
+/// Always returns null (simulates network failure / server has no chapters).
+class _NullChapterRepo extends MangaBookRepository {
+  _NullChapterRepo() : super(_dummyClient());
+
+  final List<int> calledFor = [];
+
+  @override
+  Future<List<ChapterDto>?> getStoredChapterList(int mangaId) async {
+    calledFor.add(mangaId);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUp(resetChapterCatchUpStateForTest);
+  tearDown(resetChapterCatchUpStateForTest);
+
+  // --- Original bug: empty offlineChapters silently breaks reconcile ----------
+
+  group('original bug — empty offlineChapters causes silent no-op', () {
+    test(
+      'chaptersForManga returns empty when syncChapters was never called',
+      () async {
+        // This documents the precondition that triggers the bug.
+        // When a manga has a keep rule but its chapters were never fetched
+        // (e.g. the user never opened the manga details screen), the local DB
+        // has an offlineMangas row but no offlineChapters rows.
+        // reconcileMangaCore then calls chaptersForManga → [], produces
+        // desiredChapterIds([], rule, count) = {}, and silently does nothing.
+        final db = testOfflineDatabase();
+        addTearDown(db.close);
+
+        await db.upsertMangaMetadata(
+          id: 1,
+          title: 'Manga A',
+          updatedAt: DateTime(2026),
+        );
+        await db.setKeepRule(1, OfflineKeepRule.nUnread, 5);
+
+        final chapters = await db.chaptersForManga(1);
+        expect(
+          chapters,
+          isEmpty,
+          reason: 'chapters have never been synced; the reconciler would '
+              'see an empty list and queue nothing',
+        );
+      },
+    );
+  });
+
+  // --- syncAndReconcileMangaSet guards -----------------------------------------
+
+  group('syncAndReconcileMangaSet — guards', () {
+    test('empty set is a no-op — repo and starter are never called', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final db = testOfflineDatabase();
+      addTearDown(db.close);
+      final repo = _NullChapterRepo();
+      final starterCalls = <bool>[];
+
+      final container = ProviderContainer(overrides: [
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        offlineActiveProvider.overrideWithValue(true),
+        offlineDatabaseProvider.overrideWithValue(db),
+        mangaBookRepositoryProvider.overrideWithValue(repo),
+        downloadStarterProvider.overrideWithValue(
+          ({bool userInitiated = false}) async => starterCalls.add(userInitiated),
+        ),
+      ]);
+      addTearDown(container.dispose);
+
+      await syncAndReconcileMangaSet(container, {});
+
+      expect(
+        repo.calledFor,
+        isEmpty,
+        reason: 'an empty set must skip the fetch loop entirely',
+      );
+      expect(
+        starterCalls,
+        isEmpty,
+        reason: 'no point starting downloads when there is nothing to sync',
+      );
+    });
+
+    test(
+      'offline inactive → no-op even when manga IDs are provided',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final db = testOfflineDatabase();
+        addTearDown(db.close);
+        final repo = _NullChapterRepo();
+        final starterCalls = <bool>[];
+
+        final container = ProviderContainer(overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          offlineActiveProvider.overrideWithValue(false),
+          offlineDatabaseProvider.overrideWithValue(db),
+          mangaBookRepositoryProvider.overrideWithValue(repo),
+          downloadStarterProvider.overrideWithValue(
+            ({bool userInitiated = false}) async =>
+                starterCalls.add(userInitiated),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        await syncAndReconcileMangaSet(container, {1, 2});
+
+        expect(
+          repo.calledFor,
+          isEmpty,
+          reason: 'offline inactive means no catalog is available; no '
+              'sync or download should start',
+        );
+        expect(starterCalls, isEmpty);
+      },
+    );
+  });
+
+  // --- syncAndReconcileMangaSet integration ------------------------------------
+
+  group('syncAndReconcileMangaSet — chapter fetch and download start', () {
+    test(
+      'calls getStoredChapterList for each manga, then kicks the download starter',
+      () async {
+        // This is the happy path of the fix: manga IDs provided, offline
+        // active, chapters fetched (even null = network error) for each,
+        // then download starter called once at the end.
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final db = testOfflineDatabase();
+        addTearDown(db.close);
+        final repo = _NullChapterRepo();
+        final starterCalls = <bool>[];
+
+        final container = ProviderContainer(overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          offlineActiveProvider.overrideWithValue(true),
+          offlineDatabaseProvider.overrideWithValue(db),
+          mangaBookRepositoryProvider.overrideWithValue(repo),
+          downloadStarterProvider.overrideWithValue(
+            ({bool userInitiated = false}) async =>
+                starterCalls.add(userInitiated),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        await syncAndReconcileMangaSet(container, {1, 2});
+
+        expect(
+          repo.calledFor.toSet(),
+          {1, 2},
+          reason: 'the chapter list must be fetched from the server for '
+              'every manga in the set, not just the first',
+        );
+        expect(
+          starterCalls.length,
+          1,
+          reason: 'the download starter is kicked exactly once at the end '
+              'of the full sync so freshly-queued chapters begin transferring',
+        );
+      },
+    );
+
+    test(
+      'fetch failure for every manga still calls the download starter once',
+      () async {
+        // Even when all fetches fail (network error, server unreachable),
+        // the starter fires so any pre-existing queued work can still make
+        // progress. This mirrors runKeepRuleCatchUp's own behaviour.
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final db = testOfflineDatabase();
+        addTearDown(db.close);
+        final repo = _NullChapterRepo();
+        final starterCalls = <bool>[];
+
+        final container = ProviderContainer(overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          offlineActiveProvider.overrideWithValue(true),
+          offlineDatabaseProvider.overrideWithValue(db),
+          mangaBookRepositoryProvider.overrideWithValue(repo),
+          downloadStarterProvider.overrideWithValue(
+            ({bool userInitiated = false}) async =>
+                starterCalls.add(userInitiated),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        await syncAndReconcileMangaSet(container, {1, 2, 3});
+
+        expect(
+          repo.calledFor.toSet(),
+          {1, 2, 3},
+          reason: 'all manga are attempted even when every fetch returns null',
+        );
+        expect(
+          starterCalls,
+          [false],
+          reason: 'the starter fires once regardless of individual sync '
+              'failures — the same pattern as runKeepRuleCatchUp',
+        );
+      },
+    );
+  });
+}

--- a/test/src/features/offline/data/bulk_keep_rule_chapter_sync_test.dart
+++ b/test/src/features/offline/data/bulk_keep_rule_chapter_sync_test.dart
@@ -88,6 +88,44 @@ void main() {
         );
       },
     );
+
+    test(
+      'setKeepRule silently no-ops when the manga has no offlineMangas row',
+      () async {
+        // Root cause of failure mode #3 ("nothing happens, not even the keep
+        // rule change"). setKeepRule is a pure UPDATE, so with no row it
+        // touches zero rows and the rule never persists. The bulk handler must
+        // mirror the manga row (from the DTO it holds) before calling this.
+        final db = testOfflineDatabase();
+        addTearDown(db.close);
+
+        // No upsertMangaMetadata — the row is deliberately absent.
+        await db.setKeepRule(42, OfflineKeepRule.all, 3);
+
+        final row = await (db.select(db.offlineMangas)
+              ..where((t) => t.id.equals(42)))
+            .getSingleOrNull();
+        expect(
+          row,
+          isNull,
+          reason: 'setKeepRule is an UPDATE, not an upsert — it cannot create '
+              'the row, so the keep rule is lost with no error raised',
+        );
+
+        // After the row exists, the same call persists.
+        await db.upsertMangaMetadata(
+          id: 42,
+          title: 'Manga B',
+          updatedAt: DateTime(2026),
+        );
+        await db.setKeepRule(42, OfflineKeepRule.all, 3);
+        final after = await (db.select(db.offlineMangas)
+              ..where((t) => t.id.equals(42)))
+            .getSingle();
+        expect(after.keepRule, OfflineKeepRule.all);
+        expect(after.keepUnreadCount, 3);
+      },
+    );
   });
 
   // --- syncAndReconcileMangaSet guards -----------------------------------------
@@ -243,6 +281,41 @@ void main() {
           [false],
           reason: 'the starter fires once regardless of individual sync '
               'failures — the same pattern as runKeepRuleCatchUp',
+        );
+      },
+    );
+
+    test(
+      'userInitiated is passed through to the download starter',
+      () async {
+        // The bulk keep-rule change is an explicit user gesture, so the FGS
+        // must start in user-initiated mode (drives the "X/Y" notification).
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final db = testOfflineDatabase();
+        addTearDown(db.close);
+        final repo = _NullChapterRepo();
+        final starterCalls = <bool>[];
+
+        final container = ProviderContainer(overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          offlineActiveProvider.overrideWithValue(true),
+          offlineDatabaseProvider.overrideWithValue(db),
+          mangaBookRepositoryProvider.overrideWithValue(repo),
+          downloadStarterProvider.overrideWithValue(
+            ({bool userInitiated = false}) async =>
+                starterCalls.add(userInitiated),
+          ),
+        ]);
+        addTearDown(container.dispose);
+
+        await syncAndReconcileMangaSet(container, {1}, userInitiated: true);
+
+        expect(
+          starterCalls,
+          [true],
+          reason: 'a user-initiated bulk keep must start the FGS in '
+              'user-initiated mode, not the background default',
         );
       },
     );


### PR DESCRIPTION
## Problem

Bulk keep-rule changes from the library list produced three distinct failure modes for different manga in the same selection:

1. **Local-only downloads bypassing the server** — chapters downloaded to the device without ever being stored on the server.
2. **Server-downloaded but never pulled to device** — the server had the chapter, the device never got it.
3. **Nothing at all** — not even the keep-rule change persisted.

## Root cause

The reconciler routes purely on the stored `serverIsDownloaded` flag (`offline_reconciler.dart:184`): `false` → server queue, `true` → local pull. Two things break that:

- **Stale mirror (modes #1, #2).** The first pass only re-synced manga whose local chapter list was empty; everything else took a "fast path" (`reconcileMangaWidget`) that reconciled against the stored flag *without refreshing it*. A stale-`true` flag routes straight to a device download (the device pulls pages the server proxies from the source but never stores → mode #1). A stale-`false` flag re-enqueues a chapter the server already holds; that queue drains with no edge, so the second-hop device pull never fires → mode #2. Only `syncChapters` (`offline_sync.dart:159`, writes the server's current `isDownloaded`) refreshes the flag, and the fast path skipped it.
- **Missing row (mode #3).** `setKeepRule` is a pure `UPDATE` (`offline_database.dart:714`). The `offlineMangas` row is only mirrored lazily — `unawaited`, and only when the library list came from the server (`library_manga_list.dart:58-61`). If the row is absent, the UPDATE hits 0 rows and the reconciler early-exits on the missing row.

## Fix

For every selected manga:
1. Mirror the `offlineMangas` row from the `MangaDto` already held in the library list (`syncManga`) **before** `setKeepRule`, so the rule always persists and the reconciler never early-exits.
2. Route the whole selection through `syncAndReconcileMangaSet`, which **always** re-fetches chapter state from the server (refreshing `serverIsDownloaded`) before reconciling, registers the second-hop device pull, and starts the download. The stale fast path is removed.

`syncAndReconcileMangaSet` gains a `userInitiated` passthrough so the foreground service starts in user-initiated mode.

## Tests

`test/src/features/offline/data/bulk_keep_rule_chapter_sync_test.dart` (7 tests):
- Empty `offlineChapters` → reconcile no-op (documents the original gap)
- `setKeepRule` silently no-ops without an `offlineMangas` row, persists after the row exists (mode #3 root cause)
- `syncAndReconcileMangaSet` guards: empty set and offline-inactive are no-ops
- Happy path: `getStoredChapterList` fetched for every manga, then the starter fires once
- All-fail resilience: the starter still fires when every fetch returns null
- `userInitiated` is passed through to the download starter

Full suite green; both changed files analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)