### PR TITLE
chore(android): modernize Gradle SDK DSL, ignore android/build, clear analyzer info

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,5 +1,6 @@
 gradle-wrapper.jar
 /.gradle
+/build
 /captures/
 /gradlew
 /gradlew.bat

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,7 +28,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 36 // bumped for background_downloader / flutter_foreground_task
+    compileSdk 36 // bumped for background_downloader / flutter_foreground_task
     ndkVersion "28.2.13676358"
     namespace "io.github.aaronbamblett.tsumiru"
     compileOptions {
@@ -43,18 +43,15 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.github.aaronbamblett.tsumiru"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion // raised for flutter_foreground_task (Android 6.0+)
-        targetSdkVersion flutter.targetSdkVersion
+        minSdk flutter.minSdkVersion // raised for flutter_foreground_task (Android 6.0+)
+        targetSdk flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         manifestPlaceholders += [appLabel: "Tsumiru"]
 
         // Opt-in side-by-side test build — leaves the daily driver untouched.
-        // Build with: ORG_GRADLE_PROJECT_devBuild=1 flutter build apk --debug
+        // Build with: flutter build apk --debug --android-project-arg=devBuild=1
         // Installs as a separate app id (…tsumiru.dev) named "Tsumiru Dev".
         if (project.hasProperty('devBuild')) {
             applicationIdSuffix ".dev"

--- a/lib/src/features/offline/data/offline_chapter_catchup.dart
+++ b/lib/src/features/offline/data/offline_chapter_catchup.dart
@@ -354,8 +354,9 @@ Future<bool> _syncAndReconcile(
         container,
         mangaId,
         newlyReadChapterIds: newlyRead,
-      ))
+      )) {
         allSynced = false;
+      }
     } catch (e) {
       // Never reconcile on a failed fetch — evictions must not run against a
       // list the server didn't actually give us.


### PR DESCRIPTION
Small Android housekeeping, no behavior change — `flutter analyze` stays clean.

- **Modernize the Gradle SDK DSL:** `compileSdkVersion`/`minSdkVersion`/`targetSdkVersion` → `compileSdk`/`minSdk`/`targetSdk`. The `*Version` method forms are deprecated in current AGP.
- **Ignore `android/build/`:** Gradle writes `reports/problems/problems-report.html` (and other output) there, which shows up as untracked in `git status`. Added `/build` to `android/.gitignore` (the conventional Flutter-template location).
- **Drop stale Flutter-template boilerplate** in `defaultConfig` (the `// TODO: Specify your own unique Application ID` / "You can update the following values…" comments) and correct the dev-build hint to pass `devBuild` via `--android-project-arg`.
- **Clear the only analyzer info:** wrap a braceless `if` in `offline_chapter_catchup.dart` (`curly_braces_in_flow_control_structures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)