### PR TITLE
chore(offline): end-to-end tracing for offline downloads (worker + foreground + reconcile)

### DIFF
--- a/lib/src/features/notifications/data/background/notification_worker.dart
+++ b/lib/src/features/notifications/data/background/notification_worker.dart
@@ -240,6 +240,21 @@ Future<bool> _runNewChapters(
     allowedMangaIds: config.allowedMangaIds(mangaCategories),
   );
 
+  // The notify list this pass will actually surface, per manga. Paired with the
+  // download side's `offline-download-resolve` line, this is how you tell
+  // "notified but not downloaded" apart: a manga appearing here but not in the
+  // download pass's `queued` (and showing up in its `droppedOutOfScope`) was
+  // notified yet is outside the background download scope.
+  final notifyList = [
+    for (final g in result.groups)
+      '${g.mangaId}:${g.chapters.map((c) => c.id).join('|')}',
+  ].join(',');
+  recordDiagnostic(
+    '[${DateTime.now().toIso8601String()}] offline-notify: detected '
+    'candidates=${all.length} groups=${result.groups.length} '
+    'notify=[$notifyList]\n',
+  );
+
   if (result.groups.isEmpty) {
     await store.writeWatermark(config.serverId, result.watermark);
     return true;
@@ -339,6 +354,31 @@ Future<bool> _runDownloadResolution(
       ],
       watermark: ledger.cursor,
       allowedMangaIds: spec.keepRuleMangaIds,
+    );
+
+    // Fresh detections whose manga carries no keep rule in the spec: they are
+    // dropped from the download plan here, even though the notify pass (scoped
+    // by the category filter, not this one) may have just surfaced them. A
+    // non-empty list for a series you expect kept means the spec — a foreground
+    // snapshot built from libraryManga() — is stale or dropped that manga while
+    // it still carries a rule (e.g. inLibraryAt='0' desync). This is the exact
+    // signature of "notified but never downloaded".
+    final droppedOutOfScope = <int, int>{
+      for (final n in all)
+        if (!ledger.cursor.recent.containsKey(n.id) &&
+            !spec.keepRuleMangaIds.contains(n.mangaId))
+          n.id: n.mangaId,
+    };
+    final queuedList = [
+      for (final group in result.groups)
+        '${group.mangaId}:${group.chapters.map((c) => c.id).join('|')}',
+    ].join(',');
+    final droppedList =
+        droppedOutOfScope.entries.map((e) => '${e.value}:${e.key}').join(',');
+    recordDiagnostic(
+      '[${DateTime.now().toIso8601String()}] offline-download-resolve: '
+      'candidates=${all.length} queued=[$queuedList] '
+      'droppedOutOfScope=[$droppedList]\n',
     );
 
     // Obligations and the advanced cursor land in ONE atomic write: the cursor

--- a/lib/src/features/offline/data/background/background_download_controller.dart
+++ b/lib/src/features/offline/data/background/background_download_controller.dart
@@ -1138,6 +1138,11 @@ class BackgroundDownloadController with WidgetsBindingObserver {
         if (ch == null ||
             ch.deviceState == OfflineDeviceState.none ||
             (data['gen'] as int? ?? 0) != ch.downloadGeneration) {
+          recordDiagnostic(
+            '[${_now().toIso8601String()}] offline-fgs: chapter-dropped '
+            'chapterId=$chapterId reason=stale-or-deleted '
+            'deviceState=${ch?.deviceState.name ?? 'missing'}\n',
+          );
           return;
         }
         final result = await commitStagedChapter(
@@ -1152,6 +1157,10 @@ class BackgroundDownloadController with WidgetsBindingObserver {
         // notification claim chapters the user doesn't have.
         if (result == ChapterCommitResult.committed) {
           _sessionDownloaded++;
+          recordDiagnostic(
+            '[${_now().toIso8601String()}] offline-fgs: downloaded-chapter '
+            'mangaId=${ch.mangaId} chapterId=$chapterId\n',
+          );
           // A chapter landed, so the server is demonstrably fine — unless a
           // later chapter parked while this one was committing.
           if (_parkEpoch == epoch) _clearPark();
@@ -1185,13 +1194,31 @@ class BackgroundDownloadController with WidgetsBindingObserver {
                 OfflineDeviceState.error,
               );
               _sessionFailed++;
+              recordDiagnostic(
+                '[${_now().toIso8601String()}] offline-fgs: commit-failed '
+                'mangaId=${ch.mangaId} chapterId=$chapterId '
+                'result=${result.name} attempts=$attempts/$_maxCommitFailures '
+                '— marked error\n',
+              );
             } else {
               await _db.setChapterDeviceState(
                 chapterId,
                 OfflineDeviceState.queued,
                 bytes: 0,
               );
+              recordDiagnostic(
+                '[${_now().toIso8601String()}] offline-fgs: commit-incomplete '
+                'mangaId=${ch.mangaId} chapterId=$chapterId '
+                'result=${result.name} attempts=$attempts/$_maxCommitFailures '
+                '— requeued\n',
+              );
             }
+          } else if (result == ChapterCommitResult.refused) {
+            recordDiagnostic(
+              '[${_now().toIso8601String()}] offline-fgs: commit-refused '
+              'mangaId=${ch.mangaId} chapterId=$chapterId '
+              '— deleted or re-queued under a new generation\n',
+            );
           }
         }
       } else {
@@ -1202,6 +1229,10 @@ class BackgroundDownloadController with WidgetsBindingObserver {
           eventGeneration: data['gen'] as int? ?? 0,
         );
         if (status == 'error') _sessionFailed++;
+        recordDiagnostic(
+          '[${_now().toIso8601String()}] offline-fgs: chapter-terminal '
+          'mangaId=${data['mangaId']} chapterId=$chapterId status=$status\n',
+        );
       }
     }
   }
@@ -1262,6 +1293,11 @@ class BackgroundDownloadController with WidgetsBindingObserver {
           await _gateway.remove(kWorkOrderKey);
           rethrow;
         }
+        recordDiagnostic(
+          '[${_now().toIso8601String()}] offline-fgs: work-order-dispatched '
+          'count=${pending.length} '
+          'chapterIds=[${[for (final c in pending) c.id].join(',')}]\n',
+        );
         return attemptId;
       });
     } finally {

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -77,6 +77,15 @@ Future<bool> runCatchupDownloads({
   var needsBackfill = spec.keepRuleMangaIds.difference(
     ledger.backfilledMangaIds,
   );
+  // Only the manga this run will actually touch — the union of the ledger's
+  // pending obligations and the backfill set. The full keep-rule scope is a
+  // ~100-id wall of noise every wake; a missing kept series now surfaces at the
+  // point it matters instead (the download resolution's `droppedOutOfScope`).
+  final workMangaIds = <int>{
+    ...ledger.pendingDownloads.values,
+    ...ledger.pendingServerFetch.values,
+    ...needsBackfill,
+  };
   recordDiagnostic(
     '[${DateTime.now().toIso8601String()}] offline-catchup: run-started '
     'pendingDownloads=${ledger.pendingDownloads.length} '
@@ -85,10 +94,8 @@ Future<bool> runCatchupDownloads({
     'pendingDownloadIds=[${ledger.pendingDownloads.keys.join(',')}] '
     'pendingServerFetchIds=[${ledger.pendingServerFetch.keys.join(',')}] '
     'needsBackfillIds=[${needsBackfill.join(',')}] '
-    // The background download scope for this run. A new chapter whose manga is
-    // absent here is invisible to both the resolution cursor and backfill —
-    // if a kept series is missing, the spec (a foreground snapshot) is stale.
-    'keepRuleMangaIds=[${spec.keepRuleMangaIds.join(',')}]\n',
+    'keepRuleMangaCount=${spec.keepRuleMangaIds.length} '
+    'workMangaIds=[${workMangaIds.join(',')}]\n',
   );
   if (ledger.pendingDownloads.isEmpty &&
       ledger.pendingServerFetch.isEmpty &&

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -81,7 +81,10 @@ Future<bool> runCatchupDownloads({
     '[${DateTime.now().toIso8601String()}] offline-catchup: run-started '
     'pendingDownloads=${ledger.pendingDownloads.length} '
     'pendingServerFetch=${ledger.pendingServerFetch.length} '
-    'needsBackfill=${needsBackfill.length}\n',
+    'needsBackfill=${needsBackfill.length} '
+    'pendingDownloadIds=[${ledger.pendingDownloads.keys.join(',')}] '
+    'pendingServerFetchIds=[${ledger.pendingServerFetch.keys.join(',')}] '
+    'needsBackfillIds=[${needsBackfill.join(',')}]\n',
   );
   if (ledger.pendingDownloads.isEmpty &&
       ledger.pendingServerFetch.isEmpty &&
@@ -418,20 +421,42 @@ Future<bool> runCatchupDownloads({
         ...await _loggedOrCommitted(logEntries, store, mangaId, desired),
       };
 
-      for (final chapterId in desired.difference(present)) {
+      final toDownload = desired.difference(present);
+      if (toDownload.isNotEmpty) {
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-catchup: '
+          'manga-plan mangaId=$mangaId keepRule=${mangaSpec.keepRule.name} '
+          'keepN=${mangaSpec.keepUnreadCount} desired=${desired.length} '
+          'onDevice=${mangaSpec.onDeviceChapterIds.length} '
+          'toDownload=[${toDownload.join(',')}]\n',
+        );
+      }
+      for (final chapterId in toDownload) {
         if (downloaded >= _maxChaptersPerRun) break;
         if (DateTime.now().isAfter(deadline)) break;
         if (await capBlocked()) {
           final partial = await store.readManifest(mangaId, chapterId);
           if (partial?.generation != mangaSpec.generationOf(chapterId) ||
               await store.stagedBytes(mangaId, chapterId) == 0) {
+            recordDiagnostic(
+              '[${DateTime.now().toIso8601String()}] offline-catchup: '
+              'skip-chapter mangaId=$mangaId chapterId=$chapterId '
+              'reason=storage-cap\n',
+            );
             continue;
           }
         }
         await checkControls();
         if (cancelled) break;
         final row = chapters.byId[chapterId];
-        if (row == null) continue;
+        if (row == null) {
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-catchup: '
+            'skip-chapter mangaId=$mangaId chapterId=$chapterId '
+            'reason=not-in-server-list\n',
+          );
+          continue;
+        }
 
         // A budget per hop, spent only on that hop's own failures. Sharing one
         // meant a slow source could exhaust a chapter before the device had
@@ -448,6 +473,12 @@ Future<bool> runCatchupDownloads({
             // which manga this chapter belongs to, so the window cleanup below
             // can drop the counter with it once the chapter is no longer
             // wanted. Skipping costs nothing — the gate is ahead of any I/O.
+            recordDiagnostic(
+              '[${DateTime.now().toIso8601String()}] offline-catchup: '
+              'skip-chapter mangaId=$mangaId chapterId=$chapterId '
+              'reason=server-fetch-budget-exhausted '
+              'attempts=$spent/$kMaxChapterAttempts\n',
+            );
             serverFetch.remove(chapterId);
             continue;
           }
@@ -486,7 +517,15 @@ Future<bool> runCatchupDownloads({
         // many runs the fetch above took.
         serverFetch.remove(chapterId);
         final dlSpent = dlRetries[chapterId] ?? 0;
-        if (dlSpent >= kMaxChapterAttempts) continue;
+        if (dlSpent >= kMaxChapterAttempts) {
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-catchup: '
+            'skip-chapter mangaId=$mangaId chapterId=$chapterId '
+            'reason=download-budget-exhausted '
+            'attempts=$dlSpent/$kMaxChapterAttempts\n',
+          );
+          continue;
+        }
 
         // Re-check connectivity before each chapter's page downloads — the
         // one-time gate at run start can't catch a WiFi drop mid-run.
@@ -522,6 +561,20 @@ Future<bool> runCatchupDownloads({
           );
         } else if (!attempt.transient) {
           dlRetries[chapterId] = dlSpent + 1;
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-catchup: '
+            'download-failed mangaId=$mangaId chapterId=$chapterId '
+            'transient=false attempt=${dlSpent + 1}/$kMaxChapterAttempts\n',
+          );
+        } else {
+          // Transient (network blip, server busy): keep the obligation and let
+          // the next wake retry — this is why a pending chapter can silently
+          // carry over run after run without ever spending its budget.
+          recordDiagnostic(
+            '[${DateTime.now().toIso8601String()}] offline-catchup: '
+            'download-deferred mangaId=$mangaId chapterId=$chapterId '
+            'reason=transient\n',
+          );
         }
       }
 

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -339,6 +339,12 @@ Future<bool> runCatchupDownloads({
           .firstOrNull;
       if (mangaSpec == null) {
         // Rule removed since resolution: drop the obligations.
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-catchup: '
+          'skip-manga mangaId=$mangaId reason=not-in-work-spec '
+          '— keep rule removed or the spec is stale; dropping its '
+          'ledger obligations\n',
+        );
         ledger = _dropManga(ledger, mangaId);
         await catchupStore.writeLedger(spec.serverId, ledger);
         continue;
@@ -611,6 +617,21 @@ Future<bool> runCatchupDownloads({
                   present.contains(e.key)))
             e.key,
       };
+      if (done.isNotEmpty) {
+        // The exclusion reason for a pending chapter that never downloaded:
+        // already on the device (present — the common "re-notified a chapter
+        // it already has" case) vs. no longer inside the keep window.
+        final droppedPresent =
+            [for (final c in done) if (present.contains(c)) c];
+        final droppedNotDesired =
+            [for (final c in done) if (!present.contains(c)) c];
+        recordDiagnostic(
+          '[${DateTime.now().toIso8601String()}] offline-catchup: '
+          'dropped-pending mangaId=$mangaId '
+          'alreadyPresent=[${droppedPresent.join(',')}] '
+          'noLongerDesired=[${droppedNotDesired.join(',')}]\n',
+        );
+      }
       for (final c in done) {
         pending.remove(c);
         serverFetch.remove(c);

--- a/lib/src/features/offline/data/background/catchup_download_executor.dart
+++ b/lib/src/features/offline/data/background/catchup_download_executor.dart
@@ -84,7 +84,11 @@ Future<bool> runCatchupDownloads({
     'needsBackfill=${needsBackfill.length} '
     'pendingDownloadIds=[${ledger.pendingDownloads.keys.join(',')}] '
     'pendingServerFetchIds=[${ledger.pendingServerFetch.keys.join(',')}] '
-    'needsBackfillIds=[${needsBackfill.join(',')}]\n',
+    'needsBackfillIds=[${needsBackfill.join(',')}] '
+    // The background download scope for this run. A new chapter whose manga is
+    // absent here is invisible to both the resolution cursor and backfill —
+    // if a kept series is missing, the spec (a foreground snapshot) is stale.
+    'keepRuleMangaIds=[${spec.keepRuleMangaIds.join(',')}]\n',
   );
   if (ledger.pendingDownloads.isEmpty &&
       ledger.pendingServerFetch.isEmpty &&

--- a/lib/src/features/offline/data/offline_reconciler.dart
+++ b/lib/src/features/offline/data/offline_reconciler.dart
@@ -233,6 +233,32 @@ class OfflineReconciler {
       toDownload.add(id);
     }
 
+    // Trace the reconcile decision: what the server-synced list + keep rule
+    // wanted, and how each desired chapter was routed against local state —
+    // pulled to the device (server already has it), asked of the server (it
+    // does not), or neither (already on device / errored). Only emitted when
+    // there is something to act on, so a steady-state library stays quiet.
+    if (toDownload.isNotEmpty || toServerDownload.isNotEmpty) {
+      var alreadyOnDevice = 0;
+      var errored = 0;
+      for (final id in desired) {
+        final st = byId[id]?.deviceState;
+        if (st == OfflineDeviceState.downloaded) {
+          alreadyOnDevice++;
+        } else if (st == OfflineDeviceState.error) {
+          errored++;
+        }
+      }
+      recordDiagnostic(
+        '[${DateTime.now().toIso8601String()}] offline-reconcile: '
+        'plan mangaId=$mangaId keepRule=${manga.keepRule.name} '
+        'keepN=${manga.keepUnreadCount} desired=${desired.length} '
+        'toDownload=[${toDownload.join(',')}] '
+        'toServerDownload=[${toServerDownload.join(',')}] '
+        'alreadyOnDevice=$alreadyOnDevice errored=$errored\n',
+      );
+    }
+
     for (final id in toEvict) {
       await onEvict(id);
     }


### PR DESCRIPTION
## Why

When an offline download run completes only part of its work -- overnight (`pendingDownloads=17` -> `downloaded=1`) or in the foreground (server found 3 new chapters, only 2 downloaded) -- the `crash.log` gave no way to tell *why*. Each of the three download paths logged almost nothing about per-chapter decisions or outcomes.

And a subtler gap: a chapter can be **notified as new yet never queued for download**, because new-chapter detection runs *twice* with *different scopes* (notifications by category filter, downloads by the keep-rule spec). Neither pass logged its output, so that divergence -- the fingerprint of the "notified but not downloaded" bug (see #458) -- was completely invisible in the log.

## What

Instruments all three download paths **and** the new-chapter detection split (logging only, no behaviour change):

### 0. New-chapter detection: notify vs download -- `notification_worker.dart`
- `offline-notify: detected candidates=… groups=… notify=[mangaId:chapterIds]` -- what the notification pass surfaces (category-filter scope).
- `offline-download-resolve: candidates=… queued=[mangaId:chapterIds] droppedOutOfScope=[mangaId:chapterId]` -- what the background download pass queues (keep-rule-spec scope), **plus** the fresh detections it drops because their manga is outside that scope. A non-empty `droppedOutOfScope` for a series the user keeps is the exact signature of "notified but not downloaded" -- you can now read, per run, which chapter of which manga was notified but declined by the download path.

### 1. Background worker -- `catchup_download_executor.dart`
- `run-started` lists the actual ids (`pendingDownloadIds`, `pendingServerFetchIds`, `needsBackfillIds`). The ~100-id `keepRuleMangaIds` dump is **replaced** by `keepRuleMangaCount` plus `workMangaIds` (only the manga actually in play this run) -- the full scope was a wall of noise every wake, and a missing kept series now surfaces where it matters instead (the `droppedOutOfScope` line above).
- `manga-plan`: per manga, keep rule / window / the exact chapter ids selected.
- `skip-chapter reason=…` (storage-cap, not-in-server-list, server-fetch-budget-exhausted, download-budget-exhausted).
- `download-failed transient=false` and `download-deferred reason=transient` -- the two previously-silent pull outcomes.

### 2. Reconcile decision -- `offline_reconciler.dart`
- `plan mangaId=… keepRule=… desired=… toDownload=[…] toServerDownload=[…] alreadyOnDevice=… errored=…` -- the server-synced-list-vs-local comparison: for each desired chapter, whether it was pulled to the device (server has it), asked of the server (it does not), or skipped (already on device / errored). Complements the existing `asking-server-to-fetch` / `giving-up-on-server-fetch` lines.

### 3. Foreground FGS execution -- `background_download_controller.dart`
- `work-order-dispatched count=… chapterIds=[…]` -- exactly what was handed to the service.
- `downloaded-chapter` (commit landed), `chapter-dropped` (stale/deleted), `commit-failed` / `commit-incomplete` / `commit-refused`, `chapter-terminal status=error`.

## Result

A chapter can now be followed end to end in `crash.log`: **detected (notify + download scopes) -> reconcile plan -> dispatch -> per-chapter outcome**, across both the background worker and the foreground service. No behaviour change. These logs are what pinned down the #458 root cause in the field: a series surfaced by the notify pass but dropped by the download pass (`droppedOutOfScope`) because it had fallen out of the keep-rule spec -- which #458 traces to a partial `getAllLibraryMangas` fetch stamping it "removed", and fixes by paginating that fetch to completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
