### PR TITLE
fix(offline): settle disk before the launch reconcile on desktop (match Android's replay-first ordering)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -408,14 +408,18 @@ Future<void> _startApp() async {
           await container.read(notificationsControllerProvider).sync();
         } catch (_) {}
         if (!container.read(offlineActiveProvider)) return;
-        // Replay FIRST: launch reconcile and the catch-up must see post-replay
-        // device state, or overnight background downloads read as missing and
-        // get re-fetched. The service restart stays after reconcile below.
+        // Settle disk FIRST: launch reconcile and the catch-up must see
+        // post-recovery device state, or overnight background downloads read as
+        // missing and get re-fetched. Android reaches this through the worker's
+        // replay; desktop/other has no replay, so it recovers here directly.
+        // The service restart / pump stays after reconcile below.
         if (isAndroidNative) {
           // register() already ran above; this is the catalog-dependent half.
           await container
               .read(backgroundDownloadControllerProvider)
               .replayAtLaunch();
+        } else {
+          await recoverDiskAtLaunch(container);
         }
         await pushPendingProgress(container);
         await reconcileAllAtLaunch(container);

--- a/lib/src/features/offline/data/offline_background_downloads.dart
+++ b/lib/src/features/offline/data/offline_background_downloads.dart
@@ -121,11 +121,36 @@ OfflineDownloadCoordinator? offlineDownloadCoordinator(Ref ref) {
   );
 }
 
+/// Settle on-disk chapter files against the catalog at launch, BEFORE the launch
+/// reconcile and catch-up run. Android reaches this through the background
+/// worker's launch replay (ordered ahead of reconcile in `main`); every other
+/// platform has no replay at all, so without this a chapter whose commit landed
+/// but whose catalog write didn't would be seen as missing and downloaded all
+/// over again, and files left by a crashed delete would never be swept.
+///
+/// Split out of [initOfflineDownloads] so the launch path can order recovery
+/// ahead of the reconcile pass (which must see post-recovery device state),
+/// mirroring Android's replay-before-reconcile ordering. Depends only on the
+/// database and page store — no coordinator — so it is safe to run this early,
+/// before the download pump.
+Future<void> recoverDiskAtLaunch(ProviderContainer container) async {
+  if (!container.read(offlineActiveProvider)) return;
+  // On Android the foreground-service worker's replay owns recovery.
+  if (isAndroidNative) return;
+  await recoverChaptersOnDisk(
+    db: container.read(offlineDatabaseProvider),
+    store: container.read(offlinePageStoreProvider),
+  );
+}
+
 /// Resume offline downloads at launch. Chapters left `downloading` by a previous
 /// run (the in-memory loop doesn't survive a process death) are stranded; the
 /// pump resumes them one at a time, re-fetching only pages not already on disk.
 /// Chapters previously marked `error` get one fresh attempt — most past errors
 /// were the stale-token 401s the run-time-auth engine now avoids.
+///
+/// Disk recovery is NOT done here — it runs earlier via [recoverDiskAtLaunch],
+/// which the launch path invokes before the reconcile pass. This is pump-only.
 Future<void> initOfflineDownloads(ProviderContainer container) async {
   if (!container.read(offlineActiveProvider)) return;
   // On Android the foreground-service worker owns downloads (see the corruption
@@ -134,16 +159,6 @@ Future<void> initOfflineDownloads(ProviderContainer container) async {
   if (isAndroidNative) return;
   final coord = container.read(offlineDownloadCoordinatorProvider);
   if (coord == null) return;
-  final db = container.read(offlineDatabaseProvider);
-  // Settle disk against the catalog BEFORE anything resumes. Android reaches
-  // this through the worker's launch replay; every other platform has no
-  // replay at all, so without this a chapter whose commit landed but whose
-  // catalog write didn't would be downloaded all over again, and files left by
-  // a crashed delete would never be swept.
-  await recoverChaptersOnDisk(
-    db: db,
-    store: container.read(offlinePageStoreProvider),
-  );
   // `error` is terminal: this used to promote every errored chapter on each
   // launch, retrying forever. The user retries from the save button.
   await coord.pumpDownloads();

--- a/test/src/features/offline/data/offline_launch_recovery_test.dart
+++ b/test/src/features/offline/data/offline_launch_recovery_test.dart
@@ -77,6 +77,14 @@ void main() {
     updatedAt: DateTime(2026),
   );
 
+  // Mirror the desktop launch order: disk recovery (now split out of
+  // initOfflineDownloads) runs first, then the pump resumes the queue.
+  Future<void> launchRecoverAndResume(Future<ProviderContainer> cf) async {
+    final c = await cf;
+    await recoverDiskAtLaunch(c);
+    await initOfflineDownloads(c);
+  }
+
   test(
     'launch adopts a chapter whose commit landed but was never recorded',
     () async {
@@ -85,7 +93,7 @@ void main() {
       // The rename happened; the catalog write didn't.
       store.seedCommitted(1, {0: 5, 1: 5});
 
-      await initOfflineDownloads(await container());
+      await launchRecoverAndResume(container());
 
       expect(
         (await db.chapterById(1))!.deviceState,
@@ -101,7 +109,7 @@ void main() {
     await db.setChapterDeviceState(1, OfflineDeviceState.none);
     store.seedCommitted(1, {0: 5, 1: 5});
 
-    await initOfflineDownloads(await container());
+    await launchRecoverAndResume(container());
 
     expect(store.deletedChapters, contains(1));
     expect((await db.chapterById(1))!.deviceState, OfflineDeviceState.none);
@@ -117,7 +125,7 @@ void main() {
     store.seedCommitted(1, {0: 5, 1: 5});
     store.setAside(1);
 
-    await initOfflineDownloads(await container());
+    await launchRecoverAndResume(container());
 
     expect(
       store.committed.containsKey(1),
@@ -141,7 +149,7 @@ void main() {
     store.setAside(1);
     store.seedStaged(1, {0: 9, 1: 9, 2: 9}, indices: [0, 1, 2]);
 
-    await initOfflineDownloads(await container());
+    await launchRecoverAndResume(container());
 
     expect(
       await db.downloadedPageCount(1),
@@ -153,4 +161,24 @@ void main() {
       OfflineDeviceState.downloaded,
     );
   });
+
+  test(
+    'recoverDiskAtLaunch settles disk on its own, with no pump — it is the '
+    'step the launch path runs before reconcile',
+    () async {
+      await seedChapter(1, 7);
+      await db.setChapterDeviceState(1, OfflineDeviceState.downloading);
+      // Commit landed, catalog write didn't.
+      store.seedCommitted(1, {0: 5, 1: 5});
+
+      await recoverDiskAtLaunch(await container());
+
+      expect(
+        (await db.chapterById(1))!.deviceState,
+        OfflineDeviceState.downloaded,
+        reason: 'recovery adopts the on-disk copy without needing the pump',
+      );
+      expect(store.written, isEmpty, reason: 'nothing was re-downloaded');
+    },
+  );
 }


### PR DESCRIPTION
## Summary

On desktop and other non-Android platforms, launch-time disk recovery (`recoverChaptersOnDisk`) ran **after** the launch reconcile and the new-chapter catch-up, instead of before. That reverses the ordering the offline engine documents and that Android already upholds. This PR settles on-disk state against the catalog before anything reads it, and splits the recovery step out of the download-resume step so the ordering is explicit and hard to regress.

## The invariant

At launch, on-disk chapter files must be reconciled against the catalog **before** the launch reconcile pass (`reconcileAllAtLaunch`) and the keep-rule catch-up (`initChapterCatchUp`) run. If they are not:

- a chapter whose commit rename landed but whose catalog write was lost (a crash/kill between the two) is seen as *missing* and re-downloaded;
- files left behind by a delete that crashed mid-way are never swept;
- the storage-cap and time-based eviction safety nets run against stale byte totals.

The code states this in several places, e.g. `initOfflineDownloads` ("Settle disk against the catalog BEFORE anything resumes …") and `main` ("… launch reconcile and the catch-up must see post-replay device state, or overnight background downloads read as missing and get re-fetched.").

## The bug (ordering)

Android reaches recovery through the background worker's launch replay, which `main` deliberately runs **before** reconcile/catch-up.

Every other platform has no replay. Its only recovery call lived inside `initOfflineDownloads`, which `main` invokes in the desktop branch **after** reconcile and catch-up:

```dart
await reconcileAllAtLaunch(container);   // reads device state
initChapterCatchUp(container);           // reads device state
// …
} else {
  await initOfflineDownloads(container); // recoverChaptersOnDisk ran in here — too late
}
```

So on desktop the effective order was `reconcile → catch-up → recovery`, the reverse of the documented contract.

## Impact

The worst outcome (re-fetching an adopted chapter) is today largely masked by guards: `queueChapter` no-ops on `downloading`/`queued`/`downloaded`/`error` rows and doesn't bump generation for them, and recovery still runs before the pump. So this is mostly a **latent contract violation** rather than active data loss. The residual, real risks:

- the launch storage-cap / time-based safety nets run against **pre-recovery** byte totals (a complete-but-uncommitted chapter reports stale bytes), so the cap can under- or over-count and mis-queue or mis-evict;
- an eviction acting on stale state bumps the download generation; a later recovery pass then sees a generation mismatch and sweeps still-wanted files, which re-download on the next pass;
- any future reconcile/catch-up change that keys off device state would silently reproduce the "read as missing → re-fetched" outcome — on desktop only.

## The fix

- Extract the recovery step out of `initOfflineDownloads` into a new `recoverDiskAtLaunch(container)` that depends only on the database and page store (no coordinator), so it is safe to run early.
- Call it in the non-Android launch branch **before** `reconcileAllAtLaunch`, as the `else` to Android's `replayAtLaunch()` — giving desktop the same recover-before-reconcile ordering Android has.
- `initOfflineDownloads` is now **pump-only**.

Both platforms now share one shape: **settle disk → reconcile → catch-up → resume**, mirroring the existing Android split (`replayAtLaunch` before reconcile, `maybeStartAfterReplay` after).

## Tests

The launch-recovery tests previously drove recovery through `initOfflineDownloads`; they now call `recoverDiskAtLaunch` and then the pump (mirroring the real launch order), and a new test asserts `recoverDiskAtLaunch` settles disk on its own with no pump — the exact step that now runs before reconcile. The full offline test suite is green and `flutter analyze` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)