### PR TITLE
Recount the Browse badge after an extension update

### DIFF
--- a/lib/src/features/browse_center/presentation/extension/controller/extension_actions.dart
+++ b/lib/src/features/browse_center/presentation/extension/controller/extension_actions.dart
@@ -12,6 +12,7 @@ import '../../../../../utils/extensions/custom_extensions.dart';
 import '../../../data/extension_repository/extension_repository.dart';
 import '../../source/controller/source_controller.dart';
 import 'extension_controller.dart';
+import 'extension_update_badge.dart';
 
 part 'extension_actions.g.dart';
 
@@ -68,10 +69,18 @@ class ExtensionActions {
     }
   }
 
+  /// Refetching the list is what makes the server re-check for updates, so
+  /// the Browse badge is recounted once it lands (#444).
+  Future<void> refreshList() async {
+    _ref.invalidate(extensionProvider);
+    await _ref.read(extensionProvider.future);
+    _ref.invalidate(extensionUpdateBadgeCountProvider);
+  }
+
   Future<void> _refreshAfter(Future<void> Function() mutate) async {
     await mutate();
     _ref.invalidate(sourceListProvider);
-    return _ref.refresh(extensionProvider.future);
+    return refreshList();
   }
 }
 

--- a/lib/src/features/browse_center/presentation/extension/extension_screen.dart
+++ b/lib/src/features/browse_center/presentation/extension/extension_screen.dart
@@ -15,6 +15,7 @@ import '../../../../utils/misc/toast/toast.dart';
 import '../../../../widgets/emoticons.dart';
 import '../../../../widgets/search_field.dart';
 import '../../domain/extension/extension_model.dart';
+import 'controller/extension_actions.dart';
 import 'controller/extension_controller.dart';
 import 'widgets/extension_list_tile.dart';
 
@@ -55,7 +56,7 @@ class ExtensionScreen extends HookConsumerWidget {
     final update = extensionMap.remove("update");
     final all = extensionMap.remove("all");
 
-    refresh() => ref.refresh(extensionProvider.future);
+    refresh() => ref.read(extensionActionsProvider).refreshList();
 
     useEffect(() {
       // Effect bodies run during build; invalidating a provider there throws.
@@ -92,7 +93,7 @@ class ExtensionScreen extends HookConsumerWidget {
               ),
             )
           : RefreshIndicator(
-              onRefresh: () => ref.refresh(extensionProvider.future),
+              onRefresh: refresh,
               child: CustomScrollView(
                 slivers: [
                   if (update.isNotBlank)

--- a/test/helpers/fake_extension_repository.dart
+++ b/test/helpers/fake_extension_repository.dart
@@ -15,6 +15,14 @@ GraphQLClient dummyGraphQLClient() =>
 
 /// Records every mutation the app sends; [calls] keeps their order.
 class FakeExtensionRepository extends ExtensionRepository {
+  int updateCountCalls = 0;
+
+  @override
+  Future<int> getExtensionUpdateCount() async {
+    updateCountCalls++;
+    return 0;
+  }
+
   FakeExtensionRepository() : super(dummyGraphQLClient());
 
   final List<String> installed = <String>[];

--- a/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
+++ b/test/src/features/browse_center/presentation/extension/extension_actions_test.dart
@@ -17,6 +17,7 @@ import 'package:tsumiru/src/features/browse_center/data/source_repository/source
 import 'package:tsumiru/src/features/browse_center/domain/extension/extension_model.dart';
 import 'package:tsumiru/src/features/browse_center/domain/source/source_model.dart';
 import 'package:tsumiru/src/features/browse_center/presentation/extension/controller/extension_actions.dart';
+import 'package:tsumiru/src/features/browse_center/presentation/extension/controller/extension_update_badge.dart';
 import 'package:tsumiru/src/features/browse_center/presentation/source/controller/source_controller.dart';
 import 'package:tsumiru/src/global_providers/global_providers.dart';
 
@@ -65,6 +66,25 @@ void main() {
     await container.read(sourceListProvider.future);
     return sources.listCalls - before;
   }
+
+  Future<int> badgeCountsAfter(Future<void> Function() action) async {
+    container.listen(extensionUpdateBadgeCountProvider, (previous, next) {});
+    await container.read(extensionUpdateBadgeCountProvider.future);
+    final before = extensions.updateCountCalls;
+    await action();
+    await container.read(extensionUpdateBadgeCountProvider.future);
+    return extensions.updateCountCalls - before;
+  }
+
+  test('updating an extension recounts the Browse badge', () async {
+    final actions = container.read(extensionActionsProvider);
+    expect(await badgeCountsAfter(() => actions.update('com.example.ext')), 1);
+  });
+
+  test('refreshing the extension list recounts the Browse badge', () async {
+    final actions = container.read(extensionActionsProvider);
+    expect(await badgeCountsAfter(actions.refreshList), 1);
+  });
 
   test('installing an extension refetches the source list', () async {
     final actions = container.read(extensionActionsProvider);


### PR DESCRIPTION
## Problem

The number on the Browse tab showing how many extensions have an update is its own server query. Updating, installing or uninstalling an extension refreshed the extension list and the source list but never asked for that number again, so it stayed until the next launch.

## Change

Refreshing the extension list now recounts the badge once the list has landed, since that fetch is what makes the server re-check for updates. Every extension action already refreshes the list, so install, update, uninstall, install from file, pull-to-refresh and the empty-state Refresh button all recount it. The sequence lives in the existing long-lived actions helper so it does not touch a screen's `ref` after the slow fetch.

## Tests

Two new tests: updating an extension recounts the badge, and refreshing the list recounts the badge. Not yet verified on a device.

Closes #444